### PR TITLE
Add reactive ergonomics: @mutates, LoadContext, and dev guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,19 @@ You can also start from an HTML string — `Renderer.render("<Card ...><Button .
 Declare what state each component depends on. After a mutation, render the **primary** response with `dirtied` and `mounted`; PyJinHx appends out-of-band swaps for other mounted regions whose dependencies overlap.
 
 ```python
+from enum import Enum
 from typing import ClassVar
+
 from pyjinhx import ReactiveComponent
+
+
+class StateKey(str, Enum):
+    TODOS = "todos"
 
 
 class Counter(ReactiveComponent):
     remaining: int
-    reacts_to: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[StateKey]] = {StateKey.TODOS}
 
     @classmethod
     def load(cls) -> "Counter":
@@ -133,10 +139,12 @@ class Counter(ReactiveComponent):
 @app.post("/todos/toggle")
 def toggle(request):
     db.toggle_all()
-    return Counter.render(dirtied={"todos"}, mounted=request)
+    return Counter.render(dirtied={StateKey.TODOS}, mounted=request)
 ```
 
-The client reports mounted regions via the `X-PJX-Mounted` header; `pjx.js` is injected automatically on layout components. Instance-keyed components use bare stems in `reacts_to` (e.g. `{"todo"}` → `"todo:<key>"`).
+The client reports mounted regions via the `X-PJX-Mounted` header; `pjx.js` is injected automatically on layout components. `reacts_to`, `dirtied`, and instance keys accept strings or enums (normalized via `.value`). Instance-keyed components use bare stems in `reacts_to` (e.g. `"todo"` or `StateKey.TODO` → `"todo:<key>"`).
+
+**Reactive ergonomics:** use `StateKey` enums and `dirty_keys()` for typed keys; `@mutates` on store methods to auto-supply `dirtied`; `load_scope()` / `get_load_context()` to inject dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
 
 Details: [reactivity guide](docs/reactivity.md). Runnable demo: [examples/reactive_todo/](examples/reactive_todo/).
 
@@ -163,19 +171,24 @@ Details: [asset collection guide](docs/guide/assets.md). Optional UI kit: [pyjin
 
 ## FastAPI + HTMX (reactive)
 
-Mark the page shell with `base_layout=True` so the client runtime (`pjx.js`) is injected once. A toggle route returns the row as the primary swap; the counter updates out-of-band because both declare `reacts_to={"todos"}`.
+Mark the page shell with `base_layout=True` so the client runtime (`pjx.js`) is injected once. A toggle route returns the row as the primary swap; the counter updates out-of-band because both declare `reacts_to={StateKey.TODOS}`.
 
 ```python
 # components/todo_row.py
+from enum import Enum
 from typing import ClassVar
 
 from pyjinhx import BaseComponent, ReactiveComponent
 
 
+class StateKey(str, Enum):
+    TODOS = "todos"
+
+
 class TodoRow(ReactiveComponent):
     title: str
     done: bool = False
-    reacts_to: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[StateKey]] = {StateKey.TODOS}
 
     @classmethod
     def load(cls, key: int) -> "TodoRow":
@@ -185,7 +198,7 @@ class TodoRow(ReactiveComponent):
 
 class TodoCounter(ReactiveComponent):
     remaining: int
-    reacts_to: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[StateKey]] = {StateKey.TODOS}
 
     @classmethod
     def load(cls) -> "TodoCounter":
@@ -265,7 +278,7 @@ def index():
 def toggle_row(request: Request, todo_id: int):
     with Registry.request_scope():
         db.toggle(todo_id)
-        return TodoRow.render(todo_id, dirtied={"todos"}, mounted=request)
+        return TodoRow.render(todo_id, dirtied={StateKey.TODOS}, mounted=request)
 ```
 
 Run the full app: `uv run uvicorn examples.reactive_todo.app:app --reload` — see [examples/reactive_todo/README.md](examples/reactive_todo/README.md).

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -131,17 +131,33 @@ def index() -> str:
 ### Middleware (recommended)
 
 ```python
+from dataclasses import dataclass
+
+from pyjinhx import LoadContext, Registry, enable_reactive_dev
 from starlette.middleware.base import BaseHTTPMiddleware
+
+
+@dataclass(frozen=True)
+class AppLoadContext(LoadContext):
+    db: object  # your database/session handle
 
 
 class RegistryScopeMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
-        with Registry.request_scope():
+        with Registry.request_scope(
+            load_context=AppLoadContext(db=get_db(request)),
+        ):
             return await call_next(request)
 
 
 app.add_middleware(RegistryScopeMiddleware)
