### PR TITLE
feat(reactive): process-global load() cache with dependency-keyed invalidation (step 4)

### DIFF
--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -116,6 +116,35 @@ The dependency graph lives in exactly one place — the `depends_on` declaration
 not smeared across endpoints. Adding a progress bar that declares
 `depends_on = {"todos"}` makes it participate automatically; no endpoint changes.
 
+## 4. `load()` results are cached
+
+Every reactive component's `load()` is wrapped in a **process-global, dependency-keyed
+cache**. Repeated reads — a page render, several components, successive requests —
+return the cached result and skip the database until the relevant keys are dirtied:
+
+```python
+Counter.load()   # first call hits the DB
+Counter.load()   # cached: no DB, returns an independent copy
+```
+
+A reactive `render(dirtied=...)` (and `oob_swaps`) evicts the dirtied keys before
+reloading dependents, so swaps always reflect post-mutation state. For mutations that
+happen outside a render — a background job, a webhook — call `invalidate` yourself:
+
+```python
+from pyjinhx import invalidate
+
+def nightly_recalc():
+    db.rebuild_todos()
+    invalidate({"todos"})   # evict every cached load() that depends on "todos"
+```
+
+The cache holds one result per reactive component type (v1 is type-singleton) and
+returns a fresh copy on every call, so callers can mutate what they get back without
+affecting the cache. **Scope is per-process**: under multiple workers each process has
+its own cache; cross-worker coherence is your application's responsibility (back it
+with a shared store if you need it).
+
 ## Boundaries
 
 - **Hash gating is a skip-hint, not correctness authority**: a matching client hash
@@ -125,3 +154,6 @@ not smeared across endpoints. Adding a progress bar that declares
 - **Type-singleton**: one mounted instance per reactive type is reloaded; instance-keyed deps (`"user:42"`) are deferred.
 - **`mounted` accepts** a request-like object (header duck-typed out, no framework import), the raw header string, a parsed list, or `None`.
 - **`load()` is zero-arg in v1** (type-singleton). Reactive `render()` auto-`load()`s dependents; you never call `load()` yourself for a reactive render.
+- **`load()` cache is per-process**: it saves database work on cache hits; eviction is
+  dirtied-key driven (automatically in the reactive flow, or via `invalidate(dirtied)`).
+  Cross-worker coherence is the application's responsibility.

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -149,11 +149,140 @@ with a shared store if you need it).
 
 - **Hash gating is a skip-hint, not correctness authority**: a matching client hash
   earns permission to skip; missing/unknown/mismatched always swaps. It saves
-  bandwidth and DOM churn, not database work (a short-circuiting `load()` cache is a
-  later phase).
+  bandwidth and DOM churn; database work is saved separately by the `load()` cache.
 - **Type-singleton**: one mounted instance per reactive type is reloaded; instance-keyed deps (`"user:42"`) are deferred.
 - **`mounted` accepts** a request-like object (header duck-typed out, no framework import), the raw header string, a parsed list, or `None`.
 - **`load()` is zero-arg in v1** (type-singleton). Reactive `render()` auto-`load()`s dependents; you never call `load()` yourself for a reactive render.
 - **`load()` cache is per-process**: it saves database work on cache hits; eviction is
   dirtied-key driven (automatically in the reactive flow, or via `invalidate(dirtied)`).
   Cross-worker coherence is the application's responsibility.
