### PR TITLE
refactor(reactive)!: rename depends_on → reacts_to

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ from pyjinhx import ReactiveComponent
 
 class Counter(ReactiveComponent):
     remaining: int
-    depends_on: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
     def load(cls) -> "Counter":
@@ -154,7 +154,7 @@ class Counter(ReactiveComponent):
 @app.post("/todos/{id}/toggle")
 def toggle(id, request):
     db.toggle(id)
-    # dirtied defaults to TodoItem's own depends_on; pass dirtied={...} to override.
+    # dirtied defaults to TodoItem's own reacts_to; pass dirtied={...} to override.
     return TodoItem(id=id, ...).render(mounted=request)
 ```
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -18,9 +18,9 @@ integration and a `load()` cache are planned follow-ups.)
 
 ## 1. Make a component reactive
 
-Subclass `ReactiveComponent` and declare **both** `depends_on` and a `load()`
+Subclass `ReactiveComponent` and declare **both** `reacts_to` and a `load()`
 classmethod — `ReactiveComponent` enforces both (a missing `load()` can't be
-instantiated; a missing `depends_on` is a definition-time error):
+instantiated; a missing `reacts_to` is a definition-time error):
 
 ```python
 from typing import ClassVar
@@ -28,16 +28,20 @@ from pyjinhx import ReactiveComponent
 
 class Counter(ReactiveComponent):
     remaining: int
-    depends_on: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
     def load(cls) -> "Counter":
         return cls(id="counter", remaining=db.remaining())
 ```
 
-- `depends_on` — the named state keys this component derives from.
+- `reacts_to` — the **state keys** this component derives from. These are arbitrary
+  strings *you* choose to name pieces of state (`"todos"`, `"user:42"`) — **not**
+  component ids or types, and not client-side watchers. The server simply intersects
+  a component's `reacts_to` with the route's `dirtied` keys (and uses them to evict the
+  `load()` cache): it's cache invalidation, not signals.
 - `load()` — rebuilds the component from the current world, independent of any route.
-- `state_hash()` is provided by `BaseComponent` (hash of `model_dump_json()`); override only for custom hashing.
+- `state_hash()` is provided by `ReactiveComponent` (hash of `model_dump_json()`); override only for custom hashing.
 
 Reactive components are stamped with `data-pjx-id`, `data-pjx-type` (the class
 name), and `data-pjx-hash` on their root element automatically.
@@ -82,14 +86,14 @@ out-of-band swaps:
 @app.post("/todos/{id}/toggle")
 def toggle(id, request):
     db.toggle(id)
-    # dirtied defaults to TodoItem's own depends_on, so when the toggled item
+    # dirtied defaults to TodoItem's own reacts_to, so when the toggled item
     # depends on "todos" you can omit it; pass dirtied={...} to override.
     return TodoItem(id=id, text=..., done=...).render(mounted=request)
 ```
 
 `render(dirtied=, mounted=)` renders the component itself as the primary response,
 then appends an OOB swap for every *other* mounted reactive region whose
