### PR TITLE
refactor(reactive): ReactiveComponent ABC, base_layout kwarg, default dirtied

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ exactly the mounted regions that depend on what changed:
 
 ```python
 from typing import ClassVar
-from pyjinhx import BaseComponent, oob_swaps, PJX_MOUNTED_HEADER
+from pyjinhx import ReactiveComponent
 
-class Counter(BaseComponent):
+class Counter(ReactiveComponent):
     remaining: int
     depends_on: ClassVar[set[str]] = {"todos"}
 
@@ -154,10 +154,8 @@ class Counter(BaseComponent):
 @app.post("/todos/{id}/toggle")
 def toggle(id, request):
     db.toggle(id)
-    return TodoItem(id=id, ...).render() + oob_swaps(
-        dirtied={"todos"},
-        mounted=request.headers.get(PJX_MOUNTED_HEADER, ""),
-    )
+    # dirtied defaults to TodoItem's own depends_on; pass dirtied={...} to override.
+    return TodoItem(id=id, ...).render(mounted=request)
 ```
 
 See [the reactivity guide](docs/reactivity.md) for details.

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -198,7 +198,7 @@ because DOM mutation is the *effect* of a swap, not its cause.
 
 ```mermaid
 flowchart TD
-    A["base_layout page render"] --> B["reactive roots stamped<br/>data-pjx-* via splice stamper"]
+    A["full-page render<br/>(base_layout shell)"] --> B["reactive roots stamped<br/>data-pjx-* via splice stamper"]
     A --> C["client runtime injected once<br/>(base_layout) or client_script()"]
     B --> D["DOM holds id + type + hash<br/>per mounted region"]
     C --> E["on htmx:configRequest,<br/>pjx.js scans [data-pjx-id]"]

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -12,13 +12,15 @@ integration and a `load()` cache are planned follow-ups.)
 
 ## 1. Make a component reactive
 
-A component is reactive when it declares `depends_on` and a `load()` classmethod:
+Subclass `ReactiveComponent` and declare **both** `depends_on` and a `load()`
+classmethod — `ReactiveComponent` enforces both (a missing `load()` can't be
+instantiated; a missing `depends_on` is a definition-time error):
 
 ```python
 from typing import ClassVar
-from pyjinhx import BaseComponent
+from pyjinhx import ReactiveComponent
 
-class Counter(BaseComponent):
+class Counter(ReactiveComponent):
     remaining: int
     depends_on: ClassVar[set[str]] = {"todos"}
 
@@ -36,13 +38,13 @@ name), and `data-pjx-hash` on their root element automatically.
 
 ## 2. Ship the client runtime
 
-Subclass `Layout` for your page shell — the manifest runtime is injected once on
-full-page renders:
+Mark your page shell with `base_layout=True` — the manifest runtime is injected once
+on full-page renders (the marker is inherited, so subclasses of a shell stay layouts):
 
 ```python
-from pyjinhx import Layout
+from pyjinhx import BaseComponent
 
-class AppShell(Layout):
+class AppShell(BaseComponent, base_layout=True):
     ...  # app_shell.html is your full page template
 ```
 
@@ -74,10 +76,9 @@ out-of-band swaps:
 @app.post("/todos/{id}/toggle")
 def toggle(id, request):
     db.toggle(id)