+
+## How it works (under the hood)
+
+### The ownership split
+
+Neither pyjinhx nor htmx owned the **state→view dependency graph** before. The split
+is now explicit: the **server** owns the dependency graph and the data and decides what
+changed; the **client** owns what is currently mounted and rides that up on every
+request as a manifest. There is no per-session server state.
+
+```mermaid
+flowchart LR
+    subgraph Client["Client — browser + htmx"]
+      DOM["Mounted DOM<br/>reactive roots carry<br/>data-pjx-id / -type / -hash"]
+      RT["pjx.js runtime"]
+    end
+    subgraph Server["Server — pyjinhx"]
+      G["depends_on graph<br/>declared on components"]
+      W["oob_swaps walk"]
+      L["load() + result cache"]
+    end
+    DB[("Database")]
+
+    RT -->|"reads DOM, builds<br/>X-PJX-Mounted header"| DOM
+    DOM -->|"manifest on every request"| W
+    W --> G
+    W --> L --> DB
+    W -->|"hx-swap-oob fragments"| DOM
+```
+
+### Initial render → the manifest
+
+On a full-page render, reactive roots are stamped with `data-pjx-*` and the client
+runtime is injected once (via `Layout`, or `client_script()` in a raw shell). The
+runtime reads the already-stamped DOM at request time — it never watches for changes,
+because DOM mutation is the *effect* of a swap, not its cause.
+
+```mermaid
+flowchart TD
+    A["Layout page render"] --> B["reactive roots stamped<br/>data-pjx-* via splice stamper"]
+    A --> C["client runtime injected once<br/>(Layout) or client_script()"]
+    B --> D["DOM holds id + type + hash<br/>per mounted region"]
+    C --> E["on htmx:configRequest,<br/>pjx.js scans [data-pjx-id]"]
+    D --> E
+    E --> F["sets X-PJX-Mounted header<br/>= list of id, type, hash"]
+```
+
+### A mutation request, end to end
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser (htmx + pjx.js)
+    participant R as Route handler
+    participant RD as render(dirtied, mounted)
+    participant C as load() cache
+    participant DB as Database
+
+    B->>R: POST /todos/1/toggle  (X-PJX-Mounted header)
+    R->>DB: db.toggle(1)
+    R->>RD: TodoItem(...).render(dirtied, mounted=request)
+    RD->>C: invalidate(dirtied)
+    Note over C: evict cached load() results<br/>whose depends_on hits a dirtied key
+    RD->>RD: render self → primary response
+    RD->>RD: oob_swaps walk (exclude_ids = self.id)
+    loop each mounted region depending on a dirtied key
+        RD->>C: cls.load()
+        alt cache miss
+            C->>DB: query
+            DB-->>C: data
+        else cache hit
+            C-->>RD: model_copy() — no DB
+        end
+        RD->>RD: render + compute fresh hash
+    end
+    RD-->>R: primary + OOB fragments
+    R-->>B: one HTML response
+    B->>B: htmx swaps main target + each hx-swap-oob region
+```
+
+### Inside `oob_swaps`: the decision pipeline
+
+Every mounted region runs this gauntlet. Ordering matters: **hash-gate before
+nesting-dedup**, so an unchanged parent never suppresses a changed child.
+
+```mermaid
+flowchart TD
+    M["manifest entry"] --> F{"reactive type AND<br/>depends_on intersects dirtied?"}
+    F -->|no| X1["ignore"]
+    F -->|yes| EX{"id in exclude_ids?<br/>(it is the primary)"}
+    EX -->|yes| X2["ignore"]
+    EX -->|no| LOAD["cls.load() cached →<br/>render → fresh hash"]
+    LOAD --> GATE{"fresh hash ==<br/>reported hash?"}
+    GATE -->|yes| X3["SKIP — value unchanged"]
+    GATE -->|no| DED{"nested inside another<br/>surviving region?"}
+    DED -->|yes| X4["DROP — parent already contains it"]
+    DED -->|no| EMIT["emit hx-swap-oob fragment"]
+```
+
+The four parent/child cases (regions nested in the rendered HTML):
+
+| Parent | Child | Result |
+| --- | --- | --- |
+| changed | changed | swap parent only (its fresh HTML already holds the child) |
+| changed | unchanged | swap parent only |
+| **unchanged** | **changed** | **swap child alone** — only correct because gating removes the parent *before* dedup |
+| unchanged | unchanged | swap nothing |
+
+Governing invariant throughout: **when in doubt, swap** — missing, unknown, or
+mismatched hashes always send.
+
+### The `load()` cache
+
+`load()` is auto-wrapped at class-definition time so it is cache-aware everywhere it is
+called. Reads short-circuit the database; writes evict by dependency through a reverse
+index. A `threading.Lock` guards the compound consult-then-mutate operations, while the
+real `load()` (the database hit) runs outside the lock.
+
+```mermaid
+flowchart TD
+    CALL["Cls.load()"] --> HIT{"in cache?"}
+    HIT -->|hit| COPY["return model_copy()<br/>no DB; copy keeps cache pristine"]
+    HIT -->|miss| RUN["run real load() → DB"]
+    RUN --> STORE["cache cls = result<br/>index under each depends_on key"]
+    STORE --> COPY
+
+    INV["invalidate(dirtied)<br/>auto in reactive flow, or public"] --> REV["consult reverse index<br/>key → classes"]
+    REV --> EVICT["evict every class whose<br/>depends_on intersects dirtied"]
+    EVICT -.->|"next load() misses"| CALL
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,11 @@ plugins:
 markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - admonition

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -1,4 +1,5 @@
 from .base import BaseComponent
