### PR TITLE
Add load cache scopes and invalidation fan-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,4 +302,4 @@ def toggle_row(request: Request, todo_id: int):
 
 Run the full app: `uv run uvicorn examples.reactive_todo.app:app --reload` — see [examples/reactive_todo/README.md](examples/reactive_todo/README.md).
 
-More: [components](docs/guide/components.md) · [nesting](docs/guide/nesting.md) · [FastAPI integration](docs/integrations/fastapi.md) · [HTMX integration](docs/integrations/htmx.md)
+More: [components](docs/guide/components.md) · [nesting](docs/guide/nesting.md) · [public API index](docs/reference/public-api.md) · [FastAPI integration](docs/integrations/fastapi.md) · [HTMX integration](docs/integrations/htmx.md)

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The client reports mounted regions via the `X-PJX-Mounted` header; `pjx.js` is i
 
 **Load cache scope** (default `CacheScope.PROCESS`): `load()` results are cached per worker for cross-request hits. Use `Registry.request_scope()` on every request for instance registry isolation. For multiple workers, subclass `InvalidationBackend` (Redis reference: [examples/reactive_todo/redis_invalidation.py](examples/reactive_todo/redis_invalidation.py)) or opt into `CacheScope.REQUEST`.
 
-Details: [reactivity guide](docs/reactivity.md). Runnable demo: [examples/reactive_todo/](examples/reactive_todo/).
+Details: [reactivity guide](docs/reactivity.md). Step-by-step app tutorial: [Build an App](docs/getting-started/build-an-app.md). Runnable demo: [examples/reactive_todo/](examples/reactive_todo/).
 
 ## JS & CSS collection
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ The client reports mounted regions via the `X-PJX-Mounted` header; `pjx.js` is i
 
 **Reactive ergonomics:** use `StateKey` enums and `dirty_keys()` for typed keys; `@mutates` on store methods to auto-supply `dirtied`; `load_scope()` / `get_load_context()` to inject dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
 
+**Load cache scope** (default `CacheScope.PROCESS`): `load()` results are cached per worker for cross-request hits. Use `Registry.request_scope()` on every request for instance registry isolation. For multiple workers, subclass `InvalidationBackend` (Redis reference: [examples/reactive_todo/redis_invalidation.py](examples/reactive_todo/redis_invalidation.py)) or opt into `CacheScope.REQUEST`.
+
 Details: [reactivity guide](docs/reactivity.md). Runnable demo: [examples/reactive_todo/](examples/reactive_todo/).
 
 ## JS & CSS collection

--- a/docs/api/assets-api.md
+++ b/docs/api/assets-api.md
@@ -1,0 +1,114 @@
+# Assets API
+
+Public helpers for asset URL resolution, manifests, and layout preloading.
+
+See [Asset Collection](../guide/assets.md) for conceptual documentation and [Renderer](renderer.md) for `AssetMode` and `RenderSession`.
+
+## AssetManifest
+
+```python
+@dataclass(frozen=True)
+class AssetManifest:
+    stylesheets: tuple[str, ...]
+    scripts: tuple[str, ...]
+```
+
+Resolved public URLs for assets collected during a render session. Built by `asset_manifest()` or `RenderSession.manifest()`.
+
+## DEFAULT_RUNTIME_URL
+
+```python
+DEFAULT_RUNTIME_URL = "/static/pyjinhx/pjx.js"
+```
+
+Default public URL for the pyjinhx client runtime in `AssetMode.REFERENCE`. Override process-wide with `Renderer.set_default_runtime_url()`.
+
+## runtime_asset_path
+
+```python
+def runtime_asset_path() -> str
+```
+
+Return the absolute filesystem path to the bundled `pjx.js` client runtime. Mount this directory as static files in production.
+
+```python
+from fastapi.staticfiles import StaticFiles
+from pyjinhx import runtime_asset_path
+import os
+
+app.mount(
+    "/static/pyjinhx",
+    StaticFiles(directory=os.path.dirname(runtime_asset_path())),
+    name="pyjinhx",
+)
+```
+
+## default_asset_url
+
+```python
+def default_asset_url(path: str, *, kind: AssetKind, root: str) -> str
+```
+
+Map an absolute asset path to a default public URL under `/static/components/`. The runtime path maps to `DEFAULT_RUNTIME_URL`.
+
+## make_default_asset_url_resolver
+
+```python
+def make_default_asset_url_resolver(root: str) -> AssetUrlResolver
+```
+
+Build a callable resolver using `default_asset_url()`. Pass to `Renderer.set_asset_url_resolver()` or `asset_manifest()`.
+
+```python
+from pyjinhx import Renderer, make_default_asset_url_resolver
+
+Renderer.set_asset_url_resolver(make_default_asset_url_resolver("./components"))
+```
+
+## hashed_filename
+
+```python
+def hashed_filename(path: str, *, hash_len: int = 8) -> str
+```
+
+Return a content-hash filename such as `button.a1b2c3d4.js`. Reads the file to compute a SHA-256 digest.
+
+## resolver_with_hash
+
+```python
+def resolver_with_hash(base_url: str, root: str) -> AssetUrlResolver
+```
+
+Build an asset URL resolver that embeds a content hash in each filename. The runtime file is placed under `{base_url}/pyjinhx/{hashed}`.
+
+```python
+from pyjinhx import Renderer, resolver_with_hash
+
+Renderer.set_asset_url_resolver(resolver_with_hash("/static/components", root="./components"))
+```
+
+## asset_manifest
+
+```python
+def asset_manifest(session: RenderSession, *, resolver: AssetUrlResolver) -> AssetManifest
+```
+
+Build an `AssetManifest` from a `RenderSession` and a URL resolver. Equivalent to `session.manifest(resolver=resolver)`.
+
+## layout_asset_tags
+
+```python
+def layout_asset_tags(finder: Finder, *, resolver: AssetUrlResolver) -> Markup
+```
+
+Emit `<link>` and `<script src>` tags for every component asset discovered by a `Finder`. Use in layout shells to preload all component assets instead of per-page discovery.
+
+```python
+from pyjinhx import Finder, layout_asset_tags, make_default_asset_url_resolver
+
+finder = Finder(root="./components")
+resolver = make_default_asset_url_resolver("./components")
+head_tags = layout_asset_tags(finder, resolver=resolver)
+```
+
+Defined in `pyjinhx.finder` and re-exported from the top-level package.

--- a/docs/api/cache-invalidation.md
+++ b/docs/api/cache-invalidation.md
@@ -1,0 +1,121 @@
+# Cache & Invalidation
+
+Public API for the reactive `load()` cache and cross-process invalidation fan-out.
+
+See [Reactivity](../reactivity.md) and [FastAPI integration](../integrations/fastapi.md) for usage patterns.
+
+## CacheScope
+
+```python
+class CacheScope(str, Enum):
+    REQUEST = "request"
+    PROCESS = "process"
+    NONE = "none"
+```
+
+Controls where cached `load()` results are stored.
+
+| Scope | Behavior |
+|-------|----------|
+| `PROCESS` (default) | Shared per worker process; survives across HTTP requests |
+| `REQUEST` | Isolated per `Registry.request_scope()`; cleared when the scope exits |
+| `NONE` | No caching; every `load()` runs fresh |
+
+`Registry.request_scope()` always creates a request-scoped cache store. With `PROCESS` scope, reads fall through to the process store; with `REQUEST` scope, only the request store is used.
+
+## get_load_cache_scope
+
+```python
+def get_load_cache_scope() -> CacheScope
+```
+
+Return the active process-wide cache scope.
+
+## set_load_cache_scope
+
+```python
+def set_load_cache_scope(scope: CacheScope) -> None
+```
+
+Set the process-wide cache scope. Typically configured at application startup:
+
+```python
+from pyjinhx import CacheScope, set_load_cache_scope
+
+set_load_cache_scope(CacheScope.REQUEST)  # multi-worker without Redis
+set_load_cache_scope(CacheScope.PROCESS)  # default; pair with invalidation fan-out
+```
+
+Environment variable `PJX_LOAD_CACHE_SCOPE` is read by the reactive todo example helper; set the scope explicitly in your own app.
+
+## invalidate
+
+```python
+def invalidate(dirtied: Iterable[object], *, propagate: bool = True) -> None
+```
+
+Evict every cached `load()` result whose interpolated reactive keys intersect the dirtied keys.
+
+**Stem expansion:** invalidating `"todo"` evicts all instance-tier entries whose keys start with `"todo:"` (e.g. `"todo:42"`).
+
+**Propagation:** when `CacheScope.PROCESS` is active, an `InvalidationBackend` is configured, and `propagate=True` (default), dirtied keys are published to other workers after local eviction. Remote handlers call `invalidate(..., propagate=False)` to avoid publish loops.
+
+Called automatically by `@mutates` and `mutation_scope` after mutations complete.
+
+## InvalidationBackend
+
+```python
+class InvalidationBackend(ABC):
+    def publish(self, keys: frozenset[str]) -> None: ...
+    def start(self, handler: Callable[[frozenset[str]], None]) -> None: ...
+    def stop(self) -> None: ...
+```
+
+Abstract base class for cross-process invalidation. Implement `publish()` to broadcast dirtied keys and `start()`/`stop()` to manage a subscriber that invokes the handler on incoming messages.
+
+A reference Redis implementation lives in `examples/reactive_todo/redis_invalidation.py` (not shipped in the core package).
+
+## set_invalidation_backend
+
+```python
+def set_invalidation_backend(backend: InvalidationBackend | None) -> None
+```
+
+Configure the invalidation backend. Passing a new backend stops the previous one if a listener was running.
+
+## Listener lifecycle
+
+### start_invalidation_listener
+
+```python
+def start_invalidation_listener() -> None
+```
+
+Start listening for remote invalidations. Raises `RuntimeError` if no backend is configured. Idempotent — safe to call multiple times.
+
+### stop_invalidation_listener
+
+```python
+def stop_invalidation_listener() -> None
+```
+
+Stop the invalidation listener. Call during application shutdown.
+
+**Typical FastAPI lifespan:**
+
+```python
+from pyjinhx import (
+    InvalidationBackend,
+    set_invalidation_backend,
+    start_invalidation_listener,
+    stop_invalidation_listener,
+)
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    set_invalidation_backend(my_backend)
+    start_invalidation_listener()
+    yield
+    stop_invalidation_listener()
+    set_invalidation_backend(None)
+```

--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -1,0 +1,169 @@
+# Mutations, Keys & LoadContext
+
+Public API for reactive state keys, mutation tracking, request-scoped load context, and development guardrails.
+
+See [Reactivity](../reactivity.md) for conceptual documentation.
+
+## StateKey
+
+```python
+class StateKey(StrEnum):
+    ...
+```
+
+Base class for app-level reactive key constants. Subclass and declare members; use the enum in `reacts_to`, `dirtied`, and `@mutates` — all normalize to their string values.
+
+```python
+from pyjinhx import StateKey
+
+class Keys(StateKey):
+    TODOS = "todos"
+    TODO = "todo"
+```
+
+## instance_key
+
+```python
+def instance_key(stem: str, key: str | int) -> str
+```
+
+Build an instance-tier dirty key.
+
+```python
+instance_key("todo", 42)  # "todo:42"
+```
+
+## dirty_keys
+
+```python
+def dirty_keys(instance_stem: str, key: str | int, *collection: ReactiveKey) -> set[str]
+```
+
+Build a two-tier dirty set for instance-keyed mutations. Returns the expanded instance key plus any collection-tier keys.
+
+```python
+dirty_keys("todo", 42, "todos")
+# {"todo:42", "todos"}
+```
+
+Use with `mutation_scope()` when a mutation affects both a single row and a collection summary.
+
+## mutates
+
+```python
+def mutates(*keys: ReactiveKey) -> Callable[[F], F]
+```
+
+Decorator for store mutation methods. After the wrapped function returns, invalidates the load cache for `keys` and accumulates them as pending dirtied for the next reactive `render()` when `dirtied` is omitted.
+
+```python
+from pyjinhx import mutates
+
+class Store:
+    @mutates("todos")
+    def add(self, text: str) -> None:
+        ...
+```
+
+## mutation_scope
+
+```python
+@contextmanager
+def mutation_scope(*keys: ReactiveKey) -> Generator[None, None, None]
+```
+
+Context manager that invalidates and accumulates dirtied keys when the block exits (not on entry). Use for mutations that don't map cleanly to a single decorated method.
+
+```python
+from pyjinhx import dirty_keys, mutation_scope
+
+with mutation_scope(*dirty_keys(Keys.TODO, todo_id, Keys.TODOS)):
+    self._toggle(todo_id)
+```
+
+## LoadContext
+
+```python
+@dataclass(frozen=True)
+class LoadContext:
+    ...
+```
+
+Opaque base for request-scoped data available inside reactive `load()`. Subclass with your own frozen dataclass fields (database session, user id, feature flags).
+
+## get_load_context
+
+```python
+def get_load_context() -> Any | None
+```
+
+Return the current load context, or `None` outside a scope. Reactive `load()` methods accept an optional keyword-only `ctx=` argument when the context is set.
+
+## load_scope
+
+```python
+@contextmanager
+def load_scope(ctx: Any) -> Generator[None, None, None]
+```
+
+Set the load context for the current scope. Prefer `Registry.request_scope(load_context=ctx)` in web apps — it combines registry isolation, request cache, mutation tracking, and load context in one call.
+
+```python
+from pyjinhx import LoadContext, Registry
+
+@dataclass(frozen=True)
+class AppLoadContext(LoadContext):
+    db: Session
+
+with Registry.request_scope(load_context=AppLoadContext(db=session)):
+    html = TodoList.render(mounted=request)
+```
+
+## Reactive dev
+
+Development-time guardrails for catching common reactive mistakes.
+
+### enable_reactive_dev
+
+```python
+def enable_reactive_dev(*, strict: bool = False) -> None
+```
+
+Enable guardrails. When enabled:
+
+- Warns if `@mutates` recorded dirtied keys but no reactive `render()` consumed them in the request scope.
+- Warns if dirtied keys are set but `mounted` was not passed (OOB swaps skipped).
+- Validates that `load_reads` keys are covered by `reacts_to` on each `load()`.
+
+Set `strict=True` to raise `RuntimeError` instead of logging warnings.
+
+### disable_reactive_dev
+
+```python
+def disable_reactive_dev() -> None
+```
+
+Disable all dev guardrails.
+
+### dependency_graph
+
+```python
+def dependency_graph() -> dict[str, list[str]]
+```
+
+Map each declared reactive key to the component class names that depend on it. Instance-tier stems appear as declared (e.g. `"todo"`), not expanded per instance.
+
+### format_dependency_graph
+
+```python
+def format_dependency_graph(*, as_mermaid: bool = False) -> str
+```
+
+Format the dependency graph as a text table or Mermaid flowchart. Useful for debugging and documentation.
+
+```python
+from pyjinhx import format_dependency_graph
+
+print(format_dependency_graph())
+print(format_dependency_graph(as_mermaid=True))
+```

