### PR TITLE
fix: guard closeModal against non-open dialogs

### DIFF
--- a/pyjinhx/builtins/ui/modal/modal.js
+++ b/pyjinhx/builtins/ui/modal/modal.js
@@ -6,7 +6,7 @@ function openModal(id) {
 
 function closeModal(id) {
     const modal = document.getElementById(id);
-    if (!modal) return;
+    if (!modal || !modal.open) return;
     modal.classList.add('px-modal--closing');
     modal.addEventListener('animationend', () => {
         modal.classList.remove('px-modal--closing');


### PR DESCRIPTION
## Summary

- Add `!modal.open` guard to `closeModal()` in `modal.js`

## Problem

When `closeModal(id)` is called on a `<dialog>` that is **not currently open**, the `px-modal--closing` CSS class is added but the `modal-out` animation never plays (element is hidden), so `animationend` never fires. The class stays permanently, and `animation: modal-out 150ms ease forwards` applies on the next `openModal` — rendering the dialog at `opacity: 0` with `animation-fill-mode: forwards`.

This happens in practice when HTMX OOB swaps replace a `<dialog>` element and a `closeModal` event arrives after the swap (targeting the new, already-closed dialog).

## Fix

Early-return from `closeModal` when `modal.open` is `false`. One-line change.

## Test plan

- [ ] Open a modal, close it normally — animation plays, dialog closes
- [ ] Call `closeModal('some-id')` on a closed dialog — no-op, no stuck class
- [ ] HTMX OOB swap a dialog, then open it again — modal renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)