### PR TITLE
Production-friendly asset strategy (REFERENCE mode + client dedup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,24 @@ components/ui/
 | `Button` | `button.js`, `button.css` |
 | `ActionButton` | `action-button.js`, `action-button.css` |
 
-Each asset is included once per render session. Output order: `<style>` tags, HTML, then `<script>` tags. Pass extra paths via `js=[...]` and `css=[...]` on the component. Disable inlining with `Renderer.set_default_inline_js(False)` / `set_default_inline_css(False)`.
+Each asset is included once per render session. Output order: `<style>` tags, HTML, then `<script>` tags (inline mode). Pass extra paths via `js=[...]` and `css=[...]` on the component.
+
+**Asset delivery modes** (`AssetMode.INLINE`, `REFERENCE`, `NONE`):
+
+- **INLINE** (default): zero-config demos — assets are inlined as `<style>` / `<script>` blocks.
+- **REFERENCE**: production — emits `<link href="...">` / `<script src="...">` from a per-render manifest; configure `Renderer.set_asset_url_resolver()`.
+- **NONE**: no asset tags (legacy `set_default_inline_js(False)` behavior).
+
+Reactive partial responses (when `mounted` is set) and OOB swaps never emit assets. Full-page layout renders emit them once. For boosted navigation in REFERENCE mode, enable client asset dedup so root renders skip URLs the browser already has (`X-PJX-Assets` header + `render(client=request)`).
+
+```python
+from pyjinhx import AssetMode, Renderer
+
+Renderer.set_default_js_mode(AssetMode.REFERENCE)
+Renderer.set_default_css_mode(AssetMode.REFERENCE)
+Renderer.set_asset_url_resolver(lambda path: f"/static/{path.split('/')[-1]}")
+Renderer.set_default_asset_dedup(True)
+```
 
 Details: [asset collection guide](docs/guide/assets.md). Optional UI kit: [pyjinhx.builtins](docs/guide/builtins.md).
 

--- a/docs/api/renderer.md
+++ b/docs/api/renderer.md
@@ -23,6 +23,8 @@ def __init__(
     auto_id: bool = True,
     inline_js: bool | None = None,
     inline_css: bool | None = None,
+    js_mode: AssetMode | None = None,
+    css_mode: AssetMode | None = None,
 ) -> None
 ```
 
@@ -31,8 +33,10 @@ Initialize a Renderer with the given Jinja environment.
 **Parameters:**
 - `environment` (Environment): The Jinja2 Environment to use for template rendering
 - `auto_id` (bool): If True (default), generate UUIDs for components without explicit IDs
-- `inline_js` (bool | None): If True, JavaScript is collected and injected as `<script>` tags. If False, no scripts are injected. Defaults to the class-level setting
-- `inline_css` (bool | None): If True, CSS is collected and injected as `<style>` tags. If False, no styles are injected. Defaults to the class-level setting
+- `inline_js` (bool | None): Deprecated bool shim; maps to `AssetMode.INLINE` or `AssetMode.NONE`
+- `inline_css` (bool | None): Deprecated bool shim; maps to `AssetMode.INLINE` or `AssetMode.NONE`
+- `js_mode` (AssetMode | None): JavaScript delivery mode. Defaults to the class-level setting
+- `css_mode` (AssetMode | None): CSS delivery mode. Defaults to the class-level setting
 
 #### Class Methods
 
@@ -45,6 +49,8 @@ def get_default_renderer(
     auto_id: bool = True,
     inline_js: bool | None = None,
     inline_css: bool | None = None,
+    js_mode: AssetMode | None = None,
+    css_mode: AssetMode | None = None,
 ) -> Renderer
 ```
 
@@ -52,10 +58,57 @@ Return a cached default renderer instance.
 
 **Parameters:**
 - `auto_id` (bool): If True, generate UUIDs for components without explicit IDs
-- `inline_js` (bool | None): If True, JavaScript is collected and injected as `<script>` tags. If False, no scripts are injected. Defaults to the class-level setting
-- `inline_css` (bool | None): If True, CSS is collected and injected as `<style>` tags. If False, no styles are injected. Defaults to the class-level setting
+- `inline_js` (bool | None): Deprecated bool shim for JavaScript delivery
+- `inline_css` (bool | None): Deprecated bool shim for CSS delivery
+- `js_mode` (AssetMode | None): JavaScript delivery mode
+- `css_mode` (AssetMode | None): CSS delivery mode
 
-**Returns:** A Renderer instance cached by (environment identity, auto_id, inline_js, inline_css).
+**Returns:** A Renderer instance cached by environment identity, asset modes, and resolver identity.
+
+##### set_default_js_mode()
+
+```python
+@classmethod
+def set_default_js_mode(mode: AssetMode) -> None
+```
+
+Set the process-wide default JavaScript asset delivery mode.
+
+##### set_default_css_mode()
+
+```python
+@classmethod
+def set_default_css_mode(mode: AssetMode) -> None
+```
+
+Set the process-wide default CSS asset delivery mode.
+
+##### set_asset_url_resolver()
+
+```python
+@classmethod
+def set_asset_url_resolver(resolver: AssetUrlResolver | None) -> None
+```
+
+Set the callable that maps absolute asset paths to public URLs for `AssetMode.REFERENCE`.
+
+##### set_default_runtime_url()
+
+```python
+@classmethod
+def set_default_runtime_url(url: str) -> None
+```
+
+Set the public URL for the pyjinhx client runtime in `AssetMode.REFERENCE` (default: `/static/pyjinhx/pjx.js`).
+
+##### set_default_asset_dedup()
+
+```python
+@classmethod
+def set_default_asset_dedup(enabled: bool) -> None
+```
+
+When `True`, root REFERENCE renders skip `<link>` / `<script src>` tags for URLs the client reported via `X-PJX-Assets`. Defaults to `False`. Pass `client=request` to `render()` on boosted full-page routes.
 
 ##### get_default_environment()
 
@@ -91,10 +144,7 @@ Set or clear the process-wide default Jinja environment.
 def set_default_inline_js(inline_js: bool) -> None
 ```
 
-Set the process-wide default for inline JavaScript injection.
-
-**Parameters:**
-- `inline_js` (bool): If True (default), JavaScript is collected and injected as `<script>` tags. If False, no scripts are injected. Use Finder.collect_javascript_files() for static serving.
+Deprecated bool shim. Maps to `AssetMode.INLINE` (True) or `AssetMode.NONE` (False).
 
 ##### set_default_inline_css()
 
@@ -103,10 +153,7 @@ Set the process-wide default for inline JavaScript injection.
 def set_default_inline_css(inline_css: bool) -> None
 ```
 
-Set the process-wide default for inline CSS injection.
-
-**Parameters:**
-- `inline_css` (bool): If True (default), CSS is collected and injected as `<style>` tags. If False, no styles are injected. Use Finder.collect_css_files() for static serving.
+Deprecated bool shim. Maps to `AssetMode.INLINE` (True) or `AssetMode.NONE` (False).
 
 ##### peek_default_environment()
 
@@ -142,8 +189,6 @@ def render(source: str) -> str
 
 Render an HTML-like source string, expanding PascalCase component tags into HTML.
 
-PascalCase tags (e.g., `<MyButton text="OK">`) are matched to registered component classes or template files and rendered recursively. Standard HTML is passed through unchanged. Associated CSS and JavaScript files are collected and injected as `<style>` and `<script>` tags.
-
 **Parameters:**
 - `source` (str): HTML-like string containing component tags to render
 
@@ -159,20 +204,35 @@ Create a new render session for tracking assets during rendering.
 
 **Returns:** A fresh RenderSession instance.
 
+## AssetMode
+
+```python
+class AssetMode(str, Enum):
+    INLINE = "inline"
+    REFERENCE = "reference"
+    NONE = "none"
+```
+
 ## RenderSession
 
 Per-render state for asset aggregation and deduplication.
-
-!!! note "Internal Use"
-    `RenderSession` is primarily for internal use by the rendering engine. You typically don't need to create or manage sessions directly—they're created automatically during rendering.
-
-    If you need a new session for custom rendering logic, use `Renderer.new_session()` instead of instantiating directly.
 
 ### Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `scripts` | `list[str]` | Collected JavaScript code snippets to inject |
-| `collected_js_files` | `set[str]` | Set of JS file paths already processed (for deduplication) |
-| `styles` | `list[str]` | Collected CSS code snippets to inject |
-| `collected_css_files` | `set[str]` | Set of CSS file paths already processed (for deduplication) |
+| `assets` | `list[CollectedAsset]` | Ordered, deduplicated asset paths collected during rendering |
+| `collected_paths` | `set[str]` | Normalized paths already processed |
+| `scripts` | `list[str]` | Inline JavaScript payloads (`AssetMode.INLINE` only) |
+| `styles` | `list[str]` | Inline CSS payloads (`AssetMode.INLINE` only) |
+| `runtime_injected` | `bool` | Whether the pyjinhx client runtime was scheduled |
+
+### Methods
+
+##### manifest()
+
+```python
+def manifest(*, resolver: AssetUrlResolver) -> AssetManifest
+```
+
+Return resolved stylesheet and script URLs for assets collected in this session.

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -14,7 +14,7 @@ components/ui/
 └── my-widget.css     # Auto-collected CSS
 ```
 
-Assets are automatically injected when the component renders — CSS as `<style>` tags before the HTML, JavaScript as `<script>` tags after.
+Assets are automatically injected when the component renders. The default mode inlines them as `<style>` and `<script>` tags.
 
 ### Naming Convention
 
@@ -33,15 +33,64 @@ Assets are collected once per render session. If the same component type is rend
 Rendered output follows this structure:
 
 ```html
-<style>/* component CSS */</style>
+<style>/* component CSS — INLINE mode */</style>
+<link rel="stylesheet" href="...">  <!-- REFERENCE mode -->
 <div id="root-component">...</div>
-<script>/* component JS */</script>
+<script>/* component JS — INLINE mode */</script>
+<script src="..."></script>           <!-- REFERENCE mode -->
 ```
 
 - **CSS** is injected **before** the HTML (styles apply immediately)
 - **JS** is injected **after** the HTML (DOM elements exist when scripts run)
-- Each component gets its own `<script>` and `<style>` tag (a syntax error in one script doesn't break others)
 - Nested component assets are aggregated and injected at the root level
+
+## Asset Delivery Modes
+
+Configure how assets are delivered with `AssetMode`:
+
+| Mode | CSS | JS | Use case |
+|------|-----|----|----------|
+| `INLINE` (default) | `<style>` | inline `<script>` | Zero-config demos |
+| `REFERENCE` | `<link href>` | `<script src>` | Production monoliths with static file serving |
+| `NONE` | silence | silence | Manual static wiring (legacy `inline=False`) |
+
+```python
+from pyjinhx import AssetMode, Renderer
+
+Renderer.set_default_js_mode(AssetMode.REFERENCE)
+Renderer.set_default_css_mode(AssetMode.REFERENCE)
+Renderer.set_asset_url_resolver(lambda path: f"/static/{path}")
+```
+
+When `REFERENCE` mode is active, co-located assets and `js`/`css` fields are collected into a per-render manifest and emitted as URL tags. Override the default URL builder with `Renderer.set_asset_url_resolver()`.
+
+### Reactive partial suppression
+
+Full-page renders emit assets once at the layout root. Reactive partial responses (`render(..., mounted=...)`) and OOB swaps **never** re-ship assets — matching production expectations where the layout shell loads static files once.
+
+### Client asset dedup (REFERENCE mode, opt-in)
+
+On HTMX requests, `pjx.js` reports asset URLs already in the DOM via the `X-PJX-Assets` header. When dedup is enabled, root renders emit only missing `<link>` / `<script src>` tags — useful for hx-boost full-page swaps.
+
+```python
+Renderer.set_default_asset_dedup(True)
+
+@app.get("/page-b")
+def page_b(request: Request):
+    return str(PageB(id="app").render(client=request))
+```
+
+Partial renders ignore the asset header (no assets emitted). Dedup defaults to **off** for backward compatibility.
+
+### Client runtime (`pjx.js`)
+
+In `REFERENCE` mode, layout components (`base_layout=True`) emit `<script src="/static/pyjinhx/pjx.js">` instead of inlining the runtime. Mount the packaged file from `pyjinhx/runtime/pjx.js` or override with `Renderer.set_default_runtime_url()`.
+
+For raw Jinja shells, use `client_script(mode=AssetMode.REFERENCE)`.
+
+### CSP
+
+`REFERENCE` mode avoids inline scripts entirely — compatible with strict `script-src` policies without nonce plumbing.
 
 ## Extra Asset Files
 
@@ -59,22 +108,55 @@ widget = MyWidget(
 !!! warning
     Missing files emit a warning via the `pyjinhx` logger. Check your logs if assets aren't appearing.
 
-## Disabling Inline Assets
+## Per-Render Manifest
 
-To serve assets statically instead of inlining them:
+Inspect which assets a render used:
 
 ```python
-from pyjinhx import Renderer
+from pyjinhx import asset_manifest, make_default_asset_url_resolver
 
-Renderer.set_default_inline_js(False)
-Renderer.set_default_inline_css(False)
+resolver = make_default_asset_url_resolver("./components")
+manifest = asset_manifest(session, resolver=resolver)
+# manifest.stylesheets, manifest.scripts
 ```
 
-When disabled:
+## Layout Preload (All Components)
 
-- No `<script>` or `<style>` tags are injected
-- The `js` and `css` fields are ignored
-- Use `Finder.collect_javascript_files()` and `Finder.collect_css_files()` to discover files for static serving
+Ship every component asset from the layout shell instead of per-page discovery:
+
+```python
+from pyjinhx import Finder, layout_asset_tags, make_default_asset_url_resolver
+
+finder = Finder(root="./components")
+resolver = make_default_asset_url_resolver("./components")
+head_tags = layout_asset_tags(finder, resolver=resolver)
+```
+
+Combine with `AssetMode.REFERENCE` and reactive partial suppression so HTMX swaps never re-ship assets.
+
+## Cache-Busting
+
+Embed content hashes in filenames:
+
+```python
+from pyjinhx import hashed_filename, resolver_with_hash
+
+hashed_filename("components/ui/button.js")  # button.a1b2c3d4.js
+resolver = resolver_with_hash("/static/components", root="./components")
+```
+
+## Disabling Assets (`NONE` mode)
+
+```python
+from pyjinhx import AssetMode, Renderer
+
+Renderer.set_default_js_mode(AssetMode.NONE)
+Renderer.set_default_css_mode(AssetMode.NONE)
+```
+
+Legacy bool shims still work: `Renderer.set_default_inline_js(False)`.
+
+When disabled, no asset tags are emitted. Use `Finder.collect_javascript_files()` and `Finder.collect_css_files()` to discover files for fully manual static serving.
 
 ## Static File Serving
 
@@ -92,34 +174,37 @@ css_files = finder.collect_css_files(relative_to_root=True)
 # ['ui/button.css', 'ui/dropdown.css', ...]
 ```
 
-### Example: FastAPI Static Files
+### Example: FastAPI with REFERENCE mode
 
 ```python
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from pyjinhx import Finder
+from pyjinhx import AssetMode, Finder, Renderer, make_default_asset_url_resolver
 
 app = FastAPI()
 app.mount("/static/components", StaticFiles(directory="components"), name="components")
+app.mount(
+    "/static/pyjinhx",
+    StaticFiles(directory="path/to/pyjinhx/runtime"),
+    name="pyjinhx",
+)
 
-finder = Finder(root="./components")
-js_files = finder.collect_javascript_files(relative_to_root=True)
-css_files = finder.collect_css_files(relative_to_root=True)
+Renderer.set_default_js_mode(AssetMode.REFERENCE)
+Renderer.set_default_css_mode(AssetMode.REFERENCE)
+Renderer.set_asset_url_resolver(make_default_asset_url_resolver("components"))
 
 @app.get("/")
 def index():
-    styles = "\n".join(
-        f'<link rel="stylesheet" href="/static/components/{css}">'
-        for css in css_files
-    )
-    scripts = "\n".join(
-        f'<script src="/static/components/{js}"></script>'
-        for js in js_files
-    )
-    return f"""
-    <html>
-        <head>{styles}</head>
-        <body>...{scripts}</body>
-    </html>
-    """
+    return str(MyApp(id="app").render())  # emits link/script refs for used components
 ```
+
+### Example: Django
+
+```python
+from django.templatetags.static import static
+from pyjinhx import Renderer
+
+Renderer.set_asset_url_resolver(lambda path: static(path_relative_to_static_root(path)))
+```
+
+Map each absolute asset path to your `{% static %}` URL in the resolver callback.

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -113,7 +113,7 @@ Each component gets its own `<script>`/`<style>` tag (errors in one don't break 
 widget = MyWidget(id="w1", js=["path/to/extra.js"], css=["path/to/theme.css"])
 ```
 
-Missing extra files emit a warning (check `pyjinhx` logger). Disable inline assets with `Renderer.set_default_inline_js(False)` / `Renderer.set_default_inline_css(False)`. Use `Finder(root).collect_javascript_files()` / `Finder(root).collect_css_files()` for static serving.
+Missing extra files emit a warning (check `pyjinhx` logger). For production, use `AssetMode.REFERENCE` with `Renderer.set_asset_url_resolver()`. Disable assets with `AssetMode.NONE` or legacy `Renderer.set_default_inline_js(False)` / `Renderer.set_default_inline_css(False)`. Use `Finder(root).collect_javascript_files()` / `Finder(root).collect_css_files()` or `layout_asset_tags()` for layout preload.
 
 **Kebab vs snake for co-located assets:** `pascal_case_to_kebab_case(ClassName) + ".js"|".css"` (e.g. `TabGroup` → `tab-group.js`, `LoadingOverlay` → `loading-overlay.js`). Wrong stem (e.g. `tab_group.js`) is **not** collected.
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -76,8 +76,14 @@ from pyjinhx import client_script
 </body>
 ```
 
-The runtime attaches a manifest of mounted regions to every htmx request via the
-`X-PJX-Mounted` header.
+The runtime attaches two client manifests to every htmx request:
+
+| Header | Purpose |
+|--------|---------|
+| `X-PJX-Mounted` | Reactive regions currently in the DOM (`id`, `type`, `hash`, optional `key`) |
+| `X-PJX-Assets` | URLs of `<script src>` and `<link rel="stylesheet">` already loaded |
+
+Use `mounted=request` for reactive partials. For boosted full-page routes in REFERENCE mode, pass `client=request` and enable `Renderer.set_default_asset_dedup(True)` so root renders skip assets the browser already has.
 
 ## 3. Emit OOB swaps from your route
 

--- a/examples/reactive_todo/app.py
+++ b/examples/reactive_todo/app.py
@@ -8,6 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[2]))
 import uvicorn
 from fastapi import FastAPI, Form, Request
 from fastapi.responses import HTMLResponse
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from examples.reactive_todo import store
 from examples.reactive_todo.components import (
@@ -27,6 +28,17 @@ Renderer.set_default_environment(Path(__file__).resolve().parents[2])
 app = FastAPI(title="pyjinhx reactive todo demo")
 
 
+class RegistryScopeMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        with Registry.request_scope(
+            load_context=TodoLoadContext(store=store),
+        ):
+            return await call_next(request)
+
+
+app.add_middleware(RegistryScopeMiddleware)
+
+
 def _item(todo: store.Todo) -> TodoItem:
     return TodoItem(
         id=f"todo-{todo.id}", todo_id=todo.id, text=todo.text, done=todo.done
@@ -42,42 +54,37 @@ def _list() -> TodoList:
 
 @app.get("/", response_class=HTMLResponse)
 def index() -> str:
-    with Registry.request_scope(load_context=TodoLoadContext(store=store)):
-        return TodoApp(
-            id="todo-app",
-            todo_list=_list(),
-            counter=TodoCounter.load(),
-            total=TodoTotal.load(),
-            clear_button=TodoClearButton.load(),
-        ).render()
+    return TodoApp(
+        id="todo-app",
+        todo_list=_list(),
+        counter=TodoCounter.load(),
+        total=TodoTotal.load(),
+        clear_button=TodoClearButton.load(),
+    ).render()
 
 
 @app.post("/todos", response_class=HTMLResponse)
 def add(request: Request, text: str = Form(...)) -> str:
-    with Registry.request_scope(load_context=TodoLoadContext(store=store)):
-        store.add(text)
-        return TodoItemRow.render(store.all_todos()[-1].id, mounted=request)
+    store.add(text)
+    return TodoItemRow.render(store.all_todos()[-1].id, mounted=request)
 
 
 @app.post("/rows/{todo_id}/toggle", response_class=HTMLResponse)
 def toggle_row(request: Request, todo_id: int) -> str:
-    with Registry.request_scope(load_context=TodoLoadContext(store=store)):
-        store.toggle(todo_id)
-        return TodoItemRow.render(todo_id, mounted=request)
+    store.toggle(todo_id)
+    return TodoItemRow.render(todo_id, mounted=request)
 
 
 @app.post("/todos/{todo_id}/toggle", response_class=HTMLResponse)
 def toggle(request: Request, todo_id: int) -> str:
-    with Registry.request_scope(load_context=TodoLoadContext(store=store)):
-        todo = store.toggle(todo_id)
-        return _item(todo).render(mounted=request)
+    todo = store.toggle(todo_id)
+    return _item(todo).render(mounted=request)
 
 
 @app.post("/todos/clear-completed", response_class=HTMLResponse)
 def clear_completed(request: Request) -> str:
-    with Registry.request_scope(load_context=TodoLoadContext(store=store)):
-        store.clear_completed()
-        return _list().render(mounted=request)
+    store.clear_completed()
+    return _list().render(mounted=request)
 
 
 if __name__ == "__main__":

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -1,16 +1,29 @@
+from .assets import (
+    AssetManifest,
+    AssetMode,
+    DEFAULT_RUNTIME_URL,
+    asset_manifest,
+    default_asset_url,
+    hashed_filename,
+    make_default_asset_url_resolver,
+    resolver_with_hash,
+    runtime_asset_path,
+)
 from .base import BaseComponent
 from .cache import invalidate
 from .dataclasses import Tag
-from .finder import Finder
+from .finder import Finder, layout_asset_tags
 from .keys import StateKey, dirty_keys, instance_key
 from .load_context import LoadContext, get_load_context, load_scope
 from .mutations import mutates, mutation_scope
 from .parser import Parser
 from .reactive import (
+    PJX_ASSETS_HEADER,
     PJX_MOUNTED_HEADER,
     ReactiveComponent,
     client_script,
     oob_swaps,
+    parse_loaded_assets,
 )
 from .reactive_dev import (
     dependency_graph,
@@ -19,12 +32,15 @@ from .reactive_dev import (
     format_dependency_graph,
 )
 from .registry import Registry
-from .renderer import Renderer
+from .renderer import Renderer, RenderSession
 
 __all__ = [
+    "AssetManifest",
+    "AssetMode",
     "BaseComponent",
     "ReactiveComponent",
     "Renderer",
+    "RenderSession",
     "Finder",
     "Parser",
     "Registry",
@@ -33,6 +49,8 @@ __all__ = [
     "invalidate",
     "client_script",
     "PJX_MOUNTED_HEADER",
+    "PJX_ASSETS_HEADER",
+    "parse_loaded_assets",
     "StateKey",
     "instance_key",
     "dirty_keys",
@@ -45,4 +63,12 @@ __all__ = [
     "disable_reactive_dev",
     "dependency_graph",
     "format_dependency_graph",
+    "DEFAULT_RUNTIME_URL",
+    "asset_manifest",
+    "default_asset_url",
+    "hashed_filename",
+    "layout_asset_tags",
+    "make_default_asset_url_resolver",
+    "resolver_with_hash",
+    "runtime_asset_path",
 ]

--- a/pyjinhx/assets.py
+++ b/pyjinhx/assets.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Literal
+
+AssetKind = Literal["js", "css"]
+AssetUrlResolver = Callable[[str], str]
+
+DEFAULT_RUNTIME_URL = "/static/pyjinhx/pjx.js"
+DEFAULT_STATIC_PREFIX = "/static/components"
+
+
+class AssetMode(str, Enum):
+    INLINE = "inline"
+    REFERENCE = "reference"
+    NONE = "none"
+
+
+@dataclass
+class CollectedAsset:
+    path: str
+    kind: AssetKind
+
+
+@dataclass
+class RenderSession:
+    """
+    Per-render state for asset aggregation and deduplication.
+
+    Attributes:
+        assets: Ordered, deduplicated asset paths collected during rendering.
+        collected_paths: Set of normalized paths already processed.
+        scripts: Inline JavaScript payloads (INLINE mode only).
+        styles: Inline CSS payloads (INLINE mode only).
+        runtime_injected: Whether the pyjinhx client runtime was scheduled.
+    """
+
+    assets: list[CollectedAsset] = field(default_factory=list)
+    collected_paths: set[str] = field(default_factory=set)
+    scripts: list[str] = field(default_factory=list)
+    styles: list[str] = field(default_factory=list)
+    runtime_injected: bool = False
+
+
+    def manifest(self, *, resolver: AssetUrlResolver) -> AssetManifest:
+        return asset_manifest(self, resolver=resolver)
+
+
+@dataclass(frozen=True)
+class AssetManifest:
+    stylesheets: tuple[str, ...]
+    scripts: tuple[str, ...]
+
+
+def runtime_asset_path() -> str:
+    """Return the absolute path to the bundled pyjinhx client runtime."""
+    return os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "runtime", "pjx.js")
+    )
+
+
+def asset_mode_from_inline(inline: bool) -> AssetMode:
+    return AssetMode.INLINE if inline else AssetMode.NONE
+
+
+def default_asset_url(path: str, *, kind: AssetKind, root: str) -> str:
+    normalized_path = os.path.normpath(path)
+    if normalized_path == os.path.normpath(runtime_asset_path()):
+        return DEFAULT_RUNTIME_URL
+    relative_path = os.path.relpath(normalized_path, root).replace("\\", "/")
+    return f"{DEFAULT_STATIC_PREFIX}/{relative_path}"
+
+
+def make_default_asset_url_resolver(root: str) -> AssetUrlResolver:
+    def resolve(path: str) -> str:
+        kind: AssetKind = "css" if path.lower().endswith(".css") else "js"
+        return default_asset_url(path, kind=kind, root=root)
+
+    return resolve
+
+
+def hashed_filename(path: str, *, hash_len: int = 8) -> str:
+    """Return a cache-busted filename such as ``button.a1b2c3d4.js``."""
+    with open(path, "rb") as asset_file:
+        digest = hashlib.sha256(asset_file.read()).hexdigest()[:hash_len]
+    base_name, extension = os.path.splitext(os.path.basename(path))
+    return f"{base_name}.{digest}{extension}"
+
+
+def resolver_with_hash(base_url: str, root: str) -> AssetUrlResolver:
+    """Build an asset URL resolver that embeds a content hash in each filename."""
+
+    def resolve(path: str) -> str:
+        normalized_path = os.path.normpath(path)
+        if normalized_path == os.path.normpath(runtime_asset_path()):
+            hashed = hashed_filename(normalized_path)
+            return f"{base_url.rstrip('/')}/pyjinhx/{hashed}"
+        relative_dir = os.path.relpath(
+            os.path.dirname(normalized_path), root
+        ).replace("\\", "/")
+        hashed = hashed_filename(normalized_path)
+        if relative_dir == ".":
+            return f"{base_url.rstrip('/')}/{hashed}"
+        return f"{base_url.rstrip('/')}/{relative_dir}/{hashed}"
+
+    return resolve
+
+
+def asset_manifest(
+    session: RenderSession,
+    *,
+    resolver: AssetUrlResolver,
+) -> AssetManifest:
+    stylesheets: list[str] = []
+    scripts: list[str] = []
+    for asset in session.assets:
+        url = resolver(asset.path)
+        if asset.kind == "css":
+            stylesheets.append(url)
+        else:
+            scripts.append(url)
+    return AssetManifest(
+        stylesheets=tuple(stylesheets),
+        scripts=tuple(scripts),
+    )

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -5,7 +5,8 @@ from markupsafe import Markup
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .registry import Registry
-from .renderer import Renderer, RenderSession
+from .renderer import Renderer
+from .assets import RenderSession
 from .utils import ReactiveKey, coerce_reactive_keys
 
 logger = logging.getLogger("pyjinhx")
@@ -145,6 +146,8 @@ class BaseComponent(BaseModel):
         _renderer: Renderer | None = None,
         _session: RenderSession | None = None,
         _template_path: str | None = None,
+        emit_assets: bool = True,
+        client: object | None = None,
     ) -> Markup:
         renderer = _renderer or Renderer.get_default_renderer()
 
@@ -166,6 +169,14 @@ class BaseComponent(BaseModel):
                 session=session,
             )
 
+        from .reactive import parse_loaded_assets
+
+        loaded_assets = (
+            parse_loaded_assets(client)
+            if client is not None and emit_assets
+            else frozenset()
+        )
+
         return renderer.render_component_with_context(
             self,
             context=context,
@@ -174,6 +185,8 @@ class BaseComponent(BaseModel):
             session=session,
             is_root=is_root,
             collect_component_js=source is None,
+            emit_assets=emit_assets,
+            loaded_assets=loaded_assets,
         )
 
     def render(
@@ -181,6 +194,7 @@ class BaseComponent(BaseModel):
         *,
         dirtied: set[ReactiveKey] | None = None,
         mounted: object | None = None,
+        client: object | None = None,
     ) -> Markup:
         """
         Render this component to HTML using its associated Jinja template.
@@ -204,12 +218,14 @@ class BaseComponent(BaseModel):
                 primary's ``reacts_to``. Enables reactive mode.
             mounted: The client manifest — a request-like object, the raw header string,
                 a parsed list, or ``None``. Enables reactive mode.
+            client: Request-like object (or raw ``X-PJX-Assets`` JSON) for REFERENCE-mode
+                asset dedup on root renders. Pass ``request`` on boosted full-page routes.
 
         Returns:
             The rendered HTML as a Markup object (safe for direct use in templates).
         """
         if dirtied is None and mounted is None:
-            return self._render()
+            return self._render(client=client)
 
         from .mutations import (
             mark_reactive_render_consumed,
@@ -223,7 +239,7 @@ class BaseComponent(BaseModel):
             dirtied=dirtied, mounted=mounted, own_keys=own_keys
         )
 
-        primary = self._render()
+        primary = self._render(emit_assets=False)
         effective_dirtied = resolve_effective_dirtied(
             dirtied=dirtied,
             mounted=mounted,

--- a/pyjinhx/finder.py
+++ b/pyjinhx/finder.py
@@ -3,6 +3,9 @@ import os
 from dataclasses import dataclass, field
 
 from jinja2 import FileSystemLoader
+from markupsafe import Markup
+
+from .assets import AssetUrlResolver
 
 from .utils import (
     detect_root_directory,
@@ -246,3 +249,17 @@ class Finder:
             A deterministic, sorted list of `.css` file paths (directories and file names are walked in sorted order).
         """
         return self._collect_files_by_extension(".css", relative_to_root)
+
+
+def layout_asset_tags(
+    finder: Finder,
+    *,
+    resolver: AssetUrlResolver,
+) -> Markup:
+    """Return link/script tags for every component asset under ``finder.root``."""
+    lines: list[str] = []
+    for css_path in finder.collect_css_files():
+        lines.append(f'<link rel="stylesheet" href="{resolver(css_path)}">')
+    for js_path in finder.collect_javascript_files():
+        lines.append(f'<script src="{resolver(js_path)}"></script>')
+    return Markup("\n".join(lines))

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -16,6 +16,7 @@ from pydantic import ConfigDict, PrivateAttr, model_validator
 from .base import BaseComponent
 from .cache import invalidate
 from .registry import Registry
+from .assets import AssetMode, DEFAULT_RUNTIME_URL
 from .renderer import Renderer
 from .utils import (
     ReactiveKey,
@@ -31,6 +32,9 @@ logger = logging.getLogger("pyjinhx")
 
 PJX_MOUNTED_HEADER = "X-PJX-Mounted"
 """Name of the HTTP header carrying the client's mounted-region manifest."""
+
+PJX_ASSETS_HEADER = "X-PJX-Assets"
+"""Name of the HTTP header carrying asset URLs already loaded in the browser."""
 
 
 def _load_param_count(func: Any) -> int:
@@ -48,15 +52,29 @@ def _load_param_count(func: Any) -> int:
     )
 
 
-def client_script() -> Markup:
+def client_script(
+    *,
+    mode: AssetMode | None = None,
+    src: str | None = None,
+) -> Markup:
     """
-    Return the pyjinhx client runtime wrapped in a ``<script>`` tag.
+    Return the pyjinhx client runtime as a ``<script>`` tag.
 
     Drop this into a page shell (e.g. a raw Jinja layout) to emit the
     ``X-PJX-Mounted`` manifest header on every htmx request. When the page shell
     is marked ``base_layout=True`` the runtime is injected automatically and you
     do not need to call this.
+
+    Args:
+        mode: ``AssetMode.INLINE`` (default) inlines the runtime source.
+            ``AssetMode.REFERENCE`` emits ``<script src="...">``.
+        src: Public URL for the runtime when ``mode`` is ``AssetMode.REFERENCE``.
+            Defaults to ``Renderer``'s configured runtime URL.
     """
+    effective_mode = mode or AssetMode.INLINE
+    if effective_mode == AssetMode.REFERENCE:
+        runtime_url = src or Renderer._default_runtime_url or DEFAULT_RUNTIME_URL
+        return Markup(f'<script src="{runtime_url}"></script>')
     return Markup(f"<script>{read_client_runtime()}</script>")
 
 
@@ -119,7 +137,7 @@ class _ReactiveRender:
         )
         invalidate(effective_dirtied | own_keys)
         instance = cls.load(skey) if keyed else cls.load()
-        primary = instance._render()
+        primary = instance._render(emit_assets=False)
         mark_reactive_render_consumed()
         swaps = oob_swaps(effective_dirtied, mounted, exclude_ids={instance.id})
         return Markup(primary) + swaps
@@ -243,6 +261,37 @@ def _parse_mounted(
     return _parse_mounted(header_value)
 
 
+def parse_loaded_assets(
+    client: str | list[str] | object | None,
+) -> frozenset[str]:
+    """
+    Parse the client-reported list of asset URLs already loaded in the browser.
+
+    Accepts a request-like object (``headers.get``), a raw JSON string, a parsed
+    list of URLs, or ``None``/``""`` (treated as nothing loaded for dedup purposes).
+    """
+    if client is None or client == "":
+        return frozenset()
+    if isinstance(client, (list, tuple, set, frozenset)):
+        return frozenset(str(url) for url in client)
+    if isinstance(client, str):
+        try:
+            parsed = json.loads(client)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Could not parse %s as JSON; ignoring.", PJX_ASSETS_HEADER
+            )
+            return frozenset()
+        if isinstance(parsed, list):
+            return frozenset(str(url) for url in parsed)
+        return frozenset()
+    try:
+        header_value = client.headers.get(PJX_ASSETS_HEADER)
+    except AttributeError:
+        return frozenset()
+    return parse_loaded_assets(header_value)
+
+
 def _drop_nested(candidates: list[_Candidate]) -> list[_Candidate]:
     """
     Drop any candidate whose data-pjx-id marker appears inside another candidate's
@@ -304,7 +353,7 @@ def oob_swaps(
         return Markup("")
 
     classes = Registry.get_classes()
-    renderer = Renderer.get_default_renderer(inline_js=False, inline_css=False)
+    renderer = Renderer.get_default_renderer()
 
     candidates: list[_Candidate] = []
     seen: set[tuple[str, str | None]] = set()
@@ -345,7 +394,7 @@ def oob_swaps(
 
         instance = component_class.load(skey) if keyed else component_class.load()
         instance.id = component_id
-        html = str(instance._render(_renderer=renderer))
+        html = str(instance._render(_renderer=renderer, emit_assets=False))
         candidates.append(
             _Candidate(
                 id=component_id,

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -5,13 +5,23 @@ import logging
 import os
 import re
 import uuid
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from jinja2 import Environment, FileSystemLoader, Template
 from jinja2.exceptions import TemplateNotFound
 from markupsafe import Markup
 
+from .assets import (
+    DEFAULT_RUNTIME_URL as _DEFAULT_RUNTIME_URL,
+    AssetKind,
+    AssetMode,
+    AssetUrlResolver,
+    CollectedAsset,
+    RenderSession,
+    asset_mode_from_inline,
+    make_default_asset_url_resolver,
+    runtime_asset_path,
+)
 from .dataclasses import Tag
 from .finder import Finder
 from .parser import Parser
@@ -80,23 +90,8 @@ def _try_autodiscover_for_tag(tag_name: str, template_path: str | None) -> None:
         pass
 
 
-@dataclass
-class RenderSession:
-    """
-    Per-render state for asset aggregation and deduplication.
-
-    Attributes:
-        scripts: Collected JavaScript code snippets to inject.
-        collected_js_files: Set of JS file paths already processed (for deduplication).
-        styles: Collected CSS code snippets to inject.
-        collected_css_files: Set of CSS file paths already processed (for deduplication).
-    """
-
-    scripts: list[str] = field(default_factory=list)
-    collected_js_files: set[str] = field(default_factory=set)
-    styles: list[str] = field(default_factory=list)
-    collected_css_files: set[str] = field(default_factory=set)
-    runtime_injected: bool = False
+def _normalize_asset_path(path: str) -> str:
+    return os.path.normpath(path).replace("\\", "/")
 
 
 class Renderer:
@@ -117,6 +112,8 @@ class Renderer:
         auto_id: bool = True,
         inline_js: bool | None = None,
         inline_css: bool | None = None,
+        js_mode: AssetMode | None = None,
+        css_mode: AssetMode | None = None,
     ) -> None:
         """
         Initialize a Renderer with the given Jinja environment.
@@ -124,25 +121,36 @@ class Renderer:
         Args:
             environment: The Jinja2 Environment to use for template rendering.
             auto_id: If True (default), generate UUIDs for components without explicit IDs.
-            inline_js: If True, JavaScript is collected and injected as <script> tags.
-                If False, no scripts are injected. Defaults to the class-level setting.
-            inline_css: If True, CSS is collected and injected as <style> tags.
-                If False, no styles are injected. Defaults to the class-level setting.
+            inline_js: Deprecated bool shim; maps to INLINE or NONE for JavaScript.
+            inline_css: Deprecated bool shim; maps to INLINE or NONE for CSS.
+            js_mode: How JavaScript assets are delivered. Defaults to the class-level setting.
+            css_mode: How CSS assets are delivered. Defaults to the class-level setting.
         """
         self._environment = environment
         self._auto_id = auto_id
-        self._inline_js = (
-            inline_js if inline_js is not None else Renderer._default_inline_js
-        )
-        self._inline_css = (
-            inline_css if inline_css is not None else Renderer._default_inline_css
-        )
+        if js_mode is not None:
+            self._js_mode = js_mode
+        elif inline_js is not None:
+            self._js_mode = asset_mode_from_inline(inline_js)
+        else:
+            self._js_mode = Renderer._default_js_mode
+        if css_mode is not None:
+            self._css_mode = css_mode
+        elif inline_css is not None:
+            self._css_mode = asset_mode_from_inline(inline_css)
+        else:
+            self._css_mode = Renderer._default_css_mode
         self._template_finder_cache: dict[str, Finder] = {}
 
     _default_environment: ClassVar[Environment | None] = None
-    _default_inline_js: ClassVar[bool] = True
-    _default_inline_css: ClassVar[bool] = True
-    _default_renderers: ClassVar[dict[tuple[int, bool, bool, bool], "Renderer"]] = {}
+    _default_js_mode: ClassVar[AssetMode] = AssetMode.INLINE
+    _default_css_mode: ClassVar[AssetMode] = AssetMode.INLINE
+    _default_runtime_url: ClassVar[str] = _DEFAULT_RUNTIME_URL
+    _asset_url_resolver: ClassVar[AssetUrlResolver | None] = None
+    _default_asset_dedup: ClassVar[bool] = False
+    _default_renderers: ClassVar[
+        dict[tuple[int, bool, AssetMode, AssetMode, int], "Renderer"]
+    ] = {}
 
     @classmethod
     def peek_default_environment(cls) -> Environment | None:
@@ -174,16 +182,27 @@ class Renderer:
         cls._default_renderers.clear()
 
     @classmethod
+    def set_default_js_mode(cls, mode: AssetMode) -> None:
+        """Set the process-wide default JavaScript asset delivery mode."""
+        cls._default_js_mode = mode
+        cls._default_renderers.clear()
+
+    @classmethod
+    def set_default_css_mode(cls, mode: AssetMode) -> None:
+        """Set the process-wide default CSS asset delivery mode."""
+        cls._default_css_mode = mode
+        cls._default_renderers.clear()
+
+    @classmethod
     def set_default_inline_js(cls, inline_js: bool) -> None:
         """
         Set the process-wide default for inline JavaScript injection.
 
         Args:
             inline_js: If True (default), JavaScript is collected and injected as <script> tags.
-                If False, no scripts are injected. Use Finder.collect_javascript_files() for static serving.
+                If False, no scripts are injected. Use AssetMode.REFERENCE for URL tags.
         """
-        cls._default_inline_js = inline_js
-        cls._default_renderers.clear()
+        cls.set_default_js_mode(asset_mode_from_inline(inline_js))
 
     @classmethod
     def set_default_inline_css(cls, inline_css: bool) -> None:
@@ -192,10 +211,26 @@ class Renderer:
 
         Args:
             inline_css: If True (default), CSS is collected and injected as <style> tags.
-                If False, no styles are injected. Use Finder.collect_css_files() for static serving.
+                If False, no styles are injected. Use AssetMode.REFERENCE for URL tags.
         """
-        cls._default_inline_css = inline_css
+        cls.set_default_css_mode(asset_mode_from_inline(inline_css))
+
+    @classmethod
+    def set_default_runtime_url(cls, url: str) -> None:
+        """Set the public URL used for the pyjinhx client runtime in REFERENCE mode."""
+        cls._default_runtime_url = url
         cls._default_renderers.clear()
+
+    @classmethod
+    def set_asset_url_resolver(cls, resolver: AssetUrlResolver | None) -> None:
+        """Set the callable that maps absolute asset paths to public URLs."""
+        cls._asset_url_resolver = resolver
+        cls._default_renderers.clear()
+
+    @classmethod
+    def set_default_asset_dedup(cls, enabled: bool) -> None:
+        """Enable filtering of REFERENCE assets already reported by the client."""
+        cls._default_asset_dedup = enabled
 
     @classmethod
     def get_default_environment(cls) -> Environment:
@@ -219,40 +254,56 @@ class Renderer:
         auto_id: bool = True,
         inline_js: bool | None = None,
         inline_css: bool | None = None,
+        js_mode: AssetMode | None = None,
+        css_mode: AssetMode | None = None,
     ) -> "Renderer":
         """
         Return a cached default renderer instance.
 
         Args:
             auto_id: If True, generate UUIDs for components without explicit IDs.
-            inline_js: If True, JavaScript is collected and injected as <script> tags.
-                If False, no scripts are injected. Defaults to the class-level setting.
-            inline_css: If True, CSS is collected and injected as <style> tags.
-                If False, no styles are injected. Defaults to the class-level setting.
+            inline_js: Deprecated bool shim for JavaScript delivery mode.
+            inline_css: Deprecated bool shim for CSS delivery mode.
+            js_mode: JavaScript asset delivery mode. Defaults to the class-level setting.
+            css_mode: CSS asset delivery mode. Defaults to the class-level setting.
 
         Returns:
-            A Renderer instance cached by (environment identity, auto_id, inline_js, inline_css).
+            A Renderer instance cached by environment identity and asset settings.
         """
         environment = cls.get_default_environment()