+from .cache import invalidate
 from .dataclasses import Tag
 from .finder import Finder
 from .parser import Parser
@@ -15,6 +16,7 @@ __all__ = [
     "Tag",
     "Layout",
     "oob_swaps",
+    "invalidate",
     "client_script",
     "PJX_MOUNTED_HEADER",
 ]

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -69,6 +69,12 @@ class BaseComponent(BaseModel):
         super().__init_subclass__(**kwargs)
         Registry.register_class(cls)
         cls._configure_reactivity()
+        if cls._pjx_reactive and "load" in cls.__dict__:
+            from .cache import (
+                install_cached_load,
+            )  # local import to avoid an import cycle
+
+            install_cached_load(cls)
 
     @classmethod
     def _configure_reactivity(cls) -> None:

--- a/pyjinhx/cache.py
+++ b/pyjinhx/cache.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .base import BaseComponent
+
+_lock = threading.Lock()
+_cache: dict[type, "BaseComponent"] = {}
+_reverse: dict[str, set[type]] = {}
+
+
+def install_cached_load(cls: type) -> None:
+    """
+    Replace a reactive component's own ``load()`` classmethod with a cache-aware
+    wrapper. Called from ``BaseComponent.__init_subclass__`` for every reactive
+    subclass that defines its own ``load``.
+    """
+    original = cls.__dict__["load"]
+    raw_func = original.__func__ if isinstance(original, classmethod) else original
+
+    def _cached_load(inner_cls):
+        return _load_through_cache(inner_cls, raw_func)
+
+    cls.load = classmethod(_cached_load)
+
+
+def _load_through_cache(cls, raw_func):
+    with _lock:
+        cached = _cache.get(cls)
+    if cached is not None:
+        return cached.model_copy()
+
+    # Run the real load() (the DB hit) OUTSIDE the lock.
+    result = raw_func(cls)
+
+    with _lock:
+        _cache[cls] = result
+        for key in getattr(cls, "_pjx_depends_on", frozenset()):
+            _reverse.setdefault(key, set()).add(cls)
+    return result.model_copy()
+
+
+def invalidate(dirtied: set[str]) -> None:
+    """
+    Evict every cached ``load()`` result whose component depends on a dirtied key.
+
+    Reactive ``render(dirtied=...)`` / ``oob_swaps`` call this automatically; call
+    it yourself for mutations that happen outside a render (e.g. a background job).
+    Per-process only — multi-worker coherence is the application's responsibility.
+    """
+    if not dirtied:
+        return
+    with _lock:
+        to_evict: set[type] = set()
+        for key in dirtied:
+            to_evict |= _reverse.get(key, set())
+        for cls in to_evict:
+            _cache.pop(cls, None)
+            for key in getattr(cls, "_pjx_depends_on", frozenset()):
+                bucket = _reverse.get(key)
+                if bucket is not None:
+                    bucket.discard(cls)
+                    if not bucket:
+                        _reverse.pop(key, None)
+
+
+def clear() -> None:
+    """Drop all cached ``load()`` results and the reverse index. Mainly for tests."""
+    with _lock:
+        _cache.clear()
+        _reverse.clear()

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -8,6 +8,7 @@ from typing import Any
 from markupsafe import Markup
 
 from .base import BaseComponent
+from .cache import invalidate
 from .registry import Registry
 from .renderer import Renderer
 from .utils import read_client_runtime, stamp_root_attributes
