### PR TITLE
feat(reactive): default a reactive component's id to its kebab class name

### DIFF
--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -32,7 +32,7 @@ class Counter(ReactiveComponent):
 
     @classmethod
     def load(cls) -> "Counter":
-        return cls(id="counter", remaining=db.remaining())
+        return cls(remaining=db.remaining())   # id defaults to "counter"
 ```
 
 - `reacts_to` — the **state keys** this component derives from. These are arbitrary
@@ -41,6 +41,10 @@ class Counter(ReactiveComponent):
   a component's `reacts_to` with the route's `dirtied` keys (and uses them to evict the
   `load()` cache): it's cache invalidation, not signals.
 - `load()` — rebuilds the component from the current world, independent of any route.
+- `id` — defaults to the **kebab-cased class name** (`Counter` → `"counter"`,
+  `TodoCounter` → `"todo-counter"`), since a type-singleton's identity is its type, so
+  `load()` need not set one. Pass an explicit `id` only for instance-keyed regions —
+  multiple mounted instances of one type, e.g. `cls(id=f"todo-row-{user_id}", ...)`.
 - `state_hash()` is provided by `ReactiveComponent` (hash of `model_dump_json()`); override only for custom hashing.
 
 Reactive components are stamped with `data-pjx-id`, `data-pjx-type` (the class

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -21,7 +21,8 @@ class TodoCounter(ReactiveComponent):
 
     @classmethod
     def load(cls) -> "TodoCounter":
-        return cls(id="todo-counter", remaining=store.remaining())
+        # No id needed: it defaults to the kebab class name -> "todo-counter".
+        return cls(remaining=store.remaining())
 
 
 class TodoTotal(ReactiveComponent):
@@ -30,7 +31,8 @@ class TodoTotal(ReactiveComponent):
 
     @classmethod
     def load(cls) -> "TodoTotal":
-        return cls(id="todo-total", total=store.total())
+        # Defaults to "todo-total".
+        return cls(total=store.total())
 
 
 class TodoClearButton(ReactiveComponent):
@@ -39,6 +41,8 @@ class TodoClearButton(ReactiveComponent):
 
     @classmethod
     def load(cls) -> "TodoClearButton":
+        # Escape hatch: pin an explicit id (here a shorter one than the default
+        # "todo-clear-button"). Required when you mount multiple instances of a type.
         return cls(id="todo-clear", completed=store.completed())
 
 

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -8,12 +8,17 @@ from dataclasses import dataclass
 from typing import Any, ClassVar
 
 from markupsafe import Markup
+from pydantic import model_validator
 
 from .base import BaseComponent
 from .cache import invalidate
 from .registry import Registry
 from .renderer import Renderer
-from .utils import read_client_runtime, stamp_root_attributes
+from .utils import (
+    pascal_case_to_kebab_case,
+    read_client_runtime,
+    stamp_root_attributes,
+)
 
 logger = logging.getLogger("pyjinhx")
 
@@ -43,11 +48,23 @@ class ReactiveComponent(BaseComponent):
     that does not implement it) and ``reacts_to`` is enforced at class-definition
     time. Reactive components are stamped with ``data-pjx-*`` on render and are the
     units the dependency walk (``oob_swaps``) reloads and swaps.
+
+    The ``id`` defaults to the kebab-cased class name (``TodoCounter`` ->
+    ``"todo-counter"``), since a type-singleton's identity is its type — so ``load()``
+    need not invent one. Pass an explicit ``id`` for instance-keyed regions (multiple
+    mounted instances of one type, e.g. ``f"todo-row-{user_id}"``).
     """
 
     # State keys this component derives from; the dependency walk swaps a region
     # when its reacts_to intersects the route's dirtied keys.
     reacts_to: ClassVar[set[str]] = set()
+
+    @model_validator(mode="before")
+    @classmethod
+    def _default_id_from_type(cls, data):
+        if isinstance(data, dict) and not data.get("id"):
+            return {**data, "id": pascal_case_to_kebab_case(cls.__name__)}
+        return data
 
     @classmethod
     @abstractmethod

--- a/tests/42_reactive_auto_id_test.py
+++ b/tests/42_reactive_auto_id_test.py
@@ -1,0 +1,30 @@
+from typing import ClassVar
+
+from pyjinhx import ReactiveComponent
+
+
+class AutoIdWidget(ReactiveComponent):
+    value: int = 0
+    reacts_to: ClassVar[set[str]] = {"things"}
+
+    @classmethod
+    def load(cls) -> "AutoIdWidget":
+        return cls(value=1)
+
+
+def test_id_defaults_to_kebab_class_name():
+    assert AutoIdWidget().id == "auto-id-widget"
+
+
+def test_load_without_explicit_id_uses_default():
+    assert AutoIdWidget.load().id == "auto-id-widget"
+
+
+def test_explicit_id_overrides_default():
+    assert AutoIdWidget(id="custom").id == "custom"
+
+
+def test_default_id_is_stamped_as_data_pjx_id():
+    html = str(AutoIdWidget()._render(source="<span>{{ value }}</span>"))
+    assert 'data-pjx-id="auto-id-widget"' in html
+    assert 'data-pjx-type="AutoIdWidget"' in html


### PR DESCRIPTION
## Summary

Reduces the identifier surface for reactive components: a `ReactiveComponent`'s `id` now **defaults to the kebab-cased class name** (`TodoCounter` → `"todo-counter"`). Since a type-singleton's identity *is* its type, `load()` no longer needs to invent an id — you author only `reacts_to` + `load()`.

```python
class Counter(ReactiveComponent):
    remaining: int
    reacts_to = {"todos"}

    @classmethod
    def load(cls):
        return cls(remaining=db.remaining())   # id defaults to "counter"
```

## Why

`reacts_to`, the component `id`, and `data-pjx-type` are three different identifier axes, but in the type-singleton model the `id` you hand-write (`"todo-counter"`) is just a restatement of the class (`TodoCounter`). Auto-deriving it removes that redundancy, so the common reactive component declares one fewer string.

## What changed

- **`ReactiveComponent`** gains a `model_validator(mode="before")` that fills in `id = kebab(cls.__name__)` when none is given. Fully **backward-compatible** — an explicit `id` always wins, and it's required for the deferred instance-keyed case (multiple mounted instances of one type, `f"todo-row-{user_id}"`).
- **Demo** (`examples/reactive_todo`): `TodoCounter`/`TodoTotal` drop their explicit ids (now auto), while `TodoClearButton` keeps an explicit one — demonstrating both the default and the escape hatch.
- **Docs**: the "Make a component reactive" example omits the id, with a note on the default + when to set it explicitly.
- New `tests/42_reactive_auto_id_test.py`: default id, explicit override, and that the default is what gets stamped as `data-pjx-id`.

## Checks

Full suite: **180 passed**, `ruff check` clean, `mkdocs build --strict` builds. Re-verified the demo live: auto-id components still drive the OOB swaps + hash-gating correctly, and the primary returns as raw HTML.

https://claude.ai/code/session_013K1kbeYc1e4vWYhRwThvNt

---
_Generated by [Claude Code](https://claude.ai/code/session_013K1kbeYc1e4vWYhRwThvNt)_