### PR TITLE
fix: rename PlainText to BareBlock in classless component test

### DIFF
--- a/tests/26_classless_component_assets_test.py
+++ b/tests/26_classless_component_assets_test.py
@@ -143,13 +143,13 @@ def test_classless_component_no_assets_no_injection():
     Registry.clear_instances()
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        with open(os.path.join(temp_dir, "plain_text.html"), "w") as f:
+        with open(os.path.join(temp_dir, "bare_block.html"), "w") as f:
             f.write('<p id="{{ id }}">{{ content }}</p>\n')
 
         env = Environment(loader=FileSystemLoader(temp_dir))
         renderer = Renderer(env, auto_id=True)
 
-        rendered = renderer.render('<PlainText id="p1">Words</PlainText>')
+        rendered = renderer.render('<BareBlock id="p1">Words</BareBlock>')
 
         assert "<script>" not in rendered
         assert "<style>" not in rendered

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "pyjinhx"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Python's `HTMLParser` treats `plaintext` (the lowercase form of `PlainText`) as a raw-text element, meaning it reads everything after the open tag as literal character data. The close tag never fires, `root_nodes` stays empty, and the render returns `''` — causing `test_classless_component_no_assets_no_injection` to fail on CI.

Renaming the component from `PlainText` to `BareBlock` avoids the HTMLParser edge case entirely. No production code was changed.

## Changes

- `tests/26_classless_component_assets_test.py`: renamed component `PlainText` → `BareBlock` and updated the corresponding template filename from `plain_text.html` → `bare_block.html`
- `uv.lock`: updated to reflect the 0.3.1 → 0.3.2 version bump committed on this branch

## Type of Change

- [x] Bug fix (patch)
- [ ] New feature (minor)
- [ ] Breaking change (major)
- [ ] Refactor / cleanup
- [ ] Documentation

## Version Bump

`0.3.1` → `0.3.2`

## Testing

The renamed test now passes locally and should pass on CI. No other tests were modified. Reviewers can verify by running the test suite — specifically `tests/26_classless_component_assets_test.py`.