--- a/docs/api/parser.md
+++ b/docs/api/parser.md
@@ -1,0 +1,59 @@
+# Parser & Tag
+
+Public API for parsing HTML strings that contain PascalCase component tags.
+
+See [PascalCase Tags](../guide/tags.md) for usage patterns and [Renderer](renderer.md) for the high-level render API.
+
+## Parser
+
+```python
+class Parser(HTMLParser):
+    root_nodes: list[Tag | str]
+```
+
+HTML parser that identifies PascalCase component tags and builds a tree of `Tag` nodes. Standard HTML tags are passed through as raw strings.
+
+### Usage
+
+```python
+from pyjinhx import Parser
+
+parser = Parser()
+parser.feed('<Button text="OK"/><p>plain html</p>')
+for node in parser.root_nodes:
+    if isinstance(node, Tag):
+        print(node.name, node.attrs)
+    else:
+        print("raw:", node)
+```
+
+`Renderer.render()` uses `Parser` internally. Use `Parser` directly when you need the parse tree without rendering (custom tooling, linting, AST transforms).
+
+### PascalCase detection
+
+Tags matching `^[A-Z](?:[a-z]+(?:[A-Z][a-z]+)*)?$` are treated as components (e.g. `Button`, `ActionButton`). All other tags pass through unchanged.
+
+## Tag
+
+```python
+@dataclass
+class Tag:
+    name: str
+    attrs: dict[str, str]
+    children: list[Tag | str]
+```
+
+Represents a parsed PascalCase component tag.
+
+| Field | Description |
+|-------|-------------|
+| `name` | Tag name (e.g. `"Button"`, `"UserCard"`) |
+| `attrs` | Attribute name → value mapping from the tag |
+| `children` | Nested `Tag` nodes or raw text/HTML strings |
+
+Inner text between opening and closing tags becomes string children. Self-closing tags have an empty `children` list.
+
+```python
+# <Card title="Note">Hello</Card>
+# Tag(name="Card", attrs={"title": "Note"}, children=["Hello"])
+```

--- a/docs/api/reactive-api.md
+++ b/docs/api/reactive-api.md
@@ -1,0 +1,124 @@
+# Reactive API
+
+Public symbols for dependency-aware reactive components and HTMX client integration.
+
+See [Reactivity](../reactivity.md) for conceptual documentation and usage patterns.
+
+## ReactiveComponent
+
+```python
+class ReactiveComponent(BaseComponent):
+    reacts_to: ClassVar[frozenset[str]]
+    load_reads: ClassVar[frozenset[str]] = frozenset()
+```
+
+Base class for components that reload from application state via a `load()` classmethod and participate in out-of-band HTMX swaps.
+
+### Requirements
+
+- Declare `reacts_to` — the reactive keys this component depends on (collection-tier stems like `"todos"` or instance-tier stems like `"todo"`).
+- Implement `load()` as a `@classmethod` that returns a fresh component instance.
+- Optionally declare `load_reads` for dev-mode validation (keys read inside `load()` must be covered by `reacts_to`).
+
+### Keyed vs singleton
+
+Set `_pjx_keyed = True` on instance-keyed components (e.g. one row per todo). Singleton components omit the key.
+
+### render()
+
+Two forms coexist via a descriptor:
+
+**Class method (route entry point):**
+
+```python
+Cls.render(key=None, *, dirtied=None, mounted=None) -> Markup
+```
+
+Auto-`load()`s the primary component, renders it, and appends OOB swaps for dependents. Pass `mounted=request` on HTMX requests so the client manifest drives swap decisions.
+
+**Instance method:**
+
+```python
+instance.render(*, dirtied=None, mounted=None) -> Markup
+```
+
+Render an already-built instance as the primary without re-loading from the world.
+
+### state_hash()
+
+```python
+def state_hash(self) -> str
+```
+
+Hash of `model_dump_json()`. Used by OOB swap gating — override only for custom hashing.
+
+## client_script
+
+```python
+def client_script(*, mode: AssetMode | None = None, src: str | None = None) -> Markup
+```
+
+Return the pyjinhx client runtime as a `<script>` tag. Drop into a raw Jinja page shell when the layout is not marked `base_layout=True`.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `mode` | `AssetMode.INLINE` | `INLINE` inlines source; `REFERENCE` emits `<script src="...">` |
+| `src` | Renderer runtime URL | Public URL when mode is `REFERENCE` |
+
+Layout components with `base_layout=True` inject the runtime automatically.
+
+## PJX headers
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `PJX_MOUNTED_HEADER` | `"X-PJX-Mounted"` | JSON manifest of mounted reactive regions (`id`, `type`, `hash`) |
+| `PJX_ASSETS_HEADER` | `"X-PJX-Assets"` | JSON list of asset URLs already loaded in the browser |
+
+The client runtime (`pjx.js`) sets both headers on HTMX requests. Pass the request object as `mounted=` and `client=` to reactive `render()` calls.
+
+## parse_loaded_assets
+
+```python
+def parse_loaded_assets(client: str | list[str] | object | None) -> frozenset[str]
+```
+
+Parse the client-reported list of asset URLs for REFERENCE-mode asset dedup.
+
+Accepts:
+
+- A request-like object with `.headers.get(PJX_ASSETS_HEADER)`
+- A raw JSON string (the header value)
+- A parsed list/tuple/set of URL strings
+- `None` or `""` (nothing loaded)
+
+Used internally when `client=request` is passed to `render()` with asset dedup enabled. Call directly for custom integrations.
+
+## oob_swaps
+
+```python
+def oob_swaps(
+    dirtied: set[ReactiveKey],
+    mounted: str | list[dict[str, Any]] | object | None,
+    *,
+    exclude_ids: set[str] | None = None,
+) -> Markup
+```
+
+Compute out-of-band swap fragments for every mounted reactive region whose declared dependencies intersect the dirtied keys.
+
+**Behavior:**
+
+1. Evicts dirtied keys from the load cache.
+2. Walks the client manifest (`X-PJX-Mounted`).
+3. Reloads each matching dependent via `load()`.
+4. Emits an OOB swap only when the fresh `state_hash()` differs from the client's reported hash.
+
+**Parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `dirtied` | State keys the route mutated (e.g. `{"todos"}` or `{"todo:42"}`) |
+| `mounted` | Request object, raw header string, parsed manifest list, or `None` |
+| `exclude_ids` | Mounted ids to skip (typically the primary response id) |
+
+`ReactiveComponent.render()` calls this automatically. Use directly only for advanced partial-response composition.

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -125,23 +125,23 @@ Remove all registered component instances from the current context.
 ```python
 @classmethod
 @contextmanager
-def request_scope(cls)
+def request_scope(cls, *, load_context: Any | None = None)
 ```
 
-Context manager for request-scoped component instances.
+Context manager for request-scoped component instances, load cache, mutation tracking, and optional load context.
 