@@ -126,7 +127,9 @@ def oob_swaps(
     or mismatched hash always swaps ("when in doubt, swap").
 
     Args:
-        dirtied: The state keys the route mutated (e.g. {"todos"}).
+        dirtied: The state keys the route mutated (e.g. {"todos"}). These keys are
+            also evicted from the process-global load() cache before dependents are
+            reloaded.
         mounted: The client manifest — a request-like object exposing
             ``.headers.get`` (the X-PJX-Mounted header is duck-typed out without
             importing any web framework), the raw header string, an already-parsed
@@ -138,6 +141,10 @@ def oob_swaps(
         A single Markup of concatenated OOB swap fragments, each carrying
         hx-swap-oob. Empty Markup if nothing needs swapping.
     """
+    # The route mutated `dirtied` before calling us, so any cached load() result
+    # for those keys is stale — evict before (re)loading dependents.
+    invalidate(dirtied)
+
     manifest = _parse_mounted(mounted)
     if not manifest:
         return Markup("")

--- a/tests/39_load_cache_test.py
+++ b/tests/39_load_cache_test.py
@@ -1,0 +1,82 @@
+from typing import ClassVar
+
+from pyjinhx import BaseComponent, invalidate
+from pyjinhx.cache import clear
+from tests.ui.reactive.cached_widget import CachedWidget, load_calls
+
+
+def _reset():
+    clear()
+    load_calls["count"] = 0
+
+
+def test_load_result_is_cached():
+    _reset()
+    a = CachedWidget.load()
+    b = CachedWidget.load()
+    assert load_calls["count"] == 1  # second call short-circuits the real load()
+    assert a.value == 1 and b.value == 1
+
+
+def test_load_returns_independent_copies():
+    _reset()
+    a = CachedWidget.load()
+    a.id = "mutated"
+    a.value = 999
+    b = CachedWidget.load()
+    assert b.id == "cached-widget"
+    assert b.value == 1
+    assert load_calls["count"] == 1
+
+
+def test_invalidate_evicts_matching_dependency():
+    _reset()
+    first = CachedWidget.load()
+    invalidate({"widgets"})
+    second = CachedWidget.load()
+    assert load_calls["count"] == 2
+    assert first.value == 1 and second.value == 2
+
+
+def test_invalidate_unrelated_key_keeps_cache():
+    _reset()
+    CachedWidget.load()
+    invalidate({"users"})
+    CachedWidget.load()
+    assert load_calls["count"] == 1
+
+
+def test_invalidate_empty_set_is_noop():
+    _reset()
+    CachedWidget.load()
+    invalidate(set())
+    CachedWidget.load()
+    assert load_calls["count"] == 1
+
+
+def test_invalidate_cleans_reverse_index_across_keys():
+    clear()
+    calls = {"n": 0}
+
+    class MultiDep(BaseComponent):
+        n: int = 0
+        depends_on: ClassVar[set[str]] = {"alpha", "beta"}
+
+        @classmethod
+        def load(cls):
+            calls["n"] += 1
+            return cls(id="multi", n=calls["n"])
+
+    MultiDep.load()  # n=1, indexed under alpha & beta
+    invalidate({"alpha"})  # evict; must also drop it from the beta bucket
+    invalidate({"beta"})  # must not raise on the now-clean bucket
+    a = MultiDep.load()  # miss -> n=2
+    b = MultiDep.load()  # hit -> still n=2
+    assert calls["n"] == 2
+    assert a.n == 2 and b.n == 2
+
+
+def test_invalidate_is_exported():
+    from pyjinhx import invalidate as exported
+
+    assert callable(exported)

--- a/tests/40_load_cache_integration_test.py
+++ b/tests/40_load_cache_integration_test.py
@@ -1,0 +1,38 @@
+from pyjinhx import oob_swaps
+from tests.ui.reactive import store
+from tests.ui.reactive.reactive_counter import ReactiveCounter
+from tests.ui.reactive.reactive_clear_button import ReactiveClearButton  # noqa: F401
+
+
+def test_oob_swaps_invalidates_dirtied_before_loading():
+    store.state["remaining"] = 1
+    warm = ReactiveCounter.load()  # warm the cache with the old value
+    assert warm.remaining == 1
+    store.state["remaining"] = 5  # mutate the world
+    # oob_swaps must evict {"todos"} and serve the fresh value, not the cached 1.
+    out = str(
+        oob_swaps(
+            {"todos"},
+            [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}],
+        )
+    )
+    assert "5 left" in out
+    assert "1 left" not in out
+
+
+def test_reactive_render_invalidates_dirtied():
+    store.state["completed"] = 2
+    warm = ReactiveClearButton.load()  # warm the cache
+    assert warm.completed == 2
+    store.state["completed"] = 9
+    primary = ReactiveCounter(id="counter", remaining=0)
+    out = str(
+        primary.render(
+            dirtied={"todos"},
+            mounted=[
+                {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
+            ],
+        )
+    )
+    assert "Clear (9)" in out
+    assert "Clear (2)" not in out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+from pyjinhx.cache import clear as clear_load_cache
+
+
+@pytest.fixture(autouse=True)
+def _isolate_load_cache():
+    """The load() cache is process-global; clear it around every test for isolation."""
+    clear_load_cache()
+    yield
+    clear_load_cache()

--- a/tests/ui/reactive/cached_widget.py
+++ b/tests/ui/reactive/cached_widget.py
@@ -1,0 +1,16 @@
+from typing import ClassVar
+
+from pyjinhx import BaseComponent
+
+# Module-level counter so tests can observe how many times the *real* load() ran.
+load_calls = {"count": 0}
+
+
+class CachedWidget(BaseComponent):
+    value: int = 0
+    depends_on: ClassVar[set[str]] = {"widgets"}
+
+    @classmethod
+    def load(cls) -> "CachedWidget":
+        load_calls["count"] += 1
+        return cls(id="cached-widget", value=load_calls["count"])


### PR DESCRIPTION
## Summary

Implements **step 4** (final step) of dependency-aware reactivity (issue #12, delta B): a process-global, dependency-keyed cache for `load()` results, so repeated reads short-circuit before the database and a write to a state key evicts exactly the cached components that derive from it. Builds on #13–#15.

## Key changes

- **Process-global cache** (`pyjinhx/cache.py`): `{class → load() result}` plus a reverse index `{dirty-key → {classes}}`, guarded by a single `threading.Lock`. The user's `load()` body (the DB hit) runs **outside** the lock; only the dict reads/writes are inside it. `clear()` is provided for resets/tests.
- **Auto-wrapped `load()`** (`base.py`): every reactive component's own `load()` is replaced at class-definition time (`__init_subclass__`) with a cache-aware classmethod. A hit returns a fresh `model_copy()` so callers (e.g. `oob_swaps` setting `.id`) can't pollute the cache; a miss runs the real `load()`, stores the result, and indexes it under each `depends_on` key.
- **Dirtied-driven eviction**: `oob_swaps` (and therefore `render(dirtied=)`) calls `invalidate(dirtied)` before reloading dependents, so swaps always reflect post-mutation state. The public **`invalidate(dirtied)`** is exported for mutations outside a render (background jobs, webhooks).
- **Test isolation** (`tests/conftest.py`): an autouse fixture clears the global cache around every test — required since auto-wrapping makes every reactive `load()` cache-aware.
- **Docs** (`docs/reactivity.md`): new "`load()` results are cached" section + boundary.

## Scope (per the issue)

**Per-process, not per-worker** — within one process the cache is shared across threads (mutations locked); cross-worker coherence is the application's responsibility (back it with a shared store if needed). pyjinhx ships only the invalidation logic. "When in doubt, miss": copies are returned and the cache is cleared on doubt.

## Tests

- `tests/39_load_cache_test.py` — unit: caching/short-circuit, independent copies, dependency-matched eviction, unrelated-key no-op, empty-set no-op, reverse-index cleanup across keys, public export.
- `tests/40_load_cache_integration_test.py` — integration: `oob_swaps` and `render(dirtied=)` serve the fresh post-mutation value rather than a warm cached one.

Full suite: **165 passed**, `ruff check` clean, `mkdocs build --strict` builds.

## Roadmap

This completes the 4-step plan in issue #12 (steps 1–4 via #13, #14, #15, this PR). The only remaining item is the explicitly-deferred **instance-keyed dependencies** (`"user:42"`) — the issue's named "main piece of unfinished design", not part of the 4-step plan; `load()` stays zero-arg / type-singleton in v1.

https://claude.ai/code/session_013K1kbeYc1e4vWYhRwThvNt

---
_Generated by [Claude Code](https://claude.ai/code/session_013K1kbeYc1e4vWYhRwThvNt)_