-    return TodoItem(id=id, text=..., done=...).render(
-        dirtied={"todos"},
-        mounted=request,
-    )
+    # dirtied defaults to TodoItem's own depends_on, so when the toggled item
+    # depends on "todos" you can omit it; pass dirtied={...} to override.
+    return TodoItem(id=id, text=..., done=...).render(mounted=request)
 ```
 
 `render(dirtied=, mounted=)` renders the component itself as the primary response,
@@ -152,7 +153,9 @@ with a shared store if you need it).
   bandwidth and DOM churn; database work is saved separately by the `load()` cache.
 - **Type-singleton**: one mounted instance per reactive type is reloaded; instance-keyed deps (`"user:42"`) are deferred.
 - **`mounted` accepts** a request-like object (header duck-typed out, no framework import), the raw header string, a parsed list, or `None`.
-- **`load()` is zero-arg in v1** (type-singleton). Reactive `render()` auto-`load()`s dependents; you never call `load()` yourself for a reactive render.
+- **Reactivity is opt-in via `ReactiveComponent`**, which requires both `load()` and
+  `depends_on`. `load()` is zero-arg in v1 (type-singleton); reactive `render()`
+  auto-`load()`s dependents, so you never call `load()` yourself for a reactive render.
 - **`load()` cache is per-process**: it saves database work on cache hits; eviction is
   dirtied-key driven (automatically in the reactive flow, or via `invalidate(dirtied)`).
   Cross-worker coherence is the application's responsibility.
@@ -189,14 +192,14 @@ flowchart LR
 ### Initial render → the manifest
 
 On a full-page render, reactive roots are stamped with `data-pjx-*` and the client
-runtime is injected once (via `Layout`, or `client_script()` in a raw shell). The
+runtime is injected once (via `base_layout=True`, or `client_script()` in a raw shell). The
 runtime reads the already-stamped DOM at request time — it never watches for changes,
 because DOM mutation is the *effect* of a swap, not its cause.
 
 ```mermaid
 flowchart TD
-    A["Layout page render"] --> B["reactive roots stamped<br/>data-pjx-* via splice stamper"]
-    A --> C["client runtime injected once<br/>(Layout) or client_script()"]
+    A["base_layout page render"] --> B["reactive roots stamped<br/>data-pjx-* via splice stamper"]
+    A --> C["client runtime injected once<br/>(base_layout) or client_script()"]
     B --> D["DOM holds id + type + hash<br/>per mounted region"]
     C --> E["on htmx:configRequest,<br/>pjx.js scans [data-pjx-id]"]
     D --> E

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -3,12 +3,19 @@ from .cache import invalidate
 from .dataclasses import Tag
 from .finder import Finder
 from .parser import Parser