-Creates a fresh instance registry on entry and restores the previous state on exit. This is useful in web applications where each request should have an isolated registry to prevent components from one request leaking into another.
+On entry: clears pending mutations, initializes the request-scoped load cache, and optionally sets a `LoadContext` for reactive `load()` methods. On exit: warns about unconsumed mutations (when reactive dev is enabled), clears mutations, and resets the request cache.
 
 **Usage:**
 
 ```python
 from pyjinhx import Registry
 
-with Registry.request_scope():
+with Registry.request_scope(load_context=AppLoadContext(db=session)):
     # Components registered here are isolated to this scope
     button = Button(id="submit-btn", text="Submit")
     # ... render template
-# Registry automatically restored to previous state
+# Registry, cache, and mutations automatically restored
 ```
 
 **Features:**

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -1,0 +1,542 @@
+# Build an App (step by step)
+
+This guide walks a complete path from zero to a **reactive FastAPI + HTMX app** with PyJinHx. Each step shows *what* to do and a **Why?** panel explaining *why it exists*.
+
+When you're done you will have used:
+
+- `BaseComponent` and `ReactiveComponent`
+- Template discovery, nesting, and PascalCase tags
+- Co-located JS/CSS and asset delivery modes
+- `Registry.request_scope`, `@mutates`, and `LoadContext`
+- Reactive `render()` with `mounted=request`
+- Load-cache scopes and optional invalidation fan-out
+
+Runnable reference: [`examples/reactive_todo/`](https://github.com/paulomtts/pyjinhx/tree/master/examples/reactive_todo).
+
+---
+
+## What you are building
+
+A small todo app:
+
+1. **Full page** on `GET /` — layout, list, counter.
+2. **Partial updates** on `POST` — toggle a row; counter updates out-of-band.
+3. **No manual swap wiring** — components declare dependencies; routes call `render()`.
+
+```mermaid
+flowchart LR
+    Browser -->|HTMX POST| Route
+    Route -->|mutate store| Store
+    Route -->|Cls.render mounted=request| PyJinHx
+    PyJinHx -->|primary HTML| Browser
+    PyJinHx -->|OOB fragments| Browser
+```
+
+---
+
+## Step 0 — Install and project layout
+
+```bash
+uv add pyjinhx fastapi uvicorn httpx python-multipart
+```
+
+```
+my_app/
+├── app.py                 # FastAPI routes
+├── store.py               # mutations + @mutates
+├── keys.py                # reactive key enums
+├── components/
+│   ├── todo_app.py
+│   ├── todo_app.html
+│   ├── todo_row.py
+│   ├── todo_row.html
+│   ├── todo_counter.py
+│   └── todo_counter.html
+└── pyproject.toml
+```
+
+???+ question "Why this layout?"
+    PyJinHx discovers templates **next to** component classes. Keeping `components/` as the template root lets `Renderer.set_default_environment("./components")` resolve every `.html` file without manual paths. Separating `store.py` from components mirrors how a real app keeps domain logic out of UI classes.
+
+---
+
+## Step 1 — Your first component
+
+`components/todo_counter.py`:
+
+```python
+from pyjinhx import BaseComponent
+
+
+class TodoCounter(BaseComponent):
+    id: str
+    remaining: int = 0
+```
+
+`components/todo_counter.html`:
+
+```html
+<span id="{{ id }}">{{ remaining }} left</span>
+```
+
+Smoke test in a shell:
+
+```python
+from pyjinhx import Renderer
+from components.todo_counter import TodoCounter
+
+Renderer.set_default_environment("./components")
+print(TodoCounter(id="counter", remaining=3).render())
+```
+
+???+ question "Why BaseComponent and a required id?"
+    `BaseComponent` is a **Pydantic model** — fields are validated at construction time. The `id` is the stable DOM identity: HTMX targets, registry lookups, and reactive `data-pjx-id` stamping all depend on it. Without an `id`, the library cannot reliably find or swap a region later.
+
+???+ question "Why set_default_environment?"
+    The renderer needs one search root for templates (and co-located assets). You set it once at startup (module import or app factory), not per render.
+
+---
+
+## Step 2 — Compose in Python
+
+`components/todo_list.py`:
+
+```python
+from pyjinhx import BaseComponent
+
+
+class TodoList(BaseComponent):
+    id: str
+    items: list[BaseComponent] = []
+```
+
+`components/todo_list.html`:
+
+```html
+<ul id="{{ id }}">
+  {% for item in items %}{{ item }}{% endfor %}
+</ul>
+```
+
+Build the tree in Python:
+
+```python
+from components.todo_counter import TodoCounter
+from components.todo_list import TodoList
+
+page = TodoList(
+    id="todo-list",
+    items=[TodoCounter(id="counter", remaining=3)],
+)
+print(page.render())
+```
+
+???+ question "Why compose in Python?"
+    Python composition gives you **type checking and explicit structure** — IDE autocomplete on fields, Pydantic validation on nested components. Use this when the page structure is decided server-side (typical for app shells and data-heavy views).
+
+    See also: [Nesting](../guide/nesting.md).
+
+---
+
+## Step 3 — Compose with PascalCase tags in templates
+
+`components/todo_panel.py`:
+
+```python
+from pyjinhx import BaseComponent
+
+
+class TodoPanel(BaseComponent):
+    id: str
+    remaining: int = 0
+```
+
+`components/todo_panel.html`:
+
+```html
+<div id="{{ id }}" class="panel">
+  <TodoCounter id="counter" remaining="{{ remaining }}"/>
+</div>
+```
+
+???+ question "Why PascalCase tags?"
+    Tags let **templates own layout** while Python owns data. The parent template emits `<TodoCounter .../>`; PyJinHx expands it using the registered `TodoCounter` class — attrs become constructor fields. Resolution order: existing instance with same class+id → registered class → template-only fallback.
+
+    See: [PascalCase tags](../guide/tags.md).
+
+---
+
+## Step 4 — Co-located assets
+
+Add `components/todo_counter.js` next to `todo_counter.py`:
+
+```javascript
+console.log("todo counter ready");
+```
+
+On the **root** render, PyJinHx collects JS/CSS once and injects it (inline by default):
+
+```python
+TodoPanel(id="panel", remaining=2).render()
+# → <style>...</style> HTML <script>...</script>
+```
+
+???+ question "Why co-located assets?"
+    Components carry their own behavior and styling. Collecting at the **root render** avoids duplicate script tags when nested components share assets. Reactive partials and OOB swaps **never** emit assets — only full layout renders do.
+
+    Production: switch to `AssetMode.REFERENCE` and a URL resolver. See [Asset collection](../guide/assets.md).
+
+---
+
+## Step 5 — FastAPI shell
+
+`app.py`:
+
+```python
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from pyjinhx import Renderer
+
+from components.todo_panel import TodoPanel
+
+Renderer.set_default_environment("./components")
+app = FastAPI()
+
+
+@app.get("/", response_class=HTMLResponse)
+def index():
+    return TodoPanel(id="panel", remaining=3).render()
+```
+
+Run: `uvicorn app:app --reload`
+
+???+ question "Why FastAPI + HTMLResponse?"
+    PyJinHx renders `Markup` (safe HTML strings). FastAPI's `HTMLResponse` accepts that directly. Any WSGI/ASGI framework works — PyJinHx is not tied to FastAPI.
+
+    See: [FastAPI integration](../integrations/fastapi.md).
+
+---
+
+## Step 6 — Request scope (registry + cache hygiene)
+
+Wrap each request:
+
+```python
+from pyjinhx import Registry
+
+
+@app.get("/", response_class=HTMLResponse)
+def index():
+    with Registry.request_scope():
+        return TodoPanel(id="panel", remaining=3).render()
+```
+
+Better: middleware so every route is covered:
+
+```python
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class RegistryScopeMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        with Registry.request_scope():
+            return await call_next(request)
+
+
+app.add_middleware(RegistryScopeMiddleware)
+```
+
+???+ question "Why Registry.request_scope?"
+    Every component instance registers itself on construction. Without a per-request scope, instances from request A can **leak into request B** and shadow template variables. The same scope also initializes the optional **request-tier** load cache when you use `CacheScope.REQUEST`.
+
+    Default load cache is **`CacheScope.PROCESS`** (cross-request per worker) — see Step 12.
+
+    See: [Component registry](../guide/registry.md).
+
+---
+
+## Step 7 — HTMX partial responses
+
+Load HTMX in your layout template:
+
+```html
+<script src="https://unpkg.com/htmx.org@2.0.3"></script>
+```
+
+Return a **fragment** from a mutation route:
+
+```python
+@app.post("/counter/bump", response_class=HTMLResponse)
+def bump():
+    with Registry.request_scope():
+        return TodoCounter(id="counter", remaining=2).render()
+```
+
+Template button:
+
+```html
+<button hx-post="/counter/bump" hx-target="#counter" hx-swap="outerHTML">
+  Bump
+</button>
+```
+
+???+ question "Why HTMX?"
+    PyJinHx owns **HTML composition**; HTMX owns **transport and swap**. You keep server-rendered components and avoid a client-side state tree. PyJinHx does not replace HTMX — they meet at the route return value.
+
+    See: [HTMX integration](../integrations/htmx.md).
+
+---
+
+## Step 8 — Reactive components
+
+Upgrade the counter:
+
+```python
+from typing import ClassVar
+from pyjinhx import ReactiveComponent
+
+
+class TodoCounter(ReactiveComponent):
+    remaining: int = 0
+    reacts_to: ClassVar[set[str]] = {"todos"}
+
+    @classmethod
+    def load(cls) -> "TodoCounter":
+        return cls(id="counter", remaining=store.remaining())
+```
+
+Mark the page shell:
+
+```python
+class TodoApp(BaseComponent, base_layout=True):
+    ...
+```
+
+???+ question "Why ReactiveComponent?"
+    Reactive components declare **what state they derive from** (`reacts_to`) and **how to rebuild** (`load()`). After a mutation, you return one primary fragment; PyJinHx appends OOB swaps for other mounted regions whose dependencies overlap — you don't list every widget in every route.
+
+    `base_layout=True` injects `pjx.js` once on full-page renders. That runtime sends `X-PJX-Mounted` on every HTMX request so the server knows what's on screen.
+
+    See: [Reactivity](../reactivity.md).
+
+---
+
+## Step 9 — Keys, mutations, and render()
+
+`keys.py`:
+
+```python
+from pyjinhx.keys import StateKey
+
+
+class Keys(StateKey):
+    TODOS = "todos"
+    TODO = "todo"
+```
+
+`store.py`:
+
+```python
+from pyjinhx import mutates, mutation_scope
+from pyjinhx.keys import dirty_keys
+
+from .keys import Keys
+
+
+@mutates(Keys.TODOS)
+def add(text: str) -> None:
+    ...
+
+
+def toggle(todo_id: int) -> None:
+    with mutation_scope(*dirty_keys(Keys.TODO, todo_id, Keys.TODOS)):
+        ...
+```
+
+Route:
+
+```python
+@app.post("/rows/{todo_id}/toggle", response_class=HTMLResponse)
+def toggle_row(request: Request, todo_id: int):
+    with Registry.request_scope():
+        store.toggle(todo_id)
+        return TodoItemRow.render(todo_id, mounted=request)
+```
+
+???+ question "Why @mutates, dirty_keys, and mounted=request?"
+    - **`@mutates` / `mutation_scope`** — after a store change, invalidate the `load()` cache and accumulate `dirtied` keys for the next reactive render.
+    - **`dirty_keys("todo", id, "todos")`** — instance-keyed rows need **both** the row key (`todo:42`) and collection keys (`todos`). Invalidating only `"todo"` is not enough for cache entries stored under `todo:42`.
+    - **`mounted=request`** — passes the client's mounted-region manifest (`X-PJX-Mounted`). Without it, PyJinHx renders the primary fragment but **skips OOB swaps** for the counter and other dependents.
+
+    `render()` on the **class** auto-calls `load()` — routes never call `load()` manually.
+
+---
+
+## Step 10 — Instance-keyed rows
+
+```python
+class TodoItemRow(ReactiveComponent):
+    title: str = ""
+    done: bool = False
+    reacts_to: ClassVar[set[str]] = {Keys.TODO}
+
+    @classmethod
+    def load(cls, key: int) -> "TodoItemRow":
+        todo = store.get(key)
+        return cls(id=f"todo-row-{key}", title=todo.text, done=todo.done)
+```
+
+Template:
+
+```html
+<li>
+  <button hx-post="/rows/{{ key }}/toggle"
+          hx-target="closest [data-pjx-id]" hx-swap="outerHTML">toggle</button>
+  <span>{{ title }}</span>
+</li>
+```
+
+???+ question "Why load(cls, key) and id=f\"todo-row-{key}\"?"
+    A parameter after `cls` makes the type **instance-keyed** — many rows, each with its own reactive identity. Give each row a **unique `id`** so the instance registry and DOM stamps don't collide (otherwise every row would register as the same key).
+
+    `reacts_to = {Keys.TODO}` uses the instance stem; the library expands it to `todo:<key>` for cache and dependency matching.
+
+---
+
+## Step 11 — LoadContext (avoid globals in load())
+
+```python
+from dataclasses import dataclass
+from pyjinhx.load_context import get_load_context
+
+
+@dataclass(frozen=True)
+class AppLoadContext:
+    store: object
+
+
+def _store():
+    ctx = get_load_context()
+    return ctx.store if isinstance(ctx, AppLoadContext) else store
+```
+
+Middleware:
+
+```python
+with Registry.request_scope(load_context=AppLoadContext(store=store)):
+    ...
+```
+
+???+ question "Why LoadContext?"
+    `load()` must rebuild components from the current world. Passing a database handle or store through a **request-scoped context** avoids hidden globals and makes tests inject a fake store. Optional `load(cls, *, ctx=...)` is supported if you prefer explicit parameters.
+
+---
+
+## Step 12 — Load cache scope and invalidation
+
+Default: **`CacheScope.PROCESS`** — `load()` results cache across requests within one worker (fewer store hits).
+
+| Scope | When to use |
+|-------|-------------|
+| `PROCESS` | Single worker, or multi-worker **with** invalidation fan-out |
+| `REQUEST` | Multi-worker **without** Redis; cache dies every request |
+| `NONE` | Debugging; always hit the store |
+
+Multi-worker fan-out (optional):
+
+```python
+from pyjinhx import (
+    CacheScope,
+    set_invalidation_backend,
+    set_load_cache_scope,
+    start_invalidation_listener,
+)
+# copy examples/reactive_todo/redis_invalidation.py into your project
+
+set_load_cache_scope(CacheScope.PROCESS)
+set_invalidation_backend(RedisInvalidationBackend(os.environ["REDIS_URL"]))
+start_invalidation_listener()  # app lifespan
+```
+
+???+ question "Why cache at all?"
+    A single page may call `TodoCounter.load()` many times during composition and OOB walks. Caching `(class, key) → component snapshot` avoids repeated store/DB work. **Invalidation** (`@mutates`, `render(dirtied=...)`, or manual `invalidate()`) evicts entries when state changes — cache is a performance layer, not the source of truth.
+
+    If toggles feel stale, check that mutations dirtied the **instance key** (`todo:42`), not just the stem (`todo`).
+
+---
+
+## Step 13 — Production assets
+
+```python
+from pyjinhx import AssetMode, Renderer
+
+Renderer.set_default_js_mode(AssetMode.REFERENCE)
+Renderer.set_default_css_mode(AssetMode.REFERENCE)
+Renderer.set_asset_url_resolver(lambda path: f"/static/{path.split('/')[-1]}")
+Renderer.set_default_asset_dedup(True)  # hx-boost: skip already-loaded URLs
+```
+
+Full-page route with boosted navigation:
+
+```python
+TodoApp(...).render(client=request)
+```
+
+???+ question "Why REFERENCE mode?"
+    Inline `<script>` blocks are fine for demos but awkward in production (CSP, caching, size). REFERENCE emits `<link>` / `<script src>` URLs. Client dedup (`X-PJX-Assets`) avoids re-downloading assets on boosted full-page swaps.
+
+---
+
+## Step 14 — Dev guardrails (optional)
+
+```python
+from pyjinhx import enable_reactive_dev, dependency_graph, format_dependency_graph
+
+enable_reactive_dev()  # warnings: missing mounted, unconsumed @mutates, etc.
+print(format_dependency_graph())
+```
+
+???+ question "Why enable_reactive_dev?"
+    Reactivity bugs are often silent (missing `mounted=`, wrong keys, `load_reads` not covered by `reacts_to`). Dev mode turns those into log warnings or strict exceptions during development.
+
+---
+
+## Step 15 — Built-in UI kit (optional)
+
+```python
+import pyjinhx.builtins  # register templates
+from pyjinhx.builtins import Alert, Button, Card
+```
+
+???+ question "Why builtins?"
+    Optional ready-made components (Alert, Modal, Panel, …) with co-located CSS/JS. Use when you want a consistent kit without building every primitive. Your app components follow the same `BaseComponent` rules.
+
+    See: [Built-in UI components](../guide/builtins.md).
+
+---
+
+## Checklist — full app wiring
+
+| Piece | Required for reactive HTMX app |
+|-------|--------------------------------|
+| `Renderer.set_default_environment(...)` | Yes |
+| `Registry.request_scope()` middleware | Yes |
+| Layout with `base_layout=True` | Yes (auto `pjx.js`) |
+| HTMX in layout | Yes |
+| `ReactiveComponent` + `reacts_to` + `load()` | Yes |
+| `@mutates` / `mutation_scope` + `dirty_keys` for rows | Yes |
+| `Cls.render(..., mounted=request)` on mutation routes | Yes |
+| `LoadContext` | Recommended |
+| Assets / REFERENCE mode | Production |
+| Invalidation backend | Multi-worker + PROCESS cache |
+| `enable_reactive_dev()` | Development |
+
+---
+
+## Where to go next
+
+- [Quick Start](quickstart.md) — minimal single component
+- [Reactivity](../reactivity.md) — deep dive on OOB swaps and hash gating
+- [FastAPI](../integrations/fastapi.md) · [HTMX](../integrations/htmx.md)
+- [API: Renderer](../api/renderer.md) · [Registry](../api/registry.md)
+- Live demo: `uv run uvicorn examples.reactive_todo.app:app --reload`

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -81,7 +81,7 @@ Output:
 
 ## What's Next?
 
-Now that you've created your first component, learn more about:
-
-- [Creating Components](../guide/components.md) - Component fields, validation, and templates
+- **[Build an App](build-an-app.md)** — full step-by-step tutorial with **Why?** panels (start here for a real app)
+- [Creating Components](../guide/components.md) - Fields, validation, and templates
 - [Nesting Components](../guide/nesting.md) - Compose components together
+- [Reactivity](../reactivity.md) - Dependency-aware HTMX updates

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -208,3 +208,18 @@ Renderer.set_asset_url_resolver(lambda path: static(path_relative_to_static_root
 ```
 
 Map each absolute asset path to your `{% static %}` URL in the resolver callback.
+
+## Asset helpers reference
+
+| Symbol | Purpose |
+|--------|---------|
+| `DEFAULT_RUNTIME_URL` | Default `/static/pyjinhx/pjx.js` URL constant |
+| `runtime_asset_path()` | Filesystem path to bundled `pjx.js` |
+| `default_asset_url()` | Map absolute path → default public URL |
+| `make_default_asset_url_resolver()` | Build a resolver from a component root |
+| `hashed_filename()` | Content-hash a filename for cache-busting |
+| `resolver_with_hash()` | Resolver that embeds hashes in URLs |
+| `asset_manifest()` | Build `AssetManifest` from a `RenderSession` |
+| `layout_asset_tags()` | Preload all component assets in a layout shell |
+
+See [Assets API](../api/assets-api.md) for signatures and examples.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -78,3 +78,54 @@ Logged events include:
 
 - Component class registration warnings (duplicates)
 - Component instance registration warnings (ID conflicts)
+
+## Load cache scope
+
+Control where reactive `load()` results are cached:
+
+```python
+from pyjinhx import CacheScope, set_load_cache_scope
+
+set_load_cache_scope(CacheScope.PROCESS)  # default — shared per worker
+set_load_cache_scope(CacheScope.REQUEST)  # isolated per request scope
+set_load_cache_scope(CacheScope.NONE)     # no caching
+```
+
+`Registry.request_scope()` initializes a request-scoped cache on entry and clears it on exit. With `PROCESS` scope, reads also use the process-wide store; with `REQUEST` scope, only the request store is used.
+
+See [Cache & Invalidation](../api/cache-invalidation.md) and [Reactivity](../reactivity.md).
+
+## Invalidation fan-out
+
+When using `CacheScope.PROCESS` with multiple workers, configure an `InvalidationBackend` so cache evictions propagate across processes:
+
+```python
+from pyjinhx import (
+    set_invalidation_backend,
+    start_invalidation_listener,
+    stop_invalidation_listener,
+)
+
+set_invalidation_backend(my_backend)
+start_invalidation_listener()
+# ... on shutdown:
+stop_invalidation_listener()
+```
+
+See [Cache & Invalidation](../api/cache-invalidation.md) and the [FastAPI integration](../integrations/fastapi.md) lifespan example.
+
+## Reactive dev mode
+
+Enable development guardrails to catch common reactive mistakes:
+
+```python
+from pyjinhx import enable_reactive_dev, disable_reactive_dev
+
+enable_reactive_dev()           # log warnings
+enable_reactive_dev(strict=True)  # raise RuntimeError instead
+disable_reactive_dev()
+```
+
+Guardrails cover: mutations without a consuming `render()`, dirtied keys without `mounted`, and `load_reads` not covered by `reacts_to`.
+
+Inspect the dependency graph with `dependency_graph()` or `format_dependency_graph()`. See [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#reactive-dev).

--- a/docs/guide/tags.md
+++ b/docs/guide/tags.md
@@ -111,7 +111,12 @@ When `auto_id=True` (default), IDs are generated automatically if not provided i
 renderer = Renderer.get_default_renderer(auto_id=False)
 ```
 
+## Parser API
+
+For programmatic access to the parse tree (without rendering), use `Parser` and `Tag` directly. See [Parser & Tag](../api/parser.md).
+
 ## See next
 
 - [Nesting](nesting.md) - Compose components together
 - [Asset Collection](assets.md) - Automatic JS and CSS handling
+- [Public API Index](../reference/public-api.md) - Full export reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,3 +69,4 @@ print(button.render())
 - [Quick Start](getting-started/quickstart.md) - Minimal first component
 - [Guide](guide/components.md) - Feature reference
 - [Built-in UI components](guide/builtins.md) - Optional `pyjinhx.builtins` package
+- [Public API Index](reference/public-api.md) - Every symbol exported from `pyjinhx`

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,7 @@ print(button.render())
 ## Next Steps
 
 - [Installation](getting-started/installation.md) - Install PyJinHx
-- [Quick Start](getting-started/quickstart.md) - Build your first component
-- [Guide](guide/components.md) - Learn all the features
+- [Build an App](getting-started/build-an-app.md) - Step-by-step tutorial with **Why?** panels (recommended for new users)
+- [Quick Start](getting-started/quickstart.md) - Minimal first component
+- [Guide](guide/components.md) - Feature reference
 - [Built-in UI components](guide/builtins.md) - Optional `pyjinhx.builtins` package

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -219,11 +219,11 @@ def toggle_row(request, todo_id):
   emits the `X-PJX-Mounted` manifest on every htmx request:
   `class Page(BaseComponent, base_layout=True): ...`. For a raw Jinja shell, drop
   `{{ client_script() }}` in the `<head>` instead.
-- Every `load()` is wrapped in a **process-global, dependency-keyed cache** (one entry per
-  `(type, key)`), returning an independent copy each call. `render()`/`oob_swaps` evict the
-  `dirtied` keys before reloading dependents, so swaps reflect post-mutation state. For
-  mutations outside a render (jobs, webhooks) call `invalidate({"todos"})` yourself. Scope is
-  per-process — back it with a shared store for multi-worker coherence.
+- Every `load()` is wrapped in a **dependency-keyed cache** (one entry per `(type, key)`),
+  returning an independent copy each call. Default scope is `PROCESS` (cross-request
+  per worker). Use `REQUEST` for multi-worker without an invalidation backend, or
+  `invalidate({"todos"})` after background mutations. Multi-worker `PROCESS` needs an
+  `InvalidationBackend`.
 
 Full guide: [docs/reactivity.md](../reactivity.md).
 

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -108,7 +108,7 @@ def index():
 
 ## Request-Scoped Registry
 
-In web apps, component instances from one request can leak into the next. Use `Registry.request_scope()` to isolate per request. See the [Registry guide](../guide/registry.md) for details.
+In web apps, component instances from one request can leak into the next. Use `Registry.request_scope()` to isolate per request. The default **cross-request `load()` cache** is `CacheScope.PROCESS`; set `CacheScope.REQUEST` when running multiple workers without an invalidation backend. See the [Registry guide](../guide/registry.md) and [Reactivity §4](../reactivity.md#4-load-results-are-cached).
 
 ### Per-Route
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -15,6 +15,8 @@ the hash the client reported, and a matching hash is skipped.
 > total, and clear button update out-of-band (and get skipped by hash-gating when their
 > value doesn't change).
 
+See the [Public API Index](reference/public-api.md) for every exported reactive symbol.
+
 ## 1. Make a component reactive
 
 Subclass `ReactiveComponent` and declare **both** `reacts_to` and a `load()`

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -290,14 +290,37 @@ print(format_dependency_graph())
 
 ## 4. `load()` results are cached
 
-Every reactive component's `load()` is wrapped in a **process-global, dependency-keyed
-cache**. Repeated reads — a page render, several components, successive requests —
-return the cached result and skip the database until the relevant keys are dirtied:
+Every reactive component's `load()` is wrapped in a **dependency-keyed cache**.
+Repeated reads within the same request return the cached result and skip the database
+until the relevant keys are dirtied:
 
 ```python
 Counter.load()   # first call hits the DB
 Counter.load()   # cached: no DB, returns an independent copy
 ```
+
+### Cache scope
+
+| Scope | Default | Storage | Cross-request | Multi-worker safe |
+|-------|---------|---------|---------------|-------------------|
+| `PROCESS` | yes | module-level dict per worker | yes | needs invalidation fan-out |
+| `REQUEST` | opt-in | `ContextVar` inside `Registry.request_scope()` | no | yes |
+| `NONE` | opt-in | disabled | — | yes |
+
+```python
+from pyjinhx import CacheScope, set_load_cache_scope
+
+set_load_cache_scope(CacheScope.PROCESS)   # default — cross-request cache per worker
+set_load_cache_scope(CacheScope.REQUEST)   # per-request only (multi-worker safe)
+set_load_cache_scope(CacheScope.NONE)      # always hit the database
+```
+
+Use `Registry.request_scope()` on every HTTP request (middleware) for instance registry
+isolation and optional request-tier cache when scope is `REQUEST`.
+
+**Cache identity:** entries are keyed by `(component class, load key)` only. Encode
+tenant or user scope in reactive keys (e.g. `"user:7:todos"`) or ensure `LoadContext`
+data is stable for all requests sharing a cache entry.
 
 A reactive `render(dirtied=...)` (and `oob_swaps`) evicts the dirtied keys before
 reloading dependents, so swaps always reflect post-mutation state. For mutations that
@@ -311,12 +334,31 @@ def nightly_recalc():
     invalidate({"todos"})   # evict every cached load() that depends on "todos"
 ```
 
-The cache holds one result per `(type, key)` — one per type for singletons, one per
-instance key for keyed components — and returns a fresh copy on every call, so callers
-can mutate what they get back without affecting the cache. **Scope is per-process**:
-under multiple workers each process has
-its own cache; cross-worker coherence is your application's responsibility (back it
-with a shared store if you need it).
+The cache holds one result per `(type, key)` and returns a fresh copy on every call, so
+callers can mutate what they get back without affecting the cache.
+
+### Multi-worker invalidation (`PROCESS` scope)
+
+When using `CacheScope.PROCESS` with multiple workers, configure an
+`InvalidationBackend` so `invalidate()` fans out to every process:
+
+```python
+from pyjinhx import (
+    CacheScope,
+    set_invalidation_backend,
+    set_load_cache_scope,
+    start_invalidation_listener,
+    stop_invalidation_listener,
+)
+from examples.reactive_todo.redis_invalidation import RedisInvalidationBackend
+
+set_load_cache_scope(CacheScope.PROCESS)
+set_invalidation_backend(RedisInvalidationBackend("redis://localhost:6379/0"))
+start_invalidation_listener()   # app lifespan startup
+# stop_invalidation_listener() on shutdown
+```
+
+Requires `pip install redis`. Copy [examples/reactive_todo/redis_invalidation.py](https://github.com/paulomtts/pyjinhx/tree/master/examples/reactive_todo/redis_invalidation.py) into your app (or wire via [invalidation.py](https://github.com/paulomtts/pyjinhx/tree/master/examples/reactive_todo/invalidation.py)).
 
 ## Boundaries
 
@@ -332,9 +374,10 @@ with a shared store if you need it).
   `reacts_to`. A zero-arg `load(cls)` is a type-singleton; `load(cls, key)` is
   instance-keyed. Reactive `render()` auto-`load()`s dependents, so you never call
   `load()` yourself for a reactive render.
-- **`load()` cache is per-process**: it saves database work on cache hits; eviction is
-  dirtied-key driven (automatically in the reactive flow, or via `invalidate(dirtied)`).
-  Cross-worker coherence is the application's responsibility.
+- **`load()` cache scope**: default `PROCESS` (cross-request per worker). Use `REQUEST`
+  for multi-worker without an invalidation backend. Eviction is dirtied-key driven
+  (automatically in the reactive flow, or via `invalidate(dirtied)`). Multi-worker
+  `PROCESS` setups need an `InvalidationBackend`.
 
 ## How it works (under the hood)
 

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -1,0 +1,75 @@
+# Public API Index
+
+Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line description and a link to detailed documentation.
+
+## Components & rendering
+
+| Symbol | Description | Documentation |
+|--------|-------------|---------------|
+| `BaseComponent` | Pydantic base class for UI components with Jinja templates | [BaseComponent](../api/base-component.md) |
+| `ReactiveComponent` | Base class for dependency-aware reactive components (`reacts_to` + `load()`) | [Reactive API](../api/reactive-api.md) |
+| `Renderer` | Renders PascalCase tag strings and manages default Jinja environment | [Renderer](../api/renderer.md) |
+| `RenderSession` | Per-render asset aggregation state | [Renderer](../api/renderer.md#rendersession) |
+| `Parser` | Parses HTML strings into a tree of `Tag` nodes and raw HTML | [Parser & Tag](../api/parser.md) |
+| `Tag` | Parsed PascalCase component tag (name, attrs, children) | [Parser & Tag](../api/parser.md#tag) |
+| `Finder` | Discovers component templates and asset files on disk | [Finder](../api/finder.md) |
+| `Registry` | Class and request-scoped instance registry | [Registry](../api/registry.md) |
+
+## Reactivity
+
+| Symbol | Description | Documentation |
+|--------|-------------|---------------|
+| `client_script()` | Emit the pyjinhx client runtime as a `<script>` tag | [Reactive API](../api/reactive-api.md#client_script) |
+| `oob_swaps()` | Compute HTMX out-of-band swap fragments for dirtied keys | [Reactive API](../api/reactive-api.md#oob_swaps) |
+| `PJX_MOUNTED_HEADER` | HTTP header name for the client mounted-region manifest | [Reactive API](../api/reactive-api.md#pjx-headers) |
+| `PJX_ASSETS_HEADER` | HTTP header name for asset URLs already loaded in the browser | [Reactive API](../api/reactive-api.md#pjx-headers) |
+| `parse_loaded_assets()` | Parse the `X-PJX-Assets` header for asset dedup | [Reactive API](../api/reactive-api.md#parse_loaded_assets) |
+| `StateKey` | Base `StrEnum` for app-level reactive key constants | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#statekey) |
+| `instance_key()` | Build an instance-tier key (`"todo:42"`) | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#instance_key) |
+| `dirty_keys()` | Build a two-tier dirty set for instance-keyed mutations | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#dirty_keys) |
+| `mutates()` | Decorator: invalidate cache and accumulate dirtied keys after mutation | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#mutates) |
+| `mutation_scope()` | Context manager: invalidate and accumulate dirtied keys on exit | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#mutation_scope) |
+| `LoadContext` | Opaque base dataclass for request-scoped `load()` data | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#loadcontext) |
+| `get_load_context()` | Return the current load context, or `None` | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#get_load_context) |
+| `load_scope()` | Context manager to set the load context | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#load_scope) |
+| `enable_reactive_dev()` | Enable dev guardrails (warnings or strict exceptions) | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#reactive-dev) |
+| `disable_reactive_dev()` | Disable dev guardrails | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#reactive-dev) |
+| `dependency_graph()` | Map reactive keys to dependent component class names | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#dependency_graph) |
+| `format_dependency_graph()` | Format the dependency graph as text or Mermaid | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#format_dependency_graph) |
+
+## Load cache & invalidation
+
+| Symbol | Description | Documentation |
+|--------|-------------|---------------|
+| `CacheScope` | Enum: `PROCESS`, `REQUEST`, or `NONE` | [Cache & Invalidation](../api/cache-invalidation.md#cachescope) |
+| `get_load_cache_scope()` | Return the active load-cache scope | [Cache & Invalidation](../api/cache-invalidation.md#get_load_cache_scope) |
+| `set_load_cache_scope()` | Set the process-wide load-cache scope | [Cache & Invalidation](../api/cache-invalidation.md#set_load_cache_scope) |
+| `invalidate()` | Evict cached `load()` results for dirtied keys | [Cache & Invalidation](../api/cache-invalidation.md#invalidate) |
+| `InvalidationBackend` | ABC for cross-process invalidation fan-out | [Cache & Invalidation](../api/cache-invalidation.md#invalidationbackend) |
+| `set_invalidation_backend()` | Configure the invalidation backend | [Cache & Invalidation](../api/cache-invalidation.md#set_invalidation_backend) |
+| `start_invalidation_listener()` | Start listening for remote invalidations | [Cache & Invalidation](../api/cache-invalidation.md#listener-lifecycle) |
+| `stop_invalidation_listener()` | Stop the invalidation listener | [Cache & Invalidation](../api/cache-invalidation.md#listener-lifecycle) |
+
+## Assets
+
+| Symbol | Description | Documentation |
+|--------|-------------|---------------|
+| `AssetMode` | Enum: `INLINE`, `REFERENCE`, or `NONE` | [Renderer](../api/renderer.md#assetmode) |
+| `AssetManifest` | Resolved stylesheet and script URLs from a render session | [Assets API](../api/assets-api.md#assetmanifest) |
+| `DEFAULT_RUNTIME_URL` | Default public URL for `pjx.js` (`/static/pyjinhx/pjx.js`) | [Assets API](../api/assets-api.md#default_runtime_url) |
+| `asset_manifest()` | Build an `AssetManifest` from a `RenderSession` | [Assets API](../api/assets-api.md#asset_manifest) |
+| `default_asset_url()` | Map an absolute asset path to a default public URL | [Assets API](../api/assets-api.md#default_asset_url) |
+| `hashed_filename()` | Content-hash a filename for cache-busting | [Assets API](../api/assets-api.md#hashed_filename) |
+| `layout_asset_tags()` | Emit `<link>` / `<script>` tags for all discovered component assets | [Assets API](../api/assets-api.md#layout_asset_tags) |
+| `make_default_asset_url_resolver()` | Build a resolver using `default_asset_url()` | [Assets API](../api/assets-api.md#make_default_asset_url_resolver) |
+| `resolver_with_hash()` | Build a resolver that embeds content hashes in URLs | [Assets API](../api/assets-api.md#resolver_with_hash) |
+| `runtime_asset_path()` | Absolute path to the bundled `pjx.js` file | [Assets API](../api/assets-api.md#runtime_asset_path) |
+
+## Conceptual guides
+
+For usage patterns and tutorials, see:
+
+- [Reactivity](../reactivity.md) — reactive components, OOB swaps, cache scopes
+- [Asset Collection](../guide/assets.md) — delivery modes, dedup, static serving
+- [Build an App](../getting-started/build-an-app.md) — end-to-end tutorial
+- [FastAPI integration](../integrations/fastapi.md) — request scope, lifespan, headers

--- a/examples/reactive_todo/README.md
+++ b/examples/reactive_todo/README.md
@@ -20,3 +20,24 @@ What to watch (open the network tab):
 The routes never mention the counter/total/clear button — they just declare
 `dirtied={"todos"}`. The dependency graph lives on the components (`reacts_to`), and
 `pjx.js` reports what's mounted via the `X-PJX-Mounted` header.
+
+## Load cache + invalidation
+
+On startup the app calls `configure_load_cache()` (FastAPI lifespan). Default is
+**`CacheScope.PROCESS`** — cross-request `load()` caching per worker. Correctness
+depends on proper invalidation (`@mutates`, `dirty_keys`, reactive `render()`).
+
+Per-request cache only (multi-worker safe without Redis):
+
+```bash
+PJX_LOAD_CACHE_SCOPE=request uv run uvicorn examples.reactive_todo.app:app --reload
+```
+
+Multi-worker with Redis fan-out:
+
+```bash
+PJX_LOAD_CACHE_SCOPE=process REDIS_URL=redis://localhost:6379/0 \
+  uv run uvicorn examples.reactive_todo.app:app --reload
+```
+
+Copy `redis_invalidation.py` into your own project to adapt the backend. Dev deps: `fakeredis`, `redis`.

--- a/examples/reactive_todo/app.py
+++ b/examples/reactive_todo/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
@@ -11,6 +12,7 @@ from fastapi.responses import HTMLResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from examples.reactive_todo import store
+from examples.reactive_todo.invalidation import configure_load_cache, shutdown_load_cache
 from examples.reactive_todo.components import (
     TodoApp,
     TodoClearButton,
@@ -25,7 +27,15 @@ from pyjinhx import Registry, Renderer
 
 Renderer.set_default_environment(Path(__file__).resolve().parents[2])
 
-app = FastAPI(title="pyjinhx reactive todo demo")
+
+@asynccontextmanager
+async def lifespan(_application: FastAPI):
+    configure_load_cache()
+    yield
+    shutdown_load_cache()
+
+
+app = FastAPI(title="pyjinhx reactive todo demo", lifespan=lifespan)
 
 
 class RegistryScopeMiddleware(BaseHTTPMiddleware):

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -39,7 +39,7 @@ class TodoItemRow(ReactiveComponent):
     def load(cls, key: str | int) -> "TodoItemRow":
         store = _store()
         todo = store.get(int(key))
-        return cls(title=todo.text, done=todo.done)
+        return cls(id=f"todo-row-{key}", title=todo.text, done=todo.done)
 
 
 class TodoList(BaseComponent):

--- a/examples/reactive_todo/invalidation.py
+++ b/examples/reactive_todo/invalidation.py
@@ -1,0 +1,39 @@
+"""
+Load-cache configuration for the reactive todo demo.
+
+Defaults to ``CacheScope.PROCESS`` (cross-request ``load()`` cache). Pair with
+``REDIS_URL`` when running multiple workers so ``invalidate()`` fans out.
+
+    PJX_LOAD_CACHE_SCOPE=request   # per-request cache only (multi-worker safe)
+    REDIS_URL=redis://localhost:6379/0
+    REDIS_URL=memory://            # fakeredis experiment, same process only
+"""
+
+from __future__ import annotations
+
+import os
+
+from pyjinhx import (
+    CacheScope,
+    set_invalidation_backend,
+    set_load_cache_scope,
+    start_invalidation_listener,
+    stop_invalidation_listener,
+)
+
+from .redis_invalidation import RedisInvalidationBackend
+
+
+def configure_load_cache() -> None:
+    scope_name = os.environ.get("PJX_LOAD_CACHE_SCOPE", "process").lower()
+    scope = CacheScope(scope_name)
+    set_load_cache_scope(scope)
+
+    redis_url = os.environ.get("REDIS_URL")
+    if scope == CacheScope.PROCESS and redis_url:
+        set_invalidation_backend(RedisInvalidationBackend(redis_url))
+        start_invalidation_listener()
+
+
+def shutdown_load_cache() -> None:
+    stop_invalidation_listener()

--- a/examples/reactive_todo/redis_invalidation.py
+++ b/examples/reactive_todo/redis_invalidation.py
@@ -1,0 +1,131 @@
+"""
+Reference Redis invalidation backend for multi-worker CacheScope.PROCESS setups.
+
+Copy or adapt for your app.
+
+- ``memory://`` — in-process FakeRedis (``pip install fakeredis``), for demos/tests
+- ``redis://...`` — real Redis (``pip install redis``)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from pyjinhx import InvalidationBackend
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CHANNEL = "pyjinhx:invalidate"
+MEMORY_REDIS_URL = "memory://"
+
+
+def _redis_clients(redis_url: str) -> tuple[Any, Any]:
+    """Return separate (publish, subscribe) clients for pub/sub."""
+    if redis_url == MEMORY_REDIS_URL or redis_url.startswith("memory://"):
+        try:
+            import fakeredis
+        except ImportError as exc:
+            raise ImportError(
+                "memory:// requires the fakeredis package: pip install fakeredis"
+            ) from exc
+        server = fakeredis.FakeServer()
+        return (
+            fakeredis.FakeRedis(server=server, decode_responses=True),
+            fakeredis.FakeRedis(server=server, decode_responses=True),
+        )
+    try:
+        import redis
+    except ImportError as exc:
+        raise ImportError(
+            "Redis URLs require the redis package: pip install redis"
+        ) from exc
+    publish_client = redis.from_url(redis_url, decode_responses=True)
+    subscribe_client = redis.from_url(redis_url, decode_responses=True)
+    return publish_client, subscribe_client
+
+
+class RedisInvalidationBackend(InvalidationBackend):
+    """Redis pub/sub fan-out for ``invalidate()`` across Gunicorn/Uvicorn workers."""
+
+    def __init__(
+        self,
+        redis_url: str,
+        *,
+        channel: str = DEFAULT_CHANNEL,
+    ) -> None:
+        self._redis_url = redis_url
+        self._channel = channel
+        self._pub_client: Any = None
+        self._sub_client: Any = None
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._handler: Callable[[frozenset[str]], None] | None = None
+
+    def _ensure_clients(self) -> tuple[Any, Any]:
+        if self._pub_client is not None and self._sub_client is not None:
+            return self._pub_client, self._sub_client
+        self._pub_client, self._sub_client = _redis_clients(self._redis_url)
+        return self._pub_client, self._sub_client
+
+    def publish(self, keys: frozenset[str]) -> None:
+        if not keys:
+            return
+        pub_client, _ = self._ensure_clients()
+        payload = json.dumps(sorted(keys))
+        pub_client.publish(self._channel, payload)
+
+    def start(self, handler: Callable[[frozenset[str]], None]) -> None:
+        self._handler = handler
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._listen_loop,
+            name="pyjinhx-redis-invalidation",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+        for client in (self._pub_client, self._sub_client):
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    logger.debug("Error closing Redis client", exc_info=True)
+        self._pub_client = None
+        self._sub_client = None
+        self._handler = None
+
+    def _listen_loop(self) -> None:
+        _, sub_client = self._ensure_clients()
+        pubsub = sub_client.pubsub(ignore_subscribe_messages=True)
+        pubsub.subscribe(self._channel)
+        try:
+            while not self._stop_event.is_set():
+                message = pubsub.get_message(timeout=1.0)
+                if message is None or message.get("type") != "message":
+                    continue
+                data = message.get("data")
+                if not data or self._handler is None:
+                    continue
+                try:
+                    parsed = json.loads(data)
+                except json.JSONDecodeError:
+                    logger.warning("Ignoring invalid invalidation payload: %r", data)
+                    continue
+                if not isinstance(parsed, list):
+                    continue
+                self._handler(frozenset(str(key) for key in parsed))
+        finally:
+            try:
+                pubsub.unsubscribe(self._channel)
+                pubsub.close()
+            except Exception:
+                logger.debug("Error closing Redis pubsub", exc_info=True)

--- a/examples/reactive_todo/store.py
+++ b/examples/reactive_todo/store.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from itertools import count
 
-from pyjinhx import mutates
+from pyjinhx import mutates, mutation_scope
+from pyjinhx.keys import dirty_keys
 
 from .keys import Keys
 
@@ -35,9 +36,9 @@ def add(text: str) -> Todo:
     return todo
 
 
-@mutates(Keys.TODO, Keys.TODOS)
 def toggle(todo_id: int) -> Todo:
-    _todos[todo_id].done = not _todos[todo_id].done
+    with mutation_scope(*dirty_keys(Keys.TODO, todo_id, Keys.TODOS)):
+        _todos[todo_id].done = not _todos[todo_id].done
     return _todos[todo_id]
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,7 +84,13 @@ nav:
       - WebAwesome: integrations/webawesome.md
       - Claude Code: integrations/claude-code.md
   - API Reference:
+      - Public API Index: reference/public-api.md
       - BaseComponent: api/base-component.md
+      - Reactive API: api/reactive-api.md
+      - Cache & Invalidation: api/cache-invalidation.md
+      - Mutations, Keys & LoadContext: api/mutations-keys-context.md
+      - Parser & Tag: api/parser.md
+      - Assets API: api/assets-api.md
       - Finder: api/finder.md
       - Registry: api/registry.md
       - Renderer: api/renderer.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
   - Getting Started:
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
+      - Build an App: getting-started/build-an-app.md
   - Guide:
       - Creating Components: guide/components.md
       - Component Registry: guide/registry.md

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -10,7 +10,13 @@ from .assets import (
     runtime_asset_path,
 )
 from .base import BaseComponent
-from .cache import invalidate
+from .cache import CacheScope, get_load_cache_scope, invalidate, set_load_cache_scope
+from .invalidation import (
+    InvalidationBackend,
+    set_invalidation_backend,
+    start_invalidation_listener,
+    stop_invalidation_listener,
+)
 from .dataclasses import Tag
 from .finder import Finder, layout_asset_tags
 from .keys import StateKey, dirty_keys, instance_key
@@ -47,6 +53,13 @@ __all__ = [
     "Tag",
     "oob_swaps",
     "invalidate",
+    "CacheScope",
+    "get_load_cache_scope",
+    "set_load_cache_scope",
+    "InvalidationBackend",
+    "set_invalidation_backend",
+    "start_invalidation_listener",
+    "stop_invalidation_listener",
     "client_script",
     "PJX_MOUNTED_HEADER",
     "PJX_ASSETS_HEADER",

--- a/pyjinhx/assets.py
+++ b/pyjinhx/assets.py
@@ -45,7 +45,6 @@ class RenderSession:
     styles: list[str] = field(default_factory=list)
     runtime_injected: bool = False
 
-
     def manifest(self, *, resolver: AssetUrlResolver) -> AssetManifest:
         return asset_manifest(self, resolver=resolver)
 
@@ -99,9 +98,9 @@ def resolver_with_hash(base_url: str, root: str) -> AssetUrlResolver:
         if normalized_path == os.path.normpath(runtime_asset_path()):
             hashed = hashed_filename(normalized_path)
             return f"{base_url.rstrip('/')}/pyjinhx/{hashed}"
-        relative_dir = os.path.relpath(
-            os.path.dirname(normalized_path), root
-        ).replace("\\", "/")
+        relative_dir = os.path.relpath(os.path.dirname(normalized_path), root).replace(
+            "\\", "/"
+        )
         hashed = hashed_filename(normalized_path)
         if relative_dir == ".":
             return f"{base_url.rstrip('/')}/{hashed}"

--- a/pyjinhx/cache.py
+++ b/pyjinhx/cache.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Callable, Iterable
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from .utils import (
@@ -14,8 +17,46 @@ if TYPE_CHECKING:
     from .base import BaseComponent
 
 _lock = threading.Lock()
-_cache: dict[tuple[type, str | None], "BaseComponent"] = {}
-_reverse: dict[str, set[tuple[type, str | None]]] = {}
+
+
+class CacheScope(str, Enum):
+    REQUEST = "request"
+    PROCESS = "process"
+    NONE = "none"
+
+
+_scope: CacheScope = CacheScope.PROCESS
+_request_cache: ContextVar[CacheState | None] = ContextVar(
+    "load_cache_request", default=None
+)
+
+
+@dataclass
+class CacheState:
+    _cache: dict[tuple[type, str | None], BaseComponent] = field(default_factory=dict)
+    _reverse: dict[str, set[tuple[type, str | None]]] = field(default_factory=dict)
+
+
+_process_state = CacheState()
+
+
+def get_load_cache_scope() -> CacheScope:
+    return _scope
+
+
+def set_load_cache_scope(scope: CacheScope) -> None:
+    global _scope
+    _scope = scope
+
+
+def init_request_cache() -> None:
+    """Create a fresh request-scoped cache. Called by ``Registry.request_scope``."""
+    _request_cache.set(CacheState())
+
+
+def reset_request_cache() -> None:
+    """Drop the request-scoped cache. Called by ``Registry.request_scope``."""
+    _request_cache.set(None)
 
 
 def _effective_keys(cls: type[Any], key: str | None) -> set[str]:
@@ -24,6 +65,62 @@ def _effective_keys(cls: type[Any], key: str | None) -> set[str]:
         key,
         keyed=getattr(cls, "_pjx_keyed", False),
     )
+
+
+def _request_store() -> CacheState | None:
+    return _request_cache.get()
+
+
+def _stores_for_read() -> list[CacheState]:
+    scope = get_load_cache_scope()
+    if scope == CacheScope.NONE:
+        return []
+    if scope == CacheScope.PROCESS:
+        return [_process_state]
+    store = _request_store()
+    return [store] if store is not None else []
+
+
+def _stores_for_write() -> list[CacheState]:
+    return _stores_for_read()
+
+
+def _stores_for_invalidate() -> list[CacheState]:
+    stores: list[CacheState] = []
+    request_store = _request_store()
+    if request_store is not None:
+        stores.append(request_store)
+    if get_load_cache_scope() == CacheScope.PROCESS:
+        stores.append(_process_state)
+    return stores
+
+
+def _evict_from_state(state: CacheState, keys: set[str]) -> None:
+    if not keys:
+        return
+    to_evict: set[tuple[type, str | None]] = set()
+    for key in keys:
+        to_evict |= state._reverse.get(key, set())
+        if ":" not in key:
+            instance_prefix = f"{key}:"
+            for reverse_key, cache_keys in state._reverse.items():
+                if reverse_key.startswith(instance_prefix):
+                    to_evict |= cache_keys
+    for cache_key in to_evict:
+        state._cache.pop(cache_key, None)
+        cls, load_key = cache_key
+        for reactive_key in _effective_keys(cls, load_key):
+            bucket = state._reverse.get(reactive_key)
+            if bucket is not None:
+                bucket.discard(cache_key)
+                if not bucket:
+                    state._reverse.pop(reactive_key, None)
+
+
+def _evict_local(keys: set[str]) -> None:
+    with _lock:
+        for state in _stores_for_invalidate():
+            _evict_from_state(state, keys)
 
 
 def install_cached_load(cls: type[Any]) -> None:
@@ -36,30 +133,51 @@ def install_cached_load(cls: type[Any]) -> None:
     original = cls.__dict__["load"]
     raw_func = original.__func__ if isinstance(original, classmethod) else original
 
-    def _cached_load(inner_cls: type[Any], *args: Any) -> "BaseComponent":
+    def _cached_load(inner_cls: type[Any], *args: Any) -> BaseComponent:
         return _load_through_cache(inner_cls, raw_func, args)
 
     cls.load = classmethod(_cached_load)
 
 
-def _with_key(instance: "BaseComponent", key: str | None) -> "BaseComponent":
+def _with_key(instance: BaseComponent, key: str | None) -> BaseComponent:
     instance._pjx_key = key
     return instance
 
 
+def _cache_get(cache_key: tuple[type, str | None]) -> BaseComponent | None:
+    for state in _stores_for_read():
+        cached = state._cache.get(cache_key)
+        if cached is not None:
+            return cached
+    return None
+
+
+def _cache_put(
+    cache_key: tuple[type, str | None],
+    result: BaseComponent,
+    cls: type[Any],
+    key: str | None,
+) -> None:
+    for state in _stores_for_write():
+        state._cache[cache_key] = result
+        for reactive_key in _effective_keys(cls, key):
+            state._reverse.setdefault(reactive_key, set()).add(cache_key)
+
+
 def _load_through_cache(
     cls: type[Any],
-    raw_func: Callable[..., "BaseComponent"],
+    raw_func: Callable[..., BaseComponent],
     args: tuple[Any, ...],
-) -> "BaseComponent":
+) -> BaseComponent:
     raw_key = args[0] if args else None
     key = coerce_load_key_str(raw_key) if raw_key is not None else None
     cache_key = (cls, key)
 
-    with _lock:
-        cached = _cache.get(cache_key)
-    if cached is not None:
-        return _with_key(cached.model_copy(), key)
+    if get_load_cache_scope() != CacheScope.NONE:
+        with _lock:
+            cached = _cache_get(cache_key)
+        if cached is not None:
+            return _with_key(cached.model_copy(), key)
 
     from .load_context import get_load_context, load_accepts_ctx
     from .reactive_dev import validate_load_reads
@@ -89,39 +207,38 @@ def _load_through_cache(
         if result.id == default_id:
             result.id = f"{default_id}-{key}"
 
-    with _lock:
-        _cache[cache_key] = result
-        for k in _effective_keys(cls, key):
-            _reverse.setdefault(k, set()).add(cache_key)
+    if get_load_cache_scope() != CacheScope.NONE:
+        with _lock:
+            _cache_put(cache_key, result, cls, key)
     return _with_key(result.model_copy(), key)
 
 
-def invalidate(dirtied: Iterable[object]) -> None:
+def invalidate(dirtied: Iterable[object], *, propagate: bool = True) -> None:
     """
     Evict every cached ``load()`` result whose (interpolated) reactive keys intersect
     the dirtied keys. ``invalidate({"todo:42"})`` evicts one row; ``invalidate({"todos"})``
-    evicts the collection-tier entries. Per-process only.
+    evicts the collection-tier entries.
+
+    When ``CacheScope.PROCESS`` is active and an ``InvalidationBackend`` is configured,
+    ``propagate=True`` (default) publishes the dirtied keys to other workers after local
+    eviction.
     """
     keys = coerce_reactive_keys(dirtied)
     if not keys:
         return
-    with _lock:
-        to_evict: set[tuple[type, str | None]] = set()
-        for k in keys:
-            to_evict |= _reverse.get(k, set())
-        for cache_key in to_evict:
-            _cache.pop(cache_key, None)
-            cls, key = cache_key
-            for k in _effective_keys(cls, key):
-                bucket = _reverse.get(k)
-                if bucket is not None:
-                    bucket.discard(cache_key)
-                    if not bucket:
-                        _reverse.pop(k, None)
+    _evict_local(keys)
+    if propagate and get_load_cache_scope() == CacheScope.PROCESS:
+        from .invalidation import publish_invalidation
+
+        publish_invalidation(frozenset(keys))
 
 
 def clear() -> None:
-    """Drop all cached ``load()`` results and the reverse index. Mainly for tests."""
+    """Drop all cached ``load()`` results and reverse indexes. Mainly for tests."""
     with _lock:
-        _cache.clear()
-        _reverse.clear()
+        _process_state._cache.clear()
+        _process_state._reverse.clear()
+        request_store = _request_store()
+        if request_store is not None:
+            request_store._cache.clear()
+            request_store._reverse.clear()

--- a/pyjinhx/invalidation.py
+++ b/pyjinhx/invalidation.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+import threading
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+
+logger = logging.getLogger("pyjinhx")
+
+_listener_lock = threading.Lock()
+_backend: InvalidationBackend | None = None
+_listener_started = False
+
+
+class InvalidationBackend(ABC):
+    """Base class for cross-process load-cache invalidation fan-out."""
+
+    @abstractmethod
+    def publish(self, keys: frozenset[str]) -> None: ...
+
+    @abstractmethod
+    def start(self, handler: Callable[[frozenset[str]], None]) -> None: ...
+
+    @abstractmethod
+    def stop(self) -> None: ...
+
+
+def set_invalidation_backend(backend: InvalidationBackend | None) -> None:
+    global _backend
+    with _listener_lock:
+        if _listener_started and _backend is not None:
+            _backend.stop()
+        _backend = backend
+
+
+def publish_invalidation(keys: frozenset[str]) -> None:
+    if not keys or _backend is None:
+        return
+    try:
+        _backend.publish(keys)
+    except Exception:
+        logger.exception("Failed to publish load-cache invalidation for keys %r", keys)
+
+
+def _on_remote_invalidation(keys: frozenset[str]) -> None:
+    from .cache import invalidate
+
+    invalidate(keys, propagate=False)
+
+
+def start_invalidation_listener() -> None:
+    global _listener_started
+    with _listener_lock:
+        if _backend is None:
+            raise RuntimeError(
+                "No InvalidationBackend configured; call set_invalidation_backend() first."
+            )
+        if _listener_started:
+            return
+        _backend.start(_on_remote_invalidation)
+        _listener_started = True
+
+
+def stop_invalidation_listener() -> None:
+    global _listener_started
+    with _listener_lock:
+        if _backend is None or not _listener_started:
+            return
+        _backend.stop()
+        _listener_started = False
+
+
+def reset_invalidation_state() -> None:
+    """Reset backend listener state. Mainly for tests."""
+    global _listener_started, _backend
+    with _listener_lock:
+        if _listener_started and _backend is not None:
+            _backend.stop()
+        _listener_started = False
+        _backend = None

--- a/pyjinhx/mutations.py
+++ b/pyjinhx/mutations.py
@@ -85,11 +85,12 @@ def mutates(*keys: ReactiveKey) -> Callable[[F], F]:
     def decorator(func: F) -> F:
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
+            result = func(*args, **kwargs)
             normalized = coerce_reactive_keys(keys)
             if normalized:
                 invalidate(normalized)
                 _accumulate_dirtied(normalized)
-            return func(*args, **kwargs)
+            return result
 
         return wrapper  # type: ignore[return-value]
 
@@ -104,10 +105,9 @@ def mutation_scope(*keys: ReactiveKey) -> Generator[None, None, None]:
     Keys passed to the scope are added on entry (and invalidate the cache).
     """
     normalized = coerce_reactive_keys(keys)
-    if normalized:
-        invalidate(normalized)
-        _accumulate_dirtied(normalized)
     try:
         yield
     finally:
-        pass
+        if normalized:
+            invalidate(normalized)
+            _accumulate_dirtied(normalized)

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -278,9 +278,7 @@ def parse_loaded_assets(
         try:
             parsed = json.loads(client)
         except json.JSONDecodeError:
-            logger.warning(
-                "Could not parse %s as JSON; ignoring.", PJX_ASSETS_HEADER
-            )
+            logger.warning("Could not parse %s as JSON; ignoring.", PJX_ASSETS_HEADER)
             return frozenset()
         if isinstance(parsed, list):
             return frozenset(str(url) for url in parsed)
@@ -332,7 +330,7 @@ def oob_swaps(
 
     Args:
         dirtied: The state keys the route mutated (e.g. {"todos"}). These keys are
-            also evicted from the process-global load() cache before dependents are
+            also evicted from the load() cache before dependents are
             reloaded.
         mounted: The client manifest — a request-like object exposing
             ``.headers.get`` (the X-PJX-Mounted header is duck-typed out without

--- a/pyjinhx/registry.py
+++ b/pyjinhx/registry.py
@@ -124,11 +124,13 @@ class Registry:
         """
         from contextlib import ExitStack
 
+        from .cache import init_request_cache, reset_request_cache
         from .load_context import load_scope
         from .mutations import clear_mutations
         from .reactive_dev import warn_mutations_without_render
 
         clear_mutations()
+        init_request_cache()
         token = _registry_context.set({})
         try:
             with ExitStack() as stack:
@@ -138,4 +140,5 @@ class Registry:
         finally:
             warn_mutations_without_render()
             clear_mutations()
+            reset_request_cache()
             _registry_context.reset(token)

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -510,7 +510,9 @@ class Renderer:
                 continue
             self._register_asset(session, normalized_path, "css", self._css_mode)
 
-    def _inject_runtime(self, session: RenderSession, component: "BaseComponent") -> None:
+    def _inject_runtime(
+        self, session: RenderSession, component: "BaseComponent"
+    ) -> None:
         if session.runtime_injected:
             return
         if not getattr(type(component), "_pjx_layout", False):
@@ -521,9 +523,7 @@ class Renderer:
             runtime_path = _normalize_asset_path(runtime_asset_path())
             if runtime_path not in session.collected_paths:
                 session.collected_paths.add(runtime_path)
-                session.assets.insert(
-                    0, CollectedAsset(path=runtime_path, kind="js")
-                )
+                session.assets.insert(0, CollectedAsset(path=runtime_path, kind="js"))
         session.runtime_injected = True
 
     def _should_emit_reference_url(
@@ -581,9 +581,7 @@ class Renderer:
         if self._js_mode == AssetMode.INLINE:
             if not session.scripts:
                 return ""
-            return "\n".join(
-                f"<script>{script}</script>" for script in session.scripts
-            )
+            return "\n".join(f"<script>{script}</script>" for script in session.scripts)
         if self._js_mode == AssetMode.REFERENCE:
             js_assets = [asset for asset in session.assets if asset.kind == "js"]
             if not js_assets:
@@ -614,7 +612,10 @@ class Renderer:
 
         rendered_children = "".join(
             self._render_tag_node(
-                child, base_context=base_context, session=session, emit_assets=emit_assets
+                child,
+                base_context=base_context,
+                session=session,
+                emit_assets=emit_assets,
             )
             for child in node.children
         ).strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyjinhx"
-version = "0.5.2"
+version = "0.6.0"
 description = "UI components for Python using Pydantic and Jinja2 templates"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -38,4 +38,6 @@ dev = [
     "httpx>=0.27.0",
     "uvicorn>=0.32.0",
     "python-multipart>=0.0.9",
+    "fakeredis>=2.26.0",
+    "redis>=5.0.0",
 ]

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -1,3 +1,5 @@
+from abc import ABC
+
 import pyjinhx
 
 
@@ -5,17 +7,24 @@ def test_reactive_api_is_exported():
     from pyjinhx import (
         PJX_ASSETS_HEADER,
         PJX_MOUNTED_HEADER,
+        CacheScope,
+        InvalidationBackend,
         ReactiveComponent,
         client_script,
         dependency_graph,
         dirty_keys,
         enable_reactive_dev,
+        get_load_cache_scope,
         get_load_context,
         instance_key,
         mutates,
         oob_swaps,
         parse_loaded_assets,
+        set_invalidation_backend,
+        set_load_cache_scope,
+        start_invalidation_listener,
         StateKey,
+        stop_invalidation_listener,
     )
 
     assert PJX_MOUNTED_HEADER == "X-PJX-Mounted"
@@ -29,6 +38,13 @@ def test_reactive_api_is_exported():
     assert callable(dirty_keys)
     assert callable(instance_key)
     assert callable(parse_loaded_assets)
+    assert callable(set_load_cache_scope)
+    assert callable(get_load_cache_scope)
+    assert callable(set_invalidation_backend)
+    assert callable(start_invalidation_listener)
+    assert callable(stop_invalidation_listener)
+    assert CacheScope.REQUEST == "request"
+    assert issubclass(InvalidationBackend, ABC)
     assert issubclass(ReactiveComponent, pyjinhx.BaseComponent)
     assert issubclass(StateKey, str)
 
@@ -53,5 +69,12 @@ def test_names_in_all():
         "disable_reactive_dev",
         "dependency_graph",
         "format_dependency_graph",
+        "CacheScope",
+        "get_load_cache_scope",
+        "set_load_cache_scope",
+        "InvalidationBackend",
+        "set_invalidation_backend",
+        "start_invalidation_listener",
+        "stop_invalidation_listener",
     ):
         assert name in pyjinhx.__all__

--- a/tests/43_instance_key_cache_test.py
+++ b/tests/43_instance_key_cache_test.py
@@ -57,6 +57,16 @@ def test_instance_invalidation_evicts_one_row():
     assert load_calls["n"] == 3
 
 
+def test_stem_invalidation_evicts_matching_instance_keys():
+    _reset()
+    Row.load("1")
+    Row.load("2")
+    invalidate({"row"})
+    Row.load("1")
+    Row.load("2")
+    assert load_calls["n"] == 4
+
+
 def test_collection_invalidation_evicts_all_rows():
     _reset()
     Row.load("1")

--- a/tests/49_mutations_test.py
+++ b/tests/49_mutations_test.py
@@ -8,6 +8,7 @@ from pyjinhx.mutations import (
     resolve_effective_dirtied,
 )
 from tests.ui.reactive.reactive_clear_button import ReactiveClearButton
+from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401
 from tests.ui.reactive.store import state
 
 UI_ROOT = Path(__file__).parent / "ui" / "reactive"

--- a/tests/50_asset_reference_mode_test.py
+++ b/tests/50_asset_reference_mode_test.py
@@ -49,9 +49,7 @@ def test_reference_mode_emits_link_and_script_tags():
         css_mode=AssetMode.REFERENCE,
     )
 
-    rendered = str(
-        UnifiedComponent(id="ref-1", text="Ref")._render(_renderer=renderer)
-    )
+    rendered = str(UnifiedComponent(id="ref-1", text="Ref")._render(_renderer=renderer))
 
     assert '<link rel="stylesheet" href="/assets/unified-component.css">' in rendered
     assert '<script src="/assets/unified-component.js"></script>' in rendered
@@ -209,7 +207,11 @@ def test_layout_reference_mode_emits_runtime_src():
     Renderer.set_default_runtime_url("/static/pyjinhx/pjx.js")
     renderer = Renderer.get_default_renderer(js_mode=AssetMode.REFERENCE)
 
-    rendered = str(Page(id="page")._render(source="<html><body>hi</body></html>", _renderer=renderer))
+    rendered = str(
+        Page(id="page")._render(
+            source="<html><body>hi</body></html>", _renderer=renderer
+        )
+    )
 
     assert '<script src="/static/pyjinhx/pjx.js"></script>' in rendered
     assert read_client_runtime() not in rendered

--- a/tests/51_client_asset_manifest_test.py
+++ b/tests/51_client_asset_manifest_test.py
@@ -3,7 +3,13 @@ import os
 
 import pytest
 
-from pyjinhx import AssetMode, BaseComponent, PJX_ASSETS_HEADER, Renderer, parse_loaded_assets
+from pyjinhx import (
+    AssetMode,
+    BaseComponent,
+    PJX_ASSETS_HEADER,
+    Renderer,
+    parse_loaded_assets,
+)
 from pyjinhx.reactive import oob_swaps
 from pyjinhx.utils import read_client_runtime
 from tests.ui.reactive.reactive_counter import ReactiveCounter
@@ -105,9 +111,7 @@ def test_root_reference_render_emits_all_when_nothing_loaded():
         css_mode=AssetMode.REFERENCE,
     )
 
-    rendered = str(
-        UnifiedComponent(id="all-1", text="All")._render(_renderer=renderer)
-    )
+    rendered = str(UnifiedComponent(id="all-1", text="All")._render(_renderer=renderer))
 
     assert 'rel="stylesheet"' in rendered
     assert "<script src=" in rendered

--- a/tests/53_load_cache_scope_test.py
+++ b/tests/53_load_cache_scope_test.py
@@ -1,0 +1,79 @@
+from pyjinhx import (
+    CacheScope,
+    Registry,
+    get_load_cache_scope,
+    invalidate,
+    set_load_cache_scope,
+)
+from pyjinhx.cache import clear
+from tests.ui.reactive.cached_widget import CachedWidget, load_calls
+
+
+def _reset():
+    clear()
+    load_calls["count"] = 0
+
+
+def test_request_scope_within_request_caches():
+    _reset()
+    CachedWidget.load()
+    CachedWidget.load()
+    assert load_calls["count"] == 1
+
+
+def test_request_scope_invalidate_evicts_within_request():
+    _reset()
+    first = CachedWidget.load()
+    invalidate({"widgets"})
+    second = CachedWidget.load()
+    assert load_calls["count"] == 2
+    assert first.value == 1 and second.value == 2
+
+
+def test_request_scope_no_cross_request_cache():
+    _reset()
+    original = get_load_cache_scope()
+    try:
+        set_load_cache_scope(CacheScope.REQUEST)
+        with Registry.request_scope():
+            CachedWidget.load()
+        with Registry.request_scope():
+            CachedWidget.load()
+        assert load_calls["count"] == 2
+    finally:
+        set_load_cache_scope(original)
+
+
+def test_process_scope_cross_request_cache():
+    _reset()
+    original = get_load_cache_scope()
+    try:
+        set_load_cache_scope(CacheScope.PROCESS)
+        CachedWidget.load()
+        CachedWidget.load()
+        assert load_calls["count"] == 1
+    finally:
+        set_load_cache_scope(original)
+
+
+def test_none_scope_always_loads():
+    _reset()
+    original = get_load_cache_scope()
+    try:
+        set_load_cache_scope(CacheScope.NONE)
+        CachedWidget.load()
+        CachedWidget.load()
+        assert load_calls["count"] == 2
+    finally:
+        set_load_cache_scope(original)
+
+
+def test_scope_setter_getter_round_trip():
+    original = get_load_cache_scope()
+    try:
+        set_load_cache_scope(CacheScope.PROCESS)
+        assert get_load_cache_scope() == CacheScope.PROCESS
+        set_load_cache_scope(CacheScope.NONE)
+        assert get_load_cache_scope() == CacheScope.NONE
+    finally:
+        set_load_cache_scope(original)

--- a/tests/54_invalidation_backend_test.py
+++ b/tests/54_invalidation_backend_test.py
@@ -1,0 +1,97 @@
+from collections.abc import Callable
+
+from pyjinhx import (
+    CacheScope,
+    InvalidationBackend,
+    invalidate,
+    set_invalidation_backend,
+    set_load_cache_scope,
+    start_invalidation_listener,
+    stop_invalidation_listener,
+)
+from pyjinhx.cache import clear, get_load_cache_scope
+from pyjinhx.invalidation import reset_invalidation_state
+from tests.ui.reactive.cached_widget import CachedWidget, load_calls
+
+
+class FakeInvalidationBackend(InvalidationBackend):
+    def __init__(self) -> None:
+        self.published: list[frozenset[str]] = []
+        self.handler: Callable[[frozenset[str]], None] | None = None
+
+    def publish(self, keys: frozenset[str]) -> None:
+        self.published.append(keys)
+
+    def start(self, handler: Callable[[frozenset[str]], None]) -> None:
+        self.handler = handler
+
+    def stop(self) -> None:
+        self.handler = None
+
+
+def _reset():
+    clear()
+    load_calls["count"] = 0
+
+
+def test_invalidate_publishes_under_process_scope():
+    _reset()
+    original_scope = get_load_cache_scope()
+    backend = FakeInvalidationBackend()
+    try:
+        set_load_cache_scope(CacheScope.PROCESS)
+        set_invalidation_backend(backend)
+        invalidate({"widgets"})
+        assert backend.published == [frozenset({"widgets"})]
+    finally:
+        reset_invalidation_state()
+        set_load_cache_scope(original_scope)
+
+
+def test_invalidate_propagate_false_does_not_publish():
+    _reset()
+    original_scope = get_load_cache_scope()
+    backend = FakeInvalidationBackend()
+    try:
+        set_load_cache_scope(CacheScope.PROCESS)
+        set_invalidation_backend(backend)
+        invalidate({"widgets"}, propagate=False)
+        assert backend.published == []
+    finally:
+        reset_invalidation_state()
+        set_load_cache_scope(original_scope)
+
+
+def test_invalidate_does_not_publish_under_request_scope():
+    _reset()
+    original_scope = get_load_cache_scope()
+    backend = FakeInvalidationBackend()
+    try:
+        set_load_cache_scope(CacheScope.REQUEST)
+        set_invalidation_backend(backend)
+        invalidate({"widgets"})
+        assert backend.published == []
+    finally:
+        reset_invalidation_state()
+        set_load_cache_scope(original_scope)
+
+
+def test_remote_invalidation_evicts_process_cache():
+    _reset()
+    original_scope = get_load_cache_scope()
+    backend = FakeInvalidationBackend()
+    try:
+        set_load_cache_scope(CacheScope.PROCESS)
+        set_invalidation_backend(backend)
+        start_invalidation_listener()
+        CachedWidget.load()
+        assert load_calls["count"] == 1
+        assert backend.handler is not None
+        load_calls["count"] = 0
+        backend.handler(frozenset({"widgets"}))
+        CachedWidget.load()
+        assert load_calls["count"] == 1
+    finally:
+        stop_invalidation_listener()
+        reset_invalidation_state()
+        set_load_cache_scope(original_scope)

--- a/tests/55_memory_redis_invalidation_test.py
+++ b/tests/55_memory_redis_invalidation_test.py
@@ -1,0 +1,31 @@
+from pyjinhx import CacheScope, invalidate, set_invalidation_backend, set_load_cache_scope
+from pyjinhx.cache import clear, get_load_cache_scope
+from pyjinhx.invalidation import reset_invalidation_state, start_invalidation_listener, stop_invalidation_listener
+from examples.reactive_todo.redis_invalidation import MEMORY_REDIS_URL, RedisInvalidationBackend
+from tests.ui.reactive.cached_widget import CachedWidget, load_calls
+
+
+def _reset():
+    clear()
+    load_calls["count"] = 0
+
+
+def test_memory_redis_fanout_evicts_process_cache():
+    _reset()
+    original_scope = get_load_cache_scope()
+    try:
+        set_load_cache_scope(CacheScope.PROCESS)
+        backend = RedisInvalidationBackend(MEMORY_REDIS_URL)
+        set_invalidation_backend(backend)
+        start_invalidation_listener()
+
+        CachedWidget.load()
+        assert load_calls["count"] == 1
+        invalidate({"widgets"})
+        load_calls["count"] = 0
+        CachedWidget.load()
+        assert load_calls["count"] == 1
+    finally:
+        stop_invalidation_listener()
+        reset_invalidation_state()
+        set_load_cache_scope(original_scope)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,26 +2,30 @@ from collections.abc import Generator
 
 import pytest
 
-from pyjinhx import Registry
+from pyjinhx import CacheScope, Registry, get_load_cache_scope, set_load_cache_scope
 from pyjinhx.cache import clear as clear_load_cache
+from pyjinhx.invalidation import reset_invalidation_state
 from pyjinhx.mutations import clear_mutations
 
 
 @pytest.fixture(autouse=True)
 def _isolate_reactive_state() -> Generator[None, None, None]:
     """
-    Reset pyjinhx's process-global state around every test.
+    Reset pyjinhx reactive state around every test inside a request scope.
 
-    - The load() cache is process-global.
-    - The instance registry persists across tests (it is a ContextVar), and the
-      renderer injects every registered instance into the template context by id,
-      so a leftover instance whose id collides with another test's component field
-      or template variable would shadow it. Clear both for isolation.
+    Mirrors production: load() cache (REQUEST scope), instance registry, and
+    mutation tracking are all request-scoped.
     """
+    original_scope = get_load_cache_scope()
     clear_load_cache()
     clear_mutations()
+    reset_invalidation_state()
     Registry.clear_instances()
-    yield
+    set_load_cache_scope(CacheScope.PROCESS)
+    with Registry.request_scope():
+        yield
     clear_load_cache()
     clear_mutations()
+    reset_invalidation_state()
     Registry.clear_instances()
+    set_load_cache_scope(original_scope)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from examples.reactive_todo.app import app
+from examples.reactive_todo.invalidation import configure_load_cache, shutdown_load_cache
+
+
+@pytest.fixture
+def client():
+    configure_load_cache()
+    with TestClient(app) as test_client:
+        yield test_client
+    shutdown_load_cache()

--- a/tests/integration/test_instance_keyed.py
+++ b/tests/integration/test_instance_keyed.py
@@ -2,14 +2,11 @@ import json
 from pathlib import Path
 
 import pytest
-from fastapi.testclient import TestClient
 
 from examples.reactive_todo import store
-from examples.reactive_todo.app import app
 from pyjinhx import PJX_MOUNTED_HEADER, Renderer
 
 ROOT = Path(__file__).resolve().parents[2]
-client = TestClient(app)
 
 
 @pytest.fixture(autouse=True)
@@ -28,7 +25,7 @@ def _manifest(*entries):
 def _rows(*ids):
     return [
         {
-            "id": f"todo-item-row-{i}",
+            "id": f"todo-row-{i}",
             "type": "TodoItemRow",
             "key": str(i),
             "hash": "stale",
@@ -37,31 +34,31 @@ def _rows(*ids):
     ]
 
 
-def test_index_renders_instance_keyed_rows():
+def test_index_renders_instance_keyed_rows(client):
     body = client.get("/").text
     for i in (1, 2, 3):
-        assert f'data-pjx-id="todo-item-row-{i}"' in body
+        assert f'data-pjx-id="todo-row-{i}"' in body
         assert f'data-pjx-key="{i}"' in body
     assert 'data-pjx-type="TodoItemRow"' in body
 
 
-def test_toggle_row_swaps_only_that_row():
+def test_toggle_row_swaps_only_that_row(client):
     headers = _manifest(*_rows(1, 2, 3))
     body = client.post("/rows/1/toggle", headers=headers).text
 
-    assert 'data-pjx-id="todo-item-row-1"' in body
+    assert 'data-pjx-id="todo-row-1"' in body
     assert 'data-pjx-key="1"' in body
 
-    assert "outerHTML:[data-pjx-id='todo-item-row-1']" not in body
-    assert "outerHTML:[data-pjx-id='todo-item-row-2']" not in body
-    assert "outerHTML:[data-pjx-id='todo-item-row-3']" not in body
+    assert "outerHTML:[data-pjx-id='todo-row-1']" not in body
+    assert "outerHTML:[data-pjx-id='todo-row-2']" not in body
+    assert "outerHTML:[data-pjx-id='todo-row-3']" not in body
 
 
-def test_toggle_row_does_not_resurrect_other_rows_as_oob():
+def test_toggle_row_does_not_resurrect_other_rows_as_oob(client):
     headers = _manifest(*_rows(1, 2, 3))
     body = client.post("/rows/2/toggle", headers=headers).text
 
-    assert 'data-pjx-id="todo-item-row-2"' in body
+    assert 'data-pjx-id="todo-row-2"' in body
     assert 'data-pjx-key="2"' in body
-    assert "outerHTML:[data-pjx-id='todo-item-row-1']" not in body
-    assert "outerHTML:[data-pjx-id='todo-item-row-3']" not in body
+    assert "outerHTML:[data-pjx-id='todo-row-1']" not in body
+    assert "outerHTML:[data-pjx-id='todo-row-3']" not in body

--- a/tests/integration/test_reactive_todo.py
+++ b/tests/integration/test_reactive_todo.py
@@ -2,15 +2,12 @@ import json
 from pathlib import Path
 
 import pytest
-from fastapi.testclient import TestClient
 
 from examples.reactive_todo import store
-from examples.reactive_todo.app import app
 from examples.reactive_todo.components import TodoCounter, TodoTotal
 from pyjinhx import PJX_MOUNTED_HEADER, Renderer
 
 ROOT = Path(__file__).resolve().parents[2]
-client = TestClient(app)
 
 
 @pytest.fixture(autouse=True)
@@ -26,7 +23,7 @@ def _manifest(*entries):
     return {PJX_MOUNTED_HEADER: json.dumps(list(entries))}
 
 
-def test_index_injects_runtime_and_stamps_regions():
+def test_index_injects_runtime_and_stamps_regions(client):
     body = client.get("/").text
     assert "htmx.org" in body
     assert "htmx:configRequest" in body
@@ -36,7 +33,7 @@ def test_index_injects_runtime_and_stamps_regions():
     assert "3 left" in body and "3 total" in body
 
 
-def test_toggle_swaps_changed_dependents():
+def test_toggle_swaps_changed_dependents(client):
     headers = _manifest(
         {"id": "todo-counter", "type": "TodoCounter", "hash": "stale"},
         {"id": "todo-clear", "type": "TodoClearButton", "hash": "stale"},
@@ -49,7 +46,7 @@ def test_toggle_swaps_changed_dependents():
     )
 
 
-def test_toggle_hash_gates_unchanged_total():
+def test_toggle_hash_gates_unchanged_total(client):
     fresh_total = TodoTotal.load()
     headers = _manifest(
         {"id": "todo-counter", "type": "TodoCounter", "hash": "stale"},
@@ -60,7 +57,7 @@ def test_toggle_hash_gates_unchanged_total():
     assert "outerHTML:[data-pjx-id='todo-total']" not in body
 
 
-def test_clear_completed_hash_gates_unchanged_counter():
+def test_clear_completed_hash_gates_unchanged_counter(client):
     client.post("/todos/1/toggle", headers=_manifest())
     fresh_counter = TodoCounter.load()
     headers = _manifest(
@@ -76,7 +73,7 @@ def test_clear_completed_hash_gates_unchanged_counter():
     assert "outerHTML:[data-pjx-id='todo-total']" in body
 
 
-def test_toggle_row_primary_reflects_mutation_despite_warm_cache():
+def test_toggle_row_primary_reflects_mutation_despite_warm_cache(client):
     client.get("/")
     body = client.post("/rows/1/toggle").text
     primary = body.split("hx-swap-oob")[0]
@@ -85,7 +82,7 @@ def test_toggle_row_primary_reflects_mutation_despite_warm_cache():
     assert 'class="todo done"' not in primary_off and "○" in primary_off
 
 
-def test_unknown_mounted_region_is_ignored():
+def test_unknown_mounted_region_is_ignored(client):
     body = client.post(
         "/todos/1/toggle",
         headers=_manifest({"id": "ghost", "type": "DoesNotExist", "hash": "x"}),

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,19 @@ wheels = [
 ]
 
 [[package]]
+name = "fakeredis"
+version = "2.36.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/48/c08ec5c1d0d16e15247787b83d9b2a9cb1f1a27514cd85407956040cc383/fakeredis-2.36.1.tar.gz", hash = "sha256:7240567f4e1c07a2b3d30c0fd88e5e598e948c2e25850a560727de1d1d3dc946", size = 210959, upload-time = "2026-06-07T16:11:50.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/94/1f993adaa735f2922d991e1e66e64f2de1bf044bee601d03dde5b71513d4/fakeredis-2.36.1-py3-none-any.whl", hash = "sha256:220a77bebb985c59076951336478c4c983be76b5d9f44d3011dd61171d082062", size = 139357, upload-time = "2026-06-07T16:11:48.418Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.135.1"
 source = { registry = "https://pypi.org/simple" }
@@ -559,7 +572,7 @@ wheels = [
 
 [[package]]
 name = "pyjinhx"
-version = "0.5.2"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
@@ -570,11 +583,13 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "fakeredis" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "python-multipart" },
+    { name = "redis" },
     { name = "uvicorn" },
 ]
 
@@ -588,11 +603,13 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "fakeredis", specifier = ">=2.26.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mkdocs-material", specifier = ">=9.7.1" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.9" },
+    { name = "redis", specifier = ">=5.0.0" },
     { name = "uvicorn", specifier = ">=0.32.0" },
 ]
 
@@ -695,6 +712,15 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -716,6 +742,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `CacheScope` (`PROCESS` default, `REQUEST`, `NONE`) for reactive `load()` caching, wired to `Registry.request_scope()` lifecycle
- Add `InvalidationBackend` ABC with listener hooks so `invalidate()` can fan out across workers when using `PROCESS` scope
- Fix invalidation correctness: stem key eviction (`todo` → `todo:*`), invalidate after mutation in `@mutates`/`mutation_scope`, and instance-keyed `dirty_keys` in the todo demo
- Wire the reactive todo example with lifespan cache config and an optional Redis reference backend in `examples/reactive_todo/`

## Test plan
- [x] `uv run pytest` (278 passed)
- [x] `uv run ruff check .`
- [ ] Manual: `uv run uvicorn examples.reactive_todo.app:app --reload` — row toggles respond on first click
- [ ] Optional: `REDIS_URL=memory://` with `PJX_LOAD_CACHE_SCOPE=process` for fan-out experiment


Made with [Cursor](https://cursor.com)