### PR TITLE
Accept enums in reactive keys and unify load key coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ def toggle(request):
 ```
 
 Instance-keyed components declare instance-tier stems as bare strings (`{"todo"}` expands
-to `"todo:<key>"`); `load()` unwraps enum keys to `.value` before your code runs.
+to `"todo:<key>"`). All framework keys (`reacts_to`, `dirtied`, and instance keys passed to
+`load()` / `render()`) accept strings or enums and normalize to `str` (enums via `.value`).
 
 See [the reactivity guide](docs/reactivity.md) for details.
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -157,9 +157,9 @@ class TodoItemRow(ReactiveComponent):
   to derive the keyed id `f"{kebab(class)}-{key}"` (e.g. `todo-item-row-42`). It is
   exposed to the template as `{{ key }}` and stamped on the root as `data-pjx-key`,
   so the client manifest carries it back up on every request.
-- **Keys are strings framework-side** for cache, manifest, and stamping. `load()`
-  receives the coerced key (enums are unwrapped to `.value` first). Call
-  `int(key)` in `load()` for a typed DB lookup when the value is numeric.
+- **Keys** (`reacts_to`, `dirtied`, and instance keys for `load()` / `render()`) accept
+  strings or enums and normalize to `str` (enums via `.value`). Call `int(key)` in
+  `load()` for a typed DB lookup when the value is numeric.
 
 **Two-tier dirtying.** Instance stems are *instance-tier*; collection keys are
 *collection-tier* (opt-in, just add one). A mutation route names both as needed:

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .registry import Registry
 from .renderer import Renderer, RenderSession
+from .utils import ReactiveKey, coerce_reactive_keys
 
 logger = logging.getLogger("pyjinhx")
 logger.setLevel(logging.WARNING)
@@ -178,7 +179,7 @@ class BaseComponent(BaseModel):
     def render(
         self,
         *,
-        dirtied: set[str] | None = None,
+        dirtied: set[ReactiveKey] | None = None,
         mounted: object | None = None,
     ) -> Markup:
         """
@@ -214,11 +215,11 @@ class BaseComponent(BaseModel):
 
         primary = self._render()
         effective_dirtied = (
-            dirtied
+            coerce_reactive_keys(dirtied)
             if dirtied is not None
             else getattr(self, "_pjx_reacts_to", frozenset())
         )
-        swaps = oob_swaps(effective_dirtied or set(), mounted, exclude_ids={self.id})
+        swaps = oob_swaps(effective_dirtied, mounted, exclude_ids={self.id})
         # Wrap the primary as safe markup before concatenation: _render() returns a
         # plain str (Markup.unescape()), and `str + Markup` would invoke Markup.__radd__
         # and HTML-escape the primary. Markup(primary) + swaps keeps both raw.

--- a/pyjinhx/cache.py
+++ b/pyjinhx/cache.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
-from .utils import coerce_load_key, coerce_load_key_str, interpolate_reactive_keys
+from .utils import (
+    coerce_load_key_str,
+    coerce_reactive_keys,
+    interpolate_reactive_keys,
+)
 
 if TYPE_CHECKING:
     from .base import BaseComponent
@@ -49,7 +53,6 @@ def _load_through_cache(
     args: tuple[Any, ...],
 ) -> "BaseComponent":
     raw_key = args[0] if args else None
-    coerced_key = coerce_load_key(raw_key) if raw_key is not None else None
     key = coerce_load_key_str(raw_key) if raw_key is not None else None
     cache_key = (cls, key)
 
@@ -58,7 +61,7 @@ def _load_through_cache(
     if cached is not None:
         return _with_key(cached.model_copy(), key)
 
-    result = raw_func(cls, coerced_key) if coerced_key is not None else raw_func(cls)
+    result = raw_func(cls, key) if key is not None else raw_func(cls)
     result = _with_key(result, key)
 
     if key is not None:
@@ -75,17 +78,18 @@ def _load_through_cache(
     return _with_key(result.model_copy(), key)
 
 
-def invalidate(dirtied: set[str]) -> None:
+def invalidate(dirtied: Iterable[object]) -> None:
     """
     Evict every cached ``load()`` result whose (interpolated) reactive keys intersect
     the dirtied keys. ``invalidate({"todo:42"})`` evicts one row; ``invalidate({"todos"})``
     evicts the collection-tier entries. Per-process only.
     """
-    if not dirtied:
+    keys = coerce_reactive_keys(dirtied)
+    if not keys:
         return
     with _lock:
         to_evict: set[tuple[type, str | None]] = set()
-        for k in dirtied:
+        for k in keys:
             to_evict |= _reverse.get(k, set())
         for cache_key in to_evict:
             _cache.pop(cache_key, None)

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -8,7 +8,6 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from functools import partial
 from collections.abc import Callable
-from enum import Enum
 from typing import Any, ClassVar
 
 from markupsafe import Markup

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -8,6 +8,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from functools import partial
 from collections.abc import Callable
+from enum import Enum
 from typing import Any, ClassVar
 
 from markupsafe import Markup
@@ -18,8 +19,9 @@ from .cache import invalidate
 from .registry import Registry
 from .renderer import Renderer
 from .utils import (
-    coerce_load_key,
+    ReactiveKey,
     coerce_load_key_str,
+    coerce_reactive_keys,
     interpolate_reactive_keys,
     pascal_case_to_kebab_case,
     read_client_runtime,
@@ -64,7 +66,7 @@ class _ReactiveRender:
         cls: type[ReactiveComponent],
         key: object | None = None,
         *,
-        dirtied: set[str] | None = None,
+        dirtied: set[ReactiveKey] | None = None,
         mounted: object | None = None,
     ) -> Markup:
         """
@@ -84,16 +86,17 @@ class _ReactiveRender:
         if not keyed and key is not None:
             raise TypeError(f"{cls.__name__} is a type-singleton; render() takes no key.")
 
-        coerced_key = coerce_load_key(key) if key is not None else None
         skey = coerce_load_key_str(key) if key is not None else None
         own_keys = interpolate_reactive_keys(
             getattr(cls, "_pjx_reacts_to", frozenset()), skey, keyed=keyed
         )
-        effective_dirtied = dirtied if dirtied is not None else own_keys
-        invalidate((effective_dirtied or set()) | own_keys)
-        instance = cls.load(coerced_key) if keyed else cls.load()
+        effective_dirtied = (
+            coerce_reactive_keys(dirtied) if dirtied is not None else own_keys
+        )
+        invalidate(effective_dirtied | own_keys)
+        instance = cls.load(skey) if keyed else cls.load()
         primary = instance._render()
-        swaps = oob_swaps(effective_dirtied or set(), mounted, exclude_ids={instance.id})
+        swaps = oob_swaps(effective_dirtied, mounted, exclude_ids={instance.id})
         return Markup(primary) + swaps
 
     def __get__(
@@ -125,7 +128,7 @@ class ReactiveComponent(BaseComponent):
 
     model_config = ConfigDict(extra="allow", ignored_types=(_ReactiveRender,))
 
-    reacts_to: ClassVar[set[str]] = set()
+    reacts_to: ClassVar[set[ReactiveKey]] = set()
 
     _pjx_key: str | None = PrivateAttr(default=None)
 
@@ -155,7 +158,9 @@ class ReactiveComponent(BaseComponent):
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         cls._pjx_reactive = True
-        cls._pjx_reacts_to = frozenset(getattr(cls, "reacts_to", None) or ())
+        cls._pjx_reacts_to = frozenset(
+            coerce_reactive_keys(getattr(cls, "reacts_to", None) or ())
+        )
         if "load" in cls.__dict__ and not cls._pjx_reacts_to:
             raise TypeError(
                 f"{cls.__name__} defines load() but declares no reacts_to; a "
@@ -232,7 +237,7 @@ def _drop_nested(candidates: list[_Candidate]) -> list[_Candidate]:
 
 
 def oob_swaps(
-    dirtied: set[str],
+    dirtied: set[ReactiveKey],
     mounted: str | list[dict[str, Any]] | object | None,
     *,
     exclude_ids: set[str] | None = None,
@@ -262,7 +267,8 @@ def oob_swaps(
         A single Markup of concatenated OOB swap fragments, each carrying
         hx-swap-oob. Empty Markup if nothing needs swapping.
     """
-    invalidate(dirtied)
+    dirtied_keys = coerce_reactive_keys(dirtied)
+    invalidate(dirtied_keys)
 
     manifest = _parse_mounted(mounted)
     if not manifest:
@@ -300,7 +306,7 @@ def oob_swaps(
             skey,
             keyed=keyed,
         )
-        if not (effective & dirtied):
+        if not (effective & dirtied_keys):
             continue
 
         dedup_key = (component_type, skey)

--- a/pyjinhx/utils.py
+++ b/pyjinhx/utils.py
@@ -1,7 +1,27 @@
 import os
 import re
 from collections.abc import Iterable
-from typing import Any
+from enum import Enum
+from typing import TypeAlias
+
+ReactiveKey: TypeAlias = str | Enum
+
+
+def coerce_reactive_key(key: object) -> str:
+    """Normalize a reactive key: unwrap enums to ``.value``, then ``str``."""
+    if isinstance(key, Enum):
+        key = key.value
+    return str(key)
+
+
+coerce_load_key = coerce_reactive_key
+
+
+def coerce_reactive_keys(keys: Iterable[object] | None) -> set[str]:
+    """Normalize a collection of reactive dependency keys."""
+    if not keys:
+        return set()
+    return {coerce_reactive_key(key) for key in keys}
 
 
 def pascal_case_to_snake_case(name: str) -> str:
@@ -208,20 +228,11 @@ def read_client_runtime() -> str:
         return runtime_file.read()
 
 
-def coerce_load_key(key: object) -> Any:
-    """Return an enum's ``.value``; pass all other keys through unchanged."""
-    from enum import Enum
-
-    if isinstance(key, Enum):
-        return key.value
-    return key
-
-
 def coerce_load_key_str(key: object) -> str | None:
-    """Like ``coerce_load_key``, then coerce to ``str`` for cache/manifest use."""
+    """Like ``coerce_load_key``, but returns ``None`` for a ``None`` input."""
     if key is None:
         return None
-    return str(coerce_load_key(key))
+    return coerce_load_key(key)
 
 
 def interpolate_reactive_keys(

--- a/tests/47_reactive_keys_and_enum_load_test.py
+++ b/tests/47_reactive_keys_and_enum_load_test.py
@@ -1,9 +1,20 @@
 from enum import Enum
 from typing import ClassVar
 
-from pyjinhx import ReactiveComponent
+from pyjinhx import ReactiveComponent, oob_swaps
 from pyjinhx.cache import clear
-from pyjinhx.utils import coerce_load_key, coerce_load_key_str, interpolate_reactive_keys
+from pyjinhx.utils import (
+    coerce_load_key,
+    coerce_load_key_str,
+    coerce_reactive_key,
+    coerce_reactive_keys,
+    interpolate_reactive_keys,
+)
+
+
+class StateKey(str, Enum):
+    TODOS = "todos"
+    ROW = "row"
 
 
 def test_singleton_keys_pass_through():
@@ -25,6 +36,11 @@ def test_legacy_key_placeholder_still_works():
     assert interpolate_reactive_keys({"todo:{key}"}, "7", keyed=True) == {"todo:7"}
 
 
+def test_coerce_reactive_key_unwraps_enum():
+    assert coerce_reactive_key(StateKey.TODOS) == "todos"
+    assert coerce_reactive_keys({StateKey.TODOS, "users"}) == {"todos", "users"}
+
+
 class TodoId(Enum):
     FIRST = 1
     SECOND = 2
@@ -32,20 +48,56 @@ class TodoId(Enum):
 
 class EnumRow(ReactiveComponent):
     label: str = ""
-    reacts_to: ClassVar[set[str]] = {"row"}
+    reacts_to: ClassVar[set[str | StateKey]] = {StateKey.ROW}
 
     @classmethod
-    def load(cls, key: str | int) -> "EnumRow":
+    def load(cls, key: str) -> "EnumRow":
         return cls(label=f"row {key}")
 
 
+def test_reacts_to_coerces_enums_at_class_definition():
+    assert EnumRow._pjx_reacts_to == frozenset({"row"})
+
+
+class TodoCounter(ReactiveComponent):
+    remaining: int = 0
+    reacts_to: ClassVar[set[str | StateKey]] = {StateKey.TODOS}
+
+    @classmethod
+    def load(cls) -> "TodoCounter":
+        return cls(remaining=0)
+
+
+def test_reacts_to_enum_matches_string_dirtied_in_oob_swaps():
+    clear()
+    out = str(
+        oob_swaps(
+            {"todos"},
+            [{"id": "counter", "type": "TodoCounter", "hash": "stale"}],
+        )
+    )
+    assert "outerHTML:[data-pjx-id='counter']" in out
+
+
+def test_dirtied_enum_matches_enum_reacts_to_in_oob_swaps():
+    clear()
+    out = str(
+        oob_swaps(
+            {StateKey.TODOS},
+            [{"id": "counter", "type": "TodoCounter", "hash": "stale"}],
+        )
+    )
+    assert "outerHTML:[data-pjx-id='counter']" in out
+
+
 def test_coerce_load_key_unwraps_enum():
-    assert coerce_load_key(TodoId.FIRST) == 1
+    assert coerce_load_key(TodoId.FIRST) == "1"
     assert coerce_load_key_str(TodoId.SECOND) == "2"
     assert coerce_load_key("plain") == "plain"
+    assert coerce_load_key(42) == "42"
 
 
-def test_load_coerces_enum_to_value():
+def test_load_coerces_enum_to_str_for_load():
     clear()
     row = EnumRow.load(TodoId.FIRST)
     assert row.label == "row 1"


### PR DESCRIPTION
## Summary
- `reacts_to` and `dirtied` accept strings or enums; both normalize via `coerce_reactive_key` (`.value` then `str`)
- `load()` / `render(key)` use the same coercion — instance keys are always `str` framework-side, matching the manifest and cache
- `coerce_load_key` is now an alias of `coerce_reactive_key`; `invalidate()` coerces dirtied keys before eviction

## Test plan
- [x] `uv run pytest` (218 passed)
- [x] New/updated tests in `tests/47_reactive_keys_and_enum_load_test.py`


Made with [Cursor](https://cursor.com)