### PR TITLE
Add ClientBackend for automatic header resolution in render()

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ You can also start from an HTML string — `Renderer.render("<Card ...><Button .
 
 ## Reactivity
 
-Declare what state each component depends on. After a mutation, render the **primary** response with `dirtied` and `mounted`; PyJinHx appends out-of-band swaps for other mounted regions whose dependencies overlap.
+Declare what state each component depends on. After a mutation, return `Cls.render()`; PyJinHx appends out-of-band swaps for other mounted regions whose dependencies overlap.
 
 ```python
 from enum import Enum
@@ -133,22 +133,22 @@ class Counter(ReactiveComponent):
 
     @classmethod
     def load(cls) -> "Counter":
-        return cls(id="counter", remaining=db.remaining())
+        return cls(remaining=db.remaining())  # id defaults to "counter"
 
 
 @app.post("/todos/toggle")
-def toggle(request):
+def toggle():
     db.toggle_all()
-    return Counter.render(dirtied={StateKey.TODOS}, mounted=request)
+    return Counter.render(dirtied={StateKey.TODOS})
 ```
 
-The client reports mounted regions via the `X-PJX-Mounted` header; `pjx.js` is injected automatically on layout components. `reacts_to`, `dirtied`, and instance keys accept strings or enums (normalized via `.value`). Instance-keyed components use bare stems in `reacts_to` (e.g. `"todo"` or `StateKey.TODO` → `"todo:<key>"`).
+Wire `fastapi_client_backend(request)` in your app's middleware via `Registry.request_scope(client_backend=...)` so mutation routes omit `mounted=` — the client manifest (`X-PJX-Mounted`) is read automatically after `@mutates`. `pjx.js` is injected on root full-page renders unless that header is already present.
 
 **Reactive ergonomics:** use `StateKey` enums and `dirty_keys()` for typed keys; `@mutates` on store methods to auto-supply `dirtied`; `load_scope()` / `get_load_context()` to inject dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
 
 **Load cache scope** (default `CacheScope.PROCESS`): `load()` results are cached per worker for cross-request hits. Use `Registry.request_scope()` on every request for instance registry isolation. For multiple workers, subclass `InvalidationBackend` (Redis reference: [examples/reactive_todo/redis_invalidation.py](examples/reactive_todo/redis_invalidation.py)) or opt into `CacheScope.REQUEST`.
 
-Details: [reactivity guide](docs/reactivity.md). Step-by-step app tutorial: [Build an App](docs/getting-started/build-an-app.md). Runnable demo: [examples/reactive_todo/](examples/reactive_todo/).
+Details: [usage tiers](docs/guide/usage-tiers.md) · [reactivity guide](docs/reactivity.md) · [Build an App](docs/getting-started/build-an-app.md) · [examples/reactive_todo/](examples/reactive_todo/).
 
 ## JS & CSS collection
 
@@ -175,7 +175,7 @@ Each asset is included once per render session. Output order: `<style>` tags, HT
 - **REFERENCE**: production — emits `<link href="...">` / `<script src="...">` from a per-render manifest; configure `Renderer.set_asset_url_resolver()`.
 - **NONE**: no asset tags (legacy `set_default_inline_js(False)` behavior).
 
-Reactive partial responses (when `mounted` is set) and OOB swaps never emit assets. Full-page layout renders emit them once. For boosted navigation in REFERENCE mode, enable client asset dedup so root renders skip URLs the browser already has (`X-PJX-Assets` header + `render(client=request)`).
+Reactive partial responses (when `mounted` is set) and OOB swaps never emit assets. Full-page layout renders emit them once. For boosted navigation in REFERENCE mode, enable client asset dedup so root renders skip URLs the browser already has (`X-PJX-Assets` via `ClientBackend` in middleware, or `render(client=request)`).
 
 ```python
 from pyjinhx import AssetMode, Renderer
@@ -270,34 +270,42 @@ class TodoApp(BaseComponent):
 ```
 
 ```python
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
-from pyjinhx import Registry, Renderer
+from pyjinhx import Registry, Renderer, fastapi_client_backend
+from starlette.middleware.base import BaseHTTPMiddleware
 
 Renderer.set_default_environment("./components")
 app = FastAPI()
 
 
+class RegistryScopeMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        with Registry.request_scope(client_backend=fastapi_client_backend(request)):
+            return await call_next(request)
+
+
+app.add_middleware(RegistryScopeMiddleware)
+
+
 @app.get("/", response_class=HTMLResponse)
 def index():
-    with Registry.request_scope():
-        return str(
-            TodoApp(
-                id="todo-app",
-                todo_list=TodoList(
-                    id="todo-list",
-                    items=[TodoRow.load(t.id) for t in db.all()],
-                ),
-                counter=TodoCounter.load(),
-            ).render()
-        )
+    return str(
+        TodoApp(
+            id="todo-app",
+            todo_list=TodoList(
+                id="todo-list",
+                items=[TodoRow.load(t.id) for t in db.all()],
+            ),
+            counter=TodoCounter.load(),
+        ).render()
+    )
 
 
 @app.post("/rows/{todo_id}/toggle", response_class=HTMLResponse)
-def toggle_row(request: Request, todo_id: int):
-    with Registry.request_scope():
-        db.toggle(todo_id)
-        return TodoRow.render(todo_id, dirtied={StateKey.TODOS}, mounted=request)
+def toggle_row(todo_id: int):
+    db.toggle(todo_id)
+    return TodoRow.render(todo_id)
 ```
 
 Run the full app: `uv run uvicorn examples.reactive_todo.app:app --reload` — see [examples/reactive_todo/README.md](examples/reactive_todo/README.md).

--- a/docs/api/base-component.md
+++ b/docs/api/base-component.md
@@ -23,12 +23,25 @@ Components accept extra fields beyond those defined in the class (`extra="allow"
 ##### render()
 
 ```python
-def render() -> Markup
+def render(
+    *,
+    dirtied: set[ReactiveKey] | None = None,
+    mounted: object | None = None,
+    client: object | None = None,
+) -> Markup
 ```
 
 Render this component to HTML using its associated Jinja template.
 
 The template is auto-discovered based on the component class name (e.g., `MyButton` looks for `my_button.html` or `my_button.jinja`). All component fields are available in the template context, and nested components are rendered recursively.
+
+With no arguments this is a plain render. Passing `dirtied` and/or `mounted` opts into dependency-aware reactivity: this component is the primary response, and OOB swaps are appended for other mounted reactive regions whose `reacts_to` intersects `dirtied`. See [Reactivity](../reactivity.md).
+
+| Parameter | Description |
+|-----------|-------------|
+| `dirtied` | State keys the route mutated (e.g. `{"todos"}`). Defaults to the primary's `reacts_to`. |
+| `mounted` | Client manifest — request-like object, raw `X-PJX-Mounted` string, or parsed list. When omitted, uses the request-scoped `ClientBackend` after mutations. |
+| `client` | Request-like object or raw `X-PJX-Assets` JSON for REFERENCE-mode asset dedup on root renders. When omitted, uses the request-scoped `ClientBackend`. |
 
 **Returns:** The rendered HTML as a Markup object (safe for direct use in templates).
 

--- a/docs/api/client-backend.md
+++ b/docs/api/client-backend.md
@@ -1,15 +1,42 @@
 # Client Backend
 