-        effective_inline_js = (
-            inline_js if inline_js is not None else cls._default_inline_js
+        effective_js_mode = (
+            js_mode
+            if js_mode is not None
+            else (
+                asset_mode_from_inline(inline_js)
+                if inline_js is not None
+                else cls._default_js_mode
+            )
         )
-        effective_inline_css = (
-            inline_css if inline_css is not None else cls._default_inline_css
+        effective_css_mode = (
+            css_mode
+            if css_mode is not None
+            else (
+                asset_mode_from_inline(inline_css)
+                if inline_css is not None
+                else cls._default_css_mode
+            )
         )
+        resolver_id = id(cls._asset_url_resolver)
         cache_key = (
             id(environment),
             auto_id,
-            effective_inline_js,
-            effective_inline_css,
+            effective_js_mode,
+            effective_css_mode,
+            resolver_id,
         )
         renderer = cls._default_renderers.get(cache_key)
         if renderer is None:
             renderer = Renderer(
                 environment,
                 auto_id=auto_id,
-                inline_js=effective_inline_js,
-                inline_css=effective_inline_css,
+                js_mode=effective_js_mode,
+                css_mode=effective_css_mode,
             )
             cls._default_renderers[cache_key] = renderer
         return renderer
@@ -266,6 +317,16 @@ class Renderer:
             The Jinja Environment instance.
         """
         return self._environment
+
+    def _resolve_asset_url(self, path: str) -> str:
+        normalized_path = _normalize_asset_path(path)
+        if normalized_path == _normalize_asset_path(runtime_asset_path()):
+            return Renderer._default_runtime_url
+        resolver = Renderer._asset_url_resolver
+        if resolver is not None:
+            return resolver(normalized_path)
+        root = self._get_loader_root()
+        return make_default_asset_url_resolver(root)(normalized_path)
 
     def new_session(self) -> RenderSession:
         """
@@ -335,6 +396,38 @@ class Renderer:
             ", ".join(relative_template_paths) if relative_template_paths else "unknown"
         )
 
+    def _register_asset(
+        self,
+        session: RenderSession,
+        path: str,
+        kind: AssetKind,
+        mode: AssetMode,
+    ) -> None:
+        normalized_path = _normalize_asset_path(path)
+        if normalized_path in session.collected_paths:
+            return
+
+        if mode == AssetMode.INLINE:
+            with open(normalized_path, encoding="utf-8") as asset_file:
+                content = asset_file.read()
+            if not content:
+                return
+            if kind == "js":
+                session.scripts.append(content)
+            else:
+                session.styles.append(content)
+        elif mode == AssetMode.REFERENCE:
+            if not os.path.isfile(normalized_path):
+                return
+            with open(normalized_path, encoding="utf-8") as asset_file:
+                if not asset_file.read():
+                    return
+        else:
+            return
+
+        session.collected_paths.add(normalized_path)
+        session.assets.append(CollectedAsset(path=normalized_path, kind=kind))
+
     def _collect_component_javascript(
         self,
         component: "BaseComponent",
@@ -343,6 +436,9 @@ class Renderer:
         component_dir: str | None = None,
         asset_name: str | None = None,
     ) -> None:
+        if self._js_mode == AssetMode.NONE:
+            return
+
         component_directory = component_dir or Finder.get_class_directory(
             type(component)
         )
@@ -354,23 +450,16 @@ class Renderer:
         if not javascript_path:
             return
 
-        if javascript_path in session.collected_js_files:
-            return
-
-        with open(javascript_path, "r") as file:
-            javascript_content = file.read()
-
-        if not javascript_content:
-            return
-
-        session.scripts.append(javascript_content)
-        session.collected_js_files.add(javascript_path)
+        self._register_asset(session, javascript_path, "js", self._js_mode)
 
     def _collect_extra_javascript(
         self, component: "BaseComponent", session: RenderSession
     ) -> None:
+        if self._js_mode == AssetMode.NONE:
+            return
+
         for javascript_path in component.js:
-            normalized_path = os.path.normpath(javascript_path).replace("\\", "/")
+            normalized_path = _normalize_asset_path(javascript_path)
             if not os.path.exists(normalized_path):
                 logger.warning(
                     "Extra JS file not found: %s (component %s, id=%s)",
@@ -379,14 +468,7 @@ class Renderer:
                     component.id,
                 )
                 continue
-            if normalized_path in session.collected_js_files:
-                continue
-            with open(normalized_path, "r") as file:
-                javascript_content = file.read()
-            if not javascript_content:
-                continue
-            session.scripts.append(javascript_content)
-            session.collected_js_files.add(normalized_path)
+            self._register_asset(session, normalized_path, "js", self._js_mode)
 
     def _collect_component_css(
         self,
@@ -396,6 +478,9 @@ class Renderer:
         component_dir: str | None = None,
         asset_name: str | None = None,
     ) -> None:
+        if self._css_mode == AssetMode.NONE:
+            return
+
         component_directory = component_dir or Finder.get_class_directory(
             type(component)
         )
@@ -405,23 +490,16 @@ class Renderer:
         if not css_path:
             return
 
-        if css_path in session.collected_css_files:
-            return
-
-        with open(css_path, "r") as file:
-            css_content = file.read()
-
-        if not css_content:
-            return
-
-        session.styles.append(css_content)
-        session.collected_css_files.add(css_path)
+        self._register_asset(session, css_path, "css", self._css_mode)
 
     def _collect_extra_css(
         self, component: "BaseComponent", session: RenderSession
     ) -> None:
+        if self._css_mode == AssetMode.NONE:
+            return
+
         for css_path in component.css:
-            normalized_path = os.path.normpath(css_path).replace("\\", "/")
+            normalized_path = _normalize_asset_path(css_path)
             if not os.path.exists(normalized_path):
                 logger.warning(
                     "Extra CSS file not found: %s (component %s, id=%s)",
@@ -430,28 +508,93 @@ class Renderer:
                     component.id,
                 )
                 continue
-            if normalized_path in session.collected_css_files:
-                continue
-            with open(normalized_path, "r") as file:
-                css_content = file.read()
-            if not css_content:
-                continue
-            session.styles.append(css_content)
-            session.collected_css_files.add(normalized_path)
+            self._register_asset(session, normalized_path, "css", self._css_mode)
 
-    def _inject_scripts(self, markup: str, session: RenderSession) -> str:
-        if not session.scripts:
-            return markup
-        script_tags = "\n".join(
-            f"<script>{script}</script>" for script in session.scripts
-        )
-        return f"{markup}\n{script_tags}"
+    def _inject_runtime(self, session: RenderSession, component: "BaseComponent") -> None:
+        if session.runtime_injected:
+            return
+        if not getattr(type(component), "_pjx_layout", False):
+            return
+        if self._js_mode == AssetMode.INLINE:
+            session.scripts.insert(0, read_client_runtime())
+        elif self._js_mode == AssetMode.REFERENCE:
+            runtime_path = _normalize_asset_path(runtime_asset_path())
+            if runtime_path not in session.collected_paths:
+                session.collected_paths.add(runtime_path)
+                session.assets.insert(
+                    0, CollectedAsset(path=runtime_path, kind="js")
+                )
+        session.runtime_injected = True
 
-    def _inject_styles(self, markup: str, session: RenderSession) -> str:
-        if not session.styles:
-            return markup
-        style_tags = "\n".join(f"<style>{style}</style>" for style in session.styles)
-        return f"{style_tags}\n{markup}"
+    def _should_emit_reference_url(
+        self, url: str, loaded_assets: frozenset[str]
+    ) -> bool:
+        if not Renderer._default_asset_dedup:
+            return True
+        if not loaded_assets:
+            return True
+        return url not in loaded_assets
+
+    def _inject_assets(
+        self,
+        markup: str,
+        session: RenderSession,
+        *,
+        loaded_assets: frozenset[str] = frozenset(),
+    ) -> str:
+        css_markup = self._render_css_assets(session, loaded_assets=loaded_assets)
+        js_markup = self._render_js_assets(session, loaded_assets=loaded_assets)
+        if css_markup:
+            markup = f"{css_markup}\n{markup}"
+        if js_markup:
+            markup = f"{markup}\n{js_markup}"
+        return markup
+
+    def _render_css_assets(
+        self,
+        session: RenderSession,
+        *,
+        loaded_assets: frozenset[str] = frozenset(),
+    ) -> str:
+        if self._css_mode == AssetMode.INLINE:
+            if not session.styles:
+                return ""
+            return "\n".join(f"<style>{style}</style>" for style in session.styles)
+        if self._css_mode == AssetMode.REFERENCE:
+            css_assets = [asset for asset in session.assets if asset.kind == "css"]
+            if not css_assets:
+                return ""
+            tags: list[str] = []
+            for asset in css_assets:
+                url = self._resolve_asset_url(asset.path)
+                if self._should_emit_reference_url(url, loaded_assets):
+                    tags.append(f'<link rel="stylesheet" href="{url}">')
+            return "\n".join(tags)
+        return ""
+
+    def _render_js_assets(
+        self,
+        session: RenderSession,
+        *,
+        loaded_assets: frozenset[str] = frozenset(),
+    ) -> str:
+        if self._js_mode == AssetMode.INLINE:
+            if not session.scripts:
+                return ""
+            return "\n".join(
+                f"<script>{script}</script>" for script in session.scripts
+            )
+        if self._js_mode == AssetMode.REFERENCE:
+            js_assets = [asset for asset in session.assets if asset.kind == "js"]
+            if not js_assets:
+                return ""
+            tags: list[str] = []
+            for asset in js_assets:
+                url = self._resolve_asset_url(asset.path)
+                if self._should_emit_reference_url(url, loaded_assets):
+                    tags.append(f'<script src="{url}"></script>')
+            return "\n".join(tags)
+        return ""
 
     def _find_template_for_tag(self, tag_name: str) -> str:
         loader_root = self._get_loader_root()
@@ -463,12 +606,16 @@ class Renderer:
         node: Tag | str,
         base_context: dict[str, Any],
         session: RenderSession,
+        *,
+        emit_assets: bool,
     ) -> str:
         if isinstance(node, str):
             return node
 
         rendered_children = "".join(
-            self._render_tag_node(child, base_context=base_context, session=session)
+            self._render_tag_node(
+                child, base_context=base_context, session=session, emit_assets=emit_assets
+            )
             for child in node.children
         ).strip()
 