-from .reactive import PJX_MOUNTED_HEADER, Layout, client_script, oob_swaps
+from .reactive import (
+    PJX_MOUNTED_HEADER,
+    Layout,
+    ReactiveComponent,
+    client_script,
+    oob_swaps,
+)
 from .registry import Registry
 from .renderer import Renderer
 
 __all__ = [
     "BaseComponent",
+    "ReactiveComponent",
     "Renderer",
     "Finder",
     "Parser",

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -5,7 +5,6 @@ from .finder import Finder
 from .parser import Parser
 from .reactive import (
     PJX_MOUNTED_HEADER,
-    Layout,
     ReactiveComponent,
     client_script,
     oob_swaps,
@@ -21,7 +20,6 @@ __all__ = [
     "Parser",
     "Registry",
     "Tag",
-    "Layout",
     "oob_swaps",
     "invalidate",
     "client_script",

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -58,10 +58,13 @@ class BaseComponent(BaseModel):
             raise ValueError("ID is required")
         return str(v)
 
-    def __init_subclass__(cls, **kwargs):
-        """Register the component class at definition time."""
+    def __init_subclass__(cls, *, base_layout: bool = False, **kwargs):
+        """Register the component class and record whether it is a page layout."""
         super().__init_subclass__(**kwargs)
         Registry.register_class(cls)
+        # Inherited: a subclass of a layout stays a layout. The renderer injects the
+        # client runtime once for the is_root layout of a full-page render.
+        cls._pjx_layout = bool(base_layout) or getattr(cls, "_pjx_layout", False)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -1,6 +1,5 @@
-import hashlib
 import logging
-from typing import Any, ClassVar, Optional
+from typing import Any, Optional
 
 from markupsafe import Markup
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -53,11 +52,6 @@ class BaseComponent(BaseModel):
         description="List of paths to extra CSS files to include.",
     )
 
-    # State keys this component derives from. Declaring this plus a load()
-    # classmethod makes the component reactive (eligible for dependency-aware
-    # OOB swaps via oob_swaps()).
-    depends_on: ClassVar[set[str]] = set()
-
     @field_validator("id", mode="before")
     def validate_id(cls, v):
         if not v:
@@ -65,55 +59,9 @@ class BaseComponent(BaseModel):
         return str(v)
 
     def __init_subclass__(cls, **kwargs):
-        """Register the component class and configure its reactivity at definition time."""
+        """Register the component class at definition time."""
         super().__init_subclass__(**kwargs)
         Registry.register_class(cls)
-        cls._configure_reactivity()
-        if cls._pjx_reactive and "load" in cls.__dict__:
-            from .cache import (
-                install_cached_load,
-            )  # local import to avoid an import cycle
-
-            install_cached_load(cls)
-
-    @classmethod
-    def _configure_reactivity(cls) -> None:
-        """
-        Detect whether this subclass is reactive and normalize its dependencies.
-
-        A component is reactive iff it defines a ``load()`` classmethod. The
-        derived flags are stored as plain class attributes (not Pydantic fields)
-        so they are inherited by further subclasses and never validated.
-        """
-        has_load = callable(getattr(cls, "load", None))
-        declared = set(getattr(cls, "depends_on", None) or ())
-        cls._pjx_reactive = has_load
-        cls._pjx_depends_on = frozenset(declared)
-
-        if has_load and not declared:
-            logger.warning(
-                "%s defines load() but no depends_on; it will never match a "
-                "dirtied key and is effectively inert.",
-                cls.__name__,
-            )
-        if declared and not has_load:
-            logger.warning(
-                "%s declares depends_on=%s but no load(); it cannot be reloaded "
-                "for reactive OOB swaps.",
-                cls.__name__,
-                declared,
-            )
-
-    def state_hash(self) -> str:
-        """
-        Return a stable content hash of this component's state.
-
-        Used to gate reactive OOB swaps so a region whose value did not change is
-        not re-sent. The default hashes ``model_dump_json()``; override for custom
-        hashing. In the always-swap baseline (step 1) this value is stamped onto
-        the root element and reported by the client, but not yet used for gating.
-        """
-        return hashlib.sha256(self.model_dump_json().encode("utf-8")).hexdigest()[:16]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -221,4 +221,7 @@ class BaseComponent(BaseModel):
             else getattr(self, "_pjx_depends_on", frozenset())
         )
         swaps = oob_swaps(effective_dirtied or set(), mounted, exclude_ids={self.id})
-        return primary + swaps
+        # Wrap the primary as safe markup before concatenation: _render() returns a
+        # plain str (Markup.unescape()), and `str + Markup` would invoke Markup.__radd__
+        # and HTML-escape the primary. Markup(primary) + swaps keeps both raw.
+        return Markup(primary) + swaps

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -196,11 +196,15 @@ class BaseComponent(BaseModel):
         region whose ``depends_on`` intersects ``dirtied`` (each rebuilt via its own
         ``load()``). This component's own region is never additionally swapped.
 
+        When ``dirtied`` is omitted it defaults to this component's own ``depends_on``
+        (empty for a non-reactive primary); pass ``dirtied`` explicitly — including an
+        empty set — to override.
+
         Args:
-            dirtied: State keys the route mutated (e.g. ``{"todos"}``). Enables reactive mode.
-            mounted: The client manifest — a request-like object (the ``X-PJX-Mounted``
-                header is read off it without importing any web framework), the raw header
-                string, an already-parsed list, or ``None``. Enables reactive mode.
+            dirtied: State keys the route mutated (e.g. ``{"todos"}``). Defaults to the
+                primary's ``depends_on``. Enables reactive mode.
+            mounted: The client manifest — a request-like object, the raw header string,
+                a parsed list, or ``None``. Enables reactive mode.
 
         Returns:
             The rendered HTML as a Markup object (safe for direct use in templates).
@@ -211,5 +215,10 @@ class BaseComponent(BaseModel):
         from .reactive import oob_swaps  # local import to avoid an import cycle
 
         primary = self._render()
-        swaps = oob_swaps(dirtied or set(), mounted, exclude_ids={self.id})
+        effective_dirtied = (
+            dirtied
+            if dirtied is not None
+            else getattr(self, "_pjx_depends_on", frozenset())
+        )
+        swaps = oob_swaps(effective_dirtied or set(), mounted, exclude_ids={self.id})
         return primary + swaps

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -27,8 +27,8 @@ def client_script() -> Markup:
 
     Drop this into a page shell (e.g. a raw Jinja layout) to emit the
     ``X-PJX-Mounted`` manifest header on every htmx request. When the page shell
-    subclasses ``Layout`` the runtime is injected automatically and you do not
-    need to call this.
+    is marked ``base_layout=True`` the runtime is injected automatically and you
+    do not need to call this.
     """
     return Markup(f"<script>{read_client_runtime()}</script>")
 
@@ -76,21 +76,6 @@ class ReactiveComponent(BaseComponent):
             from .cache import install_cached_load
 
             install_cached_load(cls)
-
-
-class Layout(BaseComponent):
-    """
-    Base class for full-page shells.
-
-    Rendering a ``Layout`` subclass as the page root injects the pyjinhx client
-    runtime once, so mounted reactive regions report their manifest via the
-    ``X-PJX-Mounted`` header. Subclass it for your page shell and provide a
-    template as usual; fragment endpoints render ordinary components, so the
-    runtime is never injected into partial responses.
-    """
-
-
-Layout._pjx_layout = True
 
 
 @dataclass

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 from markupsafe import Markup
 
@@ -29,6 +31,51 @@ def client_script() -> Markup:
     need to call this.
     """
     return Markup(f"<script>{read_client_runtime()}</script>")
+
+
+class ReactiveComponent(BaseComponent):
+    """
+    Base class for dependency-aware reactive components.
+
+    A reactive component declares the state keys it derives from (``depends_on``)
+    and how to rebuild itself from the current world (``load()``). Both are
+    required — ``load()`` is enforced by ABC (you cannot instantiate a subclass
+    that does not implement it) and ``depends_on`` is enforced at class-definition
+    time. Reactive components are stamped with ``data-pjx-*`` on render and are the
+    units the dependency walk (``oob_swaps``) reloads and swaps.
+    """
+
+    # State keys this component derives from; the dependency walk swaps a region
+    # when its depends_on intersects the route's dirtied keys.
+    depends_on: ClassVar[set[str]] = set()
+
+    @classmethod
+    @abstractmethod
+    def load(cls) -> "ReactiveComponent":
+        """Rebuild this component from the current world (zero-arg, type-singleton in v1)."""
+        ...
+
+    def state_hash(self) -> str:
+        """
+        Stable content hash of this component's state, used to gate OOB swaps so a
+        region whose value did not change is not re-sent. Defaults to a hash of
+        ``model_dump_json()``; override for custom hashing.
+        """
+        return hashlib.sha256(self.model_dump_json().encode("utf-8")).hexdigest()[:16]
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._pjx_reactive = True
+        cls._pjx_depends_on = frozenset(getattr(cls, "depends_on", None) or ())
+        if "load" in cls.__dict__ and not cls._pjx_depends_on:
+            raise TypeError(
+                f"{cls.__name__} defines load() but declares no depends_on; a "
+                f"reactive component must declare both."
+            )
+        if "load" in cls.__dict__:
+            from .cache import install_cached_load
+
+            install_cached_load(cls)
 
 
 class Layout(BaseComponent):

--- a/tests/31_reactive_surface_test.py
+++ b/tests/31_reactive_surface_test.py
@@ -1,45 +1,39 @@
-import logging
 from typing import ClassVar
 
-from pyjinhx import BaseComponent
+import pytest
+
+from pyjinhx import BaseComponent, ReactiveComponent
+
+
+class GoodCounter(ReactiveComponent):
+    remaining: int = 0
+    depends_on: ClassVar[set[str]] = {"todos"}
+
+    @classmethod
+    def load(cls) -> "GoodCounter":
+        return cls(id="counter", remaining=0)
 
 
 def test_state_hash_is_stable_and_value_sensitive():
-    a = BaseComponent(id="x")
-    b = BaseComponent(id="x")
+    a = GoodCounter(id="x", remaining=1)
+    b = GoodCounter(id="x", remaining=1)
     assert a.state_hash() == b.state_hash()
     assert isinstance(a.state_hash(), str) and len(a.state_hash()) == 16
-    assert BaseComponent(id="x", extra="v1").state_hash() != a.state_hash()
+    assert GoodCounter(id="x", remaining=2).state_hash() != a.state_hash()
 
 
 def test_reactive_component_is_detected():
-    class Counter(BaseComponent):
-        remaining: int = 0
-        depends_on: ClassVar[set[str]] = {"todos"}
-
-        @classmethod
-        def load(cls):
-            return cls(id="counter", remaining=0)
-
-    assert Counter._pjx_reactive is True
-    assert Counter._pjx_depends_on == frozenset({"todos"})
+    assert GoodCounter._pjx_reactive is True
+    assert GoodCounter._pjx_depends_on == frozenset({"todos"})
 
 
 def test_depends_on_is_not_a_model_field():
-    class Widget(BaseComponent):
-        depends_on: ClassVar[set[str]] = {"todos"}
-
-        @classmethod
-        def load(cls):
-            return cls(id="w")
-
-    assert "depends_on" not in Widget.model_fields
-    assert Widget(id="w").id == "w"
+    assert "depends_on" not in GoodCounter.model_fields
+    assert GoodCounter(id="c", remaining=3).remaining == 3
 
 
 def test_unannotated_depends_on_assignment_works():
-    # Matches the exact syntax shown in issue #12.
-    class Plain(BaseComponent):
+    class Plain(ReactiveComponent):
         depends_on = {"todos"}
 
         @classmethod
@@ -50,31 +44,41 @@ def test_unannotated_depends_on_assignment_works():
     assert Plain._pjx_depends_on == frozenset({"todos"})
 
 
-def test_plain_component_is_not_reactive():
+def test_plain_basecomponent_is_not_reactive():
     class Static(BaseComponent):
         pass
 
-    assert Static._pjx_reactive is False
-    assert Static._pjx_depends_on == frozenset()
+    assert getattr(Static, "_pjx_reactive", False) is False
+    assert getattr(Static, "_pjx_depends_on", frozenset()) == frozenset()
 
 
-def test_warns_when_load_without_depends_on(caplog):
-    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+def test_stray_load_on_basecomponent_is_not_reactive():
+    # Duck-typing is gone: a load() on a plain BaseComponent does NOT make it reactive.
+    class HasLoad(BaseComponent):
+        @classmethod
+        def load(cls):
+            return cls(id="h")
 
-        class Inert(BaseComponent):
+    assert getattr(HasLoad, "_pjx_reactive", False) is False
+
+
+def test_load_without_depends_on_raises_at_definition():
+    with pytest.raises(TypeError, match="depends_on"):
+
+        class Inert(ReactiveComponent):
             @classmethod
             def load(cls):
                 return cls(id="i")
 
-    assert any(
-        "Inert" in r.message and "depends_on" in r.message for r in caplog.records
-    )
+
+def test_depends_on_without_load_cannot_be_instantiated():
+    class NoLoad(ReactiveComponent):
+        depends_on: ClassVar[set[str]] = {"todos"}
+
+    with pytest.raises(TypeError, match="abstract"):
+        NoLoad(id="n")
 
 
-def test_warns_when_depends_on_without_load(caplog):
-    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
-
-        class NoLoad(BaseComponent):
-            depends_on: ClassVar[set[str]] = {"todos"}
-
-    assert any("NoLoad" in r.message and "load()" in r.message for r in caplog.records)
+def test_reactive_component_base_is_abstract():
+    with pytest.raises(TypeError, match="abstract"):
+        ReactiveComponent(id="r")

--- a/tests/32_reactive_stamping_test.py
+++ b/tests/32_reactive_stamping_test.py
@@ -1,10 +1,10 @@
 from typing import ClassVar
 
-from pyjinhx import BaseComponent
+from pyjinhx import ReactiveComponent
 from tests.ui.unified_component import UnifiedComponent
 
 
-class StampCounter(BaseComponent):
+class StampCounter(ReactiveComponent):
     remaining: int = 0
     depends_on: ClassVar[set[str]] = {"todos"}
 

--- a/tests/34_layout_runtime_test.py
+++ b/tests/34_layout_runtime_test.py
@@ -1,8 +1,11 @@
 from pyjinhx import BaseComponent
-from pyjinhx.reactive import Layout
 
 
-class Page(Layout):
+class Page(BaseComponent, base_layout=True):
+    pass
+
+
+class AdminPage(Page):  # subclass of a layout — should stay a layout
     pass
 
 
@@ -22,5 +25,7 @@ def test_non_layout_root_does_not_inject_runtime():
     assert "htmx:configRequest" not in html
 
 
-def test_layout_marker_is_inherited():
+def test_base_layout_marker_is_set_and_inherited():
     assert getattr(Page, "_pjx_layout", False) is True
+    assert getattr(AdminPage, "_pjx_layout", False) is True
+    assert getattr(PlainShell, "_pjx_layout", False) is False

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -3,8 +3,8 @@ import pyjinhx
 
 def test_reactive_api_is_exported():
     from pyjinhx import (
-        Layout,
         PJX_MOUNTED_HEADER,
+        ReactiveComponent,
         client_script,
         oob_swaps,
     )
@@ -12,9 +12,14 @@ def test_reactive_api_is_exported():
     assert PJX_MOUNTED_HEADER == "X-PJX-Mounted"
     assert callable(oob_swaps)
     assert callable(client_script)
-    assert issubclass(Layout, pyjinhx.BaseComponent)
+    assert issubclass(ReactiveComponent, pyjinhx.BaseComponent)
 
 
 def test_names_in_all():
-    for name in ("oob_swaps", "Layout", "client_script", "PJX_MOUNTED_HEADER"):
+    for name in (
+        "oob_swaps",
+        "ReactiveComponent",
+        "client_script",
+        "PJX_MOUNTED_HEADER",
+    ):
         assert name in pyjinhx.__all__

--- a/tests/38_reactive_render_test.py
+++ b/tests/38_reactive_render_test.py
@@ -107,3 +107,18 @@ def test_reactive_render_returns_markup():
     primary = ReactiveCounter(id="counter", remaining=1)
     result = primary.render(dirtied={"todos"}, mounted=[])
     assert isinstance(result, Markup)
+
+
+def test_reactive_render_does_not_escape_primary_html():
+    # Regression: the primary is a plain str from _render(); concatenating it with the
+    # Markup from oob_swaps must not invoke Markup.__radd__ and HTML-escape the primary.
+    store.state["completed"] = 1
+    primary = ReactiveCounter(id="counter", remaining=2)
+    out = str(
+        primary.render(
+            dirtied={"todos"},
+            mounted=[{"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}],
+        )
+    )
+    assert "&lt;span" not in out and "&#34;" not in out
+    assert '<span class="counter" data-pjx-id="counter"' in out

--- a/tests/39_load_cache_test.py
+++ b/tests/39_load_cache_test.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from pyjinhx import BaseComponent, invalidate
+from pyjinhx import ReactiveComponent, invalidate
 from pyjinhx.cache import clear
 from tests.ui.reactive.cached_widget import CachedWidget, load_calls
 
@@ -58,7 +58,7 @@ def test_invalidate_cleans_reverse_index_across_keys():
     clear()
     calls = {"n": 0}
 
-    class MultiDep(BaseComponent):
+    class MultiDep(ReactiveComponent):
         n: int = 0
         depends_on: ClassVar[set[str]] = {"alpha", "beta"}
 

--- a/tests/41_reactive_render_defaults_test.py
+++ b/tests/41_reactive_render_defaults_test.py
@@ -1,0 +1,50 @@
+from pyjinhx import oob_swaps  # noqa: F401  (ensures package import side effects)
+from tests.ui.reactive import store
+from tests.ui.reactive.reactive_counter import ReactiveCounter
+from tests.ui.reactive.reactive_clear_button import ReactiveClearButton  # noqa: F401
+from tests.ui.unified_component import UnifiedComponent
+
+
+def test_dirtied_defaults_to_primary_depends_on():
+    store.state["completed"] = 4
+    primary = ReactiveCounter(id="counter", remaining=0)  # depends_on = {"todos"}
+    # dirtied omitted -> defaults to the primary's depends_on ({"todos"}),
+    # so the todos-dependent clear button is swapped.
+    out = str(
+        primary.render(
+            mounted=[
+                {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
+            ]
+        )
+    )
+    assert "outerHTML:[data-pjx-id='clear-btn']" in out
+    assert "Clear (4)" in out
+
+
+def test_explicit_empty_dirtied_is_respected():
+    store.state["completed"] = 4
+    primary = ReactiveCounter(id="counter", remaining=0)
+    out = str(
+        primary.render(
+            dirtied=set(),
+            mounted=[
+                {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
+            ],
+        )
+    )
+    # explicit empty set -> nothing dirtied -> no swaps
+    assert "outerHTML:[data-pjx-id='clear-btn']" not in out
+
+
+def test_non_reactive_primary_defaults_to_no_swaps():
+    store.state["completed"] = 4
+    primary = UnifiedComponent(id="u1", text="hi")  # not reactive, no depends_on
+    out = str(
+        primary.render(
+            mounted=[
+                {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
+            ]
+        )
+    )
+    assert "outerHTML:[data-pjx-id='clear-btn']" not in out
+    assert "hi" in out

--- a/tests/ui/reactive/cached_widget.py
+++ b/tests/ui/reactive/cached_widget.py
@@ -1,12 +1,12 @@
 from typing import ClassVar
 
-from pyjinhx import BaseComponent
+from pyjinhx import ReactiveComponent
 
 # Module-level counter so tests can observe how many times the *real* load() ran.
 load_calls = {"count": 0}
 
 
-class CachedWidget(BaseComponent):
+class CachedWidget(ReactiveComponent):
     value: int = 0
     depends_on: ClassVar[set[str]] = {"widgets"}
 

--- a/tests/ui/reactive/reactive_clear_button.py
+++ b/tests/ui/reactive/reactive_clear_button.py
@@ -1,11 +1,11 @@
 from typing import ClassVar
 
-from pyjinhx import BaseComponent
+from pyjinhx import ReactiveComponent
 
 from .store import state
 
 
-class ReactiveClearButton(BaseComponent):
+class ReactiveClearButton(ReactiveComponent):
     completed: int = 0
     depends_on: ClassVar[set[str]] = {"todos"}
 

--- a/tests/ui/reactive/reactive_counter.py
+++ b/tests/ui/reactive/reactive_counter.py
@@ -1,11 +1,11 @@
 from typing import ClassVar
 
-from pyjinhx import BaseComponent
+from pyjinhx import ReactiveComponent
 
 from .store import state
 
 
-class ReactiveCounter(BaseComponent):
+class ReactiveCounter(ReactiveComponent):
     remaining: int = 0
     depends_on: ClassVar[set[str]] = {"todos"}
 

--- a/tests/ui/reactive/reactive_panel.py
+++ b/tests/ui/reactive/reactive_panel.py
@@ -1,11 +1,11 @@
 from typing import ClassVar, Optional
 
-from pyjinhx import BaseComponent
+from pyjinhx import ReactiveComponent
 
 from .reactive_counter import ReactiveCounter
 
 
-class ReactivePanel(BaseComponent):
+class ReactivePanel(ReactiveComponent):
     child: Optional[ReactiveCounter] = None
     depends_on: ClassVar[set[str]] = {"todos"}
 


### PR DESCRIPTION
## Summary

A review-driven refactor of the reactive surface (follows #13–#16). Three changes, all **breaking** (fine pre-1.0/alpha). The wire format, renderer, cache internals, hash-gating, and the `oob_swaps` algorithm are unchanged — only the *source* of the `_pjx_*` flags moves.

## 1. `ReactiveComponent` ABC — reactivity is explicit and enforced

- **Reactive ⇔ subclassing `ReactiveComponent`.** Duck-typed `load()` detection is gone — a stray `load()` on a plain `BaseComponent` no longer makes it reactive.
- **Both `load()` and `depends_on` are required**, via two natural mechanisms:
  - `load()` is `@classmethod @abstractmethod` → ABC blocks instantiating a subclass that doesn't implement it.
  - A concrete class that defines `load()` but leaves `depends_on` empty raises `TypeError` **at definition time** (replaces the old warning — kills the half-reactive state).
- `depends_on`, `state_hash()`, the reactive config, and the `load()` cache-wrapping move from `BaseComponent` to `ReactiveComponent`. The renderer/cache/`oob_swaps` are untouched (they read `_pjx_reactive`/`_pjx_depends_on` via `getattr`).

```python
from pyjinhx import ReactiveComponent

class Counter(ReactiveComponent):
    remaining: int
    depends_on = {"todos"}
    @classmethod
    def load(cls): return cls(id="counter", remaining=db.remaining())
```

## 2. `Layout` class → `base_layout=True` class kwarg

The marker-only `Layout` class is removed in favor of a class keyword argument that sets the same `_pjx_layout` marker. **The marker inherits** (a subclass of a shell stays a layout, matching the old `Layout` semantics). No duplicate JS — the renderer's `is_root` + `session.runtime_injected` guards are unchanged.

```python
class AppShell(BaseComponent, base_layout=True): ...
```

## 3. `render(dirtied=…)` defaults to the primary's `depends_on`

When `dirtied` is omitted it falls back to the rendered component's own `depends_on`; an explicit `dirtied=` (including `set()`) is respected.

```python
@app.post("/todos/{id}/toggle")
def toggle(id, request):
    db.toggle(id)
    return TodoItem(id=id, ...).render(mounted=request)  # dirties TodoItem.depends_on
```

## Breaking migration

- Reactive components must now subclass `ReactiveComponent` (fixtures + inline reactive test classes migrated).
- `class X(Layout)` → `class X(BaseComponent, base_layout=True)`.
- `from pyjinhx import Layout` removed; `ReactiveComponent` added to the public API.
- The two old warnings become a definition-time `TypeError` (missing `depends_on`) / ABC instantiation error (missing `load()`).

## Tests

`tests/31` rewritten for the new enforcement (abstract base can't instantiate; `load`-without-`depends_on` raises at definition; stray `load()` on `BaseComponent` is not reactive). `tests/34` covers `base_layout` + inheritance + single-injection. New `tests/41` covers the `dirtied` default + explicit-empty override. `tests/36` public-API test migrated (`Layout` → `ReactiveComponent`).

Full suite: **170 passed**, `ruff check` clean, `mkdocs build --strict` builds. Docs (`reactivity.md` + diagrams, `README.md`) updated to the new API.

## Verified feasibility

Pydantic v2's `ModelMetaclass` is an `ABCMeta`, so `@classmethod @abstractmethod` enforcement and the `base_layout` class kwarg both work (checked before building).

## Deferred (unchanged)

Instance-keyed dependencies (`"user:42"`); `load()` stays zero-arg / type-singleton.

https://claude.ai/code/session_013K1kbeYc1e4vWYhRwThvNt

---
_Generated by [Claude Code](https://claude.ai/code/session_013K1kbeYc1e4vWYhRwThvNt)_