-Per-request HTTP header access for reactive rendering. Wire once in middleware; `render()` reads `X-PJX-Mounted` and `X-PJX-Assets` automatically.
+Per-request HTTP header access for reactive rendering. Wire once in your app's middleware; `render()` reads `X-PJX-Mounted` and `X-PJX-Assets` automatically.
+
+PyJinHx does **not** ship middleware — you define a thin wrapper (see [FastAPI integration](../integrations/fastapi.md#middleware-recommended)) that calls `Registry.request_scope(client_backend=fastapi_client_backend(request))`.
 
 ## ClientBackend
 
 ```python
 class ClientBackend(ABC):
     def get_header(self, name: str) -> str | None: ...
+
+    @classmethod
+    def current(cls) -> ClientBackend | None: ...
+
+    @classmethod
+    def scope(cls, backend: ClientBackend | None) -> ContextManager[None]: ...
+
+    @classmethod
+    def reset(cls) -> None: ...
+
+    @classmethod
+    def resolve_client(cls, explicit: object | None) -> object | None: ...
+
+    @classmethod
+    def resolve_mounted(
+        cls, explicit: object | None, *, dirtied: object | None
+    ) -> object | None: ...
 ```
 
 Abstract base — implement for non-FastAPI frameworks if needed.
+
+| Class method | Purpose |
+|--------------|---------|
+| `current()` | Return the active backend for this request, or `None`. |
+| `scope(backend)` | Set the request-scoped backend (usually via `Registry.request_scope`). |
+| `reset()` | Clear the backend. Mainly for tests. |
+| `resolve_client(explicit)` | Return `explicit` if set, else `current()`. Used by `render()`. |
+| `resolve_mounted(explicit, dirtied=...)` | Return `explicit` if set; else `current()` only when reactive mode applies (see below). |
 
 ## FastAPIClientBackend
 
@@ -26,16 +53,7 @@ Default implementation for FastAPI and Starlette. Wraps `request.headers`. The i
 def fastapi_client_backend(request: object) -> FastAPIClientBackend
 ```
 
-Factory — use this in middleware:
-
-```python
-from pyjinhx import Registry, fastapi_client_backend
-
-with Registry.request_scope(
-    client_backend=fastapi_client_backend(request),
-):
-    ...
-```
+Factory for use in your app's middleware. PyJinHx does not ship middleware — see the [canonical snippet](../integrations/fastapi.md#middleware-recommended).
 
 ## Auto-resolution in render()
 
@@ -47,3 +65,11 @@ When `client=` and `mounted=` are omitted:
 | `mounted` | Backend is set **and** (`dirtied` passed or `@mutates` left pending dirtied) |
 
 Explicit `client=` / `mounted=` always override the backend.
+
+### Mutation-only `mounted` rule
+
+`mounted` is **not** auto-resolved on every request. It applies only when the render is reactive — i.e. `dirtied` is passed (including via pending `@mutates` keys) — so hx-boost full-page GETs do not accidentally enter the OOB swap path.
+
+## Non-FastAPI frameworks
+
+Subclass `ClientBackend` and implement `get_header()`. Pass the instance to `Registry.request_scope(client_backend=...)`. The backend instance should expose `.headers.get()` for duck typing, or pass `mounted=` / `client=` explicitly on each `render()` call.

--- a/docs/api/client-backend.md
+++ b/docs/api/client-backend.md
@@ -1,6 +1,6 @@
 # Client Backend
 
-Framework-agnostic access to HTTP request headers for reactive rendering. Wire once per request in middleware; `render()` reads `X-PJX-Mounted` and `X-PJX-Assets` automatically.
+Per-request HTTP header access for reactive rendering. Wire once in middleware; `render()` reads `X-PJX-Mounted` and `X-PJX-Assets` automatically.
 
 ## ClientBackend
 
@@ -9,38 +9,33 @@ class ClientBackend(ABC):
     def get_header(self, name: str) -> str | None: ...
 ```
 
-Abstract base for reading headers on the current request.
+Abstract base — implement for non-FastAPI frameworks if needed.
 
-## RequestClientBackend (default for FastAPI / Starlette)
+## FastAPIClientBackend
 
 ```python
-class RequestClientBackend(HeadersClientBackend):
+class FastAPIClientBackend(ClientBackend):
     def __init__(self, request: object) -> None: ...
 ```
 
-Wraps any request object with `.headers.get(name)`. No `fastapi` import in core.
+Default implementation for FastAPI and Starlette. Wraps `request.headers`. The instance exposes `.headers.get()` for `render()` duck typing.
 
-## client_backend_from_request
+## fastapi_client_backend
 
 ```python
-def client_backend_from_request(request: object) -> RequestClientBackend
+def fastapi_client_backend(request: object) -> FastAPIClientBackend
 ```
 
-Factory for the default ASGI request backend.
-
-## Request scope wiring
+Factory — use this in middleware:
 
 ```python
-from pyjinhx import Registry, client_backend_from_request
+from pyjinhx import Registry, fastapi_client_backend
 
 with Registry.request_scope(
-    load_context=...,
-    client_backend=client_backend_from_request(request),
+    client_backend=fastapi_client_backend(request),
 ):
     ...
 ```
-
-Or use `ClientBackendMiddleware.bind_client_backend` inside a Starlette/FastAPI `BaseHTTPMiddleware`.
 
 ## Auto-resolution in render()
 
@@ -52,12 +47,3 @@ When `client=` and `mounted=` are omitted:
 | `mounted` | Backend is set **and** (`dirtied` passed or `@mutates` left pending dirtied) |
 
 Explicit `client=` / `mounted=` always override the backend.
-
-## HeadersClientBackend
-
-```python
-class HeadersClientBackend(ClientBackend):
-    def __init__(self, headers: Mapping[str, str]) -> None: ...
-```
-
-For tests or non-ASGI contexts with a plain header mapping.

--- a/docs/api/client-backend.md
+++ b/docs/api/client-backend.md
@@ -1,0 +1,63 @@
+# Client Backend
+
+Framework-agnostic access to HTTP request headers for reactive rendering. Wire once per request in middleware; `render()` reads `X-PJX-Mounted` and `X-PJX-Assets` automatically.
+
+## ClientBackend
+
+```python
+class ClientBackend(ABC):
+    def get_header(self, name: str) -> str | None: ...
+```
+
+Abstract base for reading headers on the current request.
+
+## RequestClientBackend (default for FastAPI / Starlette)
+
+```python
+class RequestClientBackend(HeadersClientBackend):
+    def __init__(self, request: object) -> None: ...
+```
+
+Wraps any request object with `.headers.get(name)`. No `fastapi` import in core.
+
+## client_backend_from_request
+
+```python
+def client_backend_from_request(request: object) -> RequestClientBackend
+```
+
+Factory for the default ASGI request backend.
+
+## Request scope wiring
+
+```python
+from pyjinhx import Registry, client_backend_from_request
+
+with Registry.request_scope(
+    load_context=...,
+    client_backend=client_backend_from_request(request),
+):
+    ...
+```
+
+Or use `ClientBackendMiddleware.bind_client_backend` inside a Starlette/FastAPI `BaseHTTPMiddleware`.
+
+## Auto-resolution in render()
+
+When `client=` and `mounted=` are omitted:
+
+| Parameter | Resolved from backend when |
+|-----------|---------------------------|
+| `client` | Backend is set (runtime skip, asset dedup) |
+| `mounted` | Backend is set **and** (`dirtied` passed or `@mutates` left pending dirtied) |
+
+Explicit `client=` / `mounted=` always override the backend.
+
+## HeadersClientBackend
+
+```python
+class HeadersClientBackend(ClientBackend):
+    def __init__(self, headers: Mapping[str, str]) -> None: ...
+```
+
+For tests or non-ASGI contexts with a plain header mapping.

--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -109,15 +109,20 @@ def load_scope(ctx: Any) -> Generator[None, None, None]
 Set the load context for the current scope. Prefer `Registry.request_scope(load_context=ctx)` in web apps — it combines registry isolation, request cache, mutation tracking, and load context in one call.
 
 ```python
-from pyjinhx import LoadContext, Registry
+from pyjinhx import LoadContext, Registry, fastapi_client_backend
 
 @dataclass(frozen=True)
 class AppLoadContext(LoadContext):
     db: Session
 
-with Registry.request_scope(load_context=AppLoadContext(db=session)):
-    html = TodoList.render(mounted=request)
+with Registry.request_scope(
+    load_context=AppLoadContext(db=session),
+    client_backend=fastapi_client_backend(request),
+):
+    html = TodoList.render()  # mounted from ClientBackend after @mutates
 ```
+
+Without `ClientBackend`, pass `mounted=request` on reactive `render()` calls.
 
 ## Reactive dev
 

--- a/docs/api/reactive-api.md
+++ b/docs/api/reactive-api.md
@@ -24,6 +24,8 @@ Base class for components that reload from application state via a `load()` clas
 
 Set `_pjx_keyed = True` on instance-keyed components (e.g. one row per todo). Singleton components omit the key.
 
+Singleton reactive components default `id` to the kebab-cased class name (`TodoCounter` → `"todo-counter"`); `load()` need not set one unless you want a custom id.
+
 ### render()
 
 Two forms coexist via a descriptor:
@@ -31,18 +33,21 @@ Two forms coexist via a descriptor:
 **Class method (route entry point):**
 
 ```python
-Cls.render(key=None, *, dirtied=None, mounted=None) -> Markup
+Cls.render(key=None, *, dirtied=None, mounted=None, client=None) -> Markup
 ```
 
-Auto-`load()`s the primary component, renders it, and appends OOB swaps for dependents. Pass `mounted=request` on HTMX requests so the client manifest drives swap decisions.
+Auto-`load()`s the primary component, renders it, and appends OOB swaps for dependents. With `ClientBackend` wired in middleware, omit `mounted` and `client` on mutation routes — headers are read from the backend after `@mutates`.
 
 **Instance method:**
 
 ```python
-instance.render(*, dirtied=None, mounted=None) -> Markup
+instance.render(*, dirtied=None, mounted=None, client=None) -> Markup
 ```
 
 Render an already-built instance as the primary without re-loading from the world.
+
+!!! note "Without ClientBackend"
+    Pass `mounted=request` (and `client=request` for asset dedup) when not using a request-scoped backend. See [Client Backend](client-backend.md).
 
 ### state_hash()
 
@@ -84,7 +89,7 @@ runtime should be injected on root full-page renders.
 | `PJX_MOUNTED_HEADER` | `"X-PJX-Mounted"` | JSON manifest of mounted reactive regions (`id`, `type`, `hash`) |
 | `PJX_ASSETS_HEADER` | `"X-PJX-Assets"` | JSON list of asset URLs already loaded in the browser |
 
-The client runtime (`pjx.js`) sets both headers on HTMX requests. Pass the request object as `mounted=` and `client=` to reactive `render()` calls.
+The client runtime (`pjx.js`) sets both headers on HTMX requests. With [ClientBackend](client-backend.md) wired in middleware, `render()` reads them automatically; otherwise pass the request as `mounted=` and `client=`.
 
 ## parse_loaded_assets
 
@@ -101,7 +106,7 @@ Accepts:
 - A parsed list/tuple/set of URL strings
 - `None` or `""` (nothing loaded)
 
-Used internally when `client=request` is passed to `render()` with asset dedup enabled. Call directly for custom integrations.
+Used internally when a client source is resolved for `render()` with asset dedup enabled (explicit `client=` or `ClientBackend`). Call directly for custom integrations.
 
 ## oob_swaps
 

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -139,7 +139,7 @@ from pyjinhx import Registry
 
 with Registry.request_scope(
     load_context=AppLoadContext(db=session),
-    client_backend=client_backend_from_request(request),
+    client_backend=fastapi_client_backend(request),
 ):
     # Components registered here are isolated to this scope
     button = Button(id="submit-btn", text="Submit")

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -125,19 +125,22 @@ Remove all registered component instances from the current context.
 ```python
 @classmethod
 @contextmanager
-def request_scope(cls, *, load_context: Any | None = None)
+def request_scope(cls, *, load_context: Any | None = None, client_backend: ClientBackend | None = None)
 ```
 
-Context manager for request-scoped component instances, load cache, mutation tracking, and optional load context.
+Context manager for request-scoped component instances, load cache, mutation tracking, optional load context, and optional client backend for HTTP headers.
 
-On entry: clears pending mutations, initializes the request-scoped load cache, and optionally sets a `LoadContext` for reactive `load()` methods. On exit: warns about unconsumed mutations (when reactive dev is enabled), clears mutations, and resets the request cache.
+On entry: clears pending mutations, initializes the request-scoped load cache, and optionally sets a `LoadContext` for reactive `load()` methods and a `ClientBackend` for `render()` header auto-resolution. On exit: warns about unconsumed mutations (when reactive dev is enabled), clears mutations, and resets the request cache.
 
 **Usage:**
 
 ```python
 from pyjinhx import Registry
 
-with Registry.request_scope(load_context=AppLoadContext(db=session)):
+with Registry.request_scope(
+    load_context=AppLoadContext(db=session),
+    client_backend=client_backend_from_request(request),
+):
     # Components registered here are isolated to this scope
     button = Button(id="submit-btn", text="Submit")
     # ... render template

--- a/docs/api/renderer.md
+++ b/docs/api/renderer.md
@@ -108,7 +108,7 @@ Set the public URL for the pyjinhx client runtime in `AssetMode.REFERENCE` (defa
 def set_default_asset_dedup(enabled: bool) -> None
 ```
 
-When `True`, root REFERENCE renders skip `<link>` / `<script src>` tags for URLs the client reported via `X-PJX-Assets`. Defaults to `False`. Pass `client=request` to `render()` on boosted full-page routes.
+When `True`, root REFERENCE renders skip `<link>` / `<script src>` tags for URLs the client reported via `X-PJX-Assets`. Defaults to `False`. With [ClientBackend](../api/client-backend.md) wired in middleware, root renders pick up the header automatically; otherwise pass `client=request` on boosted full-page routes.
 
 ##### get_default_environment()
 

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -8,7 +8,7 @@ When you're done you will have used:
 - Template discovery, nesting, and PascalCase tags
 - Co-located JS/CSS and asset delivery modes
 - `Registry.request_scope`, `@mutates`, and `LoadContext`
-- Reactive `render()` with `mounted=request`
+- Reactive `render()` with `ClientBackend` wired in middleware
 - Load-cache scopes and optional invalidation fan-out
 
 Runnable reference: [`examples/reactive_todo/`](https://github.com/paulomtts/pyjinhx/tree/master/examples/reactive_todo).
@@ -27,7 +27,7 @@ A small todo app:
 flowchart LR
     Browser -->|HTMX POST| Route
     Route -->|mutate store| Store
-    Route -->|Cls.render mounted=request| PyJinHx
+    Route -->|Cls.render| PyJinHx
     PyJinHx -->|primary HTML| Browser
     PyJinHx -->|OOB fragments| Browser
 ```
@@ -237,9 +237,14 @@ Better: middleware so every route is covered:
 from starlette.middleware.base import BaseHTTPMiddleware
 
 
+from pyjinhx import client_backend_from_request
+
+
 class RegistryScopeMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
-        with Registry.request_scope():
+        with Registry.request_scope(
+            client_backend=client_backend_from_request(request),
+        ):
             return await call_next(request)
 
 
@@ -357,16 +362,15 @@ Route:
 
 ```python
 @app.post("/rows/{todo_id}/toggle", response_class=HTMLResponse)
-def toggle_row(request: Request, todo_id: int):
-    with Registry.request_scope():
-        store.toggle(todo_id)
-        return TodoItemRow.render(todo_id, mounted=request)
+def toggle_row(todo_id: int):
+    store.toggle(todo_id)
+    return TodoItemRow.render(todo_id)
 ```
 
-???+ question "Why @mutates, dirty_keys, and mounted=request?"
+???+ question "Why @mutates, dirty_keys, and ClientBackend?"
     - **`@mutates` / `mutation_scope`** — after a store change, invalidate the `load()` cache and accumulate `dirtied` keys for the next reactive render.
     - **`dirty_keys("todo", id, "todos")`** — instance-keyed rows need **both** the row key (`todo:42`) and collection keys (`todos`). Invalidating only `"todo"` is not enough for cache entries stored under `todo:42`.
-    - **`mounted=request`** — passes the client's mounted-region manifest (`X-PJX-Mounted`). Without it, PyJinHx renders the primary fragment but **skips OOB swaps** for the counter and other dependents.
+    - **`ClientBackend`** (wired in middleware) — supplies `X-PJX-Mounted` automatically after mutations so OOB swaps run without `mounted=request` on every route.
 
     `render()` on the **class** auto-calls `load()` — routes never call `load()` manually.
 
@@ -479,7 +483,7 @@ Renderer.set_default_asset_dedup(True)  # hx-boost: skip already-loaded URLs
 Full-page route with boosted navigation:
 
 ```python
-TodoApp(...).render(client=request)
+TodoApp(...).render()  # client headers from middleware ClientBackend
 ```
 
 ???+ question "Why REFERENCE mode?"
@@ -525,7 +529,7 @@ from pyjinhx.builtins import Alert, Button, Card
 | HTMX in layout | Yes |
 | `ReactiveComponent` + `reacts_to` + `load()` | Yes |
 | `@mutates` / `mutation_scope` + `dirty_keys` for rows | Yes |
-| `Cls.render(..., mounted=request)` on mutation routes | Yes |
+| `ClientBackend` in middleware (`client_backend_from_request`) | Yes |
 | `LoadContext` | Recommended |
 | Assets / REFERENCE mode | Production |
 | Invalidation backend | Multi-worker + PROCESS cache |

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -237,13 +237,13 @@ Better: middleware so every route is covered:
 from starlette.middleware.base import BaseHTTPMiddleware
 
 
-from pyjinhx import client_backend_from_request
+from pyjinhx import fastapi_client_backend
 
 
 class RegistryScopeMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         with Registry.request_scope(
-            client_backend=client_backend_from_request(request),
+            client_backend=fastapi_client_backend(request),
         ):
             return await call_next(request)
 
@@ -529,7 +529,7 @@ from pyjinhx.builtins import Alert, Button, Card
 | HTMX in layout | Yes |
 | `ReactiveComponent` + `reacts_to` + `load()` | Yes |
 | `@mutates` / `mutation_scope` + `dirty_keys` for rows | Yes |
-| `ClientBackend` in middleware (`client_backend_from_request`) | Yes |
+| `fastapi_client_backend` in middleware | Yes |
 | `LoadContext` | Recommended |
 | Assets / REFERENCE mode | Production |
 | Invalidation backend | Multi-worker + PROCESS cache |

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -219,7 +219,7 @@ Run: `uvicorn app:app --reload`
 
 ## Step 6 — Request scope (registry + cache hygiene)
 
-Wrap each request:
+Per-route wrapping works for demos:
 
 ```python
 from pyjinhx import Registry
@@ -231,7 +231,7 @@ def index():
         return TodoPanel(id="panel", remaining=3).render()
 ```
 
-Better: middleware so every route is covered:
+For a real app, use **middleware** so every route is covered (the rest of this guide assumes middleware from here on):
 
 ```python
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -252,11 +252,11 @@ app.add_middleware(RegistryScopeMiddleware)
 ```
 
 ???+ question "Why Registry.request_scope?"
-    Every component instance registers itself on construction. Without a per-request scope, instances from request A can **leak into request B** and shadow template variables. The same scope also initializes the optional **request-tier** load cache when you use `CacheScope.REQUEST`.
+    Every component instance registers itself on construction. Without a per-request scope, instances from request A can **leak into request B** and shadow template variables. The scope also initializes the request-tier load cache layer and resets mutation tracking. `load_context` and `client_backend` are optional kwargs — bare `request_scope()` is valid.
 
     Default load cache is **`CacheScope.PROCESS`** (cross-request per worker) — see Step 12.
 
-    See: [Component registry](../guide/registry.md).
+    PyJinHx does not ship middleware — you define `RegistryScopeMiddleware` in your app. See: [Component registry](../guide/registry.md), [FastAPI integration](../integrations/fastapi.md#middleware-recommended).
 
 ---
 
@@ -273,9 +273,11 @@ Return a **fragment** from a mutation route:
 ```python
 @app.post("/counter/bump", response_class=HTMLResponse)
 def bump():
-    with Registry.request_scope():
-        return TodoCounter(id="counter", remaining=2).render()
+    return TodoCounter(id="counter", remaining=2).render()
 ```
+
+!!! note
+    Middleware from Step 6 already wraps each request — no per-route `request_scope()` needed.
 
 Template button:
 
@@ -424,11 +426,14 @@ def _store():
     return ctx.store if isinstance(ctx, AppLoadContext) else store
 ```
 
-Middleware:
+Extend the Step 6 middleware:
 
 ```python
-with Registry.request_scope(load_context=AppLoadContext(store=store)):
-    ...
+with Registry.request_scope(
+    load_context=AppLoadContext(store=store),
+    client_backend=fastapi_client_backend(request),
+):
+    return await call_next(request)
 ```
 
 ???+ question "Why LoadContext?"

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -76,9 +76,11 @@ On HTMX requests, `pjx.js` reports asset URLs already in the DOM via the `X-PJX-
 Renderer.set_default_asset_dedup(True)
 
 @app.get("/page-b")
-def page_b(request: Request):
-    return str(PageB(id="app").render(client=request))
+def page_b():
+    return str(PageB(id="app").render())  # X-PJX-Assets from ClientBackend in middleware
 ```
+
+With [ClientBackend](../api/client-backend.md) wired in middleware, root renders pick up `X-PJX-Assets` automatically. Without it, pass `client=request` explicitly.
 
 Partial renders ignore the asset header (no assets emitted). Dedup defaults to **off** for backward compatibility.
 

--- a/docs/guide/registry.md
+++ b/docs/guide/registry.md
@@ -65,14 +65,21 @@ def index():
     # Registry automatically cleaned up
 ```
 
-For application-wide coverage, use middleware:
+On entry, `request_scope()` also clears pending mutations, initializes the request-tier load cache, and optionally sets `load_context` and `client_backend`. On exit, it warns about unconsumed mutations (when reactive dev is enabled), clears mutations, and resets the request cache.
+
+`load_context` and `client_backend` are **optional** — bare `Registry.request_scope()` is enough for instance isolation.
+
+For application-wide coverage, use middleware in your app (pyjinhx does not ship middleware). See the [canonical FastAPI snippet](../integrations/fastapi.md#middleware-recommended).
 
 ```python
 from starlette.middleware.base import BaseHTTPMiddleware
+from pyjinhx import Registry, fastapi_client_backend
 
 class RegistryScopeMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
-        with Registry.request_scope():
+        with Registry.request_scope(
+            client_backend=fastapi_client_backend(request),
+        ):
             return await call_next(request)
 
 app.add_middleware(RegistryScopeMiddleware)

--- a/docs/guide/usage-tiers.md
+++ b/docs/guide/usage-tiers.md
@@ -1,0 +1,90 @@
+# Usage tiers
+
+PyJinHx is one library with optional layers. Adopt each tier only when you need it.
+
+## Tier 1 — Components
+
+**What:** `BaseComponent` + co-located Jinja templates + `Renderer`.
+
+**Use when:** Scripts, static pages, or any server-rendered HTML without per-request state sharing.
+
+```python
+from pyjinhx import BaseComponent, Renderer
+
+Renderer.set_default_environment("./components")
+
+class Button(BaseComponent):
+    id: str
+    text: str
+
+html = Button(id="cta", text="Click").render()
+```
+
+**Docs:** [Quick Start](../getting-started/quickstart.md), [Creating Components](components.md)
+
+---
+
+## Tier 2 — Web app scoping
+
+**What:** `Registry.request_scope()` per HTTP request.
+
+**Use when:** FastAPI, Starlette, or any multi-request server — isolates component instances so request A cannot leak into request B. Also initializes the request-tier load cache layer and resets mutation tracking.
+
+```python
+from pyjinhx import Registry
+
+with Registry.request_scope():
+    return MyPage(id="app").render()
+```
+
+`load_context` and `client_backend` are **optional** — bare `request_scope()` is valid.
+
+**Docs:** [Component Registry](registry.md), [FastAPI integration](../integrations/fastapi.md)
+
+---
+
+## Tier 3 — Reactive HTMX
+
+**What:** `ReactiveComponent`, `@mutates`, dependency-aware OOB swaps.
+
+**Use when:** HTMX apps where one mutation should update multiple regions without manual swap wiring.
+
+```python
+@app.post("/todos/toggle")
+def toggle(todo_id: int):
+    store.toggle(todo_id)
+    return TodoItemRow.render(todo_id)  # OOB for dependents
+```
+
+Requires `Registry.request_scope()` on every request when using auto-dirtied from `@mutates`.
+
+**Docs:** [Reactivity](../reactivity.md), [HTMX integration](../integrations/htmx.md)
+
+---
+
+## Tier 4 — Full wiring
+
+**What:** Optional pieces on top of Tier 3.
+
+| Piece | Purpose |
+|-------|---------|
+| `load_context=` in `request_scope` | Pass DB/store into `load()` without globals |
+| `client_backend=` in `request_scope` | Auto `X-PJX-Mounted` / `X-PJX-Assets` in `render()` |
+| Load cache + `invalidate()` | Cache `load()` results; evict on mutation |
+| `InvalidationBackend` | Cross-worker cache fan-out |
+| `enable_reactive_dev()` | Warnings for missing `mounted`, unconsumed `@mutates`, etc. |
+| `pyjinhx.builtins` | Optional pre-built UI kit |
+
+**Canonical middleware** (app-defined — pyjinhx does not ship middleware):
+
+```python
+with Registry.request_scope(
+    load_context=AppLoadContext(db=get_db(request)),
+    client_backend=fastapi_client_backend(request),
+):
+    return await call_next(request)
+```
+
+See [FastAPI integration § Middleware](../integrations/fastapi.md#middleware-recommended).
+
+**Docs:** [Build an App](../getting-started/build-an-app.md), [Client Backend](../api/client-backend.md), [Cache & Invalidation](../api/cache-invalidation.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,22 @@ PyJinHx combines **Pydantic models** with **Jinja2 templates** to give you templ
 - **Asset Bundling** - Automatically collects and bundles `.js` and `.css` files from component directories
 - **Type Safety** - Pydantic models provide validation and IDE support
 
+## Choose your depth
+
+PyJinHx layers optional features on top of a small core. You can stop at any tier:
+
+| Tier | You get | Start here |
+|------|---------|------------|
+| **1 — Components** | `BaseComponent`, templates, assets | [Quick Start](getting-started/quickstart.md) |
+| **2 — Web app** | Per-request `Registry.request_scope()` | [Registry guide](guide/registry.md) |
+| **3 — Reactive** | HTMX OOB swaps, `@mutates`, `load()` | [Reactivity](reactivity.md) |
+| **4 — Full wiring** | `LoadContext`, `ClientBackend`, cache, invalidation | [Build an App](getting-started/build-an-app.md) |
+
+Details: [Usage tiers](guide/usage-tiers.md).
+
 ## Two Ways to Render
 
-PyJinHx offers two complementary approaches:
+Within Tier 1, PyJinHx offers two complementary approaches:
 
 === "Python-side"
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -158,9 +158,9 @@ call `load()` and never assemble swaps yourself.
 
 ```python
 @app.post("/todos/toggle")
-def toggle(request):
+def toggle():
     db.toggle_all()
-    return Counter.render(dirtied={"todos"}, mounted=request)
+    return Counter.render(dirtied={"todos"})
 ```
 
 `render` has two forms (one name):
@@ -174,9 +174,7 @@ def toggle(request):
 - **Instance form (plain/constructed primary)** — `instance.render(*, dirtied=None, mounted=None)`:
   a non-reactive primary has no `load()`, so build it and render the instance.
 
-`mounted` accepts a request-like object (the `X-PJX-Mounted` header is duck-typed off it — no
-web-framework import), the raw header string, a parsed list, or `None`. With neither `dirtied`
-nor `mounted`, `render()` is an ordinary plain render.
+With [ClientBackend](../api/client-backend.md) in middleware, omit `mounted` and `client` on mutation routes. Without it, pass `mounted=request` (request-like object, raw header string, or parsed list). With neither `dirtied` nor `mounted`, `render()` is an ordinary plain render.
 
 `oob_swaps(dirtied, mounted)` is what `render()` delegates to (`exclude_ids={primary.id}`);
 it's exported for tests/advanced use but is **not** how you write a route.
@@ -198,9 +196,9 @@ class TodoItemRow(ReactiveComponent):
         return cls(title=t.text)
 
 @app.post("/rows/{todo_id}/toggle")
-def toggle_row(request, todo_id):
+def toggle_row(todo_id):
     store.toggle(todo_id)
-    return TodoItemRow.render(todo_id, dirtied={f"todo:{todo_id}", "todos"}, mounted=request)
+    return TodoItemRow.render(todo_id, dirtied={f"todo:{todo_id}", "todos"})
 ```
 
 - **The key flows `render(key, …)` → `load(key)` automatically.** It derives the keyed id

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -128,7 +128,9 @@ def index() -> str:
         """
 ```
 
-### Middleware (recommended)
+### Middleware (recommended) {#middleware-recommended}
+
+PyJinHx does **not** ship middleware — define a thin wrapper in your app. This is the **canonical snippet** referenced from [Client Backend](../api/client-backend.md), [Registry guide](../guide/registry.md), and [Build an App](../getting-started/build-an-app.md).
 
 ```python
 from dataclasses import dataclass

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -133,7 +133,7 @@ def index() -> str:
 ```python
 from dataclasses import dataclass
 
-from pyjinhx import LoadContext, Registry, client_backend_from_request, enable_reactive_dev
+from pyjinhx import LoadContext, Registry, enable_reactive_dev, fastapi_client_backend
 from starlette.middleware.base import BaseHTTPMiddleware
 
 
@@ -146,7 +146,7 @@ class RegistryScopeMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         with Registry.request_scope(
             load_context=AppLoadContext(db=get_db(request)),
-            client_backend=client_backend_from_request(request),
+            client_backend=fastapi_client_backend(request),
         ):
             return await call_next(request)
 

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -133,7 +133,7 @@ def index() -> str:
 ```python
 from dataclasses import dataclass
 
-from pyjinhx import LoadContext, Registry, enable_reactive_dev
+from pyjinhx import LoadContext, Registry, client_backend_from_request, enable_reactive_dev
 from starlette.middleware.base import BaseHTTPMiddleware
 
 
@@ -146,6 +146,7 @@ class RegistryScopeMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         with Registry.request_scope(
             load_context=AppLoadContext(db=get_db(request)),
+            client_backend=client_backend_from_request(request),
         ):
             return await call_next(request)
 
@@ -156,8 +157,18 @@ app.add_middleware(RegistryScopeMiddleware)
 enable_reactive_dev()
 ```
 
-Pair with `@mutates` on store methods so mutation routes can omit explicit `dirtied` —
-see [Reactivity](../reactivity.md#mutation-tracking-mutates).
+Pair with `@mutates` on store methods so mutation routes can omit explicit `dirtied`
+and `mounted=request` — see [Reactivity](../reactivity.md#mutation-tracking-mutates)
+and [Client Backend](../api/client-backend.md).
+
+Reactive mutation routes:
+
+```python
+@app.post("/rows/{todo_id}/toggle", response_class=HTMLResponse)
+def toggle_row(todo_id: int) -> str:
+    store.toggle(todo_id)
+    return TodoItemRow.render(todo_id)  # headers from ClientBackend
+```
 
 ## Tips
 

--- a/docs/integrations/htmx.md
+++ b/docs/integrations/htmx.md
@@ -263,3 +263,13 @@ HTMX also supports WebSockets:
     <!-- Messages will be appended here -->
 </div>
 ```
+
+## Dependency-aware updates (reactive OOB)
+
+The patterns above use manual `hx-target` / `hx-swap` for each interaction. For apps where **one mutation updates multiple regions** (counter, list, totals) without wiring every swap by hand, use PyJinHx reactivity:
+
+- Declare `reacts_to` + `load()` on `ReactiveComponent` subclasses
+- Return `Cls.render()` from mutation routes — dependent regions ride along as `hx-swap-oob` fragments
+- Wire [ClientBackend](../api/client-backend.md) in middleware so routes omit `mounted=` on every handler
+
+See [Reactivity](../reactivity.md), [Usage tiers](../guide/usage-tiers.md), and the [reactive todo example](https://github.com/paulomtts/pyjinhx/tree/master/examples/reactive_todo).

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -87,7 +87,7 @@ The runtime attaches two client manifests to every htmx request:
 | `X-PJX-Mounted` | Reactive regions currently in the DOM (`id`, `type`, `hash`, optional `key`) |
 | `X-PJX-Assets` | URLs of `<script src>` and `<link rel="stylesheet">` already loaded |
 
-Wire `client_backend_from_request(request)` once in middleware (see
+Wire `fastapi_client_backend(request)` once in middleware (see
 [Client Backend](api/client-backend.md)). Mutation routes then call
 `Cls.render(key)` with no `mounted=` — headers are read from the backend after
 `@mutates`. Full-page routes call `.render()` with no `client=`; boosted

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -1,5 +1,12 @@
 # Reactivity (Dependency-Aware OOB Swaps)
 
+Reactivity is **opt-in**. You can use PyJinHx with `BaseComponent` only — see [Usage tiers](guide/usage-tiers.md). This guide covers Tier 3+: dependency-aware out-of-band HTMX swaps.
+
+!!! info "Prerequisites"
+    - HTMX for transport and swap
+    - `Registry.request_scope()` on every HTTP request
+    - [ClientBackend](api/client-backend.md) in middleware (recommended) so mutation routes omit `mounted=` / `client=`
+
 pyjinhx owns **composition**; HTMX owns **transport and swap**. Between them sits
 the **state→view dependency graph** — which regions must change when a piece of
 state changes. pyjinhx lets you declare that graph once, on the components, so a
@@ -87,8 +94,9 @@ The runtime attaches two client manifests to every htmx request:
 | `X-PJX-Mounted` | Reactive regions currently in the DOM (`id`, `type`, `hash`, optional `key`) |
 | `X-PJX-Assets` | URLs of `<script src>` and `<link rel="stylesheet">` already loaded |
 
-Wire `fastapi_client_backend(request)` once in middleware (see
-[Client Backend](api/client-backend.md)). Mutation routes then call
+Wire `fastapi_client_backend(request)` once in your app's middleware — see the
+[canonical snippet](integrations/fastapi.md#middleware-recommended) and
+[Client Backend](api/client-backend.md). Mutation routes then call
 `Cls.render(key)` with no `mounted=` — headers are read from the backend after
 `@mutates`. Full-page routes call `.render()` with no `client=`; boosted
 navigations skip re-injecting `pjx.js` when `X-PJX-Mounted` is present.
@@ -97,32 +105,31 @@ navigations skip re-injecting `pjx.js` when `X-PJX-Mounted` is present.
 
 A mutation route does exactly one thing: **`return <component>.render(...)`**. You
 never call `load()` and never assemble swaps yourself. For a **reactive** primary,
-call `render()` on the *class* — it auto-`load()`s the component for you — and pass
-what you dirtied plus the incoming request. The dependent regions ride along as
-out-of-band swaps:
+call `render()` on the *class* — it auto-`load()`s the component for you. The
+dependent regions ride along as out-of-band swaps:
 
 ```python
 @app.post("/todos/toggle")
-def toggle(request):
+def toggle():
     db.toggle_all()
     # render() loads the Counter itself — you don't. dirtied defaults to the
     # primary's own reacts_to; pass dirtied={...} to dirty more.
-    return Counter.render(dirtied={"todos"}, mounted=request)
+    return Counter.render(dirtied={"todos"})
 ```
 
-`Cls.render(key=None, *, dirtied=, mounted=)` loads the primary (by `key` for an
+With `@mutates` on the store method, you can omit `dirtied` too: `return Counter.render()`.
+
+`Cls.render(key=None, *, dirtied=, mounted=, client=)` loads the primary (by `key` for an
 instance-keyed type, zero-arg for a singleton), renders it as the main-target
 response, then appends an OOB swap for every *other* mounted reactive region whose
 `reacts_to` intersects `dirtied`, rebuilding each via its own `load()`. The primary's
 own region is never double-swapped. (Keyed example: [Instance-keyed regions](#instance-keyed-regions-rows) below.)
 
 A **plain, non-reactive** primary has no `load()` to call, so you build it and render
-the instance instead: `MyFragment(id=..., ...).render(dirtied=, mounted=request)`.
+the instance instead: `MyFragment(id=..., ...).render(dirtied=...)`.
 
-`mounted` accepts a request-like object (the `X-PJX-Mounted` header is read off it
-without importing any web framework), the raw header string, an already-parsed
-list, or `None`. With neither `dirtied` nor `mounted`, `render()` is an ordinary
-plain render.
+!!! note "Without ClientBackend"
+    Pass `mounted=request` (and `client=request` for asset dedup) when not using a request-scoped backend. `mounted` accepts a request-like object, the raw header string, an already-parsed list, or `None`. With neither `dirtied` nor `mounted`, `render()` is an ordinary plain render.
 
 ### Under the hood: `oob_swaps()`
 
@@ -180,14 +187,12 @@ class TodoItemRow(ReactiveComponent):
 
 ```python
 @app.post("/rows/{todo_id}/toggle")
-def toggle_row(request, todo_id):
+def toggle_row(todo_id):
     store.toggle(todo_id)
     # render(key, ...) loads this row itself — no manual load().
     # "todo:42" swaps just this one row; "todos" updates collection regions
     # (counter, total, …). The row's own region is the primary, never double-swapped.
-    return TodoItemRow.render(
-        todo_id, dirtied={f"todo:{todo_id}", "todos"}, mounted=request
-    )
+    return TodoItemRow.render(todo_id, dirtied={f"todo:{todo_id}", "todos"})
 ```
 
 `dirtied={"todo:42"}` reloads/swaps **only** row 42 (siblings are untouched);
@@ -234,9 +239,9 @@ def toggle(todo_id: int) -> Todo:
     ...
 
 @app.post("/rows/{todo_id}/toggle")
-def toggle_row(request, todo_id):
+def toggle_row(todo_id):
     store.toggle(todo_id)
-    return TodoItemRow.render(todo_id, mounted=request)  # dirtied auto
+    return TodoItemRow.render(todo_id)  # dirtied + mounted from @mutates + ClientBackend
 ```
 
 Use `Registry.request_scope()` on every request when relying on auto-dirtied — it
@@ -446,7 +451,7 @@ sequenceDiagram
 
     B->>R: POST /todos/1/toggle  (X-PJX-Mounted header)
     R->>DB: db.toggle(1)
-    R->>RD: Counter.render(dirtied, mounted=request)
+    R->>RD: Counter.render()  # dirtied from @mutates; mounted from ClientBackend
     RD->>C: invalidate(dirtied)
     Note over C: evict cached load() results<br/>whose reacts_to hits a dirtied key
     RD->>RD: load() + render primary → response

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -87,10 +87,11 @@ The runtime attaches two client manifests to every htmx request:
 | `X-PJX-Mounted` | Reactive regions currently in the DOM (`id`, `type`, `hash`, optional `key`) |
 | `X-PJX-Assets` | URLs of `<script src>` and `<link rel="stylesheet">` already loaded |
 
-Use `mounted=request` for reactive partials. For boosted full-page routes, pass
-`client=request` so the server can skip re-injecting `pjx.js` and (in REFERENCE
-mode with `Renderer.set_default_asset_dedup(True)`) skip asset URLs the browser
-already has.
+Wire `client_backend_from_request(request)` once in middleware (see
+[Client Backend](api/client-backend.md)). Mutation routes then call
+`Cls.render(key)` with no `mounted=` — headers are read from the backend after
+`@mutates`. Full-page routes call `.render()` with no `client=`; boosted
+navigations skip re-injecting `pjx.js` when `X-PJX-Mounted` is present.
 
 ## 3. Emit OOB swaps from your route
 

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -22,8 +22,8 @@ Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line
 | `client_script()` | Emit the pyjinhx client runtime as a `<script>` tag | [Reactive API](../api/reactive-api.md#client_script) |
 | `client_has_mounted_manifest()` | Return whether `X-PJX-Mounted` is present on the request | [Reactive API](../api/reactive-api.md#client_has_mounted_manifest) |
 | `ClientBackend` | ABC for per-request HTTP header access | [Client Backend](../api/client-backend.md#clientbackend) |
-| `RequestClientBackend` | Default backend for FastAPI/Starlette requests | [Client Backend](../api/client-backend.md) |
-| `client_backend_from_request()` | Build `RequestClientBackend` from a request | [Client Backend](../api/client-backend.md#client_backend_from_request) |
+| `FastAPIClientBackend` | Default backend for FastAPI/Starlette requests | [Client Backend](../api/client-backend.md) |
+| `fastapi_client_backend()` | Build `FastAPIClientBackend` from a request | [Client Backend](../api/client-backend.md#fastapi_client_backend) |
 | `client_scope()` | Set the request-scoped client backend | [Client Backend](../api/client-backend.md#request-scope-wiring) |
 | `get_client_backend()` | Return the active client backend | [Client Backend](../api/client-backend.md) |
 | `oob_swaps()` | Compute HTMX out-of-band swap fragments for dirtied keys | [Reactive API](../api/reactive-api.md#oob_swaps) |

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -24,8 +24,11 @@ Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line
 | `ClientBackend` | ABC for per-request HTTP header access | [Client Backend](../api/client-backend.md#clientbackend) |
 | `FastAPIClientBackend` | Default backend for FastAPI/Starlette requests | [Client Backend](../api/client-backend.md) |
 | `fastapi_client_backend()` | Build `FastAPIClientBackend` from a request | [Client Backend](../api/client-backend.md#fastapi_client_backend) |
-| `client_scope()` | Set the request-scoped client backend | [Client Backend](../api/client-backend.md#request-scope-wiring) |
-| `get_client_backend()` | Return the active client backend | [Client Backend](../api/client-backend.md) |
+| `ClientBackend.scope()` | Set the request-scoped client backend | [Client Backend](../api/client-backend.md#clientbackend) |
+| `ClientBackend.current()` | Return the active client backend | [Client Backend](../api/client-backend.md#clientbackend) |
+| `ClientBackend.reset()` | Clear the request-scoped backend (tests) | [Client Backend](../api/client-backend.md#clientbackend) |
+| `ClientBackend.resolve_client()` | Resolve explicit `client=` or fall back to backend | [Client Backend](../api/client-backend.md#auto-resolution-in-render) |
+| `ClientBackend.resolve_mounted()` | Resolve explicit `mounted=` or backend when reactive | [Client Backend](../api/client-backend.md#auto-resolution-in-render) |
 | `oob_swaps()` | Compute HTMX out-of-band swap fragments for dirtied keys | [Reactive API](../api/reactive-api.md#oob_swaps) |
 | `PJX_MOUNTED_HEADER` | HTTP header name for the client mounted-region manifest | [Reactive API](../api/reactive-api.md#pjx-headers) |
 | `PJX_ASSETS_HEADER` | HTTP header name for asset URLs already loaded in the browser | [Reactive API](../api/reactive-api.md#pjx-headers) |
@@ -75,7 +78,9 @@ Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line
 
 For usage patterns and tutorials, see:
 
+- [Usage tiers](../guide/usage-tiers.md) — bare components through full reactive wiring
 - [Reactivity](../reactivity.md) — reactive components, OOB swaps, cache scopes
+- [Client Backend](../api/client-backend.md) — per-request header access for `render()`
 - [Asset Collection](../guide/assets.md) — delivery modes, dedup, static serving
 - [Build an App](../getting-started/build-an-app.md) — end-to-end tutorial
 - [FastAPI integration](../integrations/fastapi.md) — request scope, lifespan, headers

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -21,6 +21,11 @@ Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line
 |--------|-------------|---------------|
 | `client_script()` | Emit the pyjinhx client runtime as a `<script>` tag | [Reactive API](../api/reactive-api.md#client_script) |
 | `client_has_mounted_manifest()` | Return whether `X-PJX-Mounted` is present on the request | [Reactive API](../api/reactive-api.md#client_has_mounted_manifest) |
+| `ClientBackend` | ABC for per-request HTTP header access | [Client Backend](../api/client-backend.md#clientbackend) |
+| `RequestClientBackend` | Default backend for FastAPI/Starlette requests | [Client Backend](../api/client-backend.md) |
+| `client_backend_from_request()` | Build `RequestClientBackend` from a request | [Client Backend](../api/client-backend.md#client_backend_from_request) |
+| `client_scope()` | Set the request-scoped client backend | [Client Backend](../api/client-backend.md#request-scope-wiring) |
+| `get_client_backend()` | Return the active client backend | [Client Backend](../api/client-backend.md) |
 | `oob_swaps()` | Compute HTMX out-of-band swap fragments for dirtied keys | [Reactive API](../api/reactive-api.md#oob_swaps) |
 | `PJX_MOUNTED_HEADER` | HTTP header name for the client mounted-region manifest | [Reactive API](../api/reactive-api.md#pjx-headers) |
 | `PJX_ASSETS_HEADER` | HTTP header name for asset URLs already loaded in the browser | [Reactive API](../api/reactive-api.md#pjx-headers) |

--- a/examples/reactive_todo/app.py
+++ b/examples/reactive_todo/app.py
@@ -23,7 +23,7 @@ from examples.reactive_todo.components import (
     TodoLoadContext,
     TodoTotal,
 )
-from pyjinhx import Registry, Renderer, client_backend_from_request
+from pyjinhx import Registry, Renderer, fastapi_client_backend
 
 Renderer.set_default_environment(Path(__file__).resolve().parents[2])
 
@@ -42,7 +42,7 @@ class RegistryScopeMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         with Registry.request_scope(
             load_context=TodoLoadContext(store=store),
-            client_backend=client_backend_from_request(request),
+            client_backend=fastapi_client_backend(request),
         ):
             return await call_next(request)
 

--- a/examples/reactive_todo/app.py
+++ b/examples/reactive_todo/app.py
@@ -23,7 +23,7 @@ from examples.reactive_todo.components import (
     TodoLoadContext,
     TodoTotal,
 )
-from pyjinhx import Registry, Renderer
+from pyjinhx import Registry, Renderer, client_backend_from_request
 
 Renderer.set_default_environment(Path(__file__).resolve().parents[2])
 
@@ -42,6 +42,7 @@ class RegistryScopeMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         with Registry.request_scope(
             load_context=TodoLoadContext(store=store),
+            client_backend=client_backend_from_request(request),
         ):
             return await call_next(request)
 
@@ -74,27 +75,27 @@ def index() -> str:
 
 
 @app.post("/todos", response_class=HTMLResponse)
-def add(request: Request, text: str = Form(...)) -> str:
+def add(text: str = Form(...)) -> str:
     store.add(text)
-    return TodoItemRow.render(store.all_todos()[-1].id, mounted=request)
+    return TodoItemRow.render(store.all_todos()[-1].id)
 
 
 @app.post("/rows/{todo_id}/toggle", response_class=HTMLResponse)
-def toggle_row(request: Request, todo_id: int) -> str:
+def toggle_row(todo_id: int) -> str:
     store.toggle(todo_id)
-    return TodoItemRow.render(todo_id, mounted=request)
+    return TodoItemRow.render(todo_id)
 
 
 @app.post("/todos/{todo_id}/toggle", response_class=HTMLResponse)
-def toggle(request: Request, todo_id: int) -> str:
+def toggle(todo_id: int) -> str:
     todo = store.toggle(todo_id)
-    return _item(todo).render(mounted=request)
+    return _item(todo).render()
 
 
 @app.post("/todos/clear-completed", response_class=HTMLResponse)
-def clear_completed(request: Request) -> str:
+def clear_completed() -> str:
     store.clear_completed()
-    return _list().render(mounted=request)
+    return _list().render()
 
 
 if __name__ == "__main__":

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
       - Public API Index: reference/public-api.md
       - BaseComponent: api/base-component.md
       - Reactive API: api/reactive-api.md
+      - Client Backend: api/client-backend.md
       - Cache & Invalidation: api/cache-invalidation.md
       - Mutations, Keys & LoadContext: api/mutations-keys-context.md
       - Parser & Tag: api/parser.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
       - Quick Start: getting-started/quickstart.md
       - Build an App: getting-started/build-an-app.md
   - Guide:
+      - Usage tiers: guide/usage-tiers.md
       - Creating Components: guide/components.md
       - Component Registry: guide/registry.md
       - PascalCase Tags: guide/tags.md

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -11,13 +11,7 @@ from .assets import (
 )
 from .base import BaseComponent
 from .cache import CacheScope, get_load_cache_scope, invalidate, set_load_cache_scope
-from .client_backend import (
-    ClientBackend,
-    FastAPIClientBackend,
-    client_scope,
-    fastapi_client_backend,
-    get_client_backend,
-)
+from .client_backend import ClientBackend, FastAPIClientBackend, fastapi_client_backend
 from .invalidation import (
     InvalidationBackend,
     set_invalidation_backend,
@@ -71,8 +65,6 @@ __all__ = [
     "ClientBackend",
     "FastAPIClientBackend",
     "fastapi_client_backend",
-    "client_scope",
-    "get_client_backend",
     "client_script",
     "client_has_mounted_manifest",
     "PJX_MOUNTED_HEADER",

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -13,12 +13,9 @@ from .base import BaseComponent
 from .cache import CacheScope, get_load_cache_scope, invalidate, set_load_cache_scope
 from .client_backend import (
     ClientBackend,
-    ClientBackendMiddleware,
-    HeadersClientBackend,
-    RequestClientBackend,
-    client_backend_from_request,
-    client_for_render,
+    FastAPIClientBackend,
     client_scope,
+    fastapi_client_backend,
     get_client_backend,
 )
 from .invalidation import (
@@ -72,11 +69,8 @@ __all__ = [
     "start_invalidation_listener",
     "stop_invalidation_listener",
     "ClientBackend",
-    "ClientBackendMiddleware",
-    "HeadersClientBackend",
-    "RequestClientBackend",
-    "client_backend_from_request",
-    "client_for_render",
+    "FastAPIClientBackend",
+    "fastapi_client_backend",
     "client_scope",
     "get_client_backend",
     "client_script",

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -11,6 +11,16 @@ from .assets import (
 )
 from .base import BaseComponent
 from .cache import CacheScope, get_load_cache_scope, invalidate, set_load_cache_scope
+from .client_backend import (
+    ClientBackend,
+    ClientBackendMiddleware,
+    HeadersClientBackend,
+    RequestClientBackend,
+    client_backend_from_request,
+    client_for_render,
+    client_scope,
+    get_client_backend,
+)
 from .invalidation import (
     InvalidationBackend,
     set_invalidation_backend,
@@ -61,6 +71,14 @@ __all__ = [
     "set_invalidation_backend",
     "start_invalidation_listener",
     "stop_invalidation_listener",
+    "ClientBackend",
+    "ClientBackendMiddleware",
+    "HeadersClientBackend",
+    "RequestClientBackend",
+    "client_backend_from_request",
+    "client_for_render",
+    "client_scope",
+    "get_client_backend",
     "client_script",
     "client_has_mounted_manifest",
     "PJX_MOUNTED_HEADER",

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -168,10 +168,10 @@ class BaseComponent(BaseModel):
                 session=session,
             )
 
-        from .client_backend import resolve_render_client
+        from .client_backend import ClientBackend
         from .reactive import parse_loaded_assets
 
-        resolved_client = resolve_render_client(client)
+        resolved_client = ClientBackend.resolve_client(client)
         loaded_assets = (
             parse_loaded_assets(resolved_client)
             if resolved_client is not None and emit_assets
@@ -228,10 +228,10 @@ class BaseComponent(BaseModel):
         Returns:
             The rendered HTML as a Markup object (safe for direct use in templates).
         """
-        from .client_backend import resolve_render_client, resolve_render_mounted
+        from .client_backend import ClientBackend
 
-        resolved_client = resolve_render_client(client)
-        resolved_mounted = resolve_render_mounted(mounted, dirtied=dirtied)
+        resolved_client = ClientBackend.resolve_client(client)
+        resolved_mounted = ClientBackend.resolve_mounted(mounted, dirtied=dirtied)
 
         if dirtied is None and resolved_mounted is None:
             return self._render(client=resolved_client)

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -168,11 +168,13 @@ class BaseComponent(BaseModel):
                 session=session,
             )
 
+        from .client_backend import resolve_render_client
         from .reactive import parse_loaded_assets
 
+        resolved_client = resolve_render_client(client)
         loaded_assets = (
-            parse_loaded_assets(client)
-            if client is not None and emit_assets
+            parse_loaded_assets(resolved_client)
+            if resolved_client is not None and emit_assets
             else frozenset()
         )
 
@@ -186,7 +188,7 @@ class BaseComponent(BaseModel):
             collect_component_js=source is None,
             emit_assets=emit_assets,
             loaded_assets=loaded_assets,
-            client=client,
+            client=resolved_client,
         )
 
     def render(
@@ -217,15 +219,22 @@ class BaseComponent(BaseModel):
             dirtied: State keys the route mutated (e.g. ``{"todos"}``). Defaults to the
                 primary's ``reacts_to``. Enables reactive mode.
             mounted: The client manifest — a request-like object, the raw header string,
-                a parsed list, or ``None``. Enables reactive mode.
+                a parsed list, or ``None``. When omitted, uses the request-scoped
+                ``ClientBackend`` after mutations (see ``Registry.request_scope``).
             client: Request-like object (or raw ``X-PJX-Assets`` JSON) for REFERENCE-mode
-                asset dedup on root renders. Pass ``request`` on boosted full-page routes.
+                asset dedup on root renders. When omitted, uses the request-scoped
+                ``ClientBackend``.
 
         Returns:
             The rendered HTML as a Markup object (safe for direct use in templates).
         """
-        if dirtied is None and mounted is None:
-            return self._render(client=client)
+        from .client_backend import resolve_render_client, resolve_render_mounted
+
+        resolved_client = resolve_render_client(client)
+        resolved_mounted = resolve_render_mounted(mounted, dirtied=dirtied)
+
+        if dirtied is None and resolved_mounted is None:
+            return self._render(client=resolved_client)
 
         from .mutations import (
             mark_reactive_render_consumed,
@@ -236,17 +245,17 @@ class BaseComponent(BaseModel):
 
         own_keys = coerce_reactive_keys(getattr(self, "_pjx_reacts_to", frozenset()))
         warn_reactive_render_without_mounted(
-            dirtied=dirtied, mounted=mounted, own_keys=own_keys
+            dirtied=dirtied, mounted=resolved_mounted, own_keys=own_keys
         )
 
         primary = self._render(emit_assets=False)
         effective_dirtied = resolve_effective_dirtied(
             dirtied=dirtied,
-            mounted=mounted,
+            mounted=resolved_mounted,
             own_keys=own_keys,
         )
         mark_reactive_render_consumed()
-        swaps = oob_swaps(effective_dirtied, mounted, exclude_ids={self.id})
+        swaps = oob_swaps(effective_dirtied, resolved_mounted, exclude_ids={self.id})
         # Wrap the primary as safe markup before concatenation: _render() returns a
         # plain str (Markup.unescape()), and `str + Markup` would invoke Markup.__radd__
         # and HTML-escape the primary. Markup(primary) + swaps keeps both raw.

--- a/pyjinhx/client_backend.py
+++ b/pyjinhx/client_backend.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Generator, Mapping
+from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Any
 
 _client_backend: ContextVar[ClientBackend | None] = ContextVar(
     "client_backend", default=None
@@ -18,65 +17,31 @@ class ClientBackend(ABC):
     def get_header(self, name: str) -> str | None: ...
 
 
-class HeadersClientBackend(ClientBackend):
-    """Read headers from a mapping (e.g. Starlette/FastAPI ``request.headers``)."""
-
-    def __init__(self, headers: Mapping[str, str]) -> None:
-        self._headers = headers
-
-    def get_header(self, name: str) -> str | None:
-        return self._headers.get(name)
-
-
-class RequestClientBackend(HeadersClientBackend):
+class FastAPIClientBackend(ClientBackend):
     """
-    Default HTTP client backend for ASGI frameworks (FastAPI, Starlette).
+    Default client backend for FastAPI and Starlette.
 
-    Wraps any request object that exposes ``.headers`` with ``.get(name)``.
+    Wraps a request object's ``.headers`` mapping. The backend instance is also
+    duck-typed for ``render()`` (``.headers.get``) without a separate proxy.
     """
 
     def __init__(self, request: object) -> None:
         headers = getattr(request, "headers", None)
         if headers is None:
-            raise TypeError(
-                "RequestClientBackend requires a request with a .headers mapping"
-            )
-        super().__init__(headers)
+            raise TypeError("FastAPIClientBackend requires request.headers")
+        self.headers = headers
+
+    def get_header(self, name: str) -> str | None:
+        return self.headers.get(name)
 
 
-def client_backend_from_request(request: object) -> RequestClientBackend:
-    """Build the default client backend from an ASGI request (FastAPI/Starlette)."""
-    return RequestClientBackend(request)
-
-
-class _ClientHeaderProxy:
-    """Duck-type ``.headers.get`` for ``parse_loaded_assets`` / ``_parse_mounted``."""
-
-    def __init__(self, backend: ClientBackend) -> None:
-        self._backend = backend
-
-    class _Headers:
-        def __init__(self, backend: ClientBackend) -> None:
-            self._backend = backend
-
-        def get(self, name: str, default: str | None = None) -> str | None:
-            value = self._backend.get_header(name)
-            return value if value is not None else default
-
-    @property
-    def headers(self) -> _Headers:
-        return self._Headers(self._backend)
+def fastapi_client_backend(request: object) -> FastAPIClientBackend:
+    """Build the default client backend from a FastAPI/Starlette request."""
+    return FastAPIClientBackend(request)
 
 
 def get_client_backend() -> ClientBackend | None:
     return _client_backend.get()
-
-
-def client_for_render() -> _ClientHeaderProxy | None:
-    backend = get_client_backend()
-    if backend is None:
-        return None
-    return _ClientHeaderProxy(backend)
 
 
 def reset_client_backend_state() -> None:
@@ -87,7 +52,7 @@ def reset_client_backend_state() -> None:
 def resolve_render_client(explicit: object | None) -> object | None:
     if explicit is not None:
         return explicit
-    return client_for_render()
+    return get_client_backend()
 
 
 def resolve_render_mounted(
@@ -101,7 +66,7 @@ def resolve_render_mounted(
 
     if dirtied is None and not pending_dirtied():
         return None
-    return client_for_render()
+    return get_client_backend()
 
 
 @contextmanager
@@ -111,24 +76,3 @@ def client_scope(backend: ClientBackend | None) -> Generator[None, None, None]:
         yield
     finally:
         _client_backend.reset(token)
-
-
-class ClientBackendMiddleware:
-    """
-    Starlette/FastAPI ``BaseHTTPMiddleware`` helper: bind ``RequestClientBackend``
-    for the request via ``Registry.request_scope``.
-
-    Subclass or compose with your own middleware::
-
-        class AppMiddleware(ClientBackendMiddleware, BaseHTTPMiddleware):
-            async def dispatch(self, request, call_next):
-                return await self.bind_client_backend(request, call_next)
-    """
-
-    async def bind_client_backend(self, request: object, call_next: Any) -> Any:
-        from .registry import Registry
-
-        with Registry.request_scope(
-            client_backend=client_backend_from_request(request),
-        ):
-            return await call_next(request)

--- a/pyjinhx/client_backend.py
+++ b/pyjinhx/client_backend.py
@@ -4,17 +4,57 @@ from abc import ABC, abstractmethod
 from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
-
-_client_backend: ContextVar[ClientBackend | None] = ContextVar(
-    "client_backend", default=None
-)
+from typing import ClassVar
 
 
 class ClientBackend(ABC):
     """Framework-agnostic source for HTTP headers on the current request."""
 
+    _context: ClassVar[ContextVar[ClientBackend | None]] = ContextVar(
+        "client_backend", default=None
+    )
+
     @abstractmethod
     def get_header(self, name: str) -> str | None: ...
+
+    @classmethod
+    def current(cls) -> ClientBackend | None:
+        return cls._context.get()
+
+    @classmethod
+    def reset(cls) -> None:
+        """Clear the request-scoped client backend. Mainly for tests."""
+        cls._context.set(None)
+
+    @classmethod
+    @contextmanager
+    def scope(cls, backend: ClientBackend | None) -> Generator[None, None, None]:
+        token = cls._context.set(backend)
+        try:
+            yield
+        finally:
+            cls._context.reset(token)
+
+    @classmethod
+    def resolve_client(cls, explicit: object | None) -> object | None:
+        if explicit is not None:
+            return explicit
+        return cls.current()
+
+    @classmethod
+    def resolve_mounted(
+        cls,
+        explicit: object | None,
+        *,
+        dirtied: object | None,
+    ) -> object | None:
+        if explicit is not None:
+            return explicit
+        from .mutations import pending_dirtied
+
+        if dirtied is None and not pending_dirtied():
+            return None
+        return cls.current()
 
 
 class FastAPIClientBackend(ClientBackend):
@@ -38,41 +78,3 @@ class FastAPIClientBackend(ClientBackend):
 def fastapi_client_backend(request: object) -> FastAPIClientBackend:
     """Build the default client backend from a FastAPI/Starlette request."""
     return FastAPIClientBackend(request)
-
-
-def get_client_backend() -> ClientBackend | None:
-    return _client_backend.get()
-
-
-def reset_client_backend_state() -> None:
-    """Clear the request-scoped client backend. Mainly for tests."""
-    _client_backend.set(None)
-
-
-def resolve_render_client(explicit: object | None) -> object | None:
-    if explicit is not None:
-        return explicit
-    return get_client_backend()
-
-
-def resolve_render_mounted(
-    explicit: object | None,
-    *,
-    dirtied: object | None,
-) -> object | None:
-    if explicit is not None:
-        return explicit
-    from .mutations import pending_dirtied
-
-    if dirtied is None and not pending_dirtied():
-        return None
-    return get_client_backend()
-
-
-@contextmanager
-def client_scope(backend: ClientBackend | None) -> Generator[None, None, None]:
-    token = _client_backend.set(backend)
-    try:
-        yield
-    finally:
-        _client_backend.reset(token)

--- a/pyjinhx/client_backend.py
+++ b/pyjinhx/client_backend.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Generator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+
+_client_backend: ContextVar[ClientBackend | None] = ContextVar(
+    "client_backend", default=None
+)
+
+
+class ClientBackend(ABC):
+    """Framework-agnostic source for HTTP headers on the current request."""
+
+    @abstractmethod
+    def get_header(self, name: str) -> str | None: ...
+
+
+class HeadersClientBackend(ClientBackend):
+    """Read headers from a mapping (e.g. Starlette/FastAPI ``request.headers``)."""
+
+    def __init__(self, headers: Mapping[str, str]) -> None:
+        self._headers = headers
+
+    def get_header(self, name: str) -> str | None:
+        return self._headers.get(name)
+
+
+class RequestClientBackend(HeadersClientBackend):
+    """
+    Default HTTP client backend for ASGI frameworks (FastAPI, Starlette).
+
+    Wraps any request object that exposes ``.headers`` with ``.get(name)``.
+    """
+
+    def __init__(self, request: object) -> None:
+        headers = getattr(request, "headers", None)
+        if headers is None:
+            raise TypeError(
+                "RequestClientBackend requires a request with a .headers mapping"
+            )
+        super().__init__(headers)
+
+
+def client_backend_from_request(request: object) -> RequestClientBackend:
+    """Build the default client backend from an ASGI request (FastAPI/Starlette)."""
+    return RequestClientBackend(request)
+
+
+class _ClientHeaderProxy:
+    """Duck-type ``.headers.get`` for ``parse_loaded_assets`` / ``_parse_mounted``."""
+
+    def __init__(self, backend: ClientBackend) -> None:
+        self._backend = backend
+
+    class _Headers:
+        def __init__(self, backend: ClientBackend) -> None:
+            self._backend = backend
+
+        def get(self, name: str, default: str | None = None) -> str | None:
+            value = self._backend.get_header(name)
+            return value if value is not None else default
+
+    @property
+    def headers(self) -> _Headers:
+        return self._Headers(self._backend)
+
+
+def get_client_backend() -> ClientBackend | None:
+    return _client_backend.get()
+
+
+def client_for_render() -> _ClientHeaderProxy | None:
+    backend = get_client_backend()
+    if backend is None:
+        return None
+    return _ClientHeaderProxy(backend)
+
+
+def reset_client_backend_state() -> None:
+    """Clear the request-scoped client backend. Mainly for tests."""
+    _client_backend.set(None)
+
+
+def resolve_render_client(explicit: object | None) -> object | None:
+    if explicit is not None:
+        return explicit
+    return client_for_render()
+
+
+def resolve_render_mounted(
+    explicit: object | None,
+    *,
+    dirtied: object | None,
+) -> object | None:
+    if explicit is not None:
+        return explicit
+    from .mutations import pending_dirtied
+
+    if dirtied is None and not pending_dirtied():
+        return None
+    return client_for_render()
+
+
+@contextmanager
+def client_scope(backend: ClientBackend | None) -> Generator[None, None, None]:
+    token = _client_backend.set(backend)
+    try:
+        yield
+    finally:
+        _client_backend.reset(token)
+
+
+class ClientBackendMiddleware:
+    """
+    Starlette/FastAPI ``BaseHTTPMiddleware`` helper: bind ``RequestClientBackend``
+    for the request via ``Registry.request_scope``.
+
+    Subclass or compose with your own middleware::
+
+        class AppMiddleware(ClientBackendMiddleware, BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                return await self.bind_client_backend(request, call_next)
+    """
+
+    async def bind_client_backend(self, request: object, call_next: Any) -> Any:
+        from .registry import Registry
+
+        with Registry.request_scope(
+            client_backend=client_backend_from_request(request),
+        ):
+            return await call_next(request)

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -120,11 +120,11 @@ class _ReactiveRender:
             )
 
         skey = coerce_load_key_str(key) if key is not None else None
-        from .client_backend import resolve_render_mounted
+        from .client_backend import ClientBackend
         from .mutations import mark_reactive_render_consumed, resolve_effective_dirtied
         from .reactive_dev import warn_reactive_render_without_mounted
 
-        resolved_mounted = resolve_render_mounted(mounted, dirtied=dirtied)
+        resolved_mounted = ClientBackend.resolve_mounted(mounted, dirtied=dirtied)
         own_keys = interpolate_reactive_keys(
             getattr(cls, "_pjx_reacts_to", frozenset()), skey, keyed=keyed
         )

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -120,25 +120,29 @@ class _ReactiveRender:
             )
 
         skey = coerce_load_key_str(key) if key is not None else None
+        from .client_backend import resolve_render_mounted
         from .mutations import mark_reactive_render_consumed, resolve_effective_dirtied
         from .reactive_dev import warn_reactive_render_without_mounted
 
+        resolved_mounted = resolve_render_mounted(mounted, dirtied=dirtied)
         own_keys = interpolate_reactive_keys(
             getattr(cls, "_pjx_reacts_to", frozenset()), skey, keyed=keyed
         )
         warn_reactive_render_without_mounted(
-            dirtied=dirtied, mounted=mounted, own_keys=own_keys
+            dirtied=dirtied, mounted=resolved_mounted, own_keys=own_keys
         )
         effective_dirtied = resolve_effective_dirtied(
             dirtied=dirtied,
-            mounted=mounted,
+            mounted=resolved_mounted,
             own_keys=own_keys,
         )
         invalidate(effective_dirtied | own_keys)
         instance = cls.load(skey) if keyed else cls.load()
         primary = instance._render(emit_assets=False)
         mark_reactive_render_consumed()
-        swaps = oob_swaps(effective_dirtied, mounted, exclude_ids={instance.id})
+        swaps = oob_swaps(
+            effective_dirtied, resolved_mounted, exclude_ids={instance.id}
+        )
         return Markup(primary) + swaps
 
     def __get__(

--- a/pyjinhx/registry.py
+++ b/pyjinhx/registry.py
@@ -126,7 +126,7 @@ class Registry:
         from contextlib import ExitStack
 
         from .cache import init_request_cache, reset_request_cache
-        from .client_backend import client_scope
+        from .client_backend import ClientBackend
         from .load_context import load_scope
         from .mutations import clear_mutations
         from .reactive_dev import warn_mutations_without_render
@@ -139,7 +139,7 @@ class Registry:
                 if load_context is not None:
                     stack.enter_context(load_scope(load_context))
                 if client_backend is not None:
-                    stack.enter_context(client_scope(client_backend))
+                    stack.enter_context(ClientBackend.scope(client_backend))
                 yield
         finally:
             warn_mutations_without_render()

--- a/pyjinhx/registry.py
+++ b/pyjinhx/registry.py
@@ -110,6 +110,7 @@ class Registry:
         cls,
         *,
         load_context: object | None = None,
+        client_backend: object | None = None,
     ) -> Generator[None, None, None]:
         """
         Context manager for request-scoped component instances.
@@ -125,6 +126,7 @@ class Registry:
         from contextlib import ExitStack
 
         from .cache import init_request_cache, reset_request_cache
+        from .client_backend import client_scope
         from .load_context import load_scope
         from .mutations import clear_mutations
         from .reactive_dev import warn_mutations_without_render
@@ -136,6 +138,8 @@ class Registry:
             with ExitStack() as stack:
                 if load_context is not None:
                     stack.enter_context(load_scope(load_context))
+                if client_backend is not None:
+                    stack.enter_context(client_scope(client_backend))
                 yield
         finally:
             warn_mutations_without_render()

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -9,12 +9,11 @@ def test_reactive_api_is_exported():
         PJX_MOUNTED_HEADER,
         CacheScope,
         ClientBackend,
+        FastAPIClientBackend,
         InvalidationBackend,
         ReactiveComponent,
-        RequestClientBackend,
-        client_backend_from_request,
-        client_for_render,
         client_scope,
+        fastapi_client_backend,
         get_client_backend,
         client_has_mounted_manifest,
         client_script,
@@ -54,9 +53,8 @@ def test_reactive_api_is_exported():
     assert CacheScope.REQUEST == "request"
     assert issubclass(ClientBackend, ABC)
     assert issubclass(InvalidationBackend, ABC)
-    assert issubclass(RequestClientBackend, ClientBackend)
-    assert callable(client_backend_from_request)
-    assert callable(client_for_render)
+    assert issubclass(FastAPIClientBackend, ClientBackend)
+    assert callable(fastapi_client_backend)
     assert callable(client_scope)
     assert callable(get_client_backend)
     assert issubclass(ReactiveComponent, pyjinhx.BaseComponent)
@@ -92,11 +90,8 @@ def test_names_in_all():
         "start_invalidation_listener",
         "stop_invalidation_listener",
         "ClientBackend",
-        "ClientBackendMiddleware",
-        "HeadersClientBackend",
-        "RequestClientBackend",
-        "client_backend_from_request",
-        "client_for_render",
+        "FastAPIClientBackend",
+        "fastapi_client_backend",
         "client_scope",
         "get_client_backend",
     ):

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -12,9 +12,7 @@ def test_reactive_api_is_exported():
         FastAPIClientBackend,
         InvalidationBackend,
         ReactiveComponent,
-        client_scope,
         fastapi_client_backend,
-        get_client_backend,
         client_has_mounted_manifest,
         client_script,
         dependency_graph,
@@ -55,8 +53,8 @@ def test_reactive_api_is_exported():
     assert issubclass(InvalidationBackend, ABC)
     assert issubclass(FastAPIClientBackend, ClientBackend)
     assert callable(fastapi_client_backend)
-    assert callable(client_scope)
-    assert callable(get_client_backend)
+    assert callable(ClientBackend.scope)
+    assert callable(ClientBackend.current)
     assert issubclass(ReactiveComponent, pyjinhx.BaseComponent)
     assert issubclass(StateKey, str)
 
@@ -92,7 +90,5 @@ def test_names_in_all():
         "ClientBackend",
         "FastAPIClientBackend",
         "fastapi_client_backend",
-        "client_scope",
-        "get_client_backend",
     ):
         assert name in pyjinhx.__all__

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -8,8 +8,14 @@ def test_reactive_api_is_exported():
         PJX_ASSETS_HEADER,
         PJX_MOUNTED_HEADER,
         CacheScope,
+        ClientBackend,
         InvalidationBackend,
         ReactiveComponent,
+        RequestClientBackend,
+        client_backend_from_request,
+        client_for_render,
+        client_scope,
+        get_client_backend,
         client_has_mounted_manifest,
         client_script,
         dependency_graph,
@@ -46,7 +52,13 @@ def test_reactive_api_is_exported():
     assert callable(start_invalidation_listener)
     assert callable(stop_invalidation_listener)
     assert CacheScope.REQUEST == "request"
+    assert issubclass(ClientBackend, ABC)
     assert issubclass(InvalidationBackend, ABC)
+    assert issubclass(RequestClientBackend, ClientBackend)
+    assert callable(client_backend_from_request)
+    assert callable(client_for_render)
+    assert callable(client_scope)
+    assert callable(get_client_backend)
     assert issubclass(ReactiveComponent, pyjinhx.BaseComponent)
     assert issubclass(StateKey, str)
 
@@ -79,5 +91,13 @@ def test_names_in_all():
         "set_invalidation_backend",
         "start_invalidation_listener",
         "stop_invalidation_listener",
+        "ClientBackend",
+        "ClientBackendMiddleware",
+        "HeadersClientBackend",
+        "RequestClientBackend",
+        "client_backend_from_request",
+        "client_for_render",
+        "client_scope",
+        "get_client_backend",
     ):
         assert name in pyjinhx.__all__

--- a/tests/56_client_backend_test.py
+++ b/tests/56_client_backend_test.py
@@ -1,12 +1,9 @@
-import json
-
 from pyjinhx import (
     PJX_MOUNTED_HEADER,
+    FastAPIClientBackend,
     Registry,
-    RequestClientBackend,
-    client_backend_from_request,
-    client_for_render,
     client_scope,
+    fastapi_client_backend,
 )
 from pyjinhx.client_backend import resolve_render_client, resolve_render_mounted
 from pyjinhx.mutations import mutation_scope
@@ -25,34 +22,27 @@ class _Request:
         self.headers = _Headers(headers)
 
 
-def test_request_client_backend_reads_headers():
-    backend = RequestClientBackend(_Request({PJX_MOUNTED_HEADER: "[]"}))
+def test_fastapi_client_backend_reads_headers():
+    backend = FastAPIClientBackend(_Request({PJX_MOUNTED_HEADER: "[]"}))
     assert backend.get_header(PJX_MOUNTED_HEADER) == "[]"
+    assert backend.headers.get(PJX_MOUNTED_HEADER) == "[]"
 
 
-def test_client_backend_from_request():
+def test_fastapi_client_backend_factory():
     request = _Request({"X-Test": "ok"})
-    backend = client_backend_from_request(request)
+    backend = fastapi_client_backend(request)
     assert backend.get_header("X-Test") == "ok"
 
 
-def test_client_for_render_proxy():
-    manifest = json.dumps([{"id": "c", "type": "Counter", "hash": "x"}])
-    with client_scope(RequestClientBackend(_Request({PJX_MOUNTED_HEADER: manifest}))):
-        proxy = client_for_render()
-        assert proxy is not None
-        assert proxy.headers.get(PJX_MOUNTED_HEADER) == manifest
-
-
 def test_resolve_render_client_uses_backend():
-    with client_scope(RequestClientBackend(_Request({}))):
+    with client_scope(FastAPIClientBackend(_Request({}))):
         assert resolve_render_client(None) is not None
     assert resolve_render_client(None) is None
 
 
 def test_resolve_render_mounted_mutation_only():
     manifest = "[]"
-    with client_scope(RequestClientBackend(_Request({PJX_MOUNTED_HEADER: manifest}))):
+    with client_scope(FastAPIClientBackend(_Request({PJX_MOUNTED_HEADER: manifest}))):
         assert resolve_render_mounted(None, dirtied=None) is None
         assert resolve_render_mounted(None, dirtied={"todos"}) is not None
         with mutation_scope("todos"):
@@ -62,6 +52,7 @@ def test_resolve_render_mounted_mutation_only():
 
 def test_request_scope_wires_client_backend():
     request = _Request({PJX_MOUNTED_HEADER: "[]"})
-    with Registry.request_scope(client_backend=client_backend_from_request(request)):
-        assert resolve_render_client(None) is not None
-        assert resolve_render_client(None).headers.get(PJX_MOUNTED_HEADER) == "[]"
+    with Registry.request_scope(client_backend=fastapi_client_backend(request)):
+        client = resolve_render_client(None)
+        assert client is not None
+        assert client.headers.get(PJX_MOUNTED_HEADER) == "[]"

--- a/tests/56_client_backend_test.py
+++ b/tests/56_client_backend_test.py
@@ -1,11 +1,10 @@
 from pyjinhx import (
     PJX_MOUNTED_HEADER,
+    ClientBackend,
     FastAPIClientBackend,
     Registry,
-    client_scope,
     fastapi_client_backend,
 )
-from pyjinhx.client_backend import resolve_render_client, resolve_render_mounted
 from pyjinhx.mutations import mutation_scope
 
 
@@ -35,24 +34,24 @@ def test_fastapi_client_backend_factory():
 
 
 def test_resolve_render_client_uses_backend():
-    with client_scope(FastAPIClientBackend(_Request({}))):
-        assert resolve_render_client(None) is not None
-    assert resolve_render_client(None) is None
+    with ClientBackend.scope(FastAPIClientBackend(_Request({}))):
+        assert ClientBackend.resolve_client(None) is not None
+    assert ClientBackend.resolve_client(None) is None
 
 
 def test_resolve_render_mounted_mutation_only():
     manifest = "[]"
-    with client_scope(FastAPIClientBackend(_Request({PJX_MOUNTED_HEADER: manifest}))):
-        assert resolve_render_mounted(None, dirtied=None) is None
-        assert resolve_render_mounted(None, dirtied={"todos"}) is not None
+    with ClientBackend.scope(FastAPIClientBackend(_Request({PJX_MOUNTED_HEADER: manifest}))):
+        assert ClientBackend.resolve_mounted(None, dirtied=None) is None
+        assert ClientBackend.resolve_mounted(None, dirtied={"todos"}) is not None
         with mutation_scope("todos"):
             pass
-        assert resolve_render_mounted(None, dirtied=None) is not None
+        assert ClientBackend.resolve_mounted(None, dirtied=None) is not None
 
 
 def test_request_scope_wires_client_backend():
     request = _Request({PJX_MOUNTED_HEADER: "[]"})
     with Registry.request_scope(client_backend=fastapi_client_backend(request)):
-        client = resolve_render_client(None)
+        client = ClientBackend.resolve_client(None)
         assert client is not None
         assert client.headers.get(PJX_MOUNTED_HEADER) == "[]"

--- a/tests/56_client_backend_test.py
+++ b/tests/56_client_backend_test.py
@@ -1,0 +1,67 @@
+import json
+
+from pyjinhx import (
+    PJX_MOUNTED_HEADER,
+    Registry,
+    RequestClientBackend,
+    client_backend_from_request,
+    client_for_render,
+    client_scope,
+)
+from pyjinhx.client_backend import resolve_render_client, resolve_render_mounted
+from pyjinhx.mutations import mutation_scope
+
+
+class _Headers:
+    def __init__(self, mapping: dict[str, str]) -> None:
+        self._mapping = mapping
+
+    def get(self, name: str, default: str | None = None) -> str | None:
+        return self._mapping.get(name, default)
+
+
+class _Request:
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = _Headers(headers)
+
+
+def test_request_client_backend_reads_headers():
+    backend = RequestClientBackend(_Request({PJX_MOUNTED_HEADER: "[]"}))
+    assert backend.get_header(PJX_MOUNTED_HEADER) == "[]"
+
+
+def test_client_backend_from_request():
+    request = _Request({"X-Test": "ok"})
+    backend = client_backend_from_request(request)
+    assert backend.get_header("X-Test") == "ok"
+
+
+def test_client_for_render_proxy():
+    manifest = json.dumps([{"id": "c", "type": "Counter", "hash": "x"}])
+    with client_scope(RequestClientBackend(_Request({PJX_MOUNTED_HEADER: manifest}))):
+        proxy = client_for_render()
+        assert proxy is not None
+        assert proxy.headers.get(PJX_MOUNTED_HEADER) == manifest
+
+
+def test_resolve_render_client_uses_backend():
+    with client_scope(RequestClientBackend(_Request({}))):
+        assert resolve_render_client(None) is not None
+    assert resolve_render_client(None) is None
+
+
+def test_resolve_render_mounted_mutation_only():
+    manifest = "[]"
+    with client_scope(RequestClientBackend(_Request({PJX_MOUNTED_HEADER: manifest}))):
+        assert resolve_render_mounted(None, dirtied=None) is None
+        assert resolve_render_mounted(None, dirtied={"todos"}) is not None
+        with mutation_scope("todos"):
+            pass
+        assert resolve_render_mounted(None, dirtied=None) is not None
+
+
+def test_request_scope_wires_client_backend():
+    request = _Request({PJX_MOUNTED_HEADER: "[]"})
+    with Registry.request_scope(client_backend=client_backend_from_request(request)):
+        assert resolve_render_client(None) is not None
+        assert resolve_render_client(None).headers.get(PJX_MOUNTED_HEADER) == "[]"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from pyjinhx import CacheScope, Registry, get_load_cache_scope, set_load_cache_scope
 from pyjinhx.assets import RenderSession
 from pyjinhx.cache import clear as clear_load_cache
-from pyjinhx.client_backend import reset_client_backend_state
+from pyjinhx import ClientBackend
 from pyjinhx.invalidation import reset_invalidation_state
 from pyjinhx.mutations import clear_mutations
 
@@ -43,7 +43,7 @@ def _isolate_reactive_state() -> Generator[None, None, None]:
     clear_load_cache()
     clear_mutations()
     reset_invalidation_state()
-    reset_client_backend_state()
+    ClientBackend.reset()
     Registry.clear_instances()
     set_load_cache_scope(CacheScope.PROCESS)
     with Registry.request_scope():
@@ -51,6 +51,6 @@ def _isolate_reactive_state() -> Generator[None, None, None]:
     clear_load_cache()
     clear_mutations()
     reset_invalidation_state()
-    reset_client_backend_state()
+    ClientBackend.reset()
     Registry.clear_instances()
     set_load_cache_scope(original_scope)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from pyjinhx import CacheScope, Registry, get_load_cache_scope, set_load_cache_scope
 from pyjinhx.assets import RenderSession
 from pyjinhx.cache import clear as clear_load_cache
+from pyjinhx.client_backend import reset_client_backend_state
 from pyjinhx.invalidation import reset_invalidation_state
 from pyjinhx.mutations import clear_mutations
 
@@ -42,6 +43,7 @@ def _isolate_reactive_state() -> Generator[None, None, None]:
     clear_load_cache()
     clear_mutations()
     reset_invalidation_state()
+    reset_client_backend_state()
     Registry.clear_instances()
     set_load_cache_scope(CacheScope.PROCESS)
     with Registry.request_scope():
@@ -49,5 +51,6 @@ def _isolate_reactive_state() -> Generator[None, None, None]:
     clear_load_cache()
     clear_mutations()
     reset_invalidation_state()
+    reset_client_backend_state()
     Registry.clear_instances()
     set_load_cache_scope(original_scope)


### PR DESCRIPTION
## Summary
- Add `ClientBackend` ABC with `RequestClientBackend` / `client_backend_from_request()` as the default FastAPI/Starlette adapter (no `fastapi` import in core)
- Extend `Registry.request_scope(client_backend=...)`; `render()` auto-resolves `client` and `mounted` from the backend when omitted
- `mounted` auto-resolves only after mutations (`dirtied` explicit or `pending_dirtied()` from `@mutates`) — safe for hx-boost full-page GETs
- Simplify reactive todo routes; update docs and tests

## Test plan
- [x] `uv run pytest` (287 passed)
- [x] `uv run mkdocs build --strict`
- [ ] Manual: reactive todo toggle still updates counter/total OOB without `mounted=request`


Made with [Cursor](https://cursor.com)