@@ -509,6 +656,7 @@ class Renderer:
                     _renderer=self,
                     _session=session,
                     _template_path=template_path,
+                    emit_assets=emit_assets,
                 )
             )
 
@@ -551,6 +699,7 @@ class Renderer:
                 _renderer=self,
                 _session=session,
                 _template_path=template_path,
+                emit_assets=emit_assets,
             )
         )
 
@@ -559,6 +708,8 @@ class Renderer:
         markup: str,
         base_context: dict[str, Any],
         session: RenderSession,
+        *,
+        emit_assets: bool,
     ) -> str:
         """
         Expand PascalCase custom tags found inside `markup` by parsing and rendering them into HTML.
@@ -577,7 +728,12 @@ class Renderer:
 
         parser.feed(markup)
         return "".join(
-            self._render_tag_node(node, base_context=base_context, session=session)
+            self._render_tag_node(
+                node,
+                base_context=base_context,
+                session=session,
+                emit_assets=emit_assets,
+            )
             for node in parser.root_nodes
         )
 
@@ -590,6 +746,9 @@ class Renderer:
         session: RenderSession,
         is_root: bool,
         collect_component_js: bool,
+        *,
+        emit_assets: bool = True,
+        loaded_assets: frozenset[str] = frozenset(),
     ) -> Markup:
         template = self._load_template_for_component(
             component, template_source=template_source, template_path=template_path
@@ -604,7 +763,10 @@ class Renderer:
 
         rendered_markup = template.render(render_context)
         rendered_markup = self._expand_custom_tags(
-            rendered_markup, base_context=render_context, session=session
+            rendered_markup,
+            base_context=render_context,
+            session=session,
+            emit_assets=emit_assets,
         )
 
         if getattr(type(component), "_pjx_reactive", False):
@@ -618,6 +780,9 @@ class Renderer:
                 _attrs["data-pjx-key"] = str(_key)
             rendered_markup = stamp_root_attributes(rendered_markup, _attrs)
 
+        if not emit_assets:
+            return Markup(rendered_markup).unescape()
+
         if template_path is not None and type(component).__name__ == "BaseComponent":
             _asset_dir: str | None = os.path.dirname(template_path)
             _asset_name: str | None = os.path.splitext(os.path.basename(template_path))[
@@ -627,29 +792,24 @@ class Renderer:
             _asset_dir = None
             _asset_name = None
 
-        if collect_component_js and self._inline_js:
+        if collect_component_js:
             self._collect_component_javascript(
                 component, session, component_dir=_asset_dir, asset_name=_asset_name
             )
-        if collect_component_js and self._inline_css:
             self._collect_component_css(
                 component, session, component_dir=_asset_dir, asset_name=_asset_name
             )
 
         if is_root:
-            if self._inline_css:
+            if self._css_mode != AssetMode.NONE:
                 self._collect_extra_css(component, session)
-                rendered_markup = self._inject_styles(rendered_markup, session)
-            if (
-                self._inline_js
-                and getattr(type(component), "_pjx_layout", False)
-                and not session.runtime_injected
-            ):
-                session.scripts.insert(0, read_client_runtime())
-                session.runtime_injected = True
-            if self._inline_js:
+            if self._js_mode != AssetMode.NONE:
+                self._inject_runtime(session, component)
                 self._collect_extra_javascript(component, session)
-                rendered_markup = self._inject_scripts(rendered_markup, session)
+            if self._css_mode != AssetMode.NONE or self._js_mode != AssetMode.NONE:
+                rendered_markup = self._inject_assets(
+                    rendered_markup, session, loaded_assets=loaded_assets
+                )
 
         return Markup(rendered_markup).unescape()
 
@@ -673,11 +833,11 @@ class Renderer:
         session = self.new_session()
 
         rendered_markup = "".join(
-            self._render_tag_node(node, base_context={}, session=session)
+            self._render_tag_node(
+                node, base_context={}, session=session, emit_assets=True
+            )
             for node in parser.root_nodes
         )
-        if self._inline_css:
-            rendered_markup = self._inject_styles(rendered_markup, session)
-        if self._inline_js:
-            rendered_markup = self._inject_scripts(rendered_markup, session)
+        if self._css_mode != AssetMode.NONE or self._js_mode != AssetMode.NONE:
+            rendered_markup = self._inject_assets(rendered_markup, session)
         return rendered_markup.strip()

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -13,7 +13,22 @@
     );
   }
 
+  function pjxLoadedAssets() {
+    var urls = [];
+    Array.prototype.forEach.call(
+      document.querySelectorAll('script[src], link[rel="stylesheet"][href]'),
+      function (el) {
+        var url = el.src || el.href;
+        if (url) {
+          urls.push(url);
+        }
+      }
+    );
+    return urls;
+  }
+
   document.body.addEventListener("htmx:configRequest", function (evt) {
     evt.detail.headers["X-PJX-Mounted"] = JSON.stringify(pjxManifest());
+    evt.detail.headers["X-PJX-Assets"] = JSON.stringify(pjxLoadedAssets());
   });
 })();

--- a/tests/33_client_runtime_test.py
+++ b/tests/33_client_runtime_test.py
@@ -12,6 +12,7 @@ def test_runtime_source_reports_manifest_header():
     source = read_client_runtime()
     assert "htmx:configRequest" in source
     assert "X-PJX-Mounted" in source
+    assert "X-PJX-Assets" in source
     assert "data-pjx-id" in source
 
 

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -3,6 +3,7 @@ import pyjinhx
 
 def test_reactive_api_is_exported():
     from pyjinhx import (
+        PJX_ASSETS_HEADER,
         PJX_MOUNTED_HEADER,
         ReactiveComponent,
         client_script,
@@ -13,10 +14,12 @@ def test_reactive_api_is_exported():
         instance_key,
         mutates,
         oob_swaps,
+        parse_loaded_assets,
         StateKey,
     )
 
     assert PJX_MOUNTED_HEADER == "X-PJX-Mounted"
+    assert PJX_ASSETS_HEADER == "X-PJX-Assets"
     assert callable(oob_swaps)
     assert callable(client_script)
     assert callable(mutates)
@@ -25,6 +28,7 @@ def test_reactive_api_is_exported():
     assert callable(get_load_context)
     assert callable(dirty_keys)
     assert callable(instance_key)
+    assert callable(parse_loaded_assets)
     assert issubclass(ReactiveComponent, pyjinhx.BaseComponent)
     assert issubclass(StateKey, str)
 
@@ -35,6 +39,8 @@ def test_names_in_all():
         "ReactiveComponent",
         "client_script",
         "PJX_MOUNTED_HEADER",
+        "PJX_ASSETS_HEADER",
+        "parse_loaded_assets",
         "StateKey",
         "instance_key",
         "dirty_keys",

--- a/tests/50_asset_reference_mode_test.py
+++ b/tests/50_asset_reference_mode_test.py
@@ -1,0 +1,236 @@
+import os
+
+import pytest
+
+from pyjinhx import (
+    AssetMode,
+    BaseComponent,
+    Finder,
+    Renderer,
+    asset_manifest,
+    client_script,
+    hashed_filename,
+    layout_asset_tags,
+    make_default_asset_url_resolver,
+    oob_swaps,
+    resolver_with_hash,
+)
+from pyjinhx.utils import read_client_runtime
+from tests.ui.reactive.reactive_counter import ReactiveCounter
+from tests.ui.unified_component import UnifiedComponent
+
+
+@pytest.fixture(autouse=True)
+def reset_renderer_defaults():
+    original_js = Renderer._default_js_mode
+    original_css = Renderer._default_css_mode
+    original_resolver = Renderer._asset_url_resolver
+    original_runtime_url = Renderer._default_runtime_url
+    Renderer._default_renderers.clear()
+    yield
+    Renderer.set_default_js_mode(original_js)
+    Renderer.set_default_css_mode(original_css)
+    Renderer.set_asset_url_resolver(original_resolver)
+    Renderer.set_default_runtime_url(original_runtime_url)
+    Renderer._default_renderers.clear()
+
+
+def test_reference_mode_emits_link_and_script_tags():
+    def resolver(path: str) -> str:
+        return f"/assets/{os.path.basename(path)}"
+
+    renderer = Renderer.get_default_renderer(
+        js_mode=AssetMode.REFERENCE,
+        css_mode=AssetMode.REFERENCE,
+    )
+    Renderer.set_asset_url_resolver(resolver)
+    renderer = Renderer.get_default_renderer(
+        js_mode=AssetMode.REFERENCE,
+        css_mode=AssetMode.REFERENCE,
+    )
+
+    rendered = str(
+        UnifiedComponent(id="ref-1", text="Ref")._render(_renderer=renderer)
+    )
+
+    assert '<link rel="stylesheet" href="/assets/unified-component.css">' in rendered
+    assert '<script src="/assets/unified-component.js"></script>' in rendered
+    assert "<style>" not in rendered
+    assert "<script>console.log" not in rendered
+
+
+def test_reference_mode_deduplicates_nested_components():
+    renderer = Renderer.get_default_renderer(
+        js_mode=AssetMode.REFERENCE,
+        css_mode=AssetMode.REFERENCE,
+    )
+    nested = UnifiedComponent(id="nested", text="Nested")
+    component = UnifiedComponent(id="parent", title="Parent", items=[nested])
+
+    rendered = str(component._render(_renderer=renderer))
+
+    assert rendered.count('href="/static/components/') == 1
+    assert rendered.count('src="/static/components/') == 1
+
+
+def test_reference_mode_order_css_before_html_js_after():
+    renderer = Renderer.get_default_renderer(
+        js_mode=AssetMode.REFERENCE,
+        css_mode=AssetMode.REFERENCE,
+    )
+    rendered = str(
+        UnifiedComponent(id="order-1", text="Order")._render(_renderer=renderer)
+    )
+
+    link_pos = rendered.find("<link")
+    div_pos = rendered.find("<div")
+    script_pos = rendered.find("<script")
+    assert link_pos < div_pos < script_pos
+
+
+def test_reference_mode_extra_assets():
+    renderer = Renderer.get_default_renderer(
+        js_mode=AssetMode.REFERENCE,
+        css_mode=AssetMode.REFERENCE,
+    )
+    component = UnifiedComponent(
+        id="extra-ref",
+        text="Extra",
+        js=["tests/ui/extra_script.js"],
+        css=["tests/ui/extra_style.css"],
+    )
+
+    rendered = str(component._render(_renderer=renderer))
+
+    assert "extra_style.css" in rendered
+    assert "extra_script.js" in rendered
+
+
+def test_none_mode_stays_silent():
+    renderer = Renderer.get_default_renderer(
+        js_mode=AssetMode.NONE,
+        css_mode=AssetMode.NONE,
+    )
+    rendered = str(
+        UnifiedComponent(id="none-1", text="Silent")._render(_renderer=renderer)
+    )
+
+    assert "<style>" not in rendered
+    assert "<script" not in rendered
+    assert "<link" not in rendered
+
+
+def test_set_default_inline_js_false_maps_to_none():
+    Renderer.set_default_inline_js(False)
+    renderer = Renderer.get_default_renderer()
+    assert renderer._js_mode == AssetMode.NONE
+
+
+def test_asset_manifest_matches_reference_output():
+    renderer = Renderer.get_default_renderer(
+        js_mode=AssetMode.REFERENCE,
+        css_mode=AssetMode.REFERENCE,
+    )
+    session = renderer.new_session()
+    component = UnifiedComponent(id="manifest-1", text="Manifest")
+    rendered = str(
+        renderer.render_component_with_context(
+            component,
+            context=component.model_dump(),
+            template_source=None,
+            template_path=None,
+            session=session,
+            is_root=True,
+            collect_component_js=True,
+        )
+    )
+    resolver = make_default_asset_url_resolver(os.getcwd())
+    manifest = asset_manifest(session, resolver=resolver)
+
+    for url in manifest.stylesheets:
+        assert url in rendered
+    for url in manifest.scripts:
+        assert url in rendered
+
+
+def test_layout_asset_tags_lists_all_files():
+    finder = Finder(root="tests/ui")
+
+    def resolver(path: str) -> str:
+        return f"/static/{os.path.basename(path)}"
+
+    tags = str(layout_asset_tags(finder, resolver=resolver))
+
+    assert "unified-component.css" in tags
+    assert "unified-component.js" in tags
+    assert tags.index("<link") < tags.index("<script")
+
+
+def test_hashed_filename_is_stable():
+    path = "tests/ui/unified-component.js"
+    first = hashed_filename(path)
+    second = hashed_filename(path)
+    assert first == second
+    assert first.endswith(".js")
+    assert "." in first.removesuffix(".js")
+
+
+def test_resolver_with_hash_embeds_digest():
+    resolver = resolver_with_hash("/static/components", "tests/ui")
+    url = resolver(os.path.abspath("tests/ui/unified-component.js"))
+    assert url.startswith("/static/components/")
+    assert url.count(".") >= 2
+
+
+def test_reactive_partial_render_suppresses_assets():
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    rendered = str(ReactiveCounter.render(dirtied={"todos"}, mounted=manifest))
+
+    assert "<style>" not in rendered
+    assert "<script" not in rendered
+    assert "<link" not in rendered
+
+
+def test_oob_swaps_emit_no_assets():
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    rendered = str(oob_swaps({"todos"}, manifest))
+
+    assert "<style>" not in rendered
+    assert "<script" not in rendered
+    assert "<link" not in rendered
+
+
+class Page(BaseComponent, base_layout=True):
+    pass
+
+
+def test_layout_reference_mode_emits_runtime_src():
+    renderer = Renderer.get_default_renderer(js_mode=AssetMode.REFERENCE)
+    Renderer.set_default_runtime_url("/static/pyjinhx/pjx.js")
+    renderer = Renderer.get_default_renderer(js_mode=AssetMode.REFERENCE)
+
+    rendered = str(Page(id="page")._render(source="<html><body>hi</body></html>", _renderer=renderer))
+
+    assert '<script src="/static/pyjinhx/pjx.js"></script>' in rendered
+    assert read_client_runtime() not in rendered
+
+
+def test_client_script_reference_mode():
+    Renderer.set_default_runtime_url("/static/pyjinhx/pjx.js")
+    script = str(client_script(mode=AssetMode.REFERENCE))
+
+    assert script == '<script src="/static/pyjinhx/pjx.js"></script>'
+
+
+def test_inline_mode_regression():
+    renderer = Renderer.get_default_renderer(
+        js_mode=AssetMode.INLINE,
+        css_mode=AssetMode.INLINE,
+    )
+    rendered = str(
+        UnifiedComponent(id="inline-1", text="Inline")._render(_renderer=renderer)
+    )
+
+    assert "<style>" in rendered
+    assert ".test-component { color: red; }" in rendered
+    assert "<script>console.log('Button loaded');</script>" in rendered

--- a/tests/51_client_asset_manifest_test.py
+++ b/tests/51_client_asset_manifest_test.py
@@ -1,0 +1,229 @@
+import json
+import os
+
+import pytest
+
+from pyjinhx import AssetMode, BaseComponent, PJX_ASSETS_HEADER, Renderer, parse_loaded_assets
+from pyjinhx.reactive import oob_swaps
+from pyjinhx.utils import read_client_runtime
+from tests.ui.reactive.reactive_counter import ReactiveCounter
+from tests.ui.unified_component import UnifiedComponent
+
+
+class _Headers:
+    def __init__(self, values: dict[str, str]):
+        self._values = values
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return self._values.get(key, default)
+
+
+class _Client:
+    def __init__(self, headers: dict[str, str]):
+        self.headers = _Headers(headers)
+
+
+@pytest.fixture(autouse=True)
+def reset_renderer_defaults():
+    original_js = Renderer._default_js_mode
+    original_css = Renderer._default_css_mode
+    original_dedup = Renderer._default_asset_dedup
+    original_resolver = Renderer._asset_url_resolver
+    original_runtime_url = Renderer._default_runtime_url
+    Renderer._default_renderers.clear()
+    yield
+    Renderer.set_default_js_mode(original_js)
+    Renderer.set_default_css_mode(original_css)
+    Renderer.set_default_asset_dedup(original_dedup)
+    Renderer.set_asset_url_resolver(original_resolver)
+    Renderer.set_default_runtime_url(original_runtime_url)
+    Renderer._default_renderers.clear()
+
+
+def test_runtime_source_reports_assets_header():
+    source = read_client_runtime()
+    assert "X-PJX-Assets" in source
+    assert 'link[rel="stylesheet"][href]' in source
+
+
+def test_parse_loaded_assets_from_request():
+    client = _Client(
+        {
+            PJX_ASSETS_HEADER: json.dumps(
+                ["/static/components/greeting.js", "/static/components/greeting.css"]
+            )
+        }
+    )
+    loaded = parse_loaded_assets(client)
+    assert loaded == frozenset(
+        {"/static/components/greeting.js", "/static/components/greeting.css"}
+    )
+
+
+def test_parse_loaded_assets_invalid_json_returns_empty():
+    loaded = parse_loaded_assets('["not-json"')
+    assert loaded == frozenset()
+
+
+def test_root_reference_render_skips_loaded_assets_when_dedup_enabled():
+    Renderer.set_default_js_mode(AssetMode.REFERENCE)
+    Renderer.set_default_css_mode(AssetMode.REFERENCE)
+    Renderer.set_default_asset_dedup(True)
+
+    def resolver(path: str) -> str:
+        return f"/static/{os.path.basename(path)}"
+
+    Renderer.set_asset_url_resolver(resolver)
+    renderer = Renderer.get_default_renderer(
+        js_mode=AssetMode.REFERENCE,
+        css_mode=AssetMode.REFERENCE,
+    )
+
+    loaded = frozenset(
+        {
+            "/static/unified-component.css",
+            "/static/unified-component.js",
+        }
+    )
+    rendered = str(
+        UnifiedComponent(id="dedup-1", text="Dedup")._render(
+            _renderer=renderer,
+            client=list(loaded),
+        )
+    )
+
+    assert "<link" not in rendered
+    assert "<script" not in rendered
+
+
+def test_root_reference_render_emits_all_when_nothing_loaded():
+    Renderer.set_default_js_mode(AssetMode.REFERENCE)
+    Renderer.set_default_css_mode(AssetMode.REFERENCE)
+    Renderer.set_default_asset_dedup(True)
+    renderer = Renderer.get_default_renderer(
+        js_mode=AssetMode.REFERENCE,
+        css_mode=AssetMode.REFERENCE,
+    )
+
+    rendered = str(
+        UnifiedComponent(id="all-1", text="All")._render(_renderer=renderer)
+    )
+
+    assert 'rel="stylesheet"' in rendered
+    assert "<script src=" in rendered
+
+
+def test_root_reference_render_emits_only_missing_assets():
+    Renderer.set_default_js_mode(AssetMode.REFERENCE)
+    Renderer.set_default_css_mode(AssetMode.REFERENCE)
+    Renderer.set_default_asset_dedup(True)
+
+    def resolver(path: str) -> str:
+        return f"/static/{os.path.basename(path)}"
+
+    Renderer.set_asset_url_resolver(resolver)
+    renderer = Renderer.get_default_renderer(
+        js_mode=AssetMode.REFERENCE,
+        css_mode=AssetMode.REFERENCE,
+    )
+
+    rendered = str(
+        UnifiedComponent(id="delta-1", text="Delta")._render(
+            _renderer=renderer,
+            client=["/static/unified-component.css"],
+        )
+    )
+
+    assert "<link" not in rendered
+    assert '<script src="/static/unified-component.js"></script>' in rendered
+
+
+def test_asset_dedup_disabled_ignores_client_header():
+    Renderer.set_default_js_mode(AssetMode.REFERENCE)
+    Renderer.set_default_css_mode(AssetMode.REFERENCE)
+    Renderer.set_default_asset_dedup(False)
+
+    def resolver(path: str) -> str:
+        return f"/static/{os.path.basename(path)}"
+
+    Renderer.set_asset_url_resolver(resolver)
+    renderer = Renderer.get_default_renderer(
+        js_mode=AssetMode.REFERENCE,
+        css_mode=AssetMode.REFERENCE,
+    )
+
+    rendered = str(
+        UnifiedComponent(id="off-1", text="Off")._render(
+            _renderer=renderer,
+            client=["/static/unified-component.css", "/static/unified-component.js"],
+        )
+    )
+
+    assert 'href="/static/unified-component.css"' in rendered
+    assert 'src="/static/unified-component.js"' in rendered
+
+
+def test_reactive_partial_still_emits_no_assets_with_client_header():
+    Renderer.set_default_js_mode(AssetMode.REFERENCE)
+    Renderer.set_default_css_mode(AssetMode.REFERENCE)
+    Renderer.set_default_asset_dedup(True)
+
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    client = _Client(
+        {
+            PJX_ASSETS_HEADER: json.dumps(["/static/components/counter.js"]),
+        }
+    )
+    rendered = str(
+        ReactiveCounter.load().render(
+            dirtied={"todos"}, mounted=manifest, client=client
+        )
+    )
+
+    assert "<link" not in rendered
+    assert "<script" not in rendered
+
+
+def test_oob_swaps_emit_no_assets():
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    rendered = str(oob_swaps({"todos"}, manifest))
+
+    assert "<link" not in rendered
+    assert "<script" not in rendered
+
+
+class Page(BaseComponent, base_layout=True):
+    pass
+
+
+def test_runtime_url_skipped_when_already_loaded():
+    Renderer.set_default_js_mode(AssetMode.REFERENCE)
+    Renderer.set_default_asset_dedup(True)
+    Renderer.set_default_runtime_url("/static/pyjinhx/pjx.js")
+    renderer = Renderer.get_default_renderer(js_mode=AssetMode.REFERENCE)
+
+    rendered = str(
+        Page(id="page")._render(
+            source="<html><body>hi</body></html>",
+            _renderer=renderer,
+            client=["/static/pyjinhx/pjx.js"],
+        )
+    )
+
+    assert "/static/pyjinhx/pjx.js" not in rendered
+
+
+def test_runtime_url_emitted_when_not_loaded():
+    Renderer.set_default_js_mode(AssetMode.REFERENCE)
+    Renderer.set_default_asset_dedup(True)
+    Renderer.set_default_runtime_url("/static/pyjinhx/pjx.js")
+    renderer = Renderer.get_default_renderer(js_mode=AssetMode.REFERENCE)
+
+    rendered = str(
+        Page(id="page")._render(
+            source="<html><body>hi</body></html>",
+            _renderer=renderer,
+        )
+    )
+
+    assert '<script src="/static/pyjinhx/pjx.js"></script>' in rendered


### PR DESCRIPTION
## Summary

- Add `AssetMode` (`INLINE`, `REFERENCE`, `NONE`) with pluggable `Renderer.set_asset_url_resolver()` so production apps emit cacheable `<link>` / `<script src>` tags instead of inline blobs or silence.
- Decouple asset collection from delivery mode; reactive partials and OOB swaps skip assets via `emit_assets=False`.
- Add opt-in client asset dedup: `pjx.js` sends `X-PJX-Assets` on HTMX requests; root REFERENCE renders skip URLs the browser already has when `Renderer.set_default_asset_dedup(True)` and `render(client=request)` are used.
- Ship helpers: `asset_manifest`, `layout_asset_tags`, `hashed_filename`, `resolver_with_hash`, extended `client_script(mode=...)`.

## Test plan

- [x] `uv run pytest` — 266 tests pass
- [ ] FastAPI app with REFERENCE mode + static mounts serves assets on first load
- [ ] HTMX partial route (`render(mounted=request)`) returns HTML only, no asset tags
- [ ] Boosted full-page route with `render(client=request)` + dedup enabled omits already-loaded URLs


Made with [Cursor](https://cursor.com)