+
+# optional: dev guardrails (warnings for missing mounted, unconsumed @mutates, etc.)
+enable_reactive_dev()
 ```
+
+Pair with `@mutates` on store methods so mutation routes can omit explicit `dirtied` —
+see [Reactivity](../reactivity.md#mutation-tracking-mutates).
 
 ## Tips
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -180,6 +180,108 @@ def toggle_row(request, todo_id):
 `dirtied={"todos"}` reloads **every** mounted row that declares the collection-tier
 key. The walk dedups by `(type, key)`, so each row reloads with its own key.
 
+Use `dirty_keys()` when you prefer an explicit set over string formatting:
+
+```python
+from pyjinhx import dirty_keys
+
+dirty_keys("todo", todo_id, "todos")  # {"todo:42", "todos"}
+```
+
+## State keys
+
+Centralize reactive key strings in a `StateKey` enum so `reacts_to`, `dirtied`, and
+`@mutates` share one vocabulary:
+
+```python
+from pyjinhx import StateKey
+
+class Keys(StateKey):
+    TODOS = "todos"
+    TODO = "todo"
+
+class TodoCounter(ReactiveComponent):
+    reacts_to: ClassVar[set[str | Keys]] = {Keys.TODOS}
+```
+
+Enums normalize to their `.value` everywhere keys are coerced.
+
+## Mutation tracking (`@mutates`)
+
+Decorate store mutation methods to invalidate the `load()` cache and accumulate
+dirtied keys for the current request. When a reactive `render()` omits `dirtied`,
+pending keys from `@mutates` are merged with the primary's own `reacts_to`:
+
+```python
+from pyjinhx import mutates
+
+@mutates(Keys.TODO, Keys.TODOS)
+def toggle(todo_id: int) -> Todo:
+    ...
+
+@app.post("/rows/{todo_id}/toggle")
+def toggle_row(request, todo_id):
+    store.toggle(todo_id)
+    return TodoItemRow.render(todo_id, mounted=request)  # dirtied auto
+```
+
+Use `Registry.request_scope()` on every request when relying on auto-dirtied — it
+resets mutation tracking per request. Explicit `dirtied={...}` (including an empty
+set) always overrides pending mutations.
+
+## Load context
+
+Pass request-scoped dependencies into `load()` without global imports:
+
+```python
+from dataclasses import dataclass
+from pyjinhx import LoadContext, get_load_context
+
+@dataclass(frozen=True)
+class AppContext(LoadContext):
+    db: Database
+
+class Counter(ReactiveComponent):
+    @classmethod
+    def load(cls, *, ctx: AppContext | None = None) -> "Counter":
+        ctx = ctx or get_load_context()
+        return cls(remaining=ctx.db.remaining())
+```
+
+Set context per request via `Registry.request_scope(load_context=AppContext(db=...))`
+or `load_scope(ctx)` in middleware. `load()` may also read `get_load_context()` when
+no `ctx` parameter is declared. Cache keys remain `(class, key)` — context is not
+part of the cache identity.
+
+Optionally declare `load_reads` on a component; in dev mode pyjinhx verifies every
+declared read key is covered by `reacts_to`.
+
+## Development mode
+
+Enable guardrails during local development:
+
+```python
+from pyjinhx import enable_reactive_dev
+
+enable_reactive_dev()          # warnings
+enable_reactive_dev(strict=True)  # raise instead
+```
+
+Checks include:
+
+- mutations recorded via `@mutates` but no reactive `render()` in the same request scope
+- reactive dirtied keys set but `mounted` omitted (OOB swaps skipped)
+- `load_reads` not covered by `reacts_to` (when `load_reads` is declared)
+
+Inspect the dependency graph at startup:
+
+```python
+from pyjinhx import dependency_graph, format_dependency_graph
+
+print(format_dependency_graph())
+# or format_dependency_graph(as_mermaid=True) for a flowchart
+```
+
 ## 4. `load()` results are cached
 
 Every reactive component's `load()` is wrapped in a **process-global, dependency-keyed

--- a/examples/reactive_todo/app.py
+++ b/examples/reactive_todo/app.py
@@ -43,43 +43,41 @@ def _list() -> TodoList:
 @app.get("/", response_class=HTMLResponse)
 def index() -> str:
     with Registry.request_scope(load_context=TodoLoadContext(store=store)):
-        return str(
-            TodoApp(
-                id="todo-app",
-                todo_list=_list(),
-                counter=TodoCounter.load(),
-                total=TodoTotal.load(),
-                clear_button=TodoClearButton.load(),
-            ).render()
-        )
+        return TodoApp(
+            id="todo-app",
+            todo_list=_list(),
+            counter=TodoCounter.load(),
+            total=TodoTotal.load(),
+            clear_button=TodoClearButton.load(),
+        ).render()
 
 
 @app.post("/todos", response_class=HTMLResponse)
 def add(request: Request, text: str = Form(...)) -> str:
     with Registry.request_scope(load_context=TodoLoadContext(store=store)):
         store.add(text)
-        return str(TodoItemRow.render(store.all_todos()[-1].id, mounted=request))
+        return TodoItemRow.render(store.all_todos()[-1].id, mounted=request)
 
 
 @app.post("/rows/{todo_id}/toggle", response_class=HTMLResponse)
 def toggle_row(request: Request, todo_id: int) -> str:
     with Registry.request_scope(load_context=TodoLoadContext(store=store)):
         store.toggle(todo_id)
-        return str(TodoItemRow.render(todo_id, mounted=request))
+        return TodoItemRow.render(todo_id, mounted=request)
 
 
 @app.post("/todos/{todo_id}/toggle", response_class=HTMLResponse)
 def toggle(request: Request, todo_id: int) -> str:
     with Registry.request_scope(load_context=TodoLoadContext(store=store)):
         todo = store.toggle(todo_id)
-        return str(_item(todo).render(mounted=request))
+        return _item(todo).render(mounted=request)
 
 
 @app.post("/todos/clear-completed", response_class=HTMLResponse)
 def clear_completed(request: Request) -> str:
     with Registry.request_scope(load_context=TodoLoadContext(store=store)):
         store.clear_completed()
-        return str(_list().render(mounted=request))
+        return _list().render(mounted=request)
 
 
 if __name__ == "__main__":

--- a/examples/reactive_todo/app.py
+++ b/examples/reactive_todo/app.py
@@ -17,9 +17,10 @@ from examples.reactive_todo.components import (
     TodoItem,
     TodoItemRow,
     TodoList,
+    TodoLoadContext,
     TodoTotal,
 )
-from pyjinhx import Renderer
+from pyjinhx import Registry, Renderer
 
 Renderer.set_default_environment(Path(__file__).resolve().parents[2])
 
@@ -41,41 +42,44 @@ def _list() -> TodoList:
 
 @app.get("/", response_class=HTMLResponse)
 def index() -> str:
-    return str(
-        TodoApp(
-            id="todo-app",
-            todo_list=_list(),
-            counter=TodoCounter.load(),
-            total=TodoTotal.load(),
-            clear_button=TodoClearButton.load(),
-        ).render()
-    )
+    with Registry.request_scope(load_context=TodoLoadContext(store=store)):
+        return str(
+            TodoApp(
+                id="todo-app",
+                todo_list=_list(),
+                counter=TodoCounter.load(),
+                total=TodoTotal.load(),
+                clear_button=TodoClearButton.load(),
+            ).render()
+        )
 
 
 @app.post("/todos", response_class=HTMLResponse)
 def add(request: Request, text: str = Form(...)) -> str:
-    todo = store.add(text)
-    return TodoItemRow.render(todo.id, dirtied={"todos"}, mounted=request)
+    with Registry.request_scope(load_context=TodoLoadContext(store=store)):
+        store.add(text)
+        return str(TodoItemRow.render(store.all_todos()[-1].id, mounted=request))
 
 
 @app.post("/rows/{todo_id}/toggle", response_class=HTMLResponse)
 def toggle_row(request: Request, todo_id: int) -> str:
-    store.toggle(todo_id)
-    return TodoItemRow.render(
-        todo_id, dirtied={f"todo:{todo_id}", "todos"}, mounted=request
-    )
+    with Registry.request_scope(load_context=TodoLoadContext(store=store)):
+        store.toggle(todo_id)
+        return str(TodoItemRow.render(todo_id, mounted=request))
 
 
 @app.post("/todos/{todo_id}/toggle", response_class=HTMLResponse)
 def toggle(request: Request, todo_id: int) -> str:
-    todo = store.toggle(todo_id)
-    return _item(todo).render(dirtied={"todos"}, mounted=request)
+    with Registry.request_scope(load_context=TodoLoadContext(store=store)):
+        todo = store.toggle(todo_id)
+        return str(_item(todo).render(mounted=request))
 
 
 @app.post("/todos/clear-completed", response_class=HTMLResponse)
 def clear_completed(request: Request) -> str:
-    store.clear_completed()
-    return _list().render(dirtied={"todos"}, mounted=request)
+    with Registry.request_scope(load_context=TodoLoadContext(store=store)):
+        store.clear_completed()
+        return str(_list().render(mounted=request))
 
 
 if __name__ == "__main__":

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -1,8 +1,26 @@
+from dataclasses import dataclass
 from typing import ClassVar, Optional
 
 from pyjinhx import BaseComponent, ReactiveComponent
+from pyjinhx.load_context import get_load_context
 
-from . import store
+from .keys import Keys
+
+
+@dataclass(frozen=True)
+class TodoLoadContext:
+    """Request-scoped access to the demo store module."""
+
+    store: object
+
+
+def _store():
+    ctx = get_load_context()
+    if isinstance(ctx, TodoLoadContext):
+        return ctx.store
+    from . import store
+
+    return store
 
 
 class TodoItem(BaseComponent):
@@ -14,12 +32,14 @@ class TodoItem(BaseComponent):
 class TodoItemRow(ReactiveComponent):
     title: str = ""
     done: bool = False
-    reacts_to: ClassVar[set[str]] = {"todo"}
+    reacts_to: ClassVar[set[str]] = {Keys.TODO}
+    load_reads: ClassVar[set[str]] = {Keys.TODO}
 
     @classmethod
     def load(cls, key: str | int) -> "TodoItemRow":
-        t = store.get(int(key))
-        return cls(title=t.text, done=t.done)
+        store = _store()
+        todo = store.get(int(key))
+        return cls(title=todo.text, done=todo.done)
 
 
 class TodoList(BaseComponent):
@@ -28,29 +48,32 @@ class TodoList(BaseComponent):
 
 class TodoCounter(ReactiveComponent):
     remaining: int = 0
-    reacts_to: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {Keys.TODOS}
+    load_reads: ClassVar[set[str]] = {Keys.TODOS}
 
     @classmethod
     def load(cls) -> "TodoCounter":
-        return cls(remaining=store.remaining())
+        return cls(remaining=_store().remaining())
 
 
 class TodoTotal(ReactiveComponent):
     total: int = 0
-    reacts_to: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {Keys.TODOS}
+    load_reads: ClassVar[set[str]] = {Keys.TODOS}
 
     @classmethod
     def load(cls) -> "TodoTotal":
-        return cls(total=store.total())
+        return cls(total=_store().total())
 
 
 class TodoClearButton(ReactiveComponent):
     completed: int = 0
-    reacts_to: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {Keys.TODOS}
+    load_reads: ClassVar[set[str]] = {Keys.TODOS}
 
     @classmethod
     def load(cls) -> "TodoClearButton":
-        return cls(id="todo-clear", completed=store.completed())
+        return cls(id="todo-clear", completed=_store().completed())
 
 
 class TodoApp(BaseComponent, base_layout=True):

--- a/examples/reactive_todo/keys.py
+++ b/examples/reactive_todo/keys.py
@@ -1,0 +1,6 @@
+from pyjinhx.keys import StateKey
+
+
+class Keys(StateKey):
+    TODOS = "todos"
+    TODO = "todo"

--- a/examples/reactive_todo/store.py
+++ b/examples/reactive_todo/store.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from itertools import count
 
+from pyjinhx import mutates
+
+from .keys import Keys
+
 _ids = count(1)
 _todos: dict[int, "Todo"] = {}
 
@@ -24,17 +28,20 @@ def reset() -> None:
         add(text)
 
 
+@mutates(Keys.TODOS)
 def add(text: str) -> Todo:
     todo = Todo(id=next(_ids), text=text)
     _todos[todo.id] = todo
     return todo
 
 
+@mutates(Keys.TODO, Keys.TODOS)
 def toggle(todo_id: int) -> Todo:
     _todos[todo_id].done = not _todos[todo_id].done
     return _todos[todo_id]
 
 
+@mutates(Keys.TODOS)
 def clear_completed() -> None:
     for todo_id in [tid for tid, t in _todos.items() if t.done]:
         del _todos[todo_id]

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -2,12 +2,21 @@ from .base import BaseComponent
 from .cache import invalidate
 from .dataclasses import Tag
 from .finder import Finder
+from .keys import StateKey, dirty_keys, instance_key
+from .load_context import LoadContext, get_load_context, load_scope
+from .mutations import mutates, mutation_scope
 from .parser import Parser
 from .reactive import (
     PJX_MOUNTED_HEADER,
     ReactiveComponent,
     client_script,
     oob_swaps,
+)
+from .reactive_dev import (
+    dependency_graph,
+    disable_reactive_dev,
+    enable_reactive_dev,
+    format_dependency_graph,
 )
 from .registry import Registry
 from .renderer import Renderer
@@ -24,4 +33,16 @@ __all__ = [
     "invalidate",
     "client_script",
     "PJX_MOUNTED_HEADER",
+    "StateKey",
+    "instance_key",
+    "dirty_keys",
+    "mutates",
+    "mutation_scope",
+    "LoadContext",
+    "get_load_context",
+    "load_scope",
+    "enable_reactive_dev",
+    "disable_reactive_dev",
+    "dependency_graph",
+    "format_dependency_graph",
 ]

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -211,14 +211,25 @@ class BaseComponent(BaseModel):
         if dirtied is None and mounted is None:
             return self._render()
 
+        from .mutations import (
+            mark_reactive_render_consumed,
+            resolve_effective_dirtied,
+        )
         from .reactive import oob_swaps  # local import to avoid an import cycle
+        from .reactive_dev import warn_reactive_render_without_mounted
+
+        own_keys = coerce_reactive_keys(getattr(self, "_pjx_reacts_to", frozenset()))
+        warn_reactive_render_without_mounted(
+            dirtied=dirtied, mounted=mounted, own_keys=own_keys
+        )
 
         primary = self._render()
-        effective_dirtied = (
-            coerce_reactive_keys(dirtied)
-            if dirtied is not None
-            else getattr(self, "_pjx_reacts_to", frozenset())
+        effective_dirtied = resolve_effective_dirtied(
+            dirtied=dirtied,
+            mounted=mounted,
+            own_keys=own_keys,
         )
+        mark_reactive_render_consumed()
         swaps = oob_swaps(effective_dirtied, mounted, exclude_ids={self.id})
         # Wrap the primary as safe markup before concatenation: _render() returns a
         # plain str (Markup.unescape()), and `str + Markup` would invoke Markup.__radd__

--- a/pyjinhx/builtins/ui/notification/notification.py
+++ b/pyjinhx/builtins/ui/notification/notification.py
@@ -5,5 +5,7 @@ from pyjinhx import BaseComponent
 
 class Notification(BaseComponent):
     content: str | BaseComponent = ""
-    corner: Literal["top-right", "top-left", "bottom-right", "bottom-left"] = "top-right"
+    corner: Literal["top-right", "top-left", "bottom-right", "bottom-left"] = (
+        "top-right"
+    )
     timeout: int = 5000

--- a/pyjinhx/builtins/ui/panel/panel.py
+++ b/pyjinhx/builtins/ui/panel/panel.py
@@ -20,9 +20,9 @@ _PANEL_KEY_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 class Panel(BaseComponent):
-    panels: Annotated[dict[str, str | BaseComponent], BeforeValidator(_coerce_panels)] = Field(
-        default_factory=dict
-    )
+    panels: Annotated[
+        dict[str, str | BaseComponent], BeforeValidator(_coerce_panels)
+    ] = Field(default_factory=dict)
 
     @field_validator("panels", mode="after")
     @classmethod

--- a/pyjinhx/builtins/ui/tab_group/tab_group.py
+++ b/pyjinhx/builtins/ui/tab_group/tab_group.py
@@ -16,6 +16,6 @@ def _coerce_tabs(value: Any) -> dict[str, str | BaseComponent]:
 
 
 class TabGroup(BaseComponent):
-    tabs: Annotated[dict[str, str | BaseComponent], BeforeValidator(_coerce_tabs)] = Field(
-        default_factory=dict
+    tabs: Annotated[dict[str, str | BaseComponent], BeforeValidator(_coerce_tabs)] = (
+        Field(default_factory=dict)
     )

--- a/pyjinhx/cache.py
+++ b/pyjinhx/cache.py
@@ -61,8 +61,26 @@ def _load_through_cache(
     if cached is not None:
         return _with_key(cached.model_copy(), key)
 
-    result = raw_func(cls, key) if key is not None else raw_func(cls)
+    from .load_context import get_load_context, load_accepts_ctx
+    from .reactive_dev import validate_load_reads
+
+    ctx = get_load_context()
+    if key is not None:
+        if load_accepts_ctx(raw_func):
+            result = raw_func(cls, key, ctx=ctx)
+        else:
+            result = raw_func(cls, key)
+    elif load_accepts_ctx(raw_func):
+        result = raw_func(cls, ctx=ctx)
+    else:
+        result = raw_func(cls)
     result = _with_key(result, key)
+
+    validate_load_reads(
+        cls,
+        declared_reads=set(getattr(cls, "_pjx_load_reads", frozenset())),
+        reacts_to=set(getattr(cls, "_pjx_reacts_to", frozenset())),
+    )
 
     if key is not None:
         from .utils import pascal_case_to_kebab_case

--- a/pyjinhx/keys.py
+++ b/pyjinhx/keys.py
@@ -1,0 +1,31 @@
+from enum import StrEnum
+
+from .utils import ReactiveKey, coerce_load_key, coerce_reactive_keys
+
+
+class StateKey(StrEnum):
+    """
+    Base class for app-level reactive state keys.
+
+    Subclass and declare members; use the enum in ``reacts_to``, ``dirtied``,
+    and ``@mutates`` — all normalize to their string values.
+    """
+
+
+def instance_key(stem: str, key: str | int) -> str:
+    """Build an instance-tier dirty key, e.g. ``instance_key("todo", 42)`` → ``"todo:42"``."""
+    return f"{stem}:{coerce_load_key(key)}"
+
+
+def dirty_keys(
+    instance_stem: str,
+    key: str | int,
+    *collection: ReactiveKey,
+) -> set[str]:
+    """
+    Build a two-tier dirty set for instance-keyed mutations.
+
+    Returns the expanded instance key plus any collection-tier keys, e.g.
+    ``dirty_keys("todo", 42, "todos")`` → ``{"todo:42", "todos"}``.
+    """
+    return {instance_key(instance_stem, key), *coerce_reactive_keys(collection)}

--- a/pyjinhx/load_context.py
+++ b/pyjinhx/load_context.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Generator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+
+_load_context: ContextVar[Any | None] = ContextVar("load_context", default=None)
+
+
+@dataclass(frozen=True)
+class LoadContext:
+    """
+    Opaque base for request-scoped data available inside reactive ``load()``.
+
+    Subclass or replace with your own frozen dataclass; set per request via
+    ``load_scope()`` or ``Registry.request_scope(load_context=...)``.
+    """
+
+
+def get_load_context() -> Any | None:
+    """Return the current load context, or ``None`` outside a scope."""
+    return _load_context.get()
+
+
+@contextmanager
+def load_scope(ctx: Any) -> Generator[None, None, None]:
+    """Set the load context for the current scope."""
+    token = _load_context.set(ctx)
+    try:
+        yield
+    finally:
+        _load_context.reset(token)
+
+
+def load_accepts_ctx(func: Any) -> bool:
+    """Return whether ``func`` accepts a keyword-only ``ctx`` argument."""
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return False
+    param = signature.parameters.get("ctx")
+    return param is not None and param.kind in (
+        inspect.Parameter.KEYWORD_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )

--- a/pyjinhx/mutations.py
+++ b/pyjinhx/mutations.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable, Generator, Iterable
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, TypeVar
+
+from .cache import invalidate
+from .utils import ReactiveKey, coerce_reactive_keys
+
+_mutation_dirtied: ContextVar[set[str] | None] = ContextVar(
+    "mutation_dirtied", default=None
+)
+_reactive_render_consumed: ContextVar[bool] = ContextVar(
+    "reactive_render_consumed", default=False
+)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def pending_dirtied() -> set[str]:
+    """Return accumulated dirtied keys for the current request scope."""
+    registry = _mutation_dirtied.get()
+    if registry is None:
+        return set()
+    return set(registry)
+
+
+def clear_mutations() -> None:
+    """Reset accumulated dirtied keys and render-consumed flag."""
+    _mutation_dirtied.set(set())
+    _reactive_render_consumed.set(False)
+
+
+def _accumulate_dirtied(keys: Iterable[ReactiveKey]) -> None:
+    normalized = coerce_reactive_keys(keys)
+    if not normalized:
+        return
+    current = _mutation_dirtied.get()
+    if current is None:
+        current = set()
+        _mutation_dirtied.set(current)
+    current.update(normalized)
+
+
+def mark_reactive_render_consumed() -> None:
+    """Record that a reactive render consumed pending mutations."""
+    _reactive_render_consumed.set(True)
+    _mutation_dirtied.set(set())
+
+
+def reactive_render_was_consumed() -> bool:
+    return _reactive_render_consumed.get()
+
+
+def resolve_effective_dirtied(
+    *,
+    dirtied: set[ReactiveKey] | None,
+    mounted: object | None,
+    own_keys: set[str],
+) -> set[str]:
+    """
+    Resolve dirtied keys for a reactive render.
+
+    When ``dirtied`` is omitted and reactive mode is active (``mounted`` set),
+    merge the primary's own keys with pending mutations from ``@mutates``.
+    Explicit ``dirtied`` (including an empty set) always wins.
+    """
+    if dirtied is not None:
+        return coerce_reactive_keys(dirtied)
+    if mounted is None:
+        return own_keys
+    return own_keys | pending_dirtied()
+
+
+def mutates(*keys: ReactiveKey) -> Callable[[F], F]:
+    """
+    Decorator for store mutation methods.
+
+    Invalidates the load() cache for ``keys`` and accumulates them as pending
+    dirtied for the next reactive ``render()`` when ``dirtied`` is omitted.
+    """
+
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            normalized = coerce_reactive_keys(keys)
+            if normalized:
+                invalidate(normalized)
+                _accumulate_dirtied(normalized)
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+@contextmanager
+def mutation_scope(*keys: ReactiveKey) -> Generator[None, None, None]:
+    """
+    Context manager that accumulates dirtied keys for a block.
+
+    Keys passed to the scope are added on entry (and invalidate the cache).
+    """
+    normalized = coerce_reactive_keys(keys)
+    if normalized:
+        invalidate(normalized)
+        _accumulate_dirtied(normalized)
+    try:
+        yield
+    finally:
+        pass

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -98,7 +98,9 @@ class _ReactiveRender:
                 f"{cls.__name__}.render(<id>, dirtied=..., mounted=request)."
             )
         if not keyed and key is not None:
-            raise TypeError(f"{cls.__name__} is a type-singleton; render() takes no key.")
+            raise TypeError(
+                f"{cls.__name__} is a type-singleton; render() takes no key."
+            )
 
         skey = coerce_load_key_str(key) if key is not None else None
         from .mutations import mark_reactive_render_consumed, resolve_effective_dirtied

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -33,6 +33,21 @@ PJX_MOUNTED_HEADER = "X-PJX-Mounted"
 """Name of the HTTP header carrying the client's mounted-region manifest."""
 
 
+def _load_param_count(func: Any) -> int:
+    """Count ``load()`` parameters excluding ``cls``, ``ctx``, and variadics."""
+    params = inspect.signature(func).parameters
+    return sum(
+        1
+        for name, param in params.items()
+        if name not in ("cls", "ctx")
+        and param.kind
+        not in (
+            inspect.Parameter.VAR_KEYWORD,
+            inspect.Parameter.VAR_POSITIONAL,
+        )
+    )
+
+
 def client_script() -> Markup:
     """
     Return the pyjinhx client runtime wrapped in a ``<script>`` tag.
@@ -86,15 +101,24 @@ class _ReactiveRender:
             raise TypeError(f"{cls.__name__} is a type-singleton; render() takes no key.")
 
         skey = coerce_load_key_str(key) if key is not None else None
+        from .mutations import mark_reactive_render_consumed, resolve_effective_dirtied
+        from .reactive_dev import warn_reactive_render_without_mounted
+
         own_keys = interpolate_reactive_keys(
             getattr(cls, "_pjx_reacts_to", frozenset()), skey, keyed=keyed
         )
-        effective_dirtied = (
-            coerce_reactive_keys(dirtied) if dirtied is not None else own_keys
+        warn_reactive_render_without_mounted(
+            dirtied=dirtied, mounted=mounted, own_keys=own_keys
+        )
+        effective_dirtied = resolve_effective_dirtied(
+            dirtied=dirtied,
+            mounted=mounted,
+            own_keys=own_keys,
         )
         invalidate(effective_dirtied | own_keys)
         instance = cls.load(skey) if keyed else cls.load()
         primary = instance._render()
+        mark_reactive_render_consumed()
         swaps = oob_swaps(effective_dirtied, mounted, exclude_ids={instance.id})
         return Markup(primary) + swaps
 
@@ -128,6 +152,7 @@ class ReactiveComponent(BaseComponent):
     model_config = ConfigDict(extra="allow", ignored_types=(_ReactiveRender,))
 
     reacts_to: ClassVar[set[ReactiveKey]] = set()
+    load_reads: ClassVar[set[ReactiveKey]] = set()
 
     _pjx_key: str | None = PrivateAttr(default=None)
 
@@ -160,6 +185,9 @@ class ReactiveComponent(BaseComponent):
         cls._pjx_reacts_to = frozenset(
             coerce_reactive_keys(getattr(cls, "reacts_to", None) or ())
         )
+        cls._pjx_load_reads = frozenset(
+            coerce_reactive_keys(getattr(cls, "load_reads", None) or ())
+        )
         if "load" in cls.__dict__ and not cls._pjx_reacts_to:
             raise TypeError(
                 f"{cls.__name__} defines load() but declares no reacts_to; a "
@@ -168,7 +196,7 @@ class ReactiveComponent(BaseComponent):
         if "load" in cls.__dict__:
             _load = cls.__dict__["load"]
             _func = _load.__func__ if isinstance(_load, classmethod) else _load
-            cls._pjx_keyed = len(inspect.signature(_func).parameters) > 1
+            cls._pjx_keyed = _load_param_count(_func) == 1
         if "load" in cls.__dict__:
             from .cache import install_cached_load
 

--- a/pyjinhx/reactive_dev.py
+++ b/pyjinhx/reactive_dev.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from .mutations import pending_dirtied, reactive_render_was_consumed
 from .registry import Registry
-from .utils import ReactiveKey, coerce_reactive_keys
+from .utils import ReactiveKey
 
 logger = logging.getLogger("pyjinhx")
 

--- a/pyjinhx/reactive_dev.py
+++ b/pyjinhx/reactive_dev.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from .mutations import pending_dirtied, reactive_render_was_consumed
+from .registry import Registry
+from .utils import ReactiveKey, coerce_reactive_keys
+
+logger = logging.getLogger("pyjinhx")
+
+
+@dataclass
+class ReactiveDev:
+    enabled: bool = False
+    strict: bool = False
+
+
+_dev_config: ReactiveDev = ReactiveDev()
+
+
+def enable_reactive_dev(*, strict: bool = False) -> None:
+    """Enable development-time reactive guardrails (warnings or strict exceptions)."""
+    global _dev_config
+    _dev_config = ReactiveDev(enabled=True, strict=strict)
+
+
+def disable_reactive_dev() -> None:
+    """Disable development-time reactive guardrails."""
+    global _dev_config
+    _dev_config = ReactiveDev()
+
+
+def reactive_dev_enabled() -> bool:
+    return _dev_config.enabled
+
+
+def _report(message: str) -> None:
+    if _dev_config.strict:
+        raise RuntimeError(message)
+    logger.warning(message)
+
+
+def warn_mutations_without_render() -> None:
+    if not _dev_config.enabled:
+        return
+    if pending_dirtied() and not reactive_render_was_consumed():
+        _report(
+            "Mutations were recorded via @mutates but no reactive render() "
+            "consumed them in this request scope."
+        )
+
+
+def warn_reactive_render_without_mounted(
+    *,
+    dirtied: set[ReactiveKey] | None,
+    mounted: object | None,
+    own_keys: set[str],
+) -> None:
+    if not _dev_config.enabled or mounted is not None:
+        return
+    has_dirtied = dirtied is not None or bool(pending_dirtied())
+    if has_dirtied or own_keys:
+        _report(
+            "Reactive dirtied keys are set but mounted was not passed; "
+            "out-of-band swaps will be skipped."
+        )
+
+
+def validate_load_reads(
+    component_class: type,
+    *,
+    declared_reads: set[str],
+    reacts_to: set[str],
+) -> None:
+    if not _dev_config.enabled or not declared_reads:
+        return
+    extra = declared_reads - reacts_to
+    if extra:
+        _report(
+            f"{component_class.__name__}.load_reads {extra!r} is not covered by "
+            f"reacts_to {reacts_to!r}."
+        )
+
+
+def dependency_graph() -> dict[str, list[str]]:
+    """
+    Map each declared reactive key to component class names that depend on it.
+
+    Instance-tier stems appear as declared (e.g. ``"todo"``), not expanded per key.
+    """
+    graph: dict[str, set[str]] = {}
+    for class_name, component_class in Registry.get_classes().items():
+        reacts_to = getattr(component_class, "_pjx_reacts_to", None)
+        if not reacts_to:
+            continue
+        if not getattr(component_class, "_pjx_reactive", False):
+            continue
+        for key in reacts_to:
+            graph.setdefault(key, set()).add(class_name)
+    return {key: sorted(names) for key, names in sorted(graph.items())}
+
+
+def format_dependency_graph(*, as_mermaid: bool = False) -> str:
+    """Format the dependency graph as a text table or mermaid flowchart."""
+    graph = dependency_graph()
+    if not graph:
+        return "(no reactive components registered)"
+
+    if as_mermaid:
+        lines = ["flowchart LR"]
+        for key, components in graph.items():
+            safe_key = key.replace(":", "_")
+            lines.append(f'  key_{safe_key}["{key}"]')
+            for component_name in components:
+                lines.append(f"  key_{safe_key} --> {component_name}")
+        return "\n".join(lines)
+
+    lines = ["Reactive dependency graph:", ""]
+    for key, components in graph.items():
+        lines.append(f"  {key!r} -> {', '.join(components)}")
+    return "\n".join(lines)

--- a/pyjinhx/registry.py
+++ b/pyjinhx/registry.py
@@ -106,19 +106,36 @@ class Registry:
 
     @classmethod
     @contextmanager
-    def request_scope(cls) -> Generator[None, None, None]:
+    def request_scope(
+        cls,
+        *,
+        load_context: object | None = None,
+    ) -> Generator[None, None, None]:
         """
         Context manager for request-scoped component instances.
 
         Creates a fresh instance registry on entry and restores
-        the previous state on exit.
+        the previous state on exit. Also resets mutation tracking and
+        optionally sets a load context for reactive ``load()`` calls.
 
         Usage:
             with Registry.request_scope():
                 # components registered here won't persist
         """
+        from contextlib import ExitStack
+
+        from .load_context import load_scope
+        from .mutations import clear_mutations
+        from .reactive_dev import warn_mutations_without_render
+
+        clear_mutations()
         token = _registry_context.set({})
         try:
-            yield
+            with ExitStack() as stack:
+                if load_context is not None:
+                    stack.enter_context(load_scope(load_context))
+                yield
         finally:
+            warn_mutations_without_render()
+            clear_mutations()
             _registry_context.reset(token)

--- a/tests/20_html_tag_renderer_test.py
+++ b/tests/20_html_tag_renderer_test.py
@@ -245,7 +245,9 @@ def test_renderer_with_registered_class_and_nested_components():
         with open(os.path.join(temp_dir, "album_button.html"), "w") as file:
             file.write('<button id="{{ id }}">{{ text }}</button>\n')
 
-        index_html = '<AlbumCard title="My Card"><AlbumButton text="Action"/></AlbumCard>'
+        index_html = (
+            '<AlbumCard title="My Card"><AlbumButton text="Action"/></AlbumCard>'
+        )
         rendered = Renderer(
             Environment(loader=FileSystemLoader(temp_dir)),
             auto_id=True,

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -6,13 +6,27 @@ def test_reactive_api_is_exported():
         PJX_MOUNTED_HEADER,
         ReactiveComponent,
         client_script,
+        dependency_graph,
+        dirty_keys,
+        enable_reactive_dev,
+        get_load_context,
+        instance_key,
+        mutates,
         oob_swaps,
+        StateKey,
     )
 
     assert PJX_MOUNTED_HEADER == "X-PJX-Mounted"
     assert callable(oob_swaps)
     assert callable(client_script)
+    assert callable(mutates)
+    assert callable(dependency_graph)
+    assert callable(enable_reactive_dev)
+    assert callable(get_load_context)
+    assert callable(dirty_keys)
+    assert callable(instance_key)
     assert issubclass(ReactiveComponent, pyjinhx.BaseComponent)
+    assert issubclass(StateKey, str)
 
 
 def test_names_in_all():
@@ -21,5 +35,17 @@ def test_names_in_all():
         "ReactiveComponent",
         "client_script",
         "PJX_MOUNTED_HEADER",
+        "StateKey",
+        "instance_key",
+        "dirty_keys",
+        "mutates",
+        "mutation_scope",
+        "LoadContext",
+        "get_load_context",
+        "load_scope",
+        "enable_reactive_dev",
+        "disable_reactive_dev",
+        "dependency_graph",
+        "format_dependency_graph",
     ):
         assert name in pyjinhx.__all__

--- a/tests/38_reactive_render_test.py
+++ b/tests/38_reactive_render_test.py
@@ -111,7 +111,9 @@ def test_reactive_render_does_not_escape_primary_html():
     out = str(
         primary.render(
             dirtied={"todos"},
-            mounted=[{"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}],
+            mounted=[
+                {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
+            ],
         )
     )
     assert "&lt;span" not in out and "&#34;" not in out

--- a/tests/48_reactive_keys_helpers_test.py
+++ b/tests/48_reactive_keys_helpers_test.py
@@ -1,5 +1,3 @@
-from enum import StrEnum
-
 from pyjinhx.keys import StateKey, dirty_keys, instance_key
 
 

--- a/tests/48_reactive_keys_helpers_test.py
+++ b/tests/48_reactive_keys_helpers_test.py
@@ -1,0 +1,23 @@
+from enum import StrEnum
+
+from pyjinhx.keys import StateKey, dirty_keys, instance_key
+
+
+class TodoKeys(StateKey):
+    TODOS = "todos"
+    TODO = "todo"
+
+
+def test_instance_key_formats_stem_and_key():
+    assert instance_key("todo", 42) == "todo:42"
+    assert instance_key("todo", "abc") == "todo:abc"
+
+
+def test_dirty_keys_builds_two_tier_set():
+    assert dirty_keys("todo", 42, "todos") == {"todo:42", "todos"}
+    assert dirty_keys("todo", 42, TodoKeys.TODOS) == {"todo:42", "todos"}
+
+
+def test_state_key_subclass_values():
+    assert TodoKeys.TODOS == "todos"
+    assert isinstance(TodoKeys.TODOS, str)

--- a/tests/49_mutations_test.py
+++ b/tests/49_mutations_test.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+from pyjinhx import Registry, Renderer, mutates
+from pyjinhx.cache import clear
+from pyjinhx.mutations import clear_mutations, pending_dirtied, resolve_effective_dirtied
+from tests.ui.reactive.reactive_clear_button import ReactiveClearButton
+from tests.ui.reactive.reactive_counter import ReactiveCounter
+from tests.ui.reactive.store import state
+
+UI_ROOT = Path(__file__).parent / "ui" / "reactive"
+
+
+@mutates("todos")
+def _mutate_todos() -> None:
+    state["remaining"] -= 1
+
+
+def test_mutates_accumulates_pending_dirtied():
+    clear_mutations()
+    _mutate_todos()
+    assert pending_dirtied() == {"todos"}
+
+
+def test_resolve_effective_dirtied_merges_pending():
+    clear_mutations()
+    _mutate_todos()
+    effective = resolve_effective_dirtied(
+        dirtied=None,
+        mounted=[],
+        own_keys={"todos"},
+    )
+    assert effective == {"todos"}
+
+
+def test_render_merges_pending_dirtied_when_omitted():
+    clear()
+    clear_mutations()
+    prev = Renderer.peek_default_environment()
+    Renderer.set_default_environment(UI_ROOT)
+    try:
+        _mutate_todos()
+        manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+        with Registry.request_scope():
+            out = str(ReactiveClearButton.render(mounted=manifest))
+        assert "outerHTML:[data-pjx-id='counter']" in out
+        assert pending_dirtied() == set()
+    finally:
+        Renderer.set_default_environment(prev)
+
+
+def test_explicit_dirtied_overrides_pending():
+    clear()
+    clear_mutations()
+    prev = Renderer.peek_default_environment()
+    Renderer.set_default_environment(UI_ROOT)
+    try:
+        _mutate_todos()
+        manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+        with Registry.request_scope():
+            out = str(ReactiveClearButton.render(dirtied=set(), mounted=manifest))
+        assert "outerHTML:[data-pjx-id='counter']" not in out
+    finally:
+        Renderer.set_default_environment(prev)
+
+
+def test_request_scope_isolates_mutations():
+    clear_mutations()
+    with Registry.request_scope():
+        _mutate_todos()
+        assert pending_dirtied() == {"todos"}
+    assert pending_dirtied() == set()

--- a/tests/49_mutations_test.py
+++ b/tests/49_mutations_test.py
@@ -2,9 +2,12 @@ from pathlib import Path
 
 from pyjinhx import Registry, Renderer, mutates
 from pyjinhx.cache import clear
-from pyjinhx.mutations import clear_mutations, pending_dirtied, resolve_effective_dirtied
+from pyjinhx.mutations import (
+    clear_mutations,
+    pending_dirtied,
+    resolve_effective_dirtied,
+)
 from tests.ui.reactive.reactive_clear_button import ReactiveClearButton
-from tests.ui.reactive.reactive_counter import ReactiveCounter
 from tests.ui.reactive.store import state
 
 UI_ROOT = Path(__file__).parent / "ui" / "reactive"

--- a/tests/50_load_context_test.py
+++ b/tests/50_load_context_test.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass
+from typing import ClassVar
+
+from pyjinhx import ReactiveComponent, Registry
+from pyjinhx.cache import clear
+from pyjinhx.load_context import LoadContext, get_load_context, load_scope
+
+
+@dataclass(frozen=True)
+class AppLoadContext(LoadContext):
+    value: int = 0
+
+
+class CtxSingleton(ReactiveComponent):
+    value: int = 0
+    reacts_to: ClassVar[set[str]] = {"widgets"}
+
+    @classmethod
+    def load(cls, *, ctx: AppLoadContext | None = None) -> "CtxSingleton":
+        return cls(id="ctx-singleton", value=ctx.value if ctx else -1)
+
+
+class CtxKeyed(ReactiveComponent):
+    label: str = ""
+    reacts_to: ClassVar[set[str]] = {"row"}
+
+    @classmethod
+    def load(cls, key: str, *, ctx: AppLoadContext | None = None) -> "CtxKeyed":
+        return cls(label=f"{key}:{ctx.value if ctx else 'none'}")
+
+
+class CtxPlain(ReactiveComponent):
+    value: int = 0
+    reacts_to: ClassVar[set[str]] = {"plain"}
+
+    @classmethod
+    def load(cls) -> "CtxPlain":
+        ctx = get_load_context()
+        value = ctx.value if isinstance(ctx, AppLoadContext) else -1
+        return cls(id="ctx-plain", value=value)
+
+
+def test_get_load_context_outside_scope_is_none():
+    assert get_load_context() is None
+
+
+def test_load_scope_sets_context():
+    ctx = AppLoadContext(value=7)
+    with load_scope(ctx):
+        assert get_load_context() is ctx
+    assert get_load_context() is None
+
+
+def test_load_receives_ctx_kwarg():
+    clear()
+    ctx = AppLoadContext(value=42)
+    with load_scope(ctx):
+        instance = CtxSingleton.load()
+    assert instance.value == 42
+
+
+def test_keyed_load_with_ctx_kwarg_stays_keyed():
+    assert CtxKeyed._pjx_keyed is True
+    clear()
+    ctx = AppLoadContext(value=9)
+    with load_scope(ctx):
+        row = CtxKeyed.load("a")
+    assert row.label == "a:9"
+    assert row.id == "ctx-keyed-a"
+
+
+def test_load_reads_contextvar_when_no_ctx_param():
+    clear()
+    ctx = AppLoadContext(value=5)
+    with load_scope(ctx):
+        instance = CtxPlain.load()
+    assert instance.value == 5
+
+
+def test_request_scope_accepts_load_context():
+    clear()
+    ctx = AppLoadContext(value=11)
+    with Registry.request_scope(load_context=ctx):
+        instance = CtxPlain.load()
+    assert instance.value == 11

--- a/tests/51_reactive_dev_test.py
+++ b/tests/51_reactive_dev_test.py
@@ -1,0 +1,92 @@
+import logging
+from typing import ClassVar
+
+import pytest
+
+from pyjinhx import ReactiveComponent, Registry, mutates
+from pyjinhx.cache import clear
+from pyjinhx.reactive_dev import (
+    dependency_graph,
+    disable_reactive_dev,
+    enable_reactive_dev,
+    format_dependency_graph,
+)
+
+
+@mutates("orphan")
+def _orphan_mutation() -> None:
+    pass
+
+
+class DevCounter(ReactiveComponent):
+    remaining: int = 0
+    reacts_to: ClassVar[set[str]] = {"todos"}
+
+    @classmethod
+    def load(cls) -> "DevCounter":
+        return cls(id="counter", remaining=0)
+
+
+class BadReads(ReactiveComponent):
+    value: int = 0
+    reacts_to: ClassVar[set[str]] = {"alpha"}
+    load_reads: ClassVar[set[str]] = {"alpha", "beta"}
+
+    @classmethod
+    def load(cls) -> "BadReads":
+        return cls(value=1)
+
+
+def setup_function():
+    disable_reactive_dev()
+    clear()
+
+
+def teardown_function():
+    disable_reactive_dev()
+
+
+def test_warn_mutations_without_render(caplog):
+    enable_reactive_dev()
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        with Registry.request_scope():
+            _orphan_mutation()
+    assert "no reactive render" in caplog.text.lower()
+
+
+def test_strict_mutations_without_render_raises():
+    enable_reactive_dev(strict=True)
+    with pytest.raises(RuntimeError, match="no reactive render"):
+        with Registry.request_scope():
+            _orphan_mutation()
+
+
+def test_warn_render_without_mounted(caplog):
+    from pyjinhx.reactive_dev import warn_reactive_render_without_mounted
+
+    enable_reactive_dev()
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        warn_reactive_render_without_mounted(
+            dirtied={"todos"},
+            mounted=None,
+            own_keys={"todos"},
+        )
+    assert "mounted was not passed" in caplog.text.lower()
+
+
+def test_load_reads_validation_strict():
+    enable_reactive_dev(strict=True)
+    with pytest.raises(RuntimeError, match="load_reads"):
+        BadReads.load()
+
+
+def test_dependency_graph_includes_reactive_components():
+    graph = dependency_graph()
+    assert "todos" in graph
+    assert "DevCounter" in graph["todos"]
+
+
+def test_format_dependency_graph_mermaid():
+    output = format_dependency_graph(as_mermaid=True)
+    assert "flowchart LR" in output
+    assert "DevCounter" in output

--- a/tests/52_dependency_graph_test.py
+++ b/tests/52_dependency_graph_test.py
@@ -1,0 +1,12 @@
+from pyjinhx.reactive_dev import dependency_graph, format_dependency_graph
+
+
+def test_dependency_graph_values_are_sorted():
+    graph = dependency_graph()
+    for components in graph.values():
+        assert components == sorted(components)
+
+
+def test_format_dependency_graph_text():
+    output = format_dependency_graph()
+    assert "Reactive dependency graph" in output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 from pyjinhx import Registry
 from pyjinhx.cache import clear as clear_load_cache
+from pyjinhx.mutations import clear_mutations
 
 
 @pytest.fixture(autouse=True)
@@ -18,7 +19,9 @@ def _isolate_reactive_state() -> Generator[None, None, None]:
       or template variable would shadow it. Clear both for isolation.
     """
     clear_load_cache()
+    clear_mutations()
     Registry.clear_instances()
     yield
     clear_load_cache()
+    clear_mutations()
     Registry.clear_instances()

--- a/tests/integration/test_panel_sse.py
+++ b/tests/integration/test_panel_sse.py
@@ -20,7 +20,9 @@ def _find_free_port() -> int:
 @pytest.fixture
 def gallery_server_url() -> str:
     port = _find_free_port()
-    config = uvicorn.Config(create_app(), host="127.0.0.1", port=port, log_level="warning")
+    config = uvicorn.Config(
+        create_app(), host="127.0.0.1", port=port, log_level="warning"
+    )
     server = uvicorn.Server(config)
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
@@ -51,7 +53,9 @@ def test_gallery_page_includes_panel_sse_demo_markup(gallery_server_url: str) ->
 
 def test_panel_sse_stream_emits_first_tick(gallery_server_url: str) -> None:
     with httpx.Client(timeout=httpx.Timeout(5.0, read=5.0)) as http_client:
-        with http_client.stream("GET", f"{gallery_server_url}/sse/panel-demo") as response:
+        with http_client.stream(
+            "GET", f"{gallery_server_url}/sse/panel-demo"
+        ) as response:
             response.raise_for_status()
             received = b""
             for chunk in response.iter_bytes():

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ wheels = [
 
 [[package]]
 name = "pyjinhx"
-version = "0.5.0"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- Add opt-in reactive ergonomics layer: `StateKey`/`dirty_keys`, `@mutates` auto-dirtied, `LoadContext` for per-request `load()` dependencies, and `enable_reactive_dev()` guardrails with `dependency_graph()`.
- Integrate mutation tracking into `render()` and extend `Registry.request_scope()` with `load_context=` and per-request mutation reset.
- Update the reactive todo example and docs to showcase shorter mutation routes (`mounted=request` only).

## Test plan

- [x] `uv run pytest` — 240 tests pass
- [x] New tests for keys, mutations, load context, dev mode, and dependency graph (`tests/48`–`52`)
- [ ] Manual: `uv run uvicorn examples.reactive_todo.app:app --reload` — toggle rows and verify counter/total OOB updates


Made with [Cursor](https://cursor.com)