-`depends_on` intersects `dirtied`, rebuilding each via its own `load()`. The
+`reacts_to` intersects `dirtied`, rebuilding each via its own `load()`. The
 component's own region is never double-swapped.
 
 `mounted` accepts a request-like object (the `X-PJX-Mounted` header is read off it
@@ -111,7 +115,7 @@ swaps = oob_swaps(dirtied={"todos"}, mounted=request)
 ```
 
 `oob_swaps`:
-- keeps only mounted regions whose `depends_on` intersects `dirtied`,
+- keeps only mounted regions whose `reacts_to` intersects `dirtied`,
 - calls each region's `load()` and re-renders it,
 - skips a region whose freshly computed `state_hash()` matches the hash the client
   reported (its DOM value is already current); a missing or mismatched hash always
@@ -119,9 +123,9 @@ swaps = oob_swaps(dirtied={"todos"}, mounted=request)
 - drops any region nested inside another swapped region (the parent already contains it),
 - returns concatenated `hx-swap-oob` fragments (empty if nothing changed).
 
-The dependency graph lives in exactly one place — the `depends_on` declarations —
+The dependency graph lives in exactly one place — the `reacts_to` declarations —
 not smeared across endpoints. Adding a progress bar that declares
-`depends_on = {"todos"}` makes it participate automatically; no endpoint changes.
+`reacts_to = {"todos"}` makes it participate automatically; no endpoint changes.
 
 ## 4. `load()` results are cached
 
@@ -160,7 +164,7 @@ with a shared store if you need it).
 - **Type-singleton**: one mounted instance per reactive type is reloaded; instance-keyed deps (`"user:42"`) are deferred.
 - **`mounted` accepts** a request-like object (header duck-typed out, no framework import), the raw header string, a parsed list, or `None`.
 - **Reactivity is opt-in via `ReactiveComponent`**, which requires both `load()` and
-  `depends_on`. `load()` is zero-arg in v1 (type-singleton); reactive `render()`
+  `reacts_to`. `load()` is zero-arg in v1 (type-singleton); reactive `render()`
   auto-`load()`s dependents, so you never call `load()` yourself for a reactive render.
 - **`load()` cache is per-process**: it saves database work on cache hits; eviction is
   dirtied-key driven (automatically in the reactive flow, or via `invalidate(dirtied)`).
@@ -182,7 +186,7 @@ flowchart LR
       RT["pjx.js runtime"]
     end
     subgraph Server["Server — pyjinhx"]
-      G["depends_on graph<br/>declared on components"]
+      G["reacts_to graph<br/>declared on components"]
       W["oob_swaps walk"]
       L["load() + result cache"]
     end
@@ -227,7 +231,7 @@ sequenceDiagram
     R->>DB: db.toggle(1)
     R->>RD: TodoItem(...).render(dirtied, mounted=request)
     RD->>C: invalidate(dirtied)
-    Note over C: evict cached load() results<br/>whose depends_on hits a dirtied key
+    Note over C: evict cached load() results<br/>whose reacts_to hits a dirtied key
     RD->>RD: render self → primary response
     RD->>RD: oob_swaps walk (exclude_ids = self.id)
     loop each mounted region depending on a dirtied key
@@ -252,7 +256,7 @@ nesting-dedup**, so an unchanged parent never suppresses a changed child.
 
 ```mermaid
 flowchart TD
-    M["manifest entry"] --> F{"reactive type AND<br/>depends_on intersects dirtied?"}
+    M["manifest entry"] --> F{"reactive type AND<br/>reacts_to intersects dirtied?"}
     F -->|no| X1["ignore"]
     F -->|yes| EX{"id in exclude_ids?<br/>(it is the primary)"}
     EX -->|yes| X2["ignore"]
@@ -288,10 +292,10 @@ flowchart TD
     CALL["Cls.load()"] --> HIT{"in cache?"}
     HIT -->|hit| COPY["return model_copy()<br/>no DB; copy keeps cache pristine"]
     HIT -->|miss| RUN["run real load() → DB"]
-    RUN --> STORE["cache cls = result<br/>index under each depends_on key"]
+    RUN --> STORE["cache cls = result<br/>index under each reacts_to key"]
     STORE --> COPY
 
     INV["invalidate(dirtied)<br/>auto in reactive flow, or public"] --> REV["consult reverse index<br/>key → classes"]
-    REV --> EVICT["evict every class whose<br/>depends_on intersects dirtied"]
+    REV --> EVICT["evict every class whose<br/>reacts_to intersects dirtied"]
     EVICT -.->|"next load() misses"| CALL
 ```

--- a/examples/reactive_todo/README.md
+++ b/examples/reactive_todo/README.md
@@ -18,5 +18,5 @@ What to watch (open the network tab):
   (remaining is unchanged).
 
 The routes never mention the counter/total/clear button — they just declare
-`dirtied={"todos"}`. The dependency graph lives on the components (`depends_on`), and
+`dirtied={"todos"}`. The dependency graph lives on the components (`reacts_to`), and
 `pjx.js` reports what's mounted via the `X-PJX-Mounted` header.

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -17,7 +17,7 @@ class TodoList(BaseComponent):
 
 class TodoCounter(ReactiveComponent):
     remaining: int = 0
-    depends_on: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
     def load(cls) -> "TodoCounter":
@@ -26,7 +26,7 @@ class TodoCounter(ReactiveComponent):
 
 class TodoTotal(ReactiveComponent):
     total: int = 0
-    depends_on: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
     def load(cls) -> "TodoTotal":
@@ -35,7 +35,7 @@ class TodoTotal(ReactiveComponent):
 
 class TodoClearButton(ReactiveComponent):
     completed: int = 0
-    depends_on: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
     def load(cls) -> "TodoClearButton":

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -193,16 +193,16 @@ class BaseComponent(BaseModel):
         With no arguments this is a plain render. Passing ``dirtied`` and/or ``mounted``
         opts into dependency-aware reactivity: this component is rendered as the primary
         response, and an out-of-band swap is appended for every other mounted reactive
-        region whose ``depends_on`` intersects ``dirtied`` (each rebuilt via its own
+        region whose ``reacts_to`` intersects ``dirtied`` (each rebuilt via its own
         ``load()``). This component's own region is never additionally swapped.
 
-        When ``dirtied`` is omitted it defaults to this component's own ``depends_on``
+        When ``dirtied`` is omitted it defaults to this component's own ``reacts_to``
         (empty for a non-reactive primary); pass ``dirtied`` explicitly — including an
         empty set — to override.
 
         Args:
             dirtied: State keys the route mutated (e.g. ``{"todos"}``). Defaults to the
-                primary's ``depends_on``. Enables reactive mode.
+                primary's ``reacts_to``. Enables reactive mode.
             mounted: The client manifest — a request-like object, the raw header string,
                 a parsed list, or ``None``. Enables reactive mode.
 
@@ -218,7 +218,7 @@ class BaseComponent(BaseModel):
         effective_dirtied = (
             dirtied
             if dirtied is not None
-            else getattr(self, "_pjx_depends_on", frozenset())
+            else getattr(self, "_pjx_reacts_to", frozenset())
         )
         swaps = oob_swaps(effective_dirtied or set(), mounted, exclude_ids={self.id})
         # Wrap the primary as safe markup before concatenation: _render() returns a

--- a/pyjinhx/cache.py
+++ b/pyjinhx/cache.py
@@ -37,7 +37,7 @@ def _load_through_cache(cls, raw_func):
 
     with _lock:
         _cache[cls] = result
-        for key in getattr(cls, "_pjx_depends_on", frozenset()):
+        for key in getattr(cls, "_pjx_reacts_to", frozenset()):
             _reverse.setdefault(key, set()).add(cls)
     return result.model_copy()
 
@@ -58,7 +58,7 @@ def invalidate(dirtied: set[str]) -> None:
             to_evict |= _reverse.get(key, set())
         for cls in to_evict:
             _cache.pop(cls, None)
-            for key in getattr(cls, "_pjx_depends_on", frozenset()):
+            for key in getattr(cls, "_pjx_reacts_to", frozenset()):
                 bucket = _reverse.get(key)
                 if bucket is not None:
                     bucket.discard(cls)

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -37,17 +37,17 @@ class ReactiveComponent(BaseComponent):
     """
     Base class for dependency-aware reactive components.
 
-    A reactive component declares the state keys it derives from (``depends_on``)
+    A reactive component declares the state keys it derives from (``reacts_to``)
     and how to rebuild itself from the current world (``load()``). Both are
     required — ``load()`` is enforced by ABC (you cannot instantiate a subclass
-    that does not implement it) and ``depends_on`` is enforced at class-definition
+    that does not implement it) and ``reacts_to`` is enforced at class-definition
     time. Reactive components are stamped with ``data-pjx-*`` on render and are the
     units the dependency walk (``oob_swaps``) reloads and swaps.
     """
 
     # State keys this component derives from; the dependency walk swaps a region
-    # when its depends_on intersects the route's dirtied keys.
-    depends_on: ClassVar[set[str]] = set()
+    # when its reacts_to intersects the route's dirtied keys.
+    reacts_to: ClassVar[set[str]] = set()
 
     @classmethod
     @abstractmethod
@@ -66,10 +66,10 @@ class ReactiveComponent(BaseComponent):
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         cls._pjx_reactive = True
-        cls._pjx_depends_on = frozenset(getattr(cls, "depends_on", None) or ())
-        if "load" in cls.__dict__ and not cls._pjx_depends_on:
+        cls._pjx_reacts_to = frozenset(getattr(cls, "reacts_to", None) or ())
+        if "load" in cls.__dict__ and not cls._pjx_reacts_to:
             raise TypeError(
-                f"{cls.__name__} defines load() but declares no depends_on; a "
+                f"{cls.__name__} defines load() but declares no reacts_to; a "
                 f"reactive component must declare both."
             )
         if "load" in cls.__dict__:
@@ -199,7 +199,7 @@ def oob_swaps(
             continue
         if not getattr(component_class, "_pjx_reactive", False):
             continue
-        if not (getattr(component_class, "_pjx_depends_on", frozenset()) & dirtied):
+        if not (getattr(component_class, "_pjx_reacts_to", frozenset()) & dirtied):
             continue
 
         if component_type in seen_types:

--- a/tests/31_reactive_surface_test.py
+++ b/tests/31_reactive_surface_test.py
@@ -7,7 +7,7 @@ from pyjinhx import BaseComponent, ReactiveComponent
 
 class GoodCounter(ReactiveComponent):
     remaining: int = 0
-    depends_on: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
     def load(cls) -> "GoodCounter":
@@ -24,24 +24,24 @@ def test_state_hash_is_stable_and_value_sensitive():
 
 def test_reactive_component_is_detected():
     assert GoodCounter._pjx_reactive is True
-    assert GoodCounter._pjx_depends_on == frozenset({"todos"})
+    assert GoodCounter._pjx_reacts_to == frozenset({"todos"})
 
 
-def test_depends_on_is_not_a_model_field():
-    assert "depends_on" not in GoodCounter.model_fields
+def test_reacts_to_is_not_a_model_field():
+    assert "reacts_to" not in GoodCounter.model_fields
     assert GoodCounter(id="c", remaining=3).remaining == 3
 
 
-def test_unannotated_depends_on_assignment_works():
+def test_unannotated_reacts_to_assignment_works():
     class Plain(ReactiveComponent):
-        depends_on = {"todos"}
+        reacts_to = {"todos"}
 
         @classmethod
         def load(cls):
             return cls(id="p")
 
-    assert "depends_on" not in Plain.model_fields
-    assert Plain._pjx_depends_on == frozenset({"todos"})
+    assert "reacts_to" not in Plain.model_fields
+    assert Plain._pjx_reacts_to == frozenset({"todos"})
 
 
 def test_plain_basecomponent_is_not_reactive():
@@ -49,7 +49,7 @@ def test_plain_basecomponent_is_not_reactive():
         pass
 
     assert getattr(Static, "_pjx_reactive", False) is False
-    assert getattr(Static, "_pjx_depends_on", frozenset()) == frozenset()
+    assert getattr(Static, "_pjx_reacts_to", frozenset()) == frozenset()
 
 
 def test_stray_load_on_basecomponent_is_not_reactive():
@@ -62,8 +62,8 @@ def test_stray_load_on_basecomponent_is_not_reactive():
     assert getattr(HasLoad, "_pjx_reactive", False) is False
 
 
-def test_load_without_depends_on_raises_at_definition():
-    with pytest.raises(TypeError, match="depends_on"):
+def test_load_without_reacts_to_raises_at_definition():
+    with pytest.raises(TypeError, match="reacts_to"):
 
         class Inert(ReactiveComponent):
             @classmethod
@@ -71,9 +71,9 @@ def test_load_without_depends_on_raises_at_definition():
                 return cls(id="i")
 
 
-def test_depends_on_without_load_cannot_be_instantiated():
+def test_reacts_to_without_load_cannot_be_instantiated():
     class NoLoad(ReactiveComponent):
-        depends_on: ClassVar[set[str]] = {"todos"}
+        reacts_to: ClassVar[set[str]] = {"todos"}
 
     with pytest.raises(TypeError, match="abstract"):
         NoLoad(id="n")

--- a/tests/32_reactive_stamping_test.py
+++ b/tests/32_reactive_stamping_test.py
@@ -6,7 +6,7 @@ from tests.ui.unified_component import UnifiedComponent
 
 class StampCounter(ReactiveComponent):
     remaining: int = 0
-    depends_on: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
     def load(cls):

--- a/tests/39_load_cache_test.py
+++ b/tests/39_load_cache_test.py
@@ -60,7 +60,7 @@ def test_invalidate_cleans_reverse_index_across_keys():
 
     class MultiDep(ReactiveComponent):
         n: int = 0
-        depends_on: ClassVar[set[str]] = {"alpha", "beta"}
+        reacts_to: ClassVar[set[str]] = {"alpha", "beta"}
 
         @classmethod
         def load(cls):

--- a/tests/41_reactive_render_defaults_test.py
+++ b/tests/41_reactive_render_defaults_test.py
@@ -5,10 +5,10 @@ from tests.ui.reactive.reactive_clear_button import ReactiveClearButton  # noqa:
 from tests.ui.unified_component import UnifiedComponent
 
 
-def test_dirtied_defaults_to_primary_depends_on():
+def test_dirtied_defaults_to_primary_reacts_to():
     store.state["completed"] = 4
-    primary = ReactiveCounter(id="counter", remaining=0)  # depends_on = {"todos"}
-    # dirtied omitted -> defaults to the primary's depends_on ({"todos"}),
+    primary = ReactiveCounter(id="counter", remaining=0)  # reacts_to = {"todos"}
+    # dirtied omitted -> defaults to the primary's reacts_to ({"todos"}),
     # so the todos-dependent clear button is swapped.
     out = str(
         primary.render(
@@ -38,7 +38,7 @@ def test_explicit_empty_dirtied_is_respected():
 
 def test_non_reactive_primary_defaults_to_no_swaps():
     store.state["completed"] = 4
-    primary = UnifiedComponent(id="u1", text="hi")  # not reactive, no depends_on
+    primary = UnifiedComponent(id="u1", text="hi")  # not reactive, no reacts_to
     out = str(
         primary.render(
             mounted=[

--- a/tests/ui/reactive/cached_widget.py
+++ b/tests/ui/reactive/cached_widget.py
@@ -8,7 +8,7 @@ load_calls = {"count": 0}
 
 class CachedWidget(ReactiveComponent):
     value: int = 0
-    depends_on: ClassVar[set[str]] = {"widgets"}
+    reacts_to: ClassVar[set[str]] = {"widgets"}
 
     @classmethod
     def load(cls) -> "CachedWidget":

--- a/tests/ui/reactive/reactive_clear_button.py
+++ b/tests/ui/reactive/reactive_clear_button.py
@@ -7,7 +7,7 @@ from .store import state
 
 class ReactiveClearButton(ReactiveComponent):
     completed: int = 0
-    depends_on: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
     def load(cls) -> "ReactiveClearButton":

--- a/tests/ui/reactive/reactive_counter.py
+++ b/tests/ui/reactive/reactive_counter.py
@@ -7,7 +7,7 @@ from .store import state
 
 class ReactiveCounter(ReactiveComponent):
     remaining: int = 0
-    depends_on: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
     def load(cls) -> "ReactiveCounter":

--- a/tests/ui/reactive/reactive_panel.py
+++ b/tests/ui/reactive/reactive_panel.py
@@ -7,7 +7,7 @@ from .reactive_counter import ReactiveCounter
 
 class ReactivePanel(ReactiveComponent):
     child: Optional[ReactiveCounter] = None
-    depends_on: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
     def load(cls) -> "ReactivePanel":


### PR DESCRIPTION
## Summary

Renames the reactive dependency declaration **`depends_on` → `reacts_to`** on `ReactiveComponent`.

`depends_on` is the conventional name in dependency-graph tools (Terraform, Airflow, GitHub Actions) where it points at *other nodes*. But here the values are arbitrary **state keys** (`"todos"`, `"user:42"`) — not component ids or types — so `depends_on` read like a reference to another component. `reacts_to` says "this component reacts to the *todos* state" and can't be mistaken for a component reference.

```python
class Counter(ReactiveComponent):
    remaining: int
    reacts_to = {"todos"}          # was: depends_on = {"todos"}
    @classmethod
    def load(cls): return cls(id="counter", remaining=db.remaining())
```

## What changed

- `ReactiveComponent.depends_on` ClassVar → **`reacts_to`** (and the internal `_pjx_depends_on` → `_pjx_reacts_to`), across `reactive.py`, `cache.py`, `base.py`.
- The definition-time enforcement error now reads "declares no `reacts_to`".
- All fixtures, the inline reactive test classes, `tests/31/32/39/41`, the docs, and the `examples/reactive_todo` demo updated.
- **Docs clarified** (directly addressing the confusion that prompted this): `reacts_to` lists arbitrary state-key strings — not component ids/types and not client-side watchers; matching is a server-side set intersection used for cache invalidation, **not signals**.
- Fixed a stale doc note: `state_hash()` lives on `ReactiveComponent` (it moved there in #17), not `BaseComponent`.

The route side keeps `dirtied` (it reads as the *event* — "I dirtied todos"). The renderer, cache algorithm, hash-gating, and `oob_swaps` logic are unchanged — only the identifier name moves.

## BREAKING CHANGE

Reactive components must declare `reacts_to` instead of `depends_on`. (Pre-1.0/alpha.)

## Checks

Full suite: **176 passed**, `ruff check` clean, `mkdocs build --strict` builds. Re-verified the demo live: a toggle still drives OOB swaps for the changed regions and hash-gates the unchanged one, with the primary returned as raw HTML.

https://claude.ai/code/session_013K1kbeYc1e4vWYhRwThvNt

---
_Generated by [Claude Code](https://claude.ai/code/session_013K1kbeYc1e4vWYhRwThvNt)_