### PR TITLE
Simplify reactive API with PjxLoad stamping

### DIFF
--- a/.cursor/skills/code-audit-sweep/CONVENTIONS.md
+++ b/.cursor/skills/code-audit-sweep/CONVENTIONS.md
@@ -33,9 +33,9 @@ After fixes: `uv run ruff check .` and `uv run pytest`.
 
 | Level | Meaning |
 |-------|---------|
-| P1 | Wrong layer, duplicate orchestration that will drift, misleading public API |
-| P2 | Indirection, misplaced integration code, module globals for mutable state |
-| P3 | Naming, minor duplication, doc drift |
+| P1 | Wrong layer, duplicate orchestration that will drift, misleading public API, removed API still live in code/docs |
+| P2 | Indirection, misplaced integration code, module globals for mutable state, dead symbols/branches/tests |
+| P3 | Naming, minor duplication, doc drift, unused parameters |
 
 ## pyjinhx design rules
 
@@ -44,8 +44,8 @@ Cite these in findings when relevant:
 1. **One implementation layer** — no internal module function that only delegates to a classmethod (or the reverse).
 2. **ABC + hub in core/reactive; impl in integrations** — e.g. `ClientBackend` in `pyjinhx/reactive/backend.py`, `FastAPIClientBackend` in `pyjinhx/integrations/fastapi.py`; `InvalidationBackend` + `InvalidationHub` vs `RedisInvalidationBackend` in `pyjinhx/integrations/redis.py`.
 3. **Stateful subsystems → class + classmethods + ContextVar** — `LoadCache`, `MutationTracker`, `InvalidationHub`, `ClientBackend`, `LoadContext`.
-4. **Pure transforms stay functions** — `pyjinhx/reactive/keys.py` coercion/interpolation.
-5. **Ergonomic decorators stay module-level** — `@mutates` / `mutation_scope` call `MutationTracker.record`.
+4. **Pure transforms stay functions** — `pyjinhx/reactive/keys.py` coercion; `pjx_load.py` field discovery.
+5. **Ergonomic decorators stay module-level** — `@mutates` calls `MutationTracker.record`.
 6. **Package `__init__.py` re-exports OK; internal wrappers not OK.**
 7. **Domain code not in `pyjinhx/utils.py`** — HTML/path/runtime helpers only.
 
@@ -70,5 +70,6 @@ When running a full sweep, child audits run in this order:
 5. duplication-audit
 6. indirection-audit
 7. public-api-audit
+8. dead-code-audit
 
 Merge duplicate findings at the same location; keep the highest severity.

--- a/.cursor/skills/code-audit-sweep/SKILL.md
+++ b/.cursor/skills/code-audit-sweep/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: code-audit-sweep
 description: >-
-  Orchestrate a full structural code audit of pyjinhx using seven focused lenses
+  Orchestrate a full structural code audit of pyjinhx using eight focused lenses
   (file responsibility, module placement, domain entities, state shape, duplication,
-  indirection, public API). Use when the user asks to "audit the codebase", "sweep
+  indirection, public API, dead code). Use when the user asks to "audit the codebase", "sweep
   for quality", "review architecture", "audit reactive/", or before a large PR merge.
   Produces a merged read-only report; remediation is a separate pass unless requested.
 disable-model-invocation: true
@@ -32,6 +32,7 @@ Read shared rules: [CONVENTIONS.md](CONVENTIONS.md).
    - [duplication-audit](../duplication-audit/SKILL.md)
    - [indirection-audit](../indirection-audit/SKILL.md)
    - [public-api-audit](../public-api-audit/SKILL.md)
+   - [dead-code-audit](../dead-code-audit/SKILL.md)
 3. **Merge** — same file:line → one finding, highest severity, note all lenses.
 4. **Output** combined report using CONVENTIONS template + executive summary table:
 

--- a/.cursor/skills/code-audit-sweep/VALIDATION.md
+++ b/.cursor/skills/code-audit-sweep/VALIDATION.md
@@ -36,10 +36,11 @@ Optional P3 (not reported): `load_cache.py` slightly above 250 LOC soft ceiling 
 
 ## Cross-cutting (docs, not code scope)
 
-`public-api-audit` on `docs/` finds stale symbols (`get_load_context`, `fastapi_client_backend`) — **P1 doc drift** when auditing full package + docs. Child skill correctly flags these; reactive code scope alone stays clean.
+`public-api-audit` on `docs/` should flag stale symbols (`mutation_scope`, `dirty_keys`, `get_load_context`, `fastapi_client_backend`, `dirtied=`/`mounted=` on `render()`) — **P1 doc drift** when auditing full package + docs. `docs/integrations/claude-code.md` may still lag after reactive simplification; reactive `pyjinhx/` scope stays clean.
 
 ## Rubric tuning applied
 
 - Cohesive single-class files 240–260 LOC → no finding unless mixed concerns.
 - Module-level ContextVar + class static methods (`LoadContext`, `Registry`) → OK, not P2.
 - Expected baseline in orchestrator SKILL.md matches reactive dry-run.
+- **dead-code-audit** runs last in full sweep; complements `public-api-audit` with code-path and orphan-test analysis.

--- a/.cursor/skills/dead-code-audit/SKILL.md
+++ b/.cursor/skills/dead-code-audit/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: dead-code-audit
+description: >-
+  Audit pyjinhx for dead code—removed API ghosts in code/docs/tests, symbols with
+  no callers, obsolete backward-compat paths, unused parameters, and tests for
+  deleted behavior. Use after refactors, API removals, or when the user asks to
+  "sweep for dead code", "find unused code", or "remove leftovers". Read-only report.
+disable-model-invocation: true
+---
+
+# Dead code audit
+
+## Audit ownership
+
+**I own:** symbols and paths with no live callers, removed-API remnants, obsolete compat shims, tests/docs for deleted behavior.
+
+**I don't own:** thin wrappers that still have callers (→ `indirection-audit`), export policy (→ `public-api-audit`), intentional asymmetry (→ `duplication-audit`).
+
+Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
+
+## Scope
+
+Default: `pyjinhx/`, `tests/`, `examples/`, `docs/`, `.cursor/skills/`.
+
+User may narrow (e.g. `pyjinhx/reactive/` only). Include docs when user says "full sweep".
+
+## Categories
+
+| Category | Hunt for | Typical severity |
+|----------|----------|------------------|
+| **Removed API ghost** | Symbol deleted from package but still referenced | P1 in docs/examples; P2 in code/tests |
+| **Zero-caller definition** | Function/class/method defined, never imported or called | P2 |
+| **Obsolete compat path** | Branch only serving old wire format or migration | P2 |
+| **Unused parameter** | Public/internal param never passed by any caller | P3 |
+| **Dead infrastructure** | Fields/indexes for removed feature (e.g. stem buckets) | P2 |
+| **Orphan test** | Test asserts removed behavior or imports removed symbol | P2 |
+| **Stale skill/doc grep** | Audit skills hunting symbols that no longer exist | P3 |
+
+## Known removed symbols (pyjinhx)
+
+Re-grep after each breaking reactive/API change. Absence in `pyjinhx/` but presence elsewhere = ghost.
+
+```
+mutation_scope
+coerce_dirty_args
+interpolate_reactive_keys
+StateKey.instance_key
+StateKey.dirty_keys
+dirty_keys
+resolve_mounted
+resolve_effective_dirtied
+warn_reactive_render_without_mounted
+get_load_context
+load_scope
+fastapi_client_backend
+parse_loaded_assets
+client_has_mounted_manifest
+data-pjx-key
+```
+
+Also hunt stale **usage patterns** (not necessarily symbol names):
+
+```
+render(.*dirtied=
+render(.*mounted=
+manifest.*"key"
+```
+
+## Intentional (do not flag without evidence)
+
+| Item | Why it stays |
+|------|----------------|
+| `_render(client=...)` | Tests pass explicit client for asset/runtime paths |
+| `ClientBackend.resolve_client(explicit)` | Supports `_render(client=request)` |
+| `_pjx_key` | Internal load-cache identity |
+| `depends_on()` default | Load-cache reverse index + dev validation |
+| `MutationTracker.render_was_consumed()` | Dev guardrail |
+| `pyjinhx/__init__.py` re-exports | Public API surface |
+
+Compat shims: flag only when **zero callers** remain (grep the shim body, not just the name).
+
+## Process
+
+1. **Confirm scope** and whether docs/skills/examples are in scope.
+2. **Ghost scan** — run mechanical greps (below) for removed symbols and stale patterns.
+3. **Definition scan** — for symbols touched by recent refactors, count references:
+
+```bash
+# Replace SYMBOL; expect hits in definition file only (+ maybe tests to delete)
+rg -l '\bSYMBOL\b' pyjinhx tests examples docs .cursor/skills
+```
+
+4. **Export vs usage** — compare `pyjinhx.__all__` to `tests/36_public_api_test.py` and doc tables; flag exports with no docs/tests if newly added.
+5. **Branch scan** — read compat helpers (`_manifest_load_arg`, `resolve_client`, etc.): is every branch reachable?
+6. **Test scan** — tests whose names/descriptions reference removed APIs (`mutation_scope`, `data-pjx-key`, instance-tier dirty keys).
+7. **Classify** each hit: delete | migrate caller | document as intentional compat | false positive.
+8. **Do not delete** unless user asks for remediation.
+
+## Mechanical checks
+
+```bash
+# Removed API ghosts (expand list as APIs drop)
+rg -n 'mutation_scope|coerce_dirty_args|interpolate_reactive_keys|dirty_keys|resolve_mounted|resolve_effective_dirtied|warn_reactive_render_without_mounted|get_load_context|fastapi_client_backend|data-pjx-key' \
+  pyjinhx tests examples docs .cursor/skills
+
+# Stale render kwargs in docs/examples (not in pyjinhx — may be intentional in migration docs)
+rg -n 'render\([^)]*dirtied=|render\([^)]*mounted=' docs examples .cursor/skills
+
+# Top-level invalidate wrapper (canonical: LoadCache.invalidate)
+rg -n 'from pyjinhx import .*invalidate|pyjinhx\.invalidate\b' docs examples README.md
+
+# Unused imports (run ruff; triage F401 in scope only)
+uv run ruff check pyjinhx/ --select F401
+```
+
+After remediation candidates are identified, verify survivors:
+
+```bash
+uv run pytest tests/ -q
+uv run ruff check .
+```
+
+## Checklist
+
+- [ ] No removed symbols in `pyjinhx/` (except CHANGELOG/historical notes if any)
+- [ ] No removed symbols in `tests/` imports or assertions
+- [ ] `docs/` and `examples/` use current API (`PjxLoad`, `Cls.render(*args)`, `@mutates` state keys only)
+- [ ] No orphan compat branches (manifest `key` alias, stem invalidation index, etc.) without tests or callers
+- [ ] No tests asserting deleted behavior unless explicitly marked legacy
+- [ ] Audit skills grep current symbols (`warn_reactive_render_without_client`, not `..._mounted`)
+- [ ] `__all__` / `36_public_api_test.py` / `docs/reference/public-api.md` agree
+
+## Relationship to sibling audits
+
+| Lens | Overlap |
+|------|---------|
+| `public-api-audit` | Doc/export drift; dead-code adds **code-path** and **zero-caller** analysis |
+| `indirection-audit` | Wrapper with callers ≠ dead; wrapper with **zero** callers → dead-code P2 |
+| `duplication-audit` | Parallel paths where one side is never invoked → dead-code |
+
+Run **after** `public-api-audit` in a full sweep (docs table first, then orphan code).
+
+## Report
+
+Use CONVENTIONS template.
+
+Severity guide:
+
+- **P1** — Removed API still exported, documented as current, or called from production `pyjinhx/` code
+- **P2** — Dead function/branch/test, obsolete infra, ghost in examples/tests
+- **P3** — Unused parameter, stale skill grep line, comment referencing removed API
+
+**Fix shape** examples:
+
+- Delete symbol and migrate last caller
+- Remove compat branch + test that only exercised compat
+- Update doc/snippet to canonical API
+- Drop unused parameter from signature (if all callers updated)

--- a/.cursor/skills/domain-entity-audit/SKILL.md
+++ b/.cursor/skills/domain-entity-audit/SKILL.md
@@ -29,6 +29,8 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 | Dirtied keys | `MutationTracker` | scattered ContextVar helpers |
 | Cross-worker fan-out | `InvalidationBackend` + `InvalidationHub` | Redis in `reactive/` |
 | Client manifest | `MountedManifest` | loose dict parsing only |
+| Trigger region | `TriggerManifest` | ad-hoc trigger header parsing |
+| Load round-trip marker | `PjxLoad` | magic `{{ key }}` template injection |
 | Loaded asset URLs | `LoadedAssets` | `parse_loaded_assets()` |
 | OOB swap walk | functions in `oob.py` | `OobSwaps` class (algorithm, not entity) |
 | Dev guardrails | module functions + `_DevConfig` | public class |
@@ -38,7 +40,7 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 - **Entity / aggregate** — identity, lifecycle (`ReactiveComponent`, `LoadCache`)
 - **Value object** — parse result, no mutable identity (`MountedManifest.parse` output)
 - **Service / hub** — coordinates subsystem (`InvalidationHub`, `MutationTracker`)
-- **Algorithm** — stateless transform over inputs (`oob_swaps`, `interpolate_reactive_keys`)
+- **Algorithm** — stateless transform over inputs (`oob_swaps`, `pjx_load_value`, key coercion in `keys.py`)
 - **Port / ABC** — extension point (`ClientBackend`, `InvalidationBackend`)
 
 ## Flag

--- a/.cursor/skills/duplication-audit/SKILL.md
+++ b/.cursor/skills/duplication-audit/SKILL.md
@@ -24,8 +24,8 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
    - Fixed: `component.py` + `base.py` render → `reactive/render.py` `reactive_render_bundle`.
 2. **Duplicate parsing/validation** — two ways to answer the same question.
    - Fixed: `client_has_mounted_manifest` vs manifest parse → `MountedManifest.is_present`.
-3. **Decorator + context manager** — identical bodies.
-   - Fixed: `@mutates` and `mutation_scope` → `MutationTracker.record`.
+3. **Decorator ergonomics** — mutation recording must stay one code path.
+   - Canonical: `@mutates` → `MutationTracker.record` only (no parallel context manager).
 
 ## Intentional asymmetry (document, don't merge blindly)
 
@@ -43,7 +43,7 @@ Flag as **documented divergence** if asymmetry is required; **merge candidate** 
 3. Grep repeated 5+ line blocks:
 
 ```bash
-rg -n 'warn_reactive_render_without_mounted|resolve_effective_dirtied|mark_reactive_render_consumed' pyjinhx/
+rg -n 'warn_reactive_render_without_client|mark_render_consumed|reactive_render_bundle' pyjinhx/
 ```
 
 4. Classify: merge candidate | documented divergence | unrelated.

--- a/.cursor/skills/public-api-audit/SKILL.md
+++ b/.cursor/skills/public-api-audit/SKILL.md
@@ -13,7 +13,7 @@ disable-model-invocation: true
 
 **I own:** `pyjinhx/__init__.py` `__all__`, docs index vs exports, public-api test alignment.
 
-**I don't own:** internal wrapper removal (→ `indirection-audit`), where impl files live (→ `module-placement-audit`).
+**I don't own:** internal wrapper removal (→ `indirection-audit`), where impl files live (→ `module-placement-audit`), zero-caller symbols (→ `dead-code-audit`).
 
 Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 
@@ -33,7 +33,8 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 ## Checklist
 
 - [ ] `import pyjinhx; set(pyjinhx.__all__) == set(dir intended)`
-- [ ] No removed symbols in docs (`get_load_context`, `fastapi_client_backend`, `invalidate`, etc.)
+- [ ] No removed symbols in docs (`mutation_scope`, `dirty_keys`, `get_load_context`, `fastapi_client_backend`, top-level `invalidate`, etc.)
+- [ ] New exports documented (`PjxLoad`, `TriggerManifest`, `PJX_TRIGGER_HEADER`)
 - [ ] `tests/36_public_api_test.py` imports match `__all__`
 - [ ] Examples use canonical names (`LoadContext.current`, not `get_load_context`)
 - [ ] Breaking renames noted in README if user-facing
@@ -42,7 +43,7 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 
 ```bash
 python -c "import pyjinhx; print(sorted(pyjinhx.__all__))"
-rg 'get_load_context|load_scope|fastapi_client_backend|parse_loaded_assets|client_has_mounted_manifest|set_invalidation_backend|get_load_cache_scope' docs/ README.md
+rg 'mutation_scope|dirty_keys|get_load_context|load_scope|fastapi_client_backend|data-pjx-key|dirtied=|mounted=|parse_loaded_assets|client_has_mounted_manifest|set_invalidation_backend|get_load_cache_scope' docs/ README.md
 ```
 
 Compare `docs/reference/public-api.md` table to `pyjinhx.__all__`.

--- a/.cursor/skills/state-shape-audit/SKILL.md
+++ b/.cursor/skills/state-shape-audit/SKILL.md
@@ -23,7 +23,7 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 |-----------|-------|-----------------|
 | ContextVar + locks + process/request state | Class with `@classmethod` | `LoadCache`, `MutationTracker`, `InvalidationHub`, `ClientBackend` |
 | Request-scoped opaque DI bag | Static methods on frozen dataclass base | `LoadContext` |
-| Pure input → output | Module functions | `coerce_reactive_key`, `interpolate_reactive_keys` |
+| Pure input → output | Module functions | `coerce_reactive_key`, `pjx_load_field_names`, `PjxLoad` validation |
 | Decorator ergonomics | Module decorator → class method | `@mutates` → `MutationTracker.record` |
 | Plugin extension point | ABC, no hub state | `InvalidationBackend` |
 | Runtime coordinator | Hub class | `InvalidationHub` |

--- a/README.md
+++ b/README.md
@@ -158,16 +158,17 @@ class Counter(ReactiveComponent):
 @app.post("/todos/toggle")
 def toggle():
     db.toggle_all()
-    return Counter.render(dirtied={StateKey.TODOS})
+    return Counter.render()
 ```
 
-Wire `setup(app, ...)` once — lifespan and registry middleware handle cache scope, optional invalidation, `LoadContext`, and `ClientBackend` for header auto-resolution. Mutation routes omit `mounted=`; `pjx.js` is injected on root full-page renders unless `X-PJX-Mounted` is already present.
+Wire `setup(app, ...)` once — lifespan and registry middleware handle cache scope, optional invalidation, `LoadContext`, and `ClientBackend` for header auto-resolution. Mutation routes call `Cls.render(*args)` with no framework kwargs; `pjx.js` is injected on root full-page renders unless `X-PJX-Mounted` is already present.
 
-**Reactive ergonomics:** use `StateKey` enums and `StateKey.dirty_keys()` for typed keys; `@mutates` on store methods to auto-supply `dirtied`; `LoadContext.bind()` / `LoadContext.current()` to inject dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
+**Reactive ergonomics:** use `StateKey` enums for typed keys; `@mutates` on store methods to accumulate pending dirtied keys for the next reactive `render()`; `PjxLoad` on one model field per keyed component for `data-pjx-load` round-trip; `LoadContext.bind()` / `LoadContext.current()` to inject dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
 
 **Reactive design decisions:**
-- **Two-tier dependencies:** static `reacts_to` is the cache-safety superset; override `depends_on()` on the loaded instance to narrow runtime deps (e.g. admin-only panels). `oob_swaps` pre-filters on the superset, then `load()`s, then matches on `depends_on()`.
-- **`mutation_scope`:** records dirtied keys and invalidates the load cache on **successful exit** only (same as `@mutates` after the wrapped function returns). Failed blocks do not invalidate or accumulate dirtied keys.
+- **Three identities:** `data-pjx-id` (HTMX swap target), `data-pjx-load` (round-trip `load()` arg from a `PjxLoad` field), and state keys in `reacts_to` / `@mutates` (pub-sub only).
+- **Pub-sub OOB:** every mounted region whose `reacts_to` intersects pending mutations may OOB-reload via `load(manifest.load)`; the trigger region and primary are excluded via `X-PJX-Trigger` + primary id.
+- **`depends_on()`:** optional runtime narrowing for load-cache indexing; `oob_swaps` matches on static `reacts_to` only.
 - **`state_hash()`:** canonical sorted JSON from `model_dump(mode="json")` with `id` excluded by default (`state_hash_exclude` to omit more fields). Override `state_hash()` for custom hashing.
 
 **Load cache scope** (default `CacheScope.REQUEST`): `load()` results are cached within each HTTP request via `LoadCache`. Use `LoadCache.invalidate()` to evict entries; `MutationTracker` accumulates dirtied keys from `@mutates` for the next reactive render. Use `Registry.request_scope()` on every request for instance registry isolation (included in `setup(app, ...)`). For cross-request caching per worker, pass `cache_scope=CacheScope.PROCESS` to `setup()` and pair with an `InvalidationBackend` + `InvalidationHub` ([Redis reference](pyjinhx/integrations/redis.py), `pip install pyjinhx[redis]`).

--- a/docs/api/cache-invalidation.md
+++ b/docs/api/cache-invalidation.md
@@ -37,7 +37,7 @@ class LoadCache:
     def clear(cls) -> None: ...
 ```
 
-Memoizes reactive `load()` results keyed by `(class, instance_key)`.
+Memoizes reactive `load()` results keyed by `(class, load_arg)`.
 
 Prefer [`setup()`](config.md) at app startup:
 
@@ -52,11 +52,9 @@ Or set explicitly: `LoadCache.set_scope(CacheScope.REQUEST)`.
 
 Environment variable `PJX_LOAD_CACHE_SCOPE` is read by `PyJinhxSettings.from_env()` (default `request`).
 
-**Stem expansion:** `LoadCache.invalidate({"todo"})` evicts all instance-tier entries whose keys start with `"todo:"` (e.g. `"todo:42"`).
-
 **Propagation:** when `CacheScope.PROCESS` is active, an `InvalidationBackend` is configured, and `propagate=True` (default), dirtied keys are published to other workers after local eviction. Remote handlers call `LoadCache.invalidate(..., propagate=False)` to avoid publish loops.
 
-Called automatically by `@mutates` and `mutation_scope` after mutations complete.
+Called automatically by `@mutates` after mutations complete.
 
 ## InvalidationBackend
 

--- a/docs/api/client-backend.md
+++ b/docs/api/client-backend.md
@@ -1,6 +1,6 @@
 # Client Backend
 
-Per-request HTTP header access for reactive rendering. Wire once in your app's middleware; `render()` reads `X-PJX-Mounted` and `X-PJX-Assets` automatically.
+Per-request HTTP header access for reactive rendering. Wire once in your app's middleware; `render()` reads `X-PJX-Mounted`, `X-PJX-Assets`, and `X-PJX-Trigger` from the active backend.
 
 PyJinHx does **not** ship middleware — you define a thin wrapper (see [FastAPI integration](../integrations/fastapi.md#middleware-recommended)) that calls `Registry.request_scope(client_backend=FastAPIClientBackend(request))`.
 
@@ -21,11 +21,6 @@ class ClientBackend(ABC):
 
     @classmethod
     def resolve_client(cls, explicit: object | None) -> object | None: ...
-
-    @classmethod
-    def resolve_mounted(
-        cls, explicit: object | None, *, dirtied: object | None
-    ) -> object | None: ...
 ```
 
 Abstract base — implement for non-FastAPI frameworks if needed.
@@ -35,8 +30,7 @@ Abstract base — implement for non-FastAPI frameworks if needed.
 | `current()` | Return the active backend for this request, or `None`. |
 | `scope(backend)` | Set the request-scoped backend (usually via `Registry.request_scope`). |
 | `reset()` | Clear the backend. Mainly for tests. |
-| `resolve_client(explicit)` | Return `explicit` if set, else `current()`. Used by `render()`. |
-| `resolve_mounted(explicit, dirtied=...)` | Return `explicit` if set; else `current()` only when reactive mode applies (see below). |
+| `resolve_client(explicit)` | Return `explicit` if set, else `current()`. Used by `_render()` for asset dedup. |
 
 ## FastAPIClientBackend
 
@@ -47,23 +41,17 @@ class FastAPIClientBackend(ClientBackend):
     def __init__(self, request: object) -> None: ...
 ```
 
-Default implementation for FastAPI and Starlette. Wraps `request.headers`. The instance exposes `.headers.get()` for `render()` duck typing. `setup(app, ...)` wires this automatically in middleware.
+Default implementation for FastAPI and Starlette. Wraps `request.headers`. `setup(app, ...)` wires this automatically in middleware.
 
 ## Auto-resolution in render()
 
-When `client=` and `mounted=` are omitted:
+When a `ClientBackend` is active (via `setup()` middleware or `ClientBackend.scope()`):
 
-| Parameter | Resolved from backend when |
-|-----------|---------------------------|
-| `client` | Backend is set (runtime skip, asset dedup) |
-| `mounted` | Backend is set **and** (`dirtied` passed or `@mutates` left pending dirtied) |
+- Root renders use it for asset dedup (`X-PJX-Assets`) and runtime injection gating (`X-PJX-Mounted`).
+- Reactive class/instance `render()` reads the manifest and trigger headers for OOB swaps.
 
-Explicit `client=` / `mounted=` always override the backend.
-
-### Mutation-only `mounted` rule
-
-`mounted` is **not** auto-resolved on every request. It applies only when the render is reactive — i.e. `dirtied` is passed (including via pending `@mutates` keys) — so hx-boost full-page GETs do not accidentally enter the OOB swap path.
+Mutation routes call `Cls.render(*args)` with no framework kwargs — pending keys from `@mutates` drive the OOB walk.
 
 ## Non-FastAPI frameworks
 
-Subclass `ClientBackend` and implement `get_header()`. Pass the instance to `Registry.request_scope(client_backend=...)`. The backend instance should expose `.headers.get()` for duck typing, or pass `mounted=` / `client=` explicitly on each `render()` call.
+Subclass `ClientBackend` and implement `get_header()`. Pass the instance to `Registry.request_scope(client_backend=...)`.

--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -11,42 +11,36 @@ class StateKey(StrEnum):
     ...
 ```
 
-Base class for app-level reactive key constants. Subclass and declare members; use the enum in `reacts_to`, `dirtied`, and `@mutates` — all normalize to their string values.
+Base class for app-level reactive key constants. Subclass and declare members; use the enum in `reacts_to` and `@mutates` — all normalize to their string values.
 
 ```python
 from pyjinhx import StateKey
 
 class Keys(StateKey):
     TODOS = "todos"
-    TODO = "todo"
 ```
 
-## instance_key
+## PjxLoad
 
 ```python
-def instance_key(stem: str, key: str | int) -> str
+class PjxLoad:
+    ...
 ```
 
-Build an instance-tier dirty key.
+Marker for `Annotated[..., PjxLoad()]`. Keyed components declare exactly one `PjxLoad` field; its value is stamped as `data-pjx-load` on render and returned in the client manifest as `load` for OOB `load()` round-trip.
 
 ```python
-instance_key("todo", 42)  # "todo:42"
+from typing import Annotated
+from pyjinhx import PjxLoad, ReactiveComponent
+
+class ItemRow(ReactiveComponent):
+    todo_id: Annotated[int, PjxLoad()]
+    reacts_to: ClassVar[set[str]] = {"todos"}
+
+    @classmethod
+    def load(cls, todo_id: int) -> "ItemRow":
+        ...
 ```
-
-## dirty_keys
-
-```python
-def dirty_keys(instance_stem: str, key: str | int, *collection: ReactiveKey) -> set[str]
-```
-
-Build a two-tier dirty set for instance-keyed mutations. Returns the expanded instance key plus any collection-tier keys.
-
-```python
-dirty_keys("todo", 42, "todos")
-# {"todo:42", "todos"}
-```
-
-Use with `mutation_scope()` when a mutation affects both a single row and a collection summary.
 
 ## mutates
 
@@ -54,7 +48,7 @@ Use with `mutation_scope()` when a mutation affects both a single row and a coll
 def mutates(*keys: ReactiveKey) -> Callable[[F], F]
 ```
 
-Decorator for store mutation methods. After the wrapped function returns, invalidates the load cache for `keys` and accumulates them as pending dirtied for the next reactive `render()` when `dirtied` is omitted.
+Decorator for store mutation methods. Each arg is a **state key** (string or `StateKey` enum). After the wrapped function returns, invalidates the load cache and accumulates pending dirtied keys for the next reactive `render()`.
 
 ```python
 from pyjinhx import mutates
@@ -63,22 +57,6 @@ class Store:
     @mutates("todos")
     def add(self, text: str) -> None:
         ...
-```
-
-## mutation_scope
-
-```python
-@contextmanager
-def mutation_scope(*keys: ReactiveKey) -> Generator[None, None, None]
-```
-
-Context manager that invalidates and accumulates dirtied keys when the block exits (not on entry). Use for mutations that don't map cleanly to a single decorated method.
-
-```python
-from pyjinhx import dirty_keys, mutation_scope
-
-with mutation_scope(*dirty_keys(Keys.TODO, todo_id, Keys.TODOS)):
-    self._toggle(todo_id)
 ```
 
 ## LoadContext
@@ -91,25 +69,19 @@ class LoadContext:
 
 Opaque base for request-scoped data available inside reactive `load()`. Subclass with your own frozen dataclass fields (database session, user id, feature flags).
 
-## get_load_context
+## LoadContext.current / LoadContext.bind
 
 ```python
-def get_load_context() -> Any | None
+LoadContext.current() -> Any | None
+LoadContext.bind(ctx) -> ContextManager[None]
 ```
 
-Return the current load context, or `None` outside a scope. Reactive `load()` methods accept an optional keyword-only `ctx=` argument when the context is set.
+Return or set the load context for the current scope. Reactive `load()` methods receive a parameter annotated with `LoadContext` (or a subclass) when the context is set.
 
-## load_scope
-
-```python
-@contextmanager
-def load_scope(ctx: Any) -> Generator[None, None, None]
-```
-
-Set the load context for the current scope. Prefer `Registry.request_scope(load_context=ctx)` in web apps — it combines registry isolation, request cache, mutation tracking, and load context in one call.
+Prefer `Registry.request_scope(load_context=ctx)` in web apps — it combines registry isolation, request cache, mutation tracking, and load context in one call.
 
 ```python
-from pyjinhx import LoadContext, Registry, fastapi_client_backend
+from pyjinhx import LoadContext, Registry, FastAPIClientBackend
 
 @dataclass(frozen=True)
 class AppLoadContext(LoadContext):
@@ -117,12 +89,10 @@ class AppLoadContext(LoadContext):
 
 with Registry.request_scope(
     load_context=AppLoadContext(db=session),
-    client_backend=fastapi_client_backend(request),
+    client_backend=FastAPIClientBackend(request),
 ):
-    html = TodoList.render()  # mounted from ClientBackend after @mutates
+    html = TodoList.render()
 ```
-
-Without `ClientBackend`, pass `mounted=request` on reactive `render()` calls.
 
 ## Reactive dev
 
@@ -137,7 +107,7 @@ def enable_reactive_dev(*, strict: bool = False) -> None
 Enable guardrails. When enabled:
 
 - Warns if `@mutates` recorded dirtied keys but no reactive `render()` consumed them in the request scope.
-- Warns if dirtied keys are set but `mounted` was not passed (OOB swaps skipped).
+- Warns if mutations are pending but no `ClientBackend` is active (OOB swaps skipped).
 - Validates that `depends_on()` is a subset of the static `reacts_to` superset on each `load()`.
 
 Set `strict=True` to raise `RuntimeError` instead of logging warnings.
@@ -156,7 +126,7 @@ Disable all dev guardrails.
 def dependency_graph() -> dict[str, list[str]]
 ```
 
-Map each declared reactive key to the component class names that depend on it. Instance-tier stems appear as declared (e.g. `"todo"`), not expanded per instance.
+Map each declared reactive key to the component class names that depend on it.
 
 ### format_dependency_graph
 

--- a/docs/api/reactive-api.md
+++ b/docs/api/reactive-api.md
@@ -15,14 +15,15 @@ Base class for components that reload from application state via a `load()` clas
 
 ### Requirements
 
-- Declare `reacts_to` — the reactive keys this component depends on (collection-tier stems like `"todos"` or instance-tier stems like `"todo"`).
+- Declare `reacts_to` — **state keys** this component subscribes to (e.g. `"todos"`).
 - Implement `load()` as a `@classmethod` that returns a fresh component instance.
+- For keyed `load(cls, resource)` types, declare exactly one `Annotated[..., PjxLoad()]` field.
 
 ### Keyed vs singleton
 
-Set `_pjx_keyed = True` on instance-keyed components (e.g. one row per todo). Singleton components omit the key.
+A parameter after `cls` in `load()` makes the type **instance-keyed** (e.g. one row per todo). Declare `PjxLoad` on the resource field. Zero-arg `load(cls)` is a type-singleton.
 
-Singleton reactive components default `id` to the kebab-cased class name (`TodoCounter` → `"todo-counter"`); `load()` need not set one unless you want a custom id.
+Singleton reactive components default `id` to the kebab-cased class name (`TodoCounter` → `"todo-counter"`).
 
 ### render()
 
@@ -31,21 +32,18 @@ Two forms coexist via a descriptor:
 **Class method (route entry point):**
 
 ```python
-Cls.render(key=None, *, dirtied=None, mounted=None, client=None) -> Markup
+Cls.render(*args, **kwargs) -> Markup
 ```
 
-Auto-`load()`s the primary component, renders it, and appends OOB swaps for dependents. With `ClientBackend` wired in middleware, omit `mounted` and `client` on mutation routes — headers are read from the backend after `@mutates`.
+Auto-`load()`s the primary, renders it, and appends OOB swaps when a `ClientBackend` is active and `@mutates` left pending keys.
 
 **Instance method:**
 
 ```python
-instance.render(*, dirtied=None, mounted=None, client=None) -> Markup
+instance.render() -> Markup
 ```
 
 Render an already-built instance as the primary without re-loading from the world.
-
-!!! note "Without ClientBackend"
-    Pass `mounted=request` (and `client=request` for asset dedup) when not using a request-scoped backend. See [Client Backend](client-backend.md).
 
 ### depends_on()
 
@@ -53,10 +51,7 @@ Render an already-built instance as the primary without re-loading from the worl
 def depends_on(self) -> set[str]
 ```
 
-Reactive keys this loaded instance currently depends on. Defaults to the
-interpolated static `reacts_to` declaration. Override to narrow based on instance
-state (static `reacts_to` must remain a superset). Used by `oob_swaps` after
-`load()` and by `LoadCache` reverse indexing.
+Reactive state keys this loaded instance depends on. Defaults to static `reacts_to`. Override to narrow for load-cache indexing (static `reacts_to` must remain a superset). `oob_swaps` matches on static `reacts_to` only.
 
 ### state_hash()
 
@@ -72,20 +67,22 @@ Used by OOB swap gating — override for custom hashing.
 state_hash_exclude: ClassVar[frozenset[str]] = frozenset({"id"})
 ```
 
+## PjxLoad
+
+```python
+class PjxLoad:
+    ...
+```
+
+Marker for `Annotated[..., PjxLoad()]`. The field value is stamped as `data-pjx-load` and returned in the client manifest as `load`.
+
 ## client_script
 
 ```python
 def client_script(*, mode: AssetMode | None = None, src: str | None = None) -> Markup
 ```
 
-Return the pyjinhx client runtime as a `<script>` tag. Use in raw Jinja shells outside
-the component render path. Root `BaseComponent.render()` calls inject the runtime
-automatically unless `X-PJX-Mounted` is already present on the request.
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `mode` | `AssetMode.INLINE` | `INLINE` inlines source; `REFERENCE` emits `<script src="...">` |
-| `src` | Renderer runtime URL | Public URL when mode is `REFERENCE` |
+Return the pyjinhx client runtime as a `<script>` tag. Root `BaseComponent.render()` injects the runtime automatically unless `X-PJX-Mounted` is already present on the request.
 
 ## MountedManifest
 
@@ -100,16 +97,27 @@ class MountedManifest:
 
 `parse()` returns the mounted-region manifest from a request-like object, raw JSON string, or parsed list.
 
-`is_present()` returns whether the client already sent a valid `X-PJX-Mounted` header. A JSON array (including `[]`) means `pjx.js` is active; missing or malformed values mean the runtime should be injected on root full-page renders.
+`is_present()` returns whether the client already sent a valid `X-PJX-Mounted` header.
+
+## TriggerManifest
+
+```python
+class TriggerManifest:
+    @staticmethod
+    def parse(client: str | dict[str, Any] | object | None) -> dict[str, Any] | None: ...
+```
+
+Parse `X-PJX-Trigger` — the `data-pjx-id` of the element that started the HTMX request.
 
 ## PJX headers
 
 | Constant | Value | Purpose |
 |----------|-------|---------|
-| `PJX_MOUNTED_HEADER` | `"X-PJX-Mounted"` | JSON manifest of mounted reactive regions (`id`, `type`, `hash`) |
-| `PJX_ASSETS_HEADER` | `"X-PJX-Assets"` | JSON list of asset URLs already loaded in the browser |
+| `PJX_MOUNTED_HEADER` | `"X-PJX-Mounted"` | JSON manifest of mounted regions (`id`, `type`, `hash`, optional `load`) |
+| `PJX_ASSETS_HEADER` | `"X-PJX-Assets"` | JSON list of asset URLs already loaded |
+| `PJX_TRIGGER_HEADER` | `"X-PJX-Trigger"` | JSON `{"id": "<data-pjx-id>"}` of the swap origin |
 
-The client runtime (`pjx.js`) sets both headers on HTMX requests. With [ClientBackend](client-backend.md) wired in middleware, `render()` reads them automatically; otherwise pass the request as `mounted=` and `client=`.
+Wire [ClientBackend](client-backend.md) via `setup()`; `render()` reads headers from the active backend.
 
 ## LoadedAssets
 
@@ -119,11 +127,7 @@ class LoadedAssets:
     def parse(client: str | list[str] | object | None) -> frozenset[str]: ...
 ```
 
-Parse the client-reported list of asset URLs for REFERENCE-mode asset dedup.
-
-Accepts a request-like object (`.headers.get(PJX_ASSETS_HEADER)`), a raw JSON string, a parsed list/tuple/set of URL strings, or `None`/`""` (nothing loaded).
-
-Used internally when a client source is resolved for `render()` with asset dedup enabled (explicit `client=` or `ClientBackend`).
+Parse `X-PJX-Assets` for REFERENCE-mode asset dedup on root renders.
 
 ## oob_swaps
 
@@ -133,24 +137,10 @@ def oob_swaps(
     mounted: str | list[dict[str, Any]] | object | None,
     *,
     exclude_ids: set[str] | None = None,
+    skip_invalidate: bool = False,
 ) -> Markup
 ```
 
-Compute out-of-band swap fragments for every mounted reactive region whose declared dependencies intersect the dirtied keys.
+Compute out-of-band swap fragments for every mounted reactive region whose `reacts_to` intersects `dirtied`.
 
-**Behavior:**
-
-1. Evicts dirtied keys from the load cache.
-2. Walks the client manifest (`X-PJX-Mounted`).
-3. Reloads each matching dependent via `load()`.
-4. Emits an OOB swap only when the fresh `state_hash()` differs from the client's reported hash.
-
-**Parameters:**
-
-| Parameter | Description |
-|-----------|-------------|
-| `dirtied` | State keys the route mutated (e.g. `{"todos"}` or `{"todo:42"}`) |
-| `mounted` | Request object, raw header string, parsed manifest list, or `None` |
-| `exclude_ids` | Mounted ids to skip (typically the primary response id) |
-
-`ReactiveComponent.render()` calls this automatically. Use directly only for advanced partial-response composition.
+`ReactiveComponent.render()` calls this automatically when reactive mode is active. Use directly only for tests and advanced composition.

--- a/docs/api/reactive-api.md
+++ b/docs/api/reactive-api.md
@@ -143,4 +143,6 @@ def oob_swaps(
 
 Compute out-of-band swap fragments for every mounted reactive region whose `reacts_to` intersects `dirtied`.
 
+When a keyed `load(manifest.load)` raises `LookupError` (entity removed), emits a delete OOB swap (`delete:[data-pjx-id='…']`) instead of failing.
+
 `ReactiveComponent.render()` calls this automatically when reactive mode is active. Use directly only for tests and advanced composition.

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -135,11 +135,11 @@ On entry: clears pending mutations, initializes the request-scoped load cache, a
 **Usage:**
 
 ```python
-from pyjinhx import Registry
+from pyjinhx import FastAPIClientBackend, Registry
 
 with Registry.request_scope(
     load_context=AppLoadContext(db=session),
-    client_backend=fastapi_client_backend(request),
+    client_backend=FastAPIClientBackend(request),
 ):
     # Components registered here are isolated to this scope
     button = Button(id="submit-btn", text="Submit")

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -317,19 +317,17 @@ class TodoApp(BaseComponent):
 `keys.py`:
 
 ```python
-from pyjinhx.keys import StateKey
+from pyjinhx import StateKey
 
 
 class Keys(StateKey):
     TODOS = "todos"
-    TODO = "todo"
 ```
 
 `store.py`:
 
 ```python
-from pyjinhx import mutates, mutation_scope
-from pyjinhx.keys import dirty_keys
+from pyjinhx import mutates
 
 from .keys import Keys
 
@@ -339,9 +337,9 @@ def add(text: str) -> None:
     ...
 
 
+@mutates(Keys.TODOS)
 def toggle(todo_id: int) -> None:
-    with mutation_scope(*dirty_keys(Keys.TODO, todo_id, Keys.TODOS)):
-        ...
+    ...
 ```
 
 Route:
@@ -353,10 +351,9 @@ def toggle_row(todo_id: int):
     return TodoItemRow.render(todo_id)
 ```
 
-???+ question "Why @mutates, dirty_keys, and ClientBackend?"
-    - **`@mutates` / `mutation_scope`** — after a store change, invalidate the `load()` cache and accumulate `dirtied` keys for the next reactive render.
-    - **`dirty_keys("todo", id, "todos")`** — instance-keyed rows need **both** the row key (`todo:42`) and collection keys (`todos`). Invalidating only `"todo"` is not enough for cache entries stored under `todo:42`.
-    - **`ClientBackend`** (wired in middleware) — supplies `X-PJX-Mounted` automatically after mutations so OOB swaps run without `mounted=request` on every route.
+???+ question "Why @mutates and ClientBackend?"
+    - **`@mutates`** — after a store change, invalidate the `load()` cache and accumulate pending state keys for the next reactive `render()`.
+    - **`ClientBackend`** (wired via `setup()`) — supplies `X-PJX-Mounted`, `X-PJX-Trigger`, and `X-PJX-Assets` so OOB swaps run without framework kwargs on `render()`.
 
     `render()` on the **class** auto-calls `load()` — routes never call `load()` manually.
 
@@ -365,31 +362,38 @@ def toggle_row(todo_id: int):
 ## Step 10 — Instance-keyed rows
 
 ```python
+from typing import Annotated
+from pyjinhx import PjxLoad
+
 class TodoItemRow(ReactiveComponent):
+    todo_id: Annotated[int, PjxLoad()]
     title: str = ""
     done: bool = False
-    reacts_to: ClassVar[set[str]] = {Keys.TODO}
+    reacts_to: ClassVar[set[str]] = {Keys.TODOS}
 
     @classmethod
-    def load(cls, key: int) -> "TodoItemRow":
-        todo = store.get(key)
-        return cls(id=f"todo-row-{key}", title=todo.text, done=todo.done)
+    def load(cls, todo_id: int) -> "TodoItemRow":
+        todo = store.get(todo_id)
+        return cls(
+            id=f"row-{todo_id}",
+            todo_id=todo_id,
+            title=todo.text,
+            done=todo.done,
+        )
 ```
 
 Template:
 
 ```html
 <li>
-  <button hx-post="/rows/{{ key }}/toggle"
+  <button hx-post="/rows/{{ todo_id }}/toggle"
           hx-target="closest [data-pjx-id]" hx-swap="outerHTML">toggle</button>
   <span>{{ title }}</span>
 </li>
 ```
 
-???+ question "Why load(cls, key) and id=f\"todo-row-{key}\"?"
-    A parameter after `cls` makes the type **instance-keyed** — many rows, each with its own reactive identity. Give each row a **unique `id`** so the instance registry and DOM stamps don't collide (otherwise every row would register as the same key).
-
-    `reacts_to = {Keys.TODO}` uses the instance stem; the library expands it to `todo:<key>` for cache and dependency matching.
+???+ question "Why PjxLoad and load(cls, todo_id)?"
+    A parameter after `cls` makes the type **instance-keyed**. `PjxLoad` stamps `data-pjx-load` for OOB round-trip. Use the same field in templates (`{{ todo_id }}`). `reacts_to = {Keys.TODOS}` is pub-sub — all mounted rows with matching state keys may OOB-reload when todos change.
 
 ---
 
@@ -397,27 +401,23 @@ Template:
 
 ```python
 from dataclasses import dataclass
-from pyjinhx.load_context import get_load_context
+from pyjinhx import LoadContext
 
 
 @dataclass(frozen=True)
-class AppLoadContext:
+class AppLoadContext(LoadContext):
     store: object
 
 
 def _store():
-    ctx = get_load_context()
+    ctx = LoadContext.current()
     return ctx.store if isinstance(ctx, AppLoadContext) else store
 ```
 
-Extend the Step 6 middleware:
+Pass a factory to `setup()` (Step 6):
 
 ```python
-with Registry.request_scope(
-    load_context=AppLoadContext(store=store),
-    client_backend=fastapi_client_backend(request),
-):
-    return await call_next(request)
+setup(app, load_context_factory=lambda request: AppLoadContext(store=store))
 ```
 
 ???+ question "Why LoadContext?"
@@ -451,7 +451,7 @@ setup(
 ```
 
 ???+ question "Why cache at all?"
-    A single page may call `TodoCounter.load()` many times during composition and OOB walks. Caching `(class, key) → component snapshot` avoids repeated store/DB work. **Invalidation** (`@mutates`, `render(dirtied=...)`, or manual `invalidate()`) evicts entries when state changes — cache is a performance layer, not the source of truth.
+    A single page may call `TodoCounter.load()` many times during composition and OOB walks. Caching `(class, load_arg) → component snapshot` avoids repeated store/DB work. **Invalidation** (`@mutates` or `LoadCache.invalidate`) evicts entries when state changes — cache is a performance layer, not the source of truth.
 
     If toggles feel stale, check that mutations dirtied the **instance key** (`todo:42`), not just the stem (`todo`).
 
@@ -489,7 +489,7 @@ print(format_dependency_graph())
 ```
 
 ???+ question "Why enable_reactive_dev?"
-    Reactivity bugs are often silent (missing `mounted=`, wrong keys, `depends_on()` outside `reacts_to`). Dev mode turns those into log warnings or strict exceptions during development.
+    Reactivity bugs are often silent (missing `ClientBackend`, wrong `reacts_to` keys, `depends_on()` outside `reacts_to`). Dev mode turns those into log warnings or strict exceptions during development.
 
 ---
 
@@ -516,8 +516,9 @@ from pyjinhx.builtins import Alert, Button, Card
 | Root full-page render (auto `pjx.js` unless `X-PJX-Mounted` present) | Yes |
 | HTMX in layout | Yes |
 | `ReactiveComponent` + `reacts_to` + `load()` | Yes |
-| `@mutates` / `mutation_scope` + `dirty_keys` for rows | Yes |
-| `fastapi_client_backend` in middleware | Yes |
+| `@mutates(Keys.TODOS)` on store mutations | Yes |
+| `setup()` wires `FastAPIClientBackend` | Yes |
+| `PjxLoad` on keyed row components | Yes |
 | `LoadContext` | Recommended |
 | Assets / REFERENCE mode | Production |
 | Invalidation backend | Multi-worker + PROCESS cache |

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -66,7 +66,7 @@ When `REFERENCE` mode is active, co-located assets and `js`/`css` fields are col
 
 ### Reactive partial suppression
 
-Full-page renders emit assets once at the layout root. Reactive partial responses (`render(..., mounted=...)`) and OOB swaps **never** re-ship assets — matching production expectations where the layout shell loads static files once.
+Full-page renders emit assets once at the layout root. Reactive partial responses and OOB swaps **never** re-ship assets — matching production expectations where the layout shell loads static files once.
 
 ### Client asset dedup (REFERENCE mode, opt-in)
 

--- a/docs/guide/registry.md
+++ b/docs/guide/registry.md
@@ -71,18 +71,18 @@ On entry, `request_scope()` also clears pending mutations, initializes the reque
 
 For application-wide coverage, use middleware in your app (pyjinhx does not ship middleware). See the [canonical FastAPI snippet](../integrations/fastapi.md#middleware-recommended).
 
+Prefer `setup(app, ...)` — it registers middleware that calls
+`Registry.request_scope(client_backend=FastAPIClientBackend(request))` automatically.
+
+For manual wiring:
+
 ```python
-from starlette.middleware.base import BaseHTTPMiddleware
-from pyjinhx import Registry, fastapi_client_backend
+from pyjinhx import FastAPIClientBackend, Registry, setup
 
-class RegistryScopeMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request, call_next):
-        with Registry.request_scope(
-            client_backend=fastapi_client_backend(request),
-        ):
-            return await call_next(request)
-
-app.add_middleware(RegistryScopeMiddleware)
+setup(app)  # recommended
+# or:
+with Registry.request_scope(client_backend=FastAPIClientBackend(request)):
+    ...
 ```
 
 ### Nested Scopes

--- a/docs/guide/registry.md
+++ b/docs/guide/registry.md
@@ -157,6 +157,10 @@ PyJinHx maintains two separate registries:
 
 The class registry enables the `Renderer` to instantiate components from PascalCase tags. The instance registry enables cross-referencing in templates.
 
+### Template context precedence
+
+During render, registered instances are injected into the Jinja context by `id` so templates can reference them by registry key. **Component field values from `model_dump()` take precedence** when a field name collides with an instance `id` (registry injection uses `setdefault`). Avoid naming a reactive field the same as its default `id` (e.g. a `Total` component with a `total` field defaults `id` to `"total"`).
+
 ```python
 # Class registry (automatic when you define a class)
 class MyButton(BaseComponent):

--- a/docs/guide/usage-tiers.md
+++ b/docs/guide/usage-tiers.md
@@ -80,11 +80,9 @@ Requires `Registry.request_scope()` on every request when using auto-dirtied fro
 **Canonical middleware** (app-defined — pyjinhx does not ship middleware):
 
 ```python
-with Registry.request_scope(
-    load_context=AppLoadContext(db=get_db(request)),
-    client_backend=fastapi_client_backend(request),
-):
-    return await call_next(request)
+from pyjinhx import setup
+
+setup(app, load_context_factory=lambda request: AppLoadContext(db=get_db(request)))
 ```
 
 See [FastAPI integration § Middleware](../integrations/fastapi.md#middleware-recommended).

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -128,8 +128,8 @@ Subclass `ReactiveComponent` and declare **both** `reacts_to` and a `load()` cla
 definition-time error):
 
 ```python
-from typing import ClassVar
-from pyjinhx import ReactiveComponent
+from typing import Annotated, ClassVar
+from pyjinhx import PjxLoad, ReactiveComponent, mutates
 
 class Counter(ReactiveComponent):
     remaining: int
@@ -140,87 +140,90 @@ class Counter(ReactiveComponent):
         return cls(remaining=db.remaining())     # id defaults to "counter"
 ```
 
-- **`reacts_to`** — arbitrary state-key strings *you* choose (`"todos"`, `"user:42"`). The
-  server intersects a component's `reacts_to` with a route's `dirtied` keys to decide what
-  to swap (and what to evict from the `load()` cache).
+- **`reacts_to`** — arbitrary state-key strings *you* choose (`"todos"`). The server
+  intersects a component's `reacts_to` with pending `@mutates` keys to decide what to
+  swap (and what to evict from the `load()` cache).
 - **`load()`** — rebuilds the component from the current world, independent of any route.
-- **`id`** auto-defaults to the **kebab-cased class name** (`TodoCounter` → `"todo-counter"`);
-  a singleton's identity is its type, so `load()` need not set one.
-- `state_hash()` (hash of `model_dump_json()`) gates swaps: a region is re-sent only if its
-  fresh hash differs from the one the client reported. Override only for custom hashing.
-- Roots are auto-stamped with `data-pjx-id` / `data-pjx-type` / `data-pjx-hash` (+ `data-pjx-key`
-  when keyed). A reactive component **must render a single root element**.
+- **`id`** auto-defaults to the **kebab-cased class name** (`Counter` → `"counter"`);
+  pass an explicit `id` for instance-keyed regions (e.g. `id=f"row-{todo_id}"`).
+- `state_hash()` gates swaps: a region is re-sent only if its fresh hash differs from
+  the one the client reported.
+- Roots are auto-stamped with `data-pjx-id` / `data-pjx-type` / `data-pjx-hash` (+
+  `data-pjx-load` when keyed via `PjxLoad`). A reactive component **must render a single
+  root element**.
 
 ### Mutation routes return `render()` — nothing else
 
 A mutation route does exactly one thing: **`return <component>.render(...)`**. You never
-call `load()` and never assemble swaps yourself.
+call `load()` and never assemble swaps yourself. Decorate store methods with `@mutates`
+on **state keys only**:
 
 ```python
+@mutates("todos")
+def toggle_all():
+    ...
+
 @app.post("/todos/toggle")
 def toggle():
-    db.toggle_all()
-    return Counter.render(dirtied={"todos"})
+    store.toggle_all()
+    return Counter.render()
 ```
 
 `render` has two forms (one name):
 
-- **Class form (reactive primary)** — `Cls.render(key=None, *, dirtied=None, mounted=None)`:
-  auto-`load()`s the primary (by `key` if instance-keyed, zero-arg for a singleton), renders
-  it as the main-target response, then appends an OOB swap for every *other* mounted reactive
-  region whose `reacts_to` intersects `dirtied` (each rebuilt via its own `load()`). The
-  primary's own region is never double-swapped. `dirtied` defaults to the primary's
-  (interpolated) `reacts_to`.
-- **Instance form (plain/constructed primary)** — `instance.render(*, dirtied=None, mounted=None)`:
-  a non-reactive primary has no `load()`, so build it and render the instance.
+- **Class form (route entry)** — `Cls.render(*args, **kwargs)` for keyed types,
+  `Cls.render()` for singletons: auto-`load()`s the primary, renders it as the HTMX
+  main-target response, then appends OOB swaps for every *other* mounted reactive region
+  whose `reacts_to` intersects pending `@mutates` keys. The trigger region (`X-PJX-Trigger`)
+  and primary region are excluded from OOB.
+- **Instance form** — `instance.render()`: plain render of an already-built instance
+  (no re-`load()`).
 
-With [ClientBackend](../api/client-backend.md) in middleware, omit `mounted` and `client` on mutation routes. Without it, pass `mounted=request` (request-like object, raw header string, or parsed list). With neither `dirtied` nor `mounted`, `render()` is an ordinary plain render.
+Wire `setup(app, ...)` so `ClientBackend` is active — mutation routes need no `mounted`
+or `client` kwargs. `pjx.js` sends `X-PJX-Mounted`, `X-PJX-Assets`, and `X-PJX-Trigger`
+on every HTMX request.
 
-`oob_swaps(dirtied, mounted)` is what `render()` delegates to (`exclude_ids={primary.id}`);
-it's exported for tests/advanced use but is **not** how you write a route.
+`oob_swaps(dirtied, mounted)` is exported for tests/advanced use; routes use `render()`.
 
 ### Instance-keyed regions (rows)
 
-A reactive type can have **many independently-reactive instances** (table rows, cards). A
-component is **instance-keyed iff its `load()` takes a parameter after `cls`** —
-`load(cls, key)`; zero-arg `load(cls)` stays a type-singleton. No extra field or flag.
+A component is **instance-keyed iff `load()` takes one argument after `cls`**. Declare
+exactly one `Annotated[..., PjxLoad()]` field — its value is stamped as `data-pjx-load`
+and returned in the manifest as `load` for OOB reloads.
 
 ```python
 class TodoItemRow(ReactiveComponent):
+    todo_id: Annotated[int, PjxLoad()]
     title: str = ""
-    reacts_to: ClassVar[set[str]] = {"todo"}          # instance-tier stem
+    reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
-    def load(cls, key) -> "TodoItemRow":              # param after cls ⇒ keyed
-        t = store.get(int(key))                        # keys arrive as str; coerce if typed
-        return cls(title=t.text)
+    def load(cls, todo_id: int | str) -> "TodoItemRow":
+        tid = int(todo_id)
+        t = store.get(tid)
+        return cls(id=f"row-{tid}", todo_id=tid, title=t.text)
 
 @app.post("/rows/{todo_id}/toggle")
-def toggle_row(todo_id):
+def toggle_row(todo_id: int):
     store.toggle(todo_id)
-    return TodoItemRow.render(todo_id, dirtied={f"todo:{todo_id}", "todos"})
+    return TodoItemRow.render(todo_id)
 ```
 
-- **The key flows `render(key, …)` → `load(key)` automatically.** It derives the keyed id
-  `f"{kebab(class)}-{key}"` (e.g. `todo-item-row-42`), is exposed to the template as `{{ key }}`,
-  and is stamped as `data-pjx-key` so the manifest carries it back. Enums are unwrapped to
-  `.value` before `load()`; cache/manifest keys are always `str`.
-- **Instance-tier stems** on keyed components are bare strings (`{"todo"}` → `"todo:42"` per row).
-  Collection-tier keys stay literal (`{"user", "users"}` — `"users"` is not suffixed).
-- **Two-tier dirtying:** instance stems are *instance-tier* (`"todo:42"` swaps just that row);
-  collection keys are *collection-tier* (`"todos"` swaps every mounted row that declares it, plus
-  counters/totals). Name both as needed.
+- **`render(todo_id)` → `load(todo_id)`** automatically. Set explicit `id` in `load()` for
+  stable DOM targets (e.g. `row-42`). Templates use the `PjxLoad` field:
+  `hx-post="/rows/{{ todo_id }}/toggle"`.
+- **`@mutates("todos")`** on store methods dirties collection-tier state; OOB pub-sub reloads
+  every mounted region whose `reacts_to` intersects, with hash-gating skipping unchanged regions.
+- **Removed entities:** if a keyed `load(manifest.load)` raises `LookupError`, OOB emits a
+  `delete:[data-pjx-id='…']` swap (e.g. after clear-completed removes rows still in the manifest).
 
 ### Client runtime & cache
 
-- Root full-page renders auto-inject the client runtime (`pjx.js`) unless the request
-  already carries `X-PJX-Mounted`. For a raw Jinja shell, drop `{{ client_script() }}`
-  in the `<head>` instead.
-- Every `load()` is wrapped in a **dependency-keyed cache** (one entry per `(type, key)`),
-  returning an independent copy each call. Default scope is `PROCESS` (cross-request
-  per worker). Use `REQUEST` for multi-worker without an invalidation backend, or
-  `invalidate({"todos"})` after background mutations. Multi-worker `PROCESS` needs an
-  `InvalidationBackend`.
+- Root full-page renders auto-inject `pjx.js` unless the request already carries
+  `X-PJX-Mounted`. For a raw Jinja shell, use `{{ client_script() }}` in `<head>`.
+- Every `load()` is memoized in `LoadCache` (one entry per `(type, key)`). Default scope is
+  `PROCESS`. Use `LoadCache.set_scope(CacheScope.REQUEST)` per worker without Redis, or
+  `InvalidationBackend` for multi-worker `PROCESS` scope.
 
 Full guide: [docs/reactivity.md](../reactivity.md).
 
@@ -437,20 +440,24 @@ my_app/
 ```python
 from pyjinhx import (
     BaseComponent, ReactiveComponent, Renderer, Registry, Finder, Parser, Tag,
-    oob_swaps, invalidate, client_script, PJX_MOUNTED_HEADER,
+    PjxLoad, mutates, LoadCache, oob_swaps, client_script,
+    PJX_MOUNTED_HEADER, PJX_TRIGGER_HEADER, setup,
 )
 import pyjinhx.builtins  # optional: registers all builtin classes
 from pyjinhx.builtins import Alert, Modal, Panel, PanelTrigger, TabGroup  # …
 ```
 
 - `BaseComponent` — base class for all components
-- `ReactiveComponent` — base class for dependency-aware reactive components (`reacts_to` + `load()`); `Cls.render(key=None, *, dirtied=, mounted=)` is the auto-loading route entry point
+- `ReactiveComponent` — dependency-aware components (`reacts_to` + `load()`); `Cls.render(*args)` is the route entry point
+- `PjxLoad` — `Annotated[..., PjxLoad()]` marker for keyed `data-pjx-load` / manifest `load`
+- `mutates` — decorator on store methods; state keys only (`@mutates("todos")`)
+- `setup` — wires FastAPI middleware (`Registry.request_scope`, `ClientBackend`, `LoadContext`)
 - `Renderer` — renders strings with PascalCase tags or manages environments
 - `Registry` — query/clear instances and classes, `request_scope()` context manager
 - `Finder` — template/asset discovery, `collect_javascript_files()`, `collect_css_files()`, `detect_root_directory()`
 - `Parser` / `Tag` — HTML parsing internals (rarely needed directly)
-- `oob_swaps` / `invalidate` — reactivity internals: the dependency walk and manual `load()`-cache eviction
-- `client_script` / `PJX_MOUNTED_HEADER` — client-runtime `<script>` for raw shells; the mounted-manifest header name
+- `LoadCache.invalidate` / `oob_swaps` — advanced: manual cache eviction and OOB walk
+- `client_script` / `PJX_*_HEADER` — client runtime and wire-format header names
 - `pyjinhx.builtins` — twenty optional UI components (see Builtins table above)
 ````
 

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -143,7 +143,7 @@ def index() -> str:
 If you cannot use `setup(app)`, define middleware yourself — see [Client Backend](../api/client-backend.md) and [Registry guide](../guide/registry.md).
 
 Pair with `@mutates` on store methods so mutation routes can omit explicit `dirtied`
-and `mounted=request` — see [Reactivity](../reactivity.md#mutation-tracking-mutates)
+via `setup()` — see [Reactivity](../reactivity.md#mutation-tracking-mutates)
 and [Client Backend](../api/client-backend.md).
 
 Reactive mutation routes:

--- a/docs/integrations/htmx.md
+++ b/docs/integrations/htmx.md
@@ -270,6 +270,6 @@ The patterns above use manual `hx-target` / `hx-swap` for each interaction. For 
 
 - Declare `reacts_to` + `load()` on `ReactiveComponent` subclasses
 - Return `Cls.render()` from mutation routes — dependent regions ride along as `hx-swap-oob` fragments
-- Wire [ClientBackend](../api/client-backend.md) in middleware so routes omit `mounted=` on every handler
+- Wire [ClientBackend](../api/client-backend.md) via `setup()` so routes call `Cls.render()` with no framework kwargs
 
 See [Reactivity](../reactivity.md), [Usage tiers](../guide/usage-tiers.md), and the [reactive todo example](https://github.com/paulomtts/pyjinhx/tree/master/examples/reactive_todo).

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -5,7 +5,7 @@ Reactivity is **opt-in**. You can use PyJinHx with `BaseComponent` only — see 
 !!! info "Prerequisites"
     - HTMX for transport and swap
     - `Registry.request_scope()` on every HTTP request
-    - [ClientBackend](api/client-backend.md) in middleware (recommended) so mutation routes omit `mounted=` / `client=`
+    - [ClientBackend](api/client-backend.md) in middleware (recommended) so mutation routes need no framework kwargs on `render()`
 
 pyjinhx owns **composition**; HTMX owns **transport and swap**. Between them sits
 the **state→view dependency graph** — which regions must change when a piece of
@@ -56,10 +56,9 @@ class Counter(ReactiveComponent):
 - `state_hash()` — canonical SHA-256 of sorted JSON from `model_dump(mode="json")`
   with `state_hash_exclude` applied (`id` is excluded by default). Override for custom
   hashing or add fields to `state_hash_exclude` for ephemeral UI-only state.
-- `depends_on()` — optional runtime narrowing of `reacts_to` after `load()`.
+- `depends_on()` — optional runtime narrowing for load-cache indexing after `load()`.
   Static `reacts_to` must remain a **superset** of every key `depends_on()`
-  may return (dev mode enforces this). `oob_swaps` pre-filters on the superset, calls
-  `load()`, then intersects `depends_on()` with `dirtied`.
+  may return (dev mode enforces this). `oob_swaps` matches on static `reacts_to` only.
 
 Reactive components are stamped with `data-pjx-id`, `data-pjx-type` (the class
 name), and `data-pjx-hash` on their root element automatically.
@@ -97,15 +96,16 @@ The runtime attaches two client manifests to every htmx request:
 
 | Header | Purpose |
 |--------|---------|
-| `X-PJX-Mounted` | Reactive regions currently in the DOM (`id`, `type`, `hash`, optional `key`) |
+| `X-PJX-Mounted` | Reactive regions currently in the DOM (`id`, `type`, `hash`, optional `load`) |
 | `X-PJX-Assets` | URLs of `<script src>` and `<link rel="stylesheet">` already loaded |
+| `X-PJX-Trigger` | `data-pjx-id` of the element that started the HTMX request |
 
-Wire `fastapi_client_backend(request)` once in your app's middleware — see the
+Wire `FastAPIClientBackend` via `setup(app, ...)` — see the
 [canonical snippet](integrations/fastapi.md#middleware-recommended) and
 [Client Backend](api/client-backend.md). Mutation routes then call
-`Cls.render(key)` with no `mounted=` — headers are read from the backend after
-`@mutates`. Full-page routes call `.render()` with no `client=`; boosted
-navigations skip re-injecting `pjx.js` when `X-PJX-Mounted` is present.
+`Cls.render(key)` with no extra kwargs — headers are read from the backend after
+`@mutates`. Full-page routes call `.render()` plainly; boosted navigations skip
+re-injecting `pjx.js` when `X-PJX-Mounted` is present.
 
 ## 3. Emit OOB swaps from your route
 
@@ -118,24 +118,21 @@ dependent regions ride along as out-of-band swaps:
 @app.post("/todos/toggle")
 def toggle():
     db.toggle_all()
-    # render() loads the Counter itself — you don't. dirtied defaults to the
-    # primary's own reacts_to; pass dirtied={...} to dirty more.
-    return Counter.render(dirtied={"todos"})
+    return Counter.render()
 ```
 
-With `@mutates` on the store method, you can omit `dirtied` too: `return Counter.render()`.
+With `@mutates` on the store method, pending dirtied keys drive OOB swaps automatically.
 
-`Cls.render(key=None, *, dirtied=, mounted=, client=)` loads the primary (by `key` for an
-instance-keyed type, zero-arg for a singleton), renders it as the main-target
-response, then appends an OOB swap for every *other* mounted reactive region whose
-`reacts_to` intersects `dirtied`, rebuilding each via its own `load()`. The primary's
-own region is never double-swapped. (Keyed example: [Instance-keyed regions](#instance-keyed-regions-rows) below.)
+`Cls.render(*args)` loads the primary (`load(*args)` for keyed types, `load()` for
+singletons), renders it as the main-target response, then appends OOB swaps for every
+*other* mounted reactive region whose `reacts_to` intersects pending mutations from
+`@mutates`. The trigger region (`X-PJX-Trigger`) and primary id are excluded.
 
 A **plain, non-reactive** primary has no `load()` to call, so you build it and render
-the instance instead: `MyFragment(id=..., ...).render(dirtied=...)`.
+the instance: `MyFragment(id=..., ...).render()`.
 
 !!! note "Without ClientBackend"
-    Pass `mounted=request` (and `client=request` for asset dedup) when not using a request-scoped backend. `mounted` accepts a request-like object, the raw header string, an already-parsed list, or `None`. With neither `dirtied` nor `mounted`, `render()` is an ordinary plain render.
+    Wire `ClientBackend` in middleware (via `setup()`) so `render()` reads manifest and asset headers automatically. Without a backend, reactive OOB is skipped when mutations are pending.
 
 ### Under the hood: `oob_swaps()`
 
@@ -157,60 +154,47 @@ not smeared across endpoints. Adding a progress bar that declares
 
 ### Instance-keyed regions (rows)
 
-A reactive type can have **many independently-reactive instances** — table rows,
-cards, list items — each reloaded and swapped on its own. A component is
-**instance-keyed iff its `load()` takes a parameter after `cls`** (`load(cls, key)`);
-a zero-arg `load(cls)` stays a type-singleton. No identity field or extra flag is
-needed — the signature is the switch:
+A reactive type can have **many mounted instances** — table rows, cards, list items.
+A component is **instance-keyed iff its `load()` takes one resource parameter after
+`cls`**; declare exactly one `PjxLoad` field on the model:
 
 ```python
+from typing import Annotated
+from pyjinhx import PjxLoad, ReactiveComponent
+
 class TodoItemRow(ReactiveComponent):
+    todo_id: Annotated[int, PjxLoad()]
     title: str = ""
     done: bool = False
-    reacts_to: ClassVar[set[str]] = {"todo"}         # instance-tier stem
+    reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
-    def load(cls, key) -> "TodoItemRow":             # a param after cls ⇒ keyed
-        t = store.get(int(key))                       # keys are strings; coerce if typed
-        return cls(title=t.text, done=t.done)
+    def load(cls, todo_id: int) -> "TodoItemRow":
+        t = store.get(todo_id)
+        return cls(
+            id=f"row-{todo_id}",
+            todo_id=todo_id,
+            title=t.text,
+            done=t.done,
+        )
 ```
 
-- **Instance-tier stems** on keyed components are declared as bare strings (e.g.
-  `{"todo"}`) and expanded automatically (`"todo"` → `"todo:42"` for row 42), so each
-  row depends on its *own* state key. Collection-tier keys stay literal (e.g.
-  `{"user", "users"}` — `"users"` is not suffixed).
-- **The key flows from `render()` into `load()` automatically**: you pass it to
-  `render(key, ...)`, which forwards it to `load()`; it is captured, stashed, and used
-  to derive the keyed id `f"{kebab(class)}-{key}"` (e.g. `todo-item-row-42`). It is
-  exposed to the template as `{{ key }}` and stamped on the root as `data-pjx-key`,
-  so the client manifest carries it back up on every request.
-- **Keys** (`reacts_to`, `dirtied`, and instance keys for `load()` / `render()`) accept
-  strings or enums and normalize to `str` (enums via `.value`). Call `int(key)` in
-  `load()` for a typed DB lookup when the value is numeric.
-
-**Two-tier dirtying.** Instance stems are *instance-tier*; collection keys are
-*collection-tier* (opt-in, just add one). A mutation route names both as needed:
+- **`data-pjx-load`** is stamped from the `PjxLoad` field and returned in the manifest
+  so OOB reloads call `load(manifest.load)`.
+- **Templates** use the field directly: `hx-post="/rows/{{ todo_id }}/toggle"`.
+- **`reacts_to`** lists **state keys only** (e.g. `{"todos"}`). Pub-sub OOB reloads
+  every mounted row whose `reacts_to` intersects pending mutations; hash-gating skips
+  unchanged rows.
 
 ```python
+@mutates(Keys.TODOS)
+def toggle(todo_id: int) -> Todo:
+    ...
+
 @app.post("/rows/{todo_id}/toggle")
-def toggle_row(todo_id):
+def toggle_row(todo_id: int):
     store.toggle(todo_id)
-    # render(key, ...) loads this row itself — no manual load().
-    # "todo:42" swaps just this one row; "todos" updates collection regions
-    # (counter, total, …). The row's own region is the primary, never double-swapped.
-    return TodoItemRow.render(todo_id, dirtied={f"todo:{todo_id}", "todos"})
-```
-
-`dirtied={"todo:42"}` reloads/swaps **only** row 42 (siblings are untouched);
-`dirtied={"todos"}` reloads **every** mounted row that declares the collection-tier
-key. The walk dedups by `(type, key)`, so each row reloads with its own key.
-
-Use `dirty_keys()` when you prefer an explicit set over string formatting:
-
-```python
-from pyjinhx import dirty_keys
-
-dirty_keys("todo", todo_id, "todos")  # {"todo:42", "todos"}
+    return TodoItemRow.render(todo_id)
 ```
 
 ## State keys
@@ -223,7 +207,6 @@ from pyjinhx import StateKey
 
 class Keys(StateKey):
     TODOS = "todos"
-    TODO = "todo"
 
 class TodoCounter(ReactiveComponent):
     reacts_to: ClassVar[set[str | Keys]] = {Keys.TODOS}
@@ -252,9 +235,8 @@ class AdminPanel(ReactiveComponent):
         return {"settings"}
 ```
 
-`oob_swaps` intersects the static superset with `dirtied` first (fast pre-filter),
-then `load()`s, then intersects `depends_on()` with `dirtied`. A dirtied
-`"user"` key reloads the component but skips the OOB swap for non-admin instances.
+`depends_on()` affects load-cache reverse indexing; `oob_swaps` matches on static
+`reacts_to` only.
 
 `dependency_graph()` uses the static superset only. In dev mode,
 `enable_reactive_dev()` warns (or raises) when `depends_on()` returns keys outside
@@ -263,31 +245,24 @@ the superset.
 ## Mutation tracking (`@mutates`)
 
 Decorate store mutation methods to invalidate the `load()` cache and accumulate
-dirtied keys for the current request. When a reactive `render()` omits `dirtied`,
-pending keys from `@mutates` are merged with the primary's own `reacts_to`:
+dirtied keys for the current request. The next reactive `render()` uses pending keys
+from `@mutates` for OOB pub-sub:
 
 ```python
 from pyjinhx import mutates
 
-@mutates(Keys.TODO, Keys.TODOS)
+@mutates(Keys.TODOS)
 def toggle(todo_id: int) -> Todo:
     ...
 
 @app.post("/rows/{todo_id}/toggle")
 def toggle_row(todo_id):
     store.toggle(todo_id)
-    return TodoItemRow.render(todo_id)  # dirtied + mounted from @mutates + ClientBackend
+    return TodoItemRow.render(todo_id)
 ```
 
-Use `Registry.request_scope()` on every request when relying on auto-dirtied — it
-resets mutation tracking per request. Explicit `dirtied={...}` (including an empty
-set) always overrides pending mutations.
-
-`mutation_scope()` uses the same semantics as `@mutates`: invalidate and accumulate
-dirtied keys on **successful exit** only. If the block raises, nothing is recorded.
-`load()` called inside the block before the mutation completes may still see
-pre-mutation cache — call `LoadCache.invalidate(...)` explicitly when mid-scope
-freshness is required.
+Use `Registry.request_scope()` on every request when relying on `@mutates` — it
+resets mutation tracking per request.
 
 ## Load context
 
@@ -295,7 +270,7 @@ Pass request-scoped dependencies into `load()` without global imports:
 
 ```python
 from dataclasses import dataclass
-from pyjinhx import LoadContext, get_load_context
+from pyjinhx import LoadContext
 
 @dataclass(frozen=True)
 class AppContext(LoadContext):
@@ -304,14 +279,13 @@ class AppContext(LoadContext):
 class Counter(ReactiveComponent):
     @classmethod
     def load(cls, *, ctx: AppContext | None = None) -> "Counter":
-        ctx = ctx or get_load_context()
+        ctx = ctx or LoadContext.current()
         return cls(remaining=ctx.db.remaining())
 ```
 
-Set context per request via `Registry.request_scope(load_context=AppContext(db=...))`
-or `load_scope(ctx)` in middleware. `load()` may also read `get_load_context()` when
-no `ctx` parameter is declared. Cache keys remain `(class, key)` — context is not
-part of the cache identity.
+Set context per request via `setup(app, load_context_factory=...)` or
+`Registry.request_scope(load_context=AppContext(db=...))`. Cache keys remain
+`(class, load_arg)` — context is not part of the cache identity.
 
 ## Development mode
 
@@ -327,7 +301,7 @@ enable_reactive_dev(strict=True)  # raise instead
 Checks include:
 
 - mutations recorded via `@mutates` but no reactive `render()` in the same request scope
-- reactive dirtied keys set but `mounted` omitted (OOB swaps skipped)
+- mutations pending but no `ClientBackend` active (OOB swaps skipped)
 - `depends_on()` keys outside the static `reacts_to` superset
 
 Inspect the dependency graph at startup:
@@ -373,16 +347,16 @@ isolation and optional request-tier cache when scope is `REQUEST`.
 tenant or user scope in reactive keys (e.g. `"user:7:todos"`) or ensure `LoadContext`
 data is stable for all requests sharing a cache entry.
 
-A reactive `render(dirtied=...)` (and `oob_swaps`) evicts the dirtied keys before
-reloading dependents, so swaps always reflect post-mutation state. For mutations that
-happen outside a render — a background job, a webhook — call `invalidate` yourself:
+Reactive `render()` (and `oob_swaps`) evicts pending dirtied keys before reloading
+dependents. For mutations outside a render — a background job, a webhook — call
+`LoadCache.invalidate` yourself:
 
 ```python
-from pyjinhx import invalidate
+from pyjinhx import LoadCache
 
 def nightly_recalc():
     db.rebuild_todos()
-    invalidate({"todos"})   # evict every cached load() that depends on "todos"
+    LoadCache.invalidate({"todos"})
 ```
 
 The cache holds one result per `(type, key)` and returns a fresh copy on every call, so
@@ -415,18 +389,14 @@ Requires `pip install pyjinhx[redis]`. See [Redis integration](api/integrations-
   bandwidth and DOM churn; database work is saved separately by the `load()` cache.
   Default `state_hash()` uses canonical sorted JSON with `id` excluded; set
   `state_hash_exclude` or override `state_hash()` for custom fields.
-- **Type-singleton and instance-keyed**: a zero-arg `load(cls)` is a type-singleton
-  (one mounted instance per type is reloaded); a keyed `load(cls, key)` supports many
-  independently-reactive instances with instance-tier stems (`"todo"`). See
-  *Instance-keyed regions (rows)* above.
-- **`mounted` accepts** a request-like object (header duck-typed out, no framework import), the raw header string, a parsed list, or `None`.
+- **Type-singleton and instance-keyed**: zero-arg `load(cls)` is a type-singleton;
+  `load(cls, resource)` is instance-keyed with a `PjxLoad` field. See *Instance-keyed
+  regions (rows)* above.
 - **Reactivity is opt-in via `ReactiveComponent`**, which requires both `load()` and
-  `reacts_to`. A zero-arg `load(cls)` is a type-singleton; `load(cls, key)` is
-  instance-keyed. Reactive `render()` auto-`load()`s dependents, so you never call
-  `load()` yourself for a reactive render.
-- **`load()` cache scope**: default `REQUEST` (per-request, multi-worker safe). Use `PROCESS`
-  for cross-request caching per worker; multi-worker `PROCESS` needs an `InvalidationBackend`.
-  Eviction is dirtied-key driven (automatically in the reactive flow, or via `invalidate(dirtied)`).
+  `reacts_to`. Reactive class `render()` auto-`load()`s the primary and OOB dependents.
+- **`load()` cache scope**: default `REQUEST`. Use `PROCESS` for cross-request caching
+  per worker; multi-worker `PROCESS` needs an `InvalidationBackend`. Eviction is
+  state-key driven (`@mutates` or `LoadCache.invalidate`).
 
 ## How it works (under the hood)
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -197,6 +197,11 @@ def toggle_row(todo_id: int):
     return TodoItemRow.render(todo_id)
 ```
 
+When a keyed entity is removed but still listed in the client's mounted manifest (e.g.
+after **clear completed**), `oob_swaps` catches `LookupError` from `load(manifest.load)`
+and emits a delete OOB swap (`delete:[data-pjx-id='…']`) so stale row regions are removed
+from the DOM without a server error.
+
 ## State keys
 
 Centralize reactive key strings in a `StateKey` enum so `reacts_to`, `dirtied`, and

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -26,10 +26,9 @@ Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line
 | `ClientBackend` | ABC for per-request HTTP header access | [Client Backend](../api/client-backend.md#clientbackend) |
 | `FastAPIClientBackend` | Default backend for FastAPI/Starlette requests | [Client Backend](../api/client-backend.md) |
 | `ClientBackend.scope()` | Set the request-scoped client backend | [Client Backend](../api/client-backend.md#clientbackend) |
-| `ClientBackend.current()` | Return the active client backend | [Client Backend](../api/client-backend.md#clientbackend) |
+| `ClientBackend.current()` | Return the active client backend (manifest, assets, trigger headers) | [Client Backend](../api/client-backend.md#clientbackend) |
 | `ClientBackend.reset()` | Clear the request-scoped backend (tests) | [Client Backend](../api/client-backend.md#clientbackend) |
 | `ClientBackend.resolve_client()` | Resolve explicit `client=` or fall back to backend | [Client Backend](../api/client-backend.md#auto-resolution-in-render) |
-| `ClientBackend.current()` | Request-scoped backend for manifest, assets, and trigger headers | [Client Backend](../api/client-backend.md#auto-resolution-in-render) |
 | `oob_swaps()` | Compute HTMX out-of-band swap fragments for dirtied keys | [Reactive API](../api/reactive-api.md#oob_swaps) |
 | `PJX_MOUNTED_HEADER` | HTTP header name for the client mounted-region manifest | [Reactive API](../api/reactive-api.md#pjx-headers) |
 | `PJX_ASSETS_HEADER` | HTTP header name for asset URLs already loaded in the browser | [Reactive API](../api/reactive-api.md#pjx-headers) |

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -29,16 +29,15 @@ Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line
 | `ClientBackend.current()` | Return the active client backend | [Client Backend](../api/client-backend.md#clientbackend) |
 | `ClientBackend.reset()` | Clear the request-scoped backend (tests) | [Client Backend](../api/client-backend.md#clientbackend) |
 | `ClientBackend.resolve_client()` | Resolve explicit `client=` or fall back to backend | [Client Backend](../api/client-backend.md#auto-resolution-in-render) |
-| `ClientBackend.resolve_mounted()` | Resolve explicit `mounted=` or backend when reactive | [Client Backend](../api/client-backend.md#auto-resolution-in-render) |
+| `ClientBackend.current()` | Request-scoped backend for manifest, assets, and trigger headers | [Client Backend](../api/client-backend.md#auto-resolution-in-render) |
 | `oob_swaps()` | Compute HTMX out-of-band swap fragments for dirtied keys | [Reactive API](../api/reactive-api.md#oob_swaps) |
 | `PJX_MOUNTED_HEADER` | HTTP header name for the client mounted-region manifest | [Reactive API](../api/reactive-api.md#pjx-headers) |
 | `PJX_ASSETS_HEADER` | HTTP header name for asset URLs already loaded in the browser | [Reactive API](../api/reactive-api.md#pjx-headers) |
 | `StateKey` | Base `StrEnum` for app-level reactive key constants | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#statekey) |
-| `StateKey.instance_key()` | Build an instance-tier key (`"todo:42"`) | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#instance_key) |
-| `StateKey.dirty_keys()` | Build a two-tier dirty set for instance-keyed mutations | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#dirty_keys) |
+| `PjxLoad` | Marker for `Annotated[..., PjxLoad()]` fields stamped as `data-pjx-load` | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#pjxload) |
 | `MutationTracker` | Request-scoped dirtied-key accumulation | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#mutationtracker) |
 | `mutates()` | Decorator: invalidate cache and accumulate dirtied keys after mutation | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#mutates) |
-| `mutation_scope()` | Context manager: invalidate and accumulate dirtied keys on exit | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#mutation_scope) |
+| `TriggerManifest` | Parse `X-PJX-Trigger` (swap-origin region id) | [Reactive API](../api/reactive-api.md) |
 | `LoadContext` | Opaque base dataclass for request-scoped `load()` data | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#loadcontext) |
 | `LoadContext.current()` | Return the current load context, or `None` | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#loadcontext) |
 | `LoadContext.bind()` | Context manager to set the load context | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#loadcontext) |

--- a/examples/reactive_todo/README.md
+++ b/examples/reactive_todo/README.md
@@ -18,8 +18,8 @@ What to watch (open the network tab):
   (remaining is unchanged).
 
 The routes never mention the counter/total/clear button — `@mutates` and
-`mutation_scope` accumulate dirtied keys automatically, and `setup()` wires
-`ClientBackend` so `render()` reads `X-PJX-Mounted` without `mounted=request`.
+`@mutates` accumulates dirtied keys automatically, and `setup()` wires
+`ClientBackend` so `render()` reads `X-PJX-Mounted` from the request.
 The dependency graph lives on the components (`reacts_to`), and `pjx.js` reports
 what's mounted on every HTMX request.
 

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -64,12 +64,12 @@ class Counter(ReactiveComponent):
 
 
 class Total(ReactiveComponent):
-    total: int = 0
+    count: int = 0
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}
 
     @classmethod
     def load(cls) -> "Total":
-        return cls(total=_store().total())
+        return cls(count=_store().total())
 
 
 class ClearButton(ReactiveComponent):

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from typing import ClassVar, Optional
+from typing import Annotated, ClassVar, Optional
 
-from pyjinhx import BaseComponent, LoadContext, ReactiveComponent
+from pyjinhx import BaseComponent, LoadContext, PjxLoad, ReactiveComponent
 
 from .keys import Keys
 
@@ -23,15 +23,22 @@ def _store():
 
 
 class ItemRow(ReactiveComponent):
+    todo_id: Annotated[int, PjxLoad()]
     title: str = ""
     done: bool = False
-    reacts_to: ClassVar[set[str]] = {Keys.TODO}
+    reacts_to: ClassVar[set[str]] = {Keys.TODOS}
 
     @classmethod
-    def load(cls, key: str | int) -> "ItemRow":
+    def load(cls, todo_id: int | str) -> "ItemRow":
         store = _store()
-        todo = store.get(int(key))
-        return cls(id=f"row-{key}", title=todo.text, done=todo.done)
+        resolved_id = int(todo_id)
+        todo = store.get(resolved_id)
+        return cls(
+            id=f"row-{resolved_id}",
+            todo_id=resolved_id,
+            title=todo.text,
+            done=todo.done,
+        )
 
 
 class ItemList(ReactiveComponent):
@@ -43,7 +50,7 @@ class ItemList(ReactiveComponent):
         store = _store()
         return cls(
             id="list",
-            items=[ItemRow.load(t.id) for t in store.all_todos()],
+            items=[ItemRow.load(todo.id) for todo in store.all_todos()],
         )
 
 

--- a/examples/reactive_todo/item_row.html
+++ b/examples/reactive_todo/item_row.html
@@ -1,5 +1,5 @@
 <li class="todo{% if done %} done{% endif %}">
-  <button hx-post="/rows/{{ key }}/toggle" hx-target="closest [data-pjx-id]" hx-swap="outerHTML"
+  <button hx-post="/rows/{{ todo_id }}/toggle" hx-target="closest [data-pjx-id]" hx-swap="outerHTML"
           aria-label="toggle">{% if done %}✓{% else %}○{% endif %}</button>
   <span>{{ title }}</span>
 </li>

--- a/examples/reactive_todo/keys.py
+++ b/examples/reactive_todo/keys.py
@@ -3,4 +3,3 @@ from pyjinhx import StateKey
 
 class Keys(StateKey):
     TODOS = "todos"
-    TODO = "todo"

--- a/examples/reactive_todo/store.py
+++ b/examples/reactive_todo/store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from itertools import count
 
-from pyjinhx import StateKey, mutates, mutation_scope
+from pyjinhx import mutates
 
 from .keys import Keys
 
@@ -35,9 +35,9 @@ def add(text: str) -> Todo:
     return todo
 
 
+@mutates(Keys.TODOS)
 def toggle(todo_id: int) -> Todo:
-    with mutation_scope(*StateKey.dirty_keys(Keys.TODO, todo_id, Keys.TODOS)):
-        _todos[todo_id].done = not _todos[todo_id].done
+    _todos[todo_id].done = not _todos[todo_id].done
     return _todos[todo_id]
 
 

--- a/examples/reactive_todo/total.html
+++ b/examples/reactive_todo/total.html
@@ -1,1 +1,1 @@
-<span class="total">{{ total }} total</span>
+<span class="total">{{ count }} total</span>

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -36,14 +36,17 @@ from pyjinhx.reactive.dev import (
 from pyjinhx.reactive.invalidation import InvalidationBackend, InvalidationHub
 from pyjinhx.reactive.keys import StateKey
 from pyjinhx.reactive.load_cache import CacheScope, LoadCache
-from pyjinhx.reactive.mutations import MutationTracker, mutates, mutation_scope
+from pyjinhx.reactive.mutations import MutationTracker, mutates
 from pyjinhx.reactive.oob import oob_swaps
 from pyjinhx.reactive.payload import (
     LoadedAssets,
     MountedManifest,
     PJX_ASSETS_HEADER,
     PJX_MOUNTED_HEADER,
+    PJX_TRIGGER_HEADER,
+    TriggerManifest,
 )
+from pyjinhx.reactive.pjx_load import PjxLoad
 from pyjinhx.reactive.runtime import client_script
 
 __all__ = [
@@ -73,11 +76,13 @@ __all__ = [
     "client_script",
     "LoadedAssets",
     "MountedManifest",
+    "TriggerManifest",
+    "PjxLoad",
     "PJX_MOUNTED_HEADER",
     "PJX_ASSETS_HEADER",
+    "PJX_TRIGGER_HEADER",
     "StateKey",
     "mutates",
-    "mutation_scope",
     "LoadContext",
     "enable_reactive_dev",
     "disable_reactive_dev",

--- a/pyjinhx/core/__init__.py
+++ b/pyjinhx/core/__init__.py
@@ -4,6 +4,9 @@ Core subsystem for pyjinhx.
 Modules:
 - ``base`` — ``BaseComponent`` and nesting wrappers
 - ``renderer`` — ``Renderer`` orchestration
+- ``renderer_settings`` — process-wide renderer defaults and factory cache
+- ``template_load`` — Jinja template discovery and loading
+- ``render_context`` — registry context injection and reactive stamping
 - ``render_assets`` — asset collection and injection helpers
 - ``tag_expand`` — PascalCase tag parsing and rendering
 - ``autodiscover`` — co-located component module import

--- a/pyjinhx/core/base.py
+++ b/pyjinhx/core/base.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from .registry import Registry
 from .renderer import Renderer
 from .assets import RenderSession
-from ..reactive.keys import ReactiveKey, coerce_reactive_keys
 
 logger = logging.getLogger("pyjinhx")
 logger.setLevel(logging.WARNING)
@@ -213,13 +212,7 @@ class BaseComponent(BaseModel):
             client=resolved_client,
         )
 
-    def render(
-        self,
-        *,
-        dirtied: set[ReactiveKey] | None = None,
-        mounted: object | None = None,
-        client: object | None = None,
-    ) -> Markup:
+    def render(self) -> Markup:
         """
         Render this component to HTML using its associated Jinja template.
 
@@ -227,45 +220,7 @@ class BaseComponent(BaseModel):
         for `my_button.html` or `my_button.jinja`). All component fields are available in the
         template context, and nested components are rendered recursively.
 
-        With no arguments this is a plain render. Passing ``dirtied`` and/or ``mounted``
-        opts into dependency-aware reactivity: this component is rendered as the primary
-        response, and an out-of-band swap is appended for every other mounted reactive
-        region whose ``reacts_to`` intersects ``dirtied`` (each rebuilt via its own
-        ``load()``). This component's own region is never additionally swapped.
-
-        When ``dirtied`` is omitted it defaults to this component's own ``reacts_to``
-        (empty for a non-reactive primary); pass ``dirtied`` explicitly — including an
-        empty set — to override.
-
-        Args:
-            dirtied: State keys the route mutated (e.g. ``{"todos"}``). Defaults to the
-                primary's ``reacts_to``. Enables reactive mode.
-            mounted: The client manifest — a request-like object, the raw header string,
-                a parsed list, or ``None``. When omitted, uses the request-scoped
-                ``ClientBackend`` after mutations (see ``Registry.request_scope``).
-            client: Request-like object (or raw ``X-PJX-Assets`` JSON) for REFERENCE-mode
-                asset dedup on root renders. When omitted, uses the request-scoped
-                ``ClientBackend``.
-
         Returns:
             The rendered HTML as a Markup object (safe for direct use in templates).
         """
-        from pyjinhx.reactive.backend import ClientBackend
-
-        resolved_client = ClientBackend.resolve_client(client)
-        resolved_mounted = ClientBackend.resolve_mounted(mounted, dirtied=dirtied)
-
-        if dirtied is None and resolved_mounted is None:
-            return self._render(client=resolved_client)
-
-        from pyjinhx.reactive.render import reactive_render_bundle
-
-        own_keys = coerce_reactive_keys(getattr(self, "_pjx_reacts_to", frozenset()))
-        return reactive_render_bundle(
-            primary_html=lambda: self._render(emit_assets=False),
-            own_keys=own_keys,
-            dirtied=dirtied,
-            mounted=resolved_mounted,
-            exclude_ids={self.id},
-            invalidate_before_primary=False,
-        )
+        return self._render()

--- a/pyjinhx/core/render_assets.py
+++ b/pyjinhx/core/render_assets.py
@@ -183,6 +183,84 @@ def render_assets(
     return ""
 
 
+def apply_component_render_assets(
+    component: BaseComponent,
+    rendered_markup: str,
+    session: RenderSession,
+    *,
+    template_path: str | None,
+    is_root: bool,
+    collect_component_js: bool,
+    js_mode: AssetMode,
+    css_mode: AssetMode,
+    resolve_url: Callable[[str], str],
+    loaded_assets: frozenset[str],
+    dedup_enabled: bool,
+    client: object | None,
+) -> str:
+    if template_path is not None and type(component).__name__ == "BaseComponent":
+        asset_dir: str | None = os.path.dirname(template_path)
+        asset_name: str | None = os.path.splitext(os.path.basename(template_path))[
+            0
+        ].replace("_", "-")
+    else:
+        asset_dir = None
+        asset_name = None
+
+    if collect_component_js:
+        collect_component_asset(
+            component,
+            session,
+            "js",
+            js_mode=js_mode,
+            css_mode=css_mode,
+            component_dir=asset_dir,
+            asset_name=asset_name,
+        )
+        collect_component_asset(
+            component,
+            session,
+            "css",
+            js_mode=js_mode,
+            css_mode=css_mode,
+            component_dir=asset_dir,
+            asset_name=asset_name,
+        )
+
+    if not is_root:
+        return rendered_markup
+
+    if css_mode != AssetMode.NONE:
+        collect_extra_assets(
+            component,
+            session,
+            "css",
+            js_mode=js_mode,
+            css_mode=css_mode,
+        )
+    if js_mode != AssetMode.NONE:
+        inject_runtime(session, js_mode=js_mode, client=client)
+        collect_extra_assets(
+            component,
+            session,
+            "js",
+            js_mode=js_mode,
+            css_mode=css_mode,
+        )
+    if css_mode == AssetMode.NONE and js_mode == AssetMode.NONE:
+        return rendered_markup
+
+    return inject_assets(
+        rendered_markup,
+        session,
+        js_mode=js_mode,
+        css_mode=css_mode,
+        resolve_url=resolve_url,
+        loaded_assets=loaded_assets,
+        dedup_enabled=dedup_enabled,
+    )
+
+
 def inject_assets(
     markup: str,
     session: RenderSession,

--- a/pyjinhx/core/render_context.py
+++ b/pyjinhx/core/render_context.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .registry import Registry
+from ..utils import stamp_root_attributes
+
+if TYPE_CHECKING:
+    from .base import BaseComponent
+
+
+def build_render_context(context: dict[str, Any]) -> dict[str, Any]:
+    render_context = dict(context)
+    for instance in Registry.get_instances().values():
+        render_context.setdefault(instance.id, instance)
+    return render_context
+
+
+def stamp_reactive_markup(markup: str, component: BaseComponent) -> str:
+    if not getattr(type(component), "_pjx_reactive", False):
+        return markup
+
+    from pyjinhx.reactive.pjx_load import pjx_load_value
+
+    attrs = {
+        "data-pjx-id": component.id,
+        "data-pjx-type": type(component).__name__,
+        "data-pjx-hash": component.state_hash(),
+    }
+    load_value = pjx_load_value(component)
+    if load_value is not None:
+        attrs["data-pjx-load"] = load_value
+    return stamp_root_attributes(markup, attrs)

--- a/pyjinhx/core/renderer.py
+++ b/pyjinhx/core/renderer.py
@@ -366,11 +366,8 @@ class Renderer:
         )
 
         render_context = dict(context)
-        _key = getattr(component, "_pjx_key", None)
-        if _key is not None:
-            render_context["key"] = _key
         for _instance in Registry.get_instances().values():
-            render_context[_instance.id] = _instance
+            render_context.setdefault(_instance.id, _instance)
 
         rendered_markup = template.render(render_context)
         rendered_markup = expand_custom_tags(
@@ -382,14 +379,16 @@ class Renderer:
         )
 
         if getattr(type(component), "_pjx_reactive", False):
+            from pyjinhx.reactive.pjx_load import pjx_load_value
+
             _attrs = {
                 "data-pjx-id": component.id,
                 "data-pjx-type": type(component).__name__,
                 "data-pjx-hash": component.state_hash(),
             }
-            _key = getattr(component, "_pjx_key", None)
-            if _key is not None:
-                _attrs["data-pjx-key"] = str(_key)
+            _load = pjx_load_value(component)
+            if _load is not None:
+                _attrs["data-pjx-load"] = _load
             rendered_markup = stamp_root_attributes(rendered_markup, _attrs)
 
         if not emit_assets:

--- a/pyjinhx/core/renderer.py
+++ b/pyjinhx/core/renderer.py
@@ -1,46 +1,33 @@
 from __future__ import annotations
 
-import logging
-import os
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
-from jinja2 import Environment, FileSystemLoader, Template
-from jinja2.exceptions import TemplateNotFound
+from jinja2 import Environment
 from markupsafe import Markup
 
 from .assets import (
-    DEFAULT_RUNTIME_URL as _DEFAULT_RUNTIME_URL,
     AssetMode,
-    AssetUrlResolver,
     RenderSession,
     asset_mode_from_inline,
     make_default_asset_url_resolver,
     runtime_asset_path,
 )
-from .finder import Finder
 from .parser import Parser
-from .registry import Registry
 from .render_assets import (
-    collect_component_asset,
-    collect_extra_assets,
+    apply_component_render_assets,
     inject_assets,
-    inject_runtime,
     normalize_asset_path,
 )
+from .render_context import build_render_context, stamp_reactive_markup
+from .renderer_settings import RendererSettings
 from .tag_expand import expand_custom_tags, render_tag_node
-from ..utils import (
-    detect_root_directory,
-    stamp_root_attributes,
-    tag_name_to_template_filenames,
-)
+from .template_load import find_template_for_tag, load_template_for_component
 
 if TYPE_CHECKING:
     from .base import BaseComponent
 
-logger = logging.getLogger("pyjinhx")
 
-
-class Renderer:
+class Renderer(RendererSettings):
     """
     Shared rendering engine used by `BaseComponent` rendering and HTML-like custom-tag rendering.
 
@@ -61,17 +48,6 @@ class Renderer:
         js_mode: AssetMode | None = None,
         css_mode: AssetMode | None = None,
     ) -> None:
-        """
-        Initialize a Renderer with the given Jinja environment.
-
-        Args:
-            environment: The Jinja2 Environment to use for template rendering.
-            auto_id: If True (default), generate UUIDs for components without explicit IDs.
-            inline_js: Deprecated bool shim; maps to INLINE or NONE for JavaScript.
-            inline_css: Deprecated bool shim; maps to INLINE or NONE for CSS.
-            js_mode: How JavaScript assets are delivered. Defaults to the class-level setting.
-            css_mode: How CSS assets are delivered. Defaults to the class-level setting.
-        """
         self._environment = environment
         self._auto_id = auto_id
         if js_mode is not None:
@@ -86,182 +62,10 @@ class Renderer:
             self._css_mode = asset_mode_from_inline(inline_css)
         else:
             self._css_mode = Renderer._default_css_mode
-        self._template_finder_cache: dict[str, Finder] = {}
-
-    _default_environment: ClassVar[Environment | None] = None
-    _default_js_mode: ClassVar[AssetMode] = AssetMode.INLINE
-    _default_css_mode: ClassVar[AssetMode] = AssetMode.INLINE
-    _default_runtime_url: ClassVar[str] = _DEFAULT_RUNTIME_URL
-    _asset_url_resolver: ClassVar[AssetUrlResolver | None] = None
-    _default_asset_dedup: ClassVar[bool] = False
-    _default_renderers: ClassVar[
-        dict[tuple[int, bool, AssetMode, AssetMode, int], "Renderer"]
-    ] = {}
-
-    @classmethod
-    def peek_default_environment(cls) -> Environment | None:
-        """
-        Return the currently configured default environment without auto-initializing.
-
-        Returns:
-            The default Jinja Environment, or None if not yet configured.
-        """
-        return cls._default_environment
-
-    @classmethod
-    def set_default_environment(
-        cls, environment: Environment | str | os.PathLike[str] | None
-    ) -> None:
-        """
-        Set or clear the process-wide default Jinja environment.
-
-        Args:
-            environment: A Jinja Environment instance, a path to a template directory,
-                or None to clear the default and reset to auto-detection.
-        """
-        if environment is None or isinstance(environment, Environment):
-            cls._default_environment = environment
-        else:
-            cls._default_environment = Environment(
-                loader=FileSystemLoader(os.fspath(environment))
-            )
-        cls._default_renderers.clear()
-
-    @classmethod
-    def set_default_js_mode(cls, mode: AssetMode) -> None:
-        """Set the process-wide default JavaScript asset delivery mode."""
-        cls._default_js_mode = mode
-        cls._default_renderers.clear()
-
-    @classmethod
-    def set_default_css_mode(cls, mode: AssetMode) -> None:
-        """Set the process-wide default CSS asset delivery mode."""
-        cls._default_css_mode = mode
-        cls._default_renderers.clear()
-
-    @classmethod
-    def set_default_inline_js(cls, inline_js: bool) -> None:
-        """
-        Set the process-wide default for inline JavaScript injection.
-
-        Args:
-            inline_js: If True (default), JavaScript is collected and injected as <script> tags.
-                If False, no scripts are injected. Use AssetMode.REFERENCE for URL tags.
-        """
-        cls.set_default_js_mode(asset_mode_from_inline(inline_js))
-
-    @classmethod
-    def set_default_inline_css(cls, inline_css: bool) -> None:
-        """
-        Set the process-wide default for inline CSS injection.
-
-        Args:
-            inline_css: If True (default), CSS is collected and injected as <style> tags.
-                If False, no styles are injected. Use AssetMode.REFERENCE for URL tags.
-        """
-        cls.set_default_css_mode(asset_mode_from_inline(inline_css))
-
-    @classmethod
-    def set_default_runtime_url(cls, url: str) -> None:
-        """Set the public URL used for the pyjinhx client runtime in REFERENCE mode."""
-        cls._default_runtime_url = url
-        cls._default_renderers.clear()
-
-    @classmethod
-    def set_asset_url_resolver(cls, resolver: AssetUrlResolver | None) -> None:
-        """Set the callable that maps absolute asset paths to public URLs."""
-        cls._asset_url_resolver = resolver
-        cls._default_renderers.clear()
-
-    @classmethod
-    def set_default_asset_dedup(cls, enabled: bool) -> None:
-        """Enable filtering of REFERENCE assets already reported by the client."""
-        cls._default_asset_dedup = enabled
-
-    @classmethod
-    def get_default_environment(cls) -> Environment:
-        """
-        Return the default Jinja environment, auto-initializing if needed.
-
-        If no environment is configured, one is created using auto-detected project root.
-
-        Returns:
-            The default Jinja Environment instance.
-        """
-        if cls._default_environment is None:
-            root_dir = detect_root_directory()
-            cls._default_environment = Environment(loader=FileSystemLoader(root_dir))
-        return cls._default_environment
-
-    @classmethod
-    def get_default_renderer(
-        cls,
-        *,
-        auto_id: bool = True,
-        inline_js: bool | None = None,
-        inline_css: bool | None = None,
-        js_mode: AssetMode | None = None,
-        css_mode: AssetMode | None = None,
-    ) -> "Renderer":
-        """
-        Return a cached default renderer instance.
-
-        Args:
-            auto_id: If True, generate UUIDs for components without explicit IDs.
-            inline_js: Deprecated bool shim for JavaScript delivery mode.
-            inline_css: Deprecated bool shim for CSS delivery mode.
-            js_mode: JavaScript asset delivery mode. Defaults to the class-level setting.
-            css_mode: CSS asset delivery mode. Defaults to the class-level setting.
-
-        Returns:
-            A Renderer instance cached by environment identity and asset settings.
-        """
-        environment = cls.get_default_environment()
-        effective_js_mode = (
-            js_mode
-            if js_mode is not None
-            else (
-                asset_mode_from_inline(inline_js)
-                if inline_js is not None
-                else cls._default_js_mode
-            )
-        )
-        effective_css_mode = (
-            css_mode
-            if css_mode is not None
-            else (
-                asset_mode_from_inline(inline_css)
-                if inline_css is not None
-                else cls._default_css_mode
-            )
-        )
-        resolver_id = id(cls._asset_url_resolver)
-        cache_key = (
-            id(environment),
-            auto_id,
-            effective_js_mode,
-            effective_css_mode,
-            resolver_id,
-        )
-        renderer = cls._default_renderers.get(cache_key)
-        if renderer is None:
-            renderer = Renderer(
-                environment,
-                auto_id=auto_id,
-                js_mode=effective_js_mode,
-                css_mode=effective_css_mode,
-            )
-            cls._default_renderers[cache_key] = renderer
-        return renderer
+        self._template_finder_cache: dict[str, object] = {}
 
     @property
     def environment(self) -> Environment:
-        """
-        The Jinja Environment used by this renderer.
-
-        Returns:
-            The Jinja Environment instance.
-        """
         return self._environment
 
     def _resolve_asset_url(self, path: str) -> str:
@@ -271,85 +75,34 @@ class Renderer:
         resolver = Renderer._asset_url_resolver
         if resolver is not None:
             return resolver(normalized_path)
-        root = self._get_loader_root()
+        from .template_load import get_loader_root
+
+        root = get_loader_root(self._environment)
         return make_default_asset_url_resolver(root)(normalized_path)
 
     def new_session(self) -> RenderSession:
-        """
-        Create a new render session for tracking scripts during rendering.
-
-        Returns:
-            A fresh RenderSession instance.
-        """
         return RenderSession()
-
-    def _get_loader_root(self) -> str:
-        loader = self._environment.loader
-        if not isinstance(loader, FileSystemLoader):
-            raise ValueError("Jinja2 loader must be a FileSystemLoader")
-        return Finder.get_loader_root(loader)
-
-    def _get_finder_for_root(self, search_root: str) -> Finder:
-        finder = self._template_finder_cache.get(search_root)
-        if finder is None:
-            finder = Finder(search_root)
-            self._template_finder_cache[search_root] = finder
-        return finder
 
     def _load_template_for_component(
         self,
-        component: "BaseComponent",
+        component: BaseComponent,
         *,
         template_source: str | None,
         template_path: str | None,
-    ) -> Template:
-        if template_source is not None:
-            return self._environment.from_string(template_source)
-
-        if template_path is not None:
-            loader_root = self._get_loader_root()
-            relative_path = os.path.relpath(template_path, loader_root)
-            return self._environment.get_template(relative_path)
-
-        if type(component).__name__ == "BaseComponent":
-            raise FileNotFoundError(
-                "No template found. Use a BaseComponent subclass with an adjacent template file, "
-                "or use Renderer.render() with PascalCase tags."
-            )
-
-        loader_root = self._get_loader_root()
-        relative_template_paths = Finder.get_relative_template_paths(
-            component_dir=Finder.get_class_directory(type(component)),
-            search_root=loader_root,
-            component_name=type(component).__name__,
-        )
-
-        for relative_template_path in relative_template_paths:
-            try:
-                return self._environment.get_template(relative_template_path)
-            except TemplateNotFound:
-                continue
-
-        if type(component).__module__.startswith("pyjinhx.builtins"):
-            component_dir = Finder.get_class_directory(type(component))
-            for filename in tag_name_to_template_filenames(type(component).__name__):
-                candidate_path = os.path.join(component_dir, filename)
-                if os.path.isfile(candidate_path):
-                    with open(candidate_path, encoding="utf-8") as template_file:
-                        return self._environment.from_string(template_file.read())
-
-        raise TemplateNotFound(
-            ", ".join(relative_template_paths) if relative_template_paths else "unknown"
+    ):
+        return load_template_for_component(
+            self,
+            component,
+            template_source=template_source,
+            template_path=template_path,
         )
 
     def _find_template_for_tag(self, tag_name: str) -> str:
-        loader_root = self._get_loader_root()
-        finder = self._get_finder_for_root(loader_root)
-        return finder.find_template_for_tag(tag_name)
+        return find_template_for_tag(self, tag_name)
 
     def render_component_with_context(
         self,
-        component: "BaseComponent",
+        component: BaseComponent,
         context: dict[str, Any],
         template_source: str | None,
         template_path: str | None,
@@ -365,10 +118,7 @@ class Renderer:
             component, template_source=template_source, template_path=template_path
         )
 
-        render_context = dict(context)
-        for _instance in Registry.get_instances().values():
-            render_context.setdefault(_instance.id, _instance)
-
+        render_context = build_render_context(context)
         rendered_markup = template.render(render_context)
         rendered_markup = expand_custom_tags(
             self,
@@ -377,103 +127,33 @@ class Renderer:
             session=session,
             emit_assets=emit_assets,
         )
-
-        if getattr(type(component), "_pjx_reactive", False):
-            from pyjinhx.reactive.pjx_load import pjx_load_value
-
-            _attrs = {
-                "data-pjx-id": component.id,
-                "data-pjx-type": type(component).__name__,
-                "data-pjx-hash": component.state_hash(),
-            }
-            _load = pjx_load_value(component)
-            if _load is not None:
-                _attrs["data-pjx-load"] = _load
-            rendered_markup = stamp_root_attributes(rendered_markup, _attrs)
+        rendered_markup = stamp_reactive_markup(rendered_markup, component)
 
         if not emit_assets:
             return Markup(rendered_markup).unescape()
 
-        if template_path is not None and type(component).__name__ == "BaseComponent":
-            _asset_dir: str | None = os.path.dirname(template_path)
-            _asset_name: str | None = os.path.splitext(os.path.basename(template_path))[
-                0
-            ].replace("_", "-")
-        else:
-            _asset_dir = None
-            _asset_name = None
-
-        if collect_component_js:
-            collect_component_asset(
-                component,
-                session,
-                "js",
-                js_mode=self._js_mode,
-                css_mode=self._css_mode,
-                component_dir=_asset_dir,
-                asset_name=_asset_name,
-            )
-            collect_component_asset(
-                component,
-                session,
-                "css",
-                js_mode=self._js_mode,
-                css_mode=self._css_mode,
-                component_dir=_asset_dir,
-                asset_name=_asset_name,
-            )
-
-        if is_root:
-            if self._css_mode != AssetMode.NONE:
-                collect_extra_assets(
-                    component,
-                    session,
-                    "css",
-                    js_mode=self._js_mode,
-                    css_mode=self._css_mode,
-                )
-            if self._js_mode != AssetMode.NONE:
-                inject_runtime(session, js_mode=self._js_mode, client=client)
-                collect_extra_assets(
-                    component,
-                    session,
-                    "js",
-                    js_mode=self._js_mode,
-                    css_mode=self._css_mode,
-                )
-            if self._css_mode != AssetMode.NONE or self._js_mode != AssetMode.NONE:
-                rendered_markup = inject_assets(
-                    rendered_markup,
-                    session,
-                    js_mode=self._js_mode,
-                    css_mode=self._css_mode,
-                    resolve_url=self._resolve_asset_url,
-                    loaded_assets=loaded_assets,
-                    dedup_enabled=Renderer._default_asset_dedup,
-                )
-
+        rendered_markup = apply_component_render_assets(
+            component,
+            rendered_markup,
+            session,
+            template_path=template_path,
+            is_root=is_root,
+            collect_component_js=collect_component_js,
+            js_mode=self._js_mode,
+            css_mode=self._css_mode,
+            resolve_url=self._resolve_asset_url,
+            loaded_assets=loaded_assets,
+            dedup_enabled=Renderer._default_asset_dedup,
+            client=client,
+        )
         return Markup(rendered_markup).unescape()
 
     def render(self, source: str) -> str:
-        """
-        Render an HTML-like source string, expanding PascalCase component tags into HTML.
-
-        PascalCase tags (e.g., `<MyButton text="OK">`) are matched to registered component
-        classes or template files and rendered recursively. Standard HTML is passed through
-        unchanged. Associated JavaScript files are collected and injected as a `<script>` block.
-
-        Args:
-            source: HTML-like string containing component tags to render.
-
-        Returns:
-            The fully rendered HTML string with all components expanded.
-        """
         parser = Parser()
         parser.feed(source)
         parser.close()
 
         session = self.new_session()
-
         rendered_markup = "".join(
             render_tag_node(
                 self,

--- a/pyjinhx/core/renderer_settings.py
+++ b/pyjinhx/core/renderer_settings.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+from typing import ClassVar
+
+from jinja2 import Environment, FileSystemLoader
+
+from .assets import (
+    DEFAULT_RUNTIME_URL as _DEFAULT_RUNTIME_URL,
+    AssetMode,
+    AssetUrlResolver,
+    asset_mode_from_inline,
+)
+from ..utils import detect_root_directory
+
+
+class RendererSettings:
+    """Process-wide renderer defaults and cached default-renderer factory."""
+
+    _default_environment: ClassVar[Environment | None] = None
+    _default_js_mode: ClassVar[AssetMode] = AssetMode.INLINE
+    _default_css_mode: ClassVar[AssetMode] = AssetMode.INLINE
+    _default_runtime_url: ClassVar[str] = _DEFAULT_RUNTIME_URL
+    _asset_url_resolver: ClassVar[AssetUrlResolver | None] = None
+    _default_asset_dedup: ClassVar[bool] = False
+    _default_renderers: ClassVar[dict[tuple[int, bool, AssetMode, AssetMode, int], object]] = {}
+
+    @classmethod
+    def peek_default_environment(cls) -> Environment | None:
+        return cls._default_environment
+
+    @classmethod
+    def set_default_environment(
+        cls, environment: Environment | str | os.PathLike[str] | None
+    ) -> None:
+        if environment is None or isinstance(environment, Environment):
+            cls._default_environment = environment
+        else:
+            cls._default_environment = Environment(
+                loader=FileSystemLoader(os.fspath(environment))
+            )
+        cls._default_renderers.clear()
+
+    @classmethod
+    def set_default_js_mode(cls, mode: AssetMode) -> None:
+        cls._default_js_mode = mode
+        cls._default_renderers.clear()
+
+    @classmethod
+    def set_default_css_mode(cls, mode: AssetMode) -> None:
+        cls._default_css_mode = mode
+        cls._default_renderers.clear()
+
+    @classmethod
+    def set_default_inline_js(cls, inline_js: bool) -> None:
+        cls.set_default_js_mode(asset_mode_from_inline(inline_js))
+
+    @classmethod
+    def set_default_inline_css(cls, inline_css: bool) -> None:
+        cls.set_default_css_mode(asset_mode_from_inline(inline_css))
+
+    @classmethod
+    def set_default_runtime_url(cls, url: str) -> None:
+        cls._default_runtime_url = url
+        cls._default_renderers.clear()
+
+    @classmethod
+    def set_asset_url_resolver(cls, resolver: AssetUrlResolver | None) -> None:
+        cls._asset_url_resolver = resolver
+        cls._default_renderers.clear()
+
+    @classmethod
+    def set_default_asset_dedup(cls, enabled: bool) -> None:
+        cls._default_asset_dedup = enabled
+
+    @classmethod
+    def get_default_environment(cls) -> Environment:
+        if cls._default_environment is None:
+            root_dir = detect_root_directory()
+            cls._default_environment = Environment(loader=FileSystemLoader(root_dir))
+        return cls._default_environment
+
+    @classmethod
+    def get_default_renderer(
+        cls,
+        *,
+        auto_id: bool = True,
+        inline_js: bool | None = None,
+        inline_css: bool | None = None,
+        js_mode: AssetMode | None = None,
+        css_mode: AssetMode | None = None,
+    ):
+        from .renderer import Renderer
+
+        environment = cls.get_default_environment()
+        effective_js_mode = (
+            js_mode
+            if js_mode is not None
+            else (
+                asset_mode_from_inline(inline_js)
+                if inline_js is not None
+                else cls._default_js_mode
+            )
+        )
+        effective_css_mode = (
+            css_mode
+            if css_mode is not None
+            else (
+                asset_mode_from_inline(inline_css)
+                if inline_css is not None
+                else cls._default_css_mode
+            )
+        )
+        resolver_id = id(cls._asset_url_resolver)
+        cache_key = (
+            id(environment),
+            auto_id,
+            effective_js_mode,
+            effective_css_mode,
+            resolver_id,
+        )
+        renderer = cls._default_renderers.get(cache_key)
+        if renderer is None:
+            renderer = Renderer(
+                environment,
+                auto_id=auto_id,
+                js_mode=effective_js_mode,
+                css_mode=effective_css_mode,
+            )
+            cls._default_renderers[cache_key] = renderer
+        return renderer

--- a/pyjinhx/core/template_load.py
+++ b/pyjinhx/core/template_load.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from jinja2 import Environment, FileSystemLoader, Template
+from jinja2.exceptions import TemplateNotFound
+
+from .finder import Finder
+from ..utils import tag_name_to_template_filenames
+
+if TYPE_CHECKING:
+    from .base import BaseComponent
+    from .renderer import Renderer
+
+
+def get_loader_root(environment: Environment) -> str:
+    loader = environment.loader
+    if not isinstance(loader, FileSystemLoader):
+        raise ValueError("Jinja2 loader must be a FileSystemLoader")
+    return Finder.get_loader_root(loader)
+
+
+def get_finder_for_root(renderer: Renderer, search_root: str) -> Finder:
+    finder = renderer._template_finder_cache.get(search_root)
+    if finder is None:
+        finder = Finder(search_root)
+        renderer._template_finder_cache[search_root] = finder
+    return finder
+
+
+def load_template_for_component(
+    renderer: Renderer,
+    component: BaseComponent,
+    *,
+    template_source: str | None,
+    template_path: str | None,
+) -> Template:
+    environment = renderer.environment
+    if template_source is not None:
+        return environment.from_string(template_source)
+
+    if template_path is not None:
+        loader_root = get_loader_root(environment)
+        relative_path = os.path.relpath(template_path, loader_root)
+        return environment.get_template(relative_path)
+
+    if type(component).__name__ == "BaseComponent":
+        raise FileNotFoundError(
+            "No template found. Use a BaseComponent subclass with an adjacent template file, "
+            "or use Renderer.render() with PascalCase tags."
+        )
+
+    loader_root = get_loader_root(environment)
+    relative_template_paths = Finder.get_relative_template_paths(
+        component_dir=Finder.get_class_directory(type(component)),
+        search_root=loader_root,
+        component_name=type(component).__name__,
+    )
+
+    for relative_template_path in relative_template_paths:
+        try:
+            return environment.get_template(relative_template_path)
+        except TemplateNotFound:
+            continue
+
+    if type(component).__module__.startswith("pyjinhx.builtins"):
+        component_dir = Finder.get_class_directory(type(component))
+        for filename in tag_name_to_template_filenames(type(component).__name__):
+            candidate_path = os.path.join(component_dir, filename)
+            if os.path.isfile(candidate_path):
+                with open(candidate_path, encoding="utf-8") as template_file:
+                    return environment.from_string(template_file.read())
+
+    raise TemplateNotFound(
+        ", ".join(relative_template_paths) if relative_template_paths else "unknown"
+    )
+
+
+def find_template_for_tag(renderer: Renderer, tag_name: str) -> str:
+    loader_root = get_loader_root(renderer.environment)
+    finder = get_finder_for_root(renderer, loader_root)
+    return finder.find_template_for_tag(tag_name)

--- a/pyjinhx/reactive/__init__.py
+++ b/pyjinhx/reactive/__init__.py
@@ -5,9 +5,10 @@ Modules:
 - ``component`` — ``ReactiveComponent``, ``depends_on()``, render descriptor
 - ``render`` — shared reactive render orchestration
 - ``load_cache`` — ``LoadCache`` memoization for ``load()``
-- ``mutations`` — ``MutationTracker``, ``@mutates``, ``mutation_scope``
+- ``mutations`` — ``MutationTracker``, ``@mutates``
+- ``pjx_load`` — ``PjxLoad`` field marker for ``data-pjx-load`` stamping
 - ``invalidation`` — ``InvalidationBackend`` ABC and ``InvalidationHub``
-- ``payload`` — client header parsing (``MountedManifest``, ``LoadedAssets``)
+- ``payload`` — client header parsing (``MountedManifest``, ``TriggerManifest``, ``LoadedAssets``)
 - ``oob`` — out-of-band HTMX swap computation
 - ``runtime`` — ``client_script`` injection
 - ``keys`` — reactive key coercion and ``StateKey``

--- a/pyjinhx/reactive/backend.py
+++ b/pyjinhx/reactive/backend.py
@@ -36,22 +36,7 @@ class ClientBackend(ABC):
             cls._context.reset(token)
 
     @classmethod
-    def resolve_client(cls, explicit: object | None) -> object | None:
+    def resolve_client(cls, explicit: object | None = None) -> object | None:
         if explicit is not None:
             return explicit
-        return cls.current()
-
-    @classmethod
-    def resolve_mounted(
-        cls,
-        explicit: object | None,
-        *,
-        dirtied: object | None,
-    ) -> object | None:
-        if explicit is not None:
-            return explicit
-        from .mutations import MutationTracker
-
-        if dirtied is None and not MutationTracker.pending():
-            return None
         return cls.current()

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -12,12 +12,7 @@ from markupsafe import Markup
 from pydantic import ConfigDict, PrivateAttr, model_validator
 
 from pyjinhx.core.base import BaseComponent
-from pyjinhx.reactive.keys import (
-    ReactiveKey,
-    coerce_load_key_str,
-    coerce_reactive_keys,
-    interpolate_reactive_keys,
-)
+from pyjinhx.reactive.keys import coerce_reactive_keys
 from pyjinhx.utils import pascal_case_to_kebab_case
 
 
@@ -25,57 +20,40 @@ class _ReactiveRender:
     """
     Expose ``render`` in two forms under one name on reactive components.
 
-    - ``Cls.render(key=None, *, dirtied=None, mounted=None)`` — the route entry
-      point: auto-``load()``s the primary (by key for keyed types) and appends OOB
-      swaps for dependents. The developer never names ``load()`` or ``oob_swaps()``.
-    - ``instance.render(*, dirtied=None, mounted=None)`` — render an already-built
-      instance as the primary; same contract as ``BaseComponent.render``.
-
-    A plain ``classmethod`` would shadow the instance method and make
-    ``instance.render()`` re-load from the world, dropping the instance's own state;
-    the descriptor dispatches on access so both forms coexist.
+    - ``Cls.render(*args, **kwargs)`` — route entry: ``load(*args, **kwargs)`` then
+      reactive bundle when a ``ClientBackend`` is active.
+    - ``instance.render()`` — plain ``_render()`` only.
     """
 
     @staticmethod
-    def _render_class(
-        cls: type[ReactiveComponent],
-        key: object | None = None,
-        *,
-        dirtied: set[ReactiveKey] | None = None,
-        mounted: object | None = None,
-    ) -> Markup:
+    def _render_class(cls: type[ReactiveComponent], *args: Any, **kwargs: Any) -> Markup:
         keyed = getattr(cls, "_pjx_keyed", False)
-        if keyed and key is None:
+        if keyed and not args:
             raise TypeError(
-                f"{cls.__name__} is instance-keyed; render() requires a key, e.g. "
-                f"{cls.__name__}.render(<id>, dirtied=..., mounted=request)."
+                f"{cls.__name__} is instance-keyed; render() requires the load() "
+                f"resource argument, e.g. {cls.__name__}.render(<id>)."
             )
-        if not keyed and key is not None:
+        if not keyed and args:
             raise TypeError(
-                f"{cls.__name__} is a type-singleton; render() takes no key."
+                f"{cls.__name__} is a type-singleton; render() takes no arguments."
             )
 
-        skey = coerce_load_key_str(key) if key is not None else None
-        from .backend import ClientBackend
-        from .render import reactive_render_bundle
+        from .render import _reactive_context_active, reactive_render_bundle
 
-        resolved_mounted = ClientBackend.resolve_mounted(mounted, dirtied=dirtied)
-        own_keys = interpolate_reactive_keys(
-            getattr(cls, "_pjx_reacts_to", frozenset()), skey, keyed=keyed
-        )
+        if not _reactive_context_active():
+            instance = cls.load(*args, **kwargs) if keyed else cls.load(**kwargs)
+            return Markup(instance._render(emit_assets=False))
+
         loaded: list[ReactiveComponent] = []
 
-        def build_primary() -> str:
-            instance = cls.load(skey) if keyed else cls.load()
+        def build_primary_tracked() -> str:
+            instance = cls.load(*args, **kwargs) if keyed else cls.load(**kwargs)
             loaded.append(instance)
             return instance._render(emit_assets=False)
 
         return reactive_render_bundle(
-            primary_html=build_primary,
-            own_keys=own_keys,
-            dirtied=dirtied,
-            mounted=resolved_mounted,
-            exclude_ids=lambda: {loaded[0].id},
+            primary_html=build_primary_tracked,
+            exclude_ids=lambda: {loaded[0].id} if loaded else set(),
             invalidate_before_primary=True,
         )
 
@@ -86,7 +64,19 @@ class _ReactiveRender:
     ) -> Callable[..., Markup]:
         if instance is None:
             return partial(_ReactiveRender._render_class, owner)
-        return partial(BaseComponent.render, instance)
+
+        def render() -> Markup:
+            from .render import _reactive_context_active, reactive_render_bundle
+
+            if not _reactive_context_active():
+                return instance._render()
+            return reactive_render_bundle(
+                primary_html=lambda: instance._render(emit_assets=False),
+                exclude_ids={instance.id},
+                invalidate_before_primary=False,
+            )
+
+        return render
 
 
 class ReactiveComponent(BaseComponent):
@@ -108,7 +98,7 @@ class ReactiveComponent(BaseComponent):
 
     model_config = ConfigDict(extra="allow", ignored_types=(_ReactiveRender,))
 
-    reacts_to: ClassVar[set[ReactiveKey]] = set()
+    reacts_to: ClassVar[set[str]] = set()
     state_hash_exclude: ClassVar[frozenset[str]] = frozenset({"id"})
 
     _pjx_key: str | None = PrivateAttr(default=None)
@@ -129,13 +119,17 @@ class ReactiveComponent(BaseComponent):
         ...
 
     @staticmethod
-    def _load_param_count(func: Any) -> int:
-        """Count ``load()`` parameters excluding ``cls``, ``ctx``, and variadics."""
-        params = inspect.signature(func).parameters
+    def _load_param_count(func: Any, owner: type[Any] | None = None) -> int:
+        """Count ``load()`` parameters excluding ``cls``, LoadContext params, and variadics."""
+        from .context import _is_load_context_param, _resolved_hints
+
+        signature = inspect.signature(func)
+        hints = _resolved_hints(func, owner)
         return sum(
             1
-            for name, param in params.items()
-            if name not in ("cls", "ctx")
+            for param in signature.parameters.values()
+            if param.name != "cls"
+            and not _is_load_context_param(param, hints)
             and param.kind
             not in (
                 inspect.Parameter.VAR_KEYWORD,
@@ -144,19 +138,8 @@ class ReactiveComponent(BaseComponent):
         )
 
     def depends_on(self) -> set[str]:
-        """
-        Reactive keys this loaded instance currently depends on.
-
-        Defaults to the interpolated static ``reacts_to`` declaration. Override to
-        narrow (or expand, with dev warnings) based on instance state. The static
-        ``reacts_to`` must remain a superset for cache-safety.
-        """
-        component_class = type(self)
-        return interpolate_reactive_keys(
-            getattr(component_class, "_pjx_reacts_to", frozenset()),
-            self._pjx_key,
-            keyed=getattr(component_class, "_pjx_keyed", False),
-        )
+        """Reactive state keys this loaded instance currently depends on."""
+        return set(getattr(type(self), "_pjx_reacts_to", frozenset()))
 
     def state_hash(self) -> str:
         """
@@ -183,15 +166,21 @@ class ReactiveComponent(BaseComponent):
                 f"reactive component must declare both."
             )
         if "load" in cls.__dict__:
+            from .context import resolve_load_context_param
+            from .pjx_load import resolve_pjx_load_field, validate_pjx_load_subclass
+
             _load = cls.__dict__["load"]
             _func = _load.__func__ if isinstance(_load, classmethod) else _load
-            param_count = ReactiveComponent._load_param_count(_func)
+            resolve_load_context_param(_func, cls)
+            param_count = ReactiveComponent._load_param_count(_func, cls)
             if param_count > 1:
                 raise TypeError(
                     f"{cls.__name__}.load() has {param_count} key parameters; "
                     f"at most one instance key is supported."
                 )
             cls._pjx_keyed = param_count == 1
+            validate_pjx_load_subclass(cls, keyed=cls._pjx_keyed)
+            cls._pjx_load_field = resolve_pjx_load_field(cls)
         if "load" in cls.__dict__:
             from .load_cache import LoadCache
 

--- a/pyjinhx/reactive/context.py
+++ b/pyjinhx/reactive/context.py
@@ -1,13 +1,139 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Generator
+import sys
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Any
+from types import NoneType, UnionType
+from typing import Any, Union, get_args, get_origin, get_type_hints
 
 _load_context: ContextVar[Any | None] = ContextVar("load_context", default=None)
+
+
+def _hint_namespace(owner: type[Any] | None, func: Callable[..., Any]) -> dict[str, Any]:
+    module = sys.modules.get(func.__module__)
+    globalns = dict(vars(module)) if module is not None else {}
+    if owner is not None:
+        globalns[owner.__name__] = owner
+    globalns.setdefault("LoadContext", LoadContext)
+    return globalns
+
+
+def _resolved_hints(func: Callable[..., Any], owner: type[Any] | None = None) -> dict[str, Any]:
+    try:
+        return get_type_hints(func, globalns=_hint_namespace(owner, func), localns=None)
+    except (NameError, TypeError, AttributeError):
+        return {}
+
+
+def _is_load_context_type(annotation: Any) -> bool:
+    if annotation is inspect.Parameter.empty or annotation is None:
+        return False
+
+    origin = get_origin(annotation)
+    if origin is not None:
+        if origin in (Union, UnionType):
+            return any(
+                _is_load_context_type(arg) for arg in get_args(annotation) if arg is not NoneType
+            )
+        return False
+
+    if annotation is LoadContext:
+        return True
+
+    if not isinstance(annotation, type):
+        return False
+
+    try:
+        return issubclass(annotation, LoadContext)
+    except TypeError:
+        return False
+
+
+def _is_load_context_param(
+    param: inspect.Parameter,
+    hints: dict[str, Any],
+) -> bool:
+    if param.name == "cls":
+        return False
+    annotation = hints.get(param.name, param.annotation)
+    return _is_load_context_type(annotation)
+
+
+def resolve_load_context_param(
+    func: Callable[..., Any],
+    owner: type[Any] | None = None,
+) -> inspect.Parameter | None:
+    """
+    Return the single ``load()`` parameter annotated with ``LoadContext`` (or a
+    subclass), or ``None`` when absent.
+
+    Raises ``TypeError`` when more than one parameter carries that annotation.
+    """
+    signature = inspect.signature(func)
+    hints = _resolved_hints(func, owner)
+    matches = [
+        param
+        for param in signature.parameters.values()
+        if _is_load_context_param(param, hints)
+    ]
+    if len(matches) > 1:
+        names = ", ".join(param.name for param in matches)
+        raise TypeError(
+            f"{func.__qualname__} declares multiple LoadContext parameters "
+            f"({names}); at most one is allowed."
+        )
+    return matches[0] if matches else None
+
+
+def resolve_instance_key_param(
+    func: Callable[..., Any],
+    owner: type[Any] | None = None,
+) -> inspect.Parameter | None:
+    """Return the instance-key parameter, excluding ``cls`` and LoadContext params."""
+    signature = inspect.signature(func)
+    hints = _resolved_hints(func, owner)
+    for param in signature.parameters.values():
+        if param.name == "cls":
+            continue
+        if param.kind in (
+            inspect.Parameter.VAR_KEYWORD,
+            inspect.Parameter.VAR_POSITIONAL,
+        ):
+            continue
+        if _is_load_context_param(param, hints):
+            continue
+        return param
+    return None
+
+
+def invoke_raw_load(
+    raw_func: Callable[..., Any],
+    component_class: type[Any],
+    *,
+    key: str | None,
+    ctx: Any | None,
+    owner: type[Any] | None = None,
+) -> Any:
+    """Call a raw ``load()`` implementation, injecting bound LoadContext when declared."""
+    signature = inspect.signature(raw_func)
+    ctx_param = resolve_load_context_param(raw_func, owner)
+    bind_kwargs: dict[str, Any] = {}
+    if ctx_param is not None:
+        bind_kwargs[ctx_param.name] = ctx
+    if key is not None:
+        key_param = resolve_instance_key_param(raw_func, owner)
+        if key_param is None:
+            raise TypeError(
+                f"{raw_func.__qualname__} received an instance key but declares "
+                f"no key parameter."
+            )
+        bind_kwargs[key_param.name] = key
+    bound = signature.bind(component_class, **bind_kwargs)
+    bound.apply_defaults()
+    return raw_func(*bound.args, **bound.kwargs)
 
 
 @dataclass(frozen=True)
@@ -33,16 +159,3 @@ class LoadContext:
             yield
         finally:
             _load_context.reset(token)
-
-    @staticmethod
-    def accepts_ctx(func: Any) -> bool:
-        """Return whether ``func`` accepts a keyword-only ``ctx`` argument."""
-        try:
-            signature = inspect.signature(func)
-        except (TypeError, ValueError):
-            return False
-        param = signature.parameters.get("ctx")
-        return param is not None and param.kind in (
-            inspect.Parameter.KEYWORD_ONLY,
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-        )

--- a/pyjinhx/reactive/dev.py
+++ b/pyjinhx/reactive/dev.py
@@ -4,8 +4,8 @@ import logging
 from dataclasses import dataclass
 
 from pyjinhx.core.registry import Registry
-from .keys import ReactiveKey, interpolate_reactive_keys
 
+from .backend import ClientBackend
 from .mutations import MutationTracker
 
 logger = logging.getLogger("pyjinhx")
@@ -48,18 +48,12 @@ def warn_mutations_without_render() -> None:
         )
 
 
-def warn_reactive_render_without_mounted(
-    *,
-    dirtied: set[ReactiveKey] | None,
-    mounted: object | None,
-    own_keys: set[str],
-) -> None:
-    if not _dev_config.enabled or mounted is not None:
+def warn_reactive_render_without_client(*, backend: ClientBackend | None) -> None:
+    if not _dev_config.enabled or backend is not None:
         return
-    has_dirtied = dirtied is not None or bool(MutationTracker.pending())
-    if has_dirtied or own_keys:
+    if MutationTracker.pending():
         _report(
-            "Reactive dirtied keys are set but mounted was not passed; "
+            "Mutations were recorded but no ClientBackend is active; "
             "out-of-band swaps will be skipped."
         )
 
@@ -73,11 +67,7 @@ def validate_depends_on(instance: object) -> None:
         return
     if not hasattr(instance, "depends_on"):
         return
-    superset = interpolate_reactive_keys(
-        getattr(component_class, "_pjx_reacts_to", frozenset()),
-        getattr(instance, "_pjx_key", None),
-        keyed=getattr(component_class, "_pjx_keyed", False),
-    )
+    superset = set(getattr(component_class, "_pjx_reacts_to", frozenset()))
     runtime = instance.depends_on()
     extra = runtime - superset
     if extra:
@@ -92,8 +82,7 @@ def dependency_graph() -> dict[str, list[str]]:
     Map each declared reactive key to component class names that depend on it.
 
     Shows the static ``reacts_to`` superset only — not per-instance narrowing
-    from ``depends_on()``. Instance-tier stems appear as declared
-    (e.g. ``"todo"``), not expanded per key.
+    from ``depends_on()``.
     """
     graph: dict[str, set[str]] = {}
     for class_name, component_class in Registry.get_classes().items():

--- a/pyjinhx/reactive/keys.py
+++ b/pyjinhx/reactive/keys.py
@@ -25,72 +25,10 @@ def coerce_load_key_str(key: object) -> str | None:
     return coerce_reactive_key(key)
 
 
-def interpolate_reactive_keys(
-    keys: Iterable[str],
-    key: str | None,
-    *,
-    keyed: bool = False,
-) -> set[str]:
-    """
-    Expand declared reactive keys for a component instance.
-
-    For singletons (``key is None``), declared keys are returned as-is.
-
-    For instance-keyed components, bare stems (e.g. ``"todo"``) expand to
-    ``"todo:<key>"``. When a plural sibling is present (e.g. ``"user"`` with
-    ``"users"``), the singular is the instance stem and the plural stays global.
-    Legacy ``"{key}"`` placeholders are still expanded for backward compatibility.
-    """
-    if key is None:
-        return set(keys)
-
-    declared = set(keys)
-    if not keyed:
-        return declared
-
-    result: set[str] = set()
-    for declared_key in declared:
-        if "{key}" in declared_key:
-            result.add(declared_key.replace("{key}", key))
-        elif ":" in declared_key:
-            result.add(declared_key)
-        elif f"{declared_key}s" in declared:
-            result.add(f"{declared_key}:{key}")
-        elif any(
-            declared_key == f"{other}s" for other in declared if other != declared_key
-        ):
-            result.add(declared_key)
-        else:
-            result.add(f"{declared_key}:{key}")
-    return result
-
-
 class StateKey(StrEnum):
     """
     Base class for app-level reactive state keys.
 
-    Subclass and declare members; use the enum in ``reacts_to``, ``dirtied``,
-    and ``@mutates`` — all normalize to their string values.
+    Subclass and declare members; use the enum in ``reacts_to`` and ``@mutates`` —
+    all normalize to their string values.
     """
-
-    @staticmethod
-    def instance_key(stem: str, key: str | int) -> str:
-        """Build an instance-tier dirty key, e.g. ``StateKey.instance_key("todo", 42)`` → ``"todo:42"``."""
-        return f"{stem}:{coerce_reactive_key(key)}"
-
-    @staticmethod
-    def dirty_keys(
-        instance_stem: str,
-        key: str | int,
-        *collection: ReactiveKey,
-    ) -> set[str]:
-        """
-        Build a two-tier dirty set for instance-keyed mutations.
-
-        Returns the expanded instance key plus any collection-tier keys, e.g.
-        ``StateKey.dirty_keys("todo", 42, "todos")`` → ``{"todo:42", "todos"}``.
-        """
-        return {
-            StateKey.instance_key(instance_stem, key),
-            *coerce_reactive_keys(collection),
-        }

--- a/pyjinhx/reactive/load_cache.py
+++ b/pyjinhx/reactive/load_cache.py
@@ -7,11 +7,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from .keys import (
-    coerce_load_key_str,
-    coerce_reactive_keys,
-    interpolate_reactive_keys,
-)
+from .keys import coerce_load_key_str, coerce_reactive_keys
 
 if TYPE_CHECKING:
     from pyjinhx.core.base import BaseComponent
@@ -27,7 +23,6 @@ class CacheScope(str, Enum):
 class _CacheState:
     _cache: dict[tuple[type, str | None], BaseComponent] = field(default_factory=dict)
     _reverse: dict[str, set[tuple[type, str | None]]] = field(default_factory=dict)
-    _stems: dict[str, set[str]] = field(default_factory=dict)
 
 
 class LoadCache:
@@ -64,12 +59,10 @@ class LoadCache:
         with cls._lock:
             cls._process_state._cache.clear()
             cls._process_state._reverse.clear()
-            cls._process_state._stems.clear()
             request_store = cls._request_store()
             if request_store is not None:
                 request_store._cache.clear()
                 request_store._reverse.clear()
-                request_store._stems.clear()
 
     @classmethod
     def invalidate(cls, dirtied: Iterable[object], *, propagate: bool = True) -> None:
@@ -92,7 +85,7 @@ class LoadCache:
     def install_cached_load(cls, component_class: type[Any]) -> None:
         """
         Replace a reactive component's ``load()`` with a cache-aware wrapper keyed by
-        ``(class, instance_key)``.
+        ``(class, load_arg)``.
         """
         original = component_class.__dict__["load"]
         component_class._pjx_raw_load = (
@@ -117,18 +110,15 @@ class LoadCache:
             if cached is not None:
                 return cls._with_key(cached.model_copy(), key)
 
-        from .context import LoadContext
+        from .context import LoadContext, invoke_raw_load
 
-        ctx = LoadContext.current()
-        if key is not None:
-            if LoadContext.accepts_ctx(raw_func):
-                result = raw_func(component_class, key, ctx=ctx)
-            else:
-                result = raw_func(component_class, key)
-        elif LoadContext.accepts_ctx(raw_func):
-            result = raw_func(component_class, ctx=ctx)
-        else:
-            result = raw_func(component_class)
+        result = invoke_raw_load(
+            raw_func,
+            component_class,
+            key=key,
+            ctx=LoadContext.current(),
+            owner=component_class,
+        )
         result = cls._with_key(result, key)
 
         from .dev import validate_depends_on
@@ -144,7 +134,7 @@ class LoadCache:
 
         if cls.scope() != CacheScope.NONE:
             with cls._lock:
-                cls._cache_put(cache_key, result, component_class, key)
+                cls._cache_put(cache_key, result)
         return cls._with_key(result.model_copy(), key)
 
     @classmethod
@@ -169,22 +159,11 @@ class LoadCache:
         store = cls._request_store()
         return [store] if store is not None else []
 
-    @staticmethod
-    def _static_effective_keys(component_class: type[Any], key: str | None) -> set[str]:
-        return interpolate_reactive_keys(
-            getattr(component_class, "_pjx_reacts_to", frozenset()),
-            key,
-            keyed=getattr(component_class, "_pjx_keyed", False),
-        )
-
     @classmethod
     def _indexed_keys(cls, instance: BaseComponent) -> set[str]:
         if hasattr(instance, "depends_on"):
             return instance.depends_on()
-        return cls._static_effective_keys(
-            instance.__class__,
-            getattr(instance, "_pjx_key", None),
-        )
+        return set(getattr(instance.__class__, "_pjx_reacts_to", frozenset()))
 
     @classmethod
     def _unindex_cache_key(
@@ -199,13 +178,6 @@ class LoadCache:
                 bucket.discard(cache_key)
                 if not bucket:
                     state._reverse.pop(reactive_key, None)
-            if ":" in reactive_key:
-                stem = reactive_key.split(":", 1)[0]
-                stem_bucket = state._stems.get(stem)
-                if stem_bucket is not None:
-                    stem_bucket.discard(reactive_key)
-                    if not stem_bucket:
-                        state._stems.pop(stem, None)
 
     @classmethod
     def _evict_from_state(cls, state: _CacheState, keys: set[str]) -> None:
@@ -214,9 +186,6 @@ class LoadCache:
         to_evict: set[tuple[type, str | None]] = set()
         for key in keys:
             to_evict |= state._reverse.get(key, set())
-            if ":" not in key:
-                for reverse_key in state._stems.get(key, set()):
-                    to_evict |= state._reverse.get(reverse_key, set())
         for cache_key in to_evict:
             cached = state._cache.pop(cache_key, None)
             if cached is None:
@@ -227,13 +196,6 @@ class LoadCache:
                     bucket.discard(cache_key)
                     if not bucket:
                         state._reverse.pop(reactive_key, None)
-                if ":" in reactive_key:
-                    stem = reactive_key.split(":", 1)[0]
-                    stem_bucket = state._stems.get(stem)
-                    if stem_bucket is not None:
-                        stem_bucket.discard(reactive_key)
-                        if not stem_bucket:
-                            state._stems.pop(stem, None)
 
     @classmethod
     def _evict_local(cls, keys: set[str]) -> None:
@@ -259,14 +221,9 @@ class LoadCache:
         cls,
         cache_key: tuple[type, str | None],
         result: BaseComponent,
-        component_class: type[Any],
-        key: str | None,
     ) -> None:
         for state in cls._active_stores(for_invalidate=False):
             cls._unindex_cache_key(state, cache_key)
             state._cache[cache_key] = result
             for reactive_key in cls._indexed_keys(result):
                 state._reverse.setdefault(reactive_key, set()).add(cache_key)
-                if ":" in reactive_key:
-                    stem = reactive_key.split(":", 1)[0]
-                    state._stems.setdefault(stem, set()).add(reactive_key)

--- a/pyjinhx/reactive/mutations.py
+++ b/pyjinhx/reactive/mutations.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Callable, Generator, Iterable
-from contextlib import contextmanager
+from collections.abc import Callable, Iterable
 from contextvars import ContextVar
 from typing import Any, ClassVar, TypeVar
 
@@ -55,27 +54,13 @@ class MutationTracker:
     def render_was_consumed(cls) -> bool:
         return cls._render_consumed.get()
 
-    @classmethod
-    def resolve_effective_dirtied(
-        cls,
-        *,
-        dirtied: set[ReactiveKey] | None,
-        mounted: object | None,
-        own_keys: set[str],
-    ) -> set[str]:
-        if dirtied is not None:
-            return coerce_reactive_keys(dirtied)
-        if mounted is None:
-            return own_keys
-        return own_keys | cls.pending()
-
 
 def mutates(*keys: ReactiveKey) -> Callable[[F], F]:
     """
     Decorator for store mutation methods.
 
-    Invalidates the load() cache for ``keys`` and accumulates them as pending
-    dirtied for the next reactive ``render()`` when ``dirtied`` is omitted.
+    Invalidates the load cache for ``keys`` and accumulates them as pending
+    dirtied for the next reactive ``render()``.
     """
 
     def decorator(func: F) -> F:
@@ -88,20 +73,3 @@ def mutates(*keys: ReactiveKey) -> Callable[[F], F]:
         return wrapper  # type: ignore[return-value]
 
     return decorator
-
-
-@contextmanager
-def mutation_scope(*keys: ReactiveKey) -> Generator[None, None, None]:
-    """
-    Context manager that invalidates and accumulates dirtied keys.
-
-    Keys are recorded on successful exit (same semantics as ``@mutates``).
-    If the block raises, the cache is not invalidated and no dirtied keys
-    are accumulated.
-    """
-    try:
-        yield
-    except BaseException:
-        raise
-    else:
-        MutationTracker.record(keys)

--- a/pyjinhx/reactive/oob.py
+++ b/pyjinhx/reactive/oob.py
@@ -7,11 +7,7 @@ from markupsafe import Markup
 
 from pyjinhx.core.registry import Registry
 from pyjinhx.core.renderer import Renderer
-from pyjinhx.reactive.keys import (
-    ReactiveKey,
-    coerce_reactive_keys,
-    interpolate_reactive_keys,
-)
+from pyjinhx.reactive.keys import ReactiveKey, coerce_reactive_keys
 from pyjinhx.utils import css_attribute_selector_attr_value, stamp_root_attributes
 
 from .load_cache import LoadCache
@@ -24,8 +20,9 @@ class _Candidate:
 
     id: str
     html: str
-    fresh_hash: str
+    fresh_hash: str | None
     reported_hash: str | None
+    delete: bool = False
 
 
 def _drop_nested(candidates: list[_Candidate]) -> list[_Candidate]:
@@ -56,6 +53,18 @@ def _oob_swap_selector(component_id: str) -> str:
     return f"outerHTML:[data-pjx-id='{escaped_id}']"
 
 
+def _oob_delete_selector(component_id: str) -> str:
+    escaped_id = css_attribute_selector_attr_value(component_id)
+    return f"delete:[data-pjx-id='{escaped_id}']"
+
+
+def _manifest_load_arg(entry: dict[str, Any]) -> str | None:
+    load = entry.get("load")
+    if load is None:
+        return None
+    return str(load)
+
+
 def oob_swaps(
     dirtied: set[ReactiveKey],
     mounted: str | list[dict[str, Any]] | object | None,
@@ -83,8 +92,7 @@ def oob_swaps(
     for entry in manifest:
         component_type = entry.get("type")
         component_id = entry.get("id")
-        key = entry.get("key")
-        skey = str(key) if key is not None else None
+        load_arg = _manifest_load_arg(entry)
         if not component_type or not component_id:
             continue
         if exclude_ids and component_id in exclude_ids:
@@ -97,30 +105,40 @@ def oob_swaps(
             continue
 
         keyed = getattr(component_class, "_pjx_keyed", False)
-        if keyed and skey is None:
+        if keyed and load_arg is None:
             continue
         if not keyed:
-            skey = None
+            load_arg = None
 
-        static_keys = interpolate_reactive_keys(
-            getattr(component_class, "_pjx_reacts_to", frozenset()),
-            skey,
-            keyed=keyed,
-        )
+        static_keys = set(getattr(component_class, "_pjx_reacts_to", frozenset()))
         if not (static_keys & dirtied_keys):
             continue
 
-        dedup_key = (component_type, skey)
+        dedup_key = (component_type, load_arg)
         if dedup_key in seen:
             continue
         seen.add(dedup_key)
 
-        instance = component_class.load(skey) if keyed else component_class.load()
-        if not (instance.depends_on() & dirtied_keys):
+        reported_hash = entry.get("hash")
+        try:
+            if keyed and load_arg is not None:
+                instance = component_class.load(load_arg)
+            else:
+                instance = component_class.load()
+        except LookupError:
+            candidates.append(
+                _Candidate(
+                    id=component_id,
+                    html="",
+                    fresh_hash=None,
+                    reported_hash=reported_hash,
+                    delete=True,
+                )
+            )
             continue
+
         instance.id = component_id
         fresh_hash = instance.state_hash()
-        reported_hash = entry.get("hash")
         if fresh_hash == reported_hash:
             continue
         html = str(instance._render(_renderer=renderer, emit_assets=False))
@@ -137,10 +155,16 @@ def oob_swaps(
     if not surviving:
         return Markup("")
 
-    fragments = [
-        stamp_root_attributes(
-            c.html, {"hx-swap-oob": _oob_swap_selector(c.id)}
-        )
-        for c in surviving
-    ]
+    fragments: list[str] = []
+    for candidate in surviving:
+        if candidate.delete:
+            fragments.append(
+                f'<div hx-swap-oob="{_oob_delete_selector(candidate.id)}"></div>'
+            )
+        else:
+            fragments.append(
+                stamp_root_attributes(
+                    candidate.html, {"hx-swap-oob": _oob_swap_selector(candidate.id)}
+                )
+            )
     return Markup("\n".join(fragments))

--- a/pyjinhx/reactive/payload.py
+++ b/pyjinhx/reactive/payload.py
@@ -13,6 +13,9 @@ PJX_MOUNTED_HEADER = "X-PJX-Mounted"
 PJX_ASSETS_HEADER = "X-PJX-Assets"
 """Name of the HTTP header carrying asset URLs already loaded in the browser."""
 
+PJX_TRIGGER_HEADER = "X-PJX-Trigger"
+"""Name of the HTTP header carrying the data-pjx-id of the element that started the request."""
+
 T = TypeVar("T")
 
 
@@ -98,6 +101,21 @@ class MountedManifest:
         except AttributeError:
             return False
         return MountedManifest.is_present(header_value)
+
+
+class TriggerManifest:
+    @staticmethod
+    def parse(client: str | dict[str, Any] | object | None) -> dict[str, Any] | None:
+        def _coerce(parsed: Any) -> dict[str, Any] | None:
+            if isinstance(parsed, dict) and parsed.get("id"):
+                return parsed
+            return None
+
+        return _parse_client_payload(
+            client,
+            header_name=PJX_TRIGGER_HEADER,
+            parse_value=_coerce,
+        )
 
 
 class LoadedAssets:

--- a/pyjinhx/reactive/pjx_load.py
+++ b/pyjinhx/reactive/pjx_load.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import typing
+from typing import Annotated, Any, get_args, get_origin
+
+from pydantic.fields import FieldInfo
+
+from .keys import coerce_load_key_str
+
+
+class PjxLoad:
+    """Marker for ``Annotated[..., PjxLoad()]`` fields stamped as ``data-pjx-load``."""
+
+
+def _metadata_has_pjx_load(metadata: tuple[Any, ...]) -> bool:
+    return any(isinstance(meta, PjxLoad) for meta in metadata)
+
+
+def _annotation_has_pjx_load(annotation: Any) -> bool:
+    if get_origin(annotation) is Annotated:
+        return _metadata_has_pjx_load(get_args(annotation)[1:])
+    return False
+
+
+def _field_has_pjx_load(field_info: FieldInfo) -> bool:
+    if _metadata_has_pjx_load(field_info.metadata):
+        return True
+    return _annotation_has_pjx_load(field_info.annotation)
+
+
+def pjx_load_field_names(model_cls: type[Any]) -> list[str]:
+    names: list[str] = []
+    for name, field_info in model_cls.model_fields.items():
+        if _field_has_pjx_load(field_info):
+            names.append(name)
+    if names:
+        return names
+    for name, annotation in getattr(model_cls, "__annotations__", {}).items():
+        if _annotation_has_pjx_load(annotation):
+            names.append(name)
+    return names
+
+
+def resolve_pjx_load_field(model_cls: type[Any]) -> str | None:
+    names = pjx_load_field_names(model_cls)
+    if not names:
+        return None
+    if len(names) > 1:
+        raise TypeError(
+            f"{model_cls.__name__} declares multiple PjxLoad fields {names!r}; "
+            f"at most one is allowed."
+        )
+    return names[0]
+
+
+def validate_pjx_load_subclass(
+    cls: type[Any],
+    *,
+    keyed: bool,
+) -> None:
+    names = pjx_load_field_names(cls)
+    if keyed and len(names) != 1:
+        raise TypeError(
+            f"{cls.__name__}.load() takes a resource argument; declare exactly "
+            f"one field as Annotated[..., PjxLoad()]."
+        )
+    if not keyed and names:
+        raise TypeError(
+            f"{cls.__name__}.load() takes no resource argument; PjxLoad fields "
+            f"are not allowed ({names!r})."
+        )
+
+
+def pjx_load_value(instance: Any) -> str | None:
+    field_name = getattr(type(instance), "_pjx_load_field", None)
+    if field_name is None:
+        return None
+    return coerce_load_key_str(getattr(instance, field_name, None))

--- a/pyjinhx/reactive/pjx_load.py
+++ b/pyjinhx/reactive/pjx_load.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import typing
 from typing import Annotated, Any, get_args, get_origin
 
 from pydantic.fields import FieldInfo

--- a/pyjinhx/reactive/render.py
+++ b/pyjinhx/reactive/render.py
@@ -4,47 +4,50 @@ from collections.abc import Callable
 
 from markupsafe import Markup
 
-from pyjinhx.reactive.keys import ReactiveKey
-
-from .dev import warn_reactive_render_without_mounted
+from .backend import ClientBackend
+from .dev import warn_reactive_render_without_client
 from .load_cache import LoadCache
 from .mutations import MutationTracker
 from .oob import oob_swaps
+from .payload import MountedManifest, TriggerManifest
+
+
+def _reactive_context_active() -> bool:
+    backend = ClientBackend.current()
+    if backend is None:
+        return False
+    if MutationTracker.pending():
+        return True
+    return bool(MountedManifest.parse(backend))
 
 
 def reactive_render_bundle(
     *,
     primary_html: Markup | Callable[[], Markup | str],
-    own_keys: set[str],
-    dirtied: set[ReactiveKey] | None,
-    mounted: object | None,
     exclude_ids: set[str] | Callable[[], set[str]],
     invalidate_before_primary: bool,
 ) -> Markup:
     """
     Shared reactive render orchestration for class and instance ``render()`` paths.
-
-    When ``invalidate_before_primary`` is True (class render), the load cache is
-    evicted before the primary is built and OOB swaps skip a second invalidation.
-    When False (instance render), invalidation happens inside ``oob_swaps``.
     """
-    warn_reactive_render_without_mounted(
-        dirtied=dirtied, mounted=mounted, own_keys=own_keys
-    )
-    effective_dirtied = MutationTracker.resolve_effective_dirtied(
-        dirtied=dirtied,
-        mounted=mounted,
-        own_keys=own_keys,
-    )
+    backend = ClientBackend.current()
+    warn_reactive_render_without_client(backend=backend)
+
+    effective_dirtied = MutationTracker.pending()
     if invalidate_before_primary:
-        LoadCache.invalidate(effective_dirtied | own_keys)
+        LoadCache.invalidate(effective_dirtied)
 
     primary = primary_html() if callable(primary_html) else primary_html
     MutationTracker.mark_render_consumed()
-    resolved_exclude = exclude_ids() if callable(exclude_ids) else exclude_ids
+
+    resolved_exclude = set(exclude_ids() if callable(exclude_ids) else exclude_ids)
+    trigger = TriggerManifest.parse(backend) if backend is not None else None
+    if trigger and trigger.get("id"):
+        resolved_exclude.add(str(trigger["id"]))
+
     swaps = oob_swaps(
         effective_dirtied,
-        mounted,
+        backend,
         exclude_ids=resolved_exclude,
         skip_invalidate=invalidate_before_primary,
     )

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -1,16 +1,31 @@
 (function () {
+  function pjxRoot(el) {
+    return el && el.closest ? el.closest("[data-pjx-id]") : null;
+  }
+
   function pjxManifest() {
     return Array.prototype.map.call(
       document.querySelectorAll("[data-pjx-id]"),
       function (el) {
-        return {
+        var entry = {
           id: el.dataset.pjxId,
           type: el.dataset.pjxType,
           hash: el.dataset.pjxHash,
-          key: el.dataset.pjxKey ?? null,
         };
+        if (el.dataset.pjxLoad != null && el.dataset.pjxLoad !== "") {
+          entry.load = el.dataset.pjxLoad;
+        }
+        return entry;
       }
     );
+  }
+
+  function pjxTrigger(elt) {
+    var root = pjxRoot(elt);
+    if (!root) {
+      return null;
+    }
+    return { id: root.dataset.pjxId };
   }
 
   function pjxLoadedAssets() {
@@ -30,5 +45,9 @@
   document.body.addEventListener("htmx:configRequest", function (evt) {
     evt.detail.headers["X-PJX-Mounted"] = JSON.stringify(pjxManifest());
     evt.detail.headers["X-PJX-Assets"] = JSON.stringify(pjxLoadedAssets());
+    var trigger = pjxTrigger(evt.detail.elt);
+    if (trigger) {
+      evt.detail.headers["X-PJX-Trigger"] = JSON.stringify(trigger);
+    }
   });
 })();

--- a/tests/34_layout_runtime_test.py
+++ b/tests/34_layout_runtime_test.py
@@ -74,7 +74,7 @@ def test_root_render_skips_runtime_when_manifest_header_present():
 
 def test_root_render_skips_runtime_for_valid_manifest():
     manifest = json.dumps(
-        [{"id": "page", "type": "Page", "hash": "abc123", "key": None}]
+        [{"id": "page", "type": "Page", "hash": "abc123"}]
     )
     request = _Request({PJX_MOUNTED_HEADER: manifest})
     html = str(

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -67,6 +67,7 @@ def test_reactive_api_is_exported():
     assert callable(MutationTracker.record)
     assert issubclass(ReactiveComponent, pyjinhx.BaseComponent)
     assert issubclass(StateKey, str)
+    assert PjxLoad.__name__ == "PjxLoad"
 
 
 def test_names_in_all():

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -7,6 +7,7 @@ def test_reactive_api_is_exported():
     from pyjinhx import (
         PJX_ASSETS_HEADER,
         PJX_MOUNTED_HEADER,
+        PJX_TRIGGER_HEADER,
         CacheScope,
         ClientBackend,
         FastAPIClientBackend,
@@ -17,7 +18,9 @@ def test_reactive_api_is_exported():
         LoadedAssets,
         MountedManifest,
         MutationTracker,
+        PjxLoad,
         ReactiveComponent,
+        TriggerManifest,
         client_script,
         dependency_graph,
         enable_reactive_dev,
@@ -33,6 +36,7 @@ def test_reactive_api_is_exported():
 
     assert PJX_MOUNTED_HEADER == "X-PJX-Mounted"
     assert PJX_ASSETS_HEADER == "X-PJX-Assets"
+    assert PJX_TRIGGER_HEADER == "X-PJX-Trigger"
     assert callable(oob_swaps)
     assert callable(client_script)
     assert callable(mutates)
@@ -41,6 +45,7 @@ def test_reactive_api_is_exported():
     assert callable(LoadedAssets.parse)
     assert callable(MountedManifest.parse)
     assert callable(MountedManifest.is_present)
+    assert callable(TriggerManifest.parse)
     assert callable(LoadCache.set_scope)
     assert callable(LoadCache.scope)
     assert callable(InvalidationHub.set_backend)
@@ -59,8 +64,6 @@ def test_reactive_api_is_exported():
     assert callable(ClientBackend.current)
     assert callable(LoadContext.current)
     assert callable(LoadContext.bind)
-    assert callable(StateKey.instance_key)
-    assert callable(StateKey.dirty_keys)
     assert callable(MutationTracker.record)
     assert issubclass(ReactiveComponent, pyjinhx.BaseComponent)
     assert issubclass(StateKey, str)
@@ -73,11 +76,13 @@ def test_names_in_all():
         "client_script",
         "LoadedAssets",
         "MountedManifest",
+        "TriggerManifest",
+        "PjxLoad",
         "PJX_MOUNTED_HEADER",
         "PJX_ASSETS_HEADER",
+        "PJX_TRIGGER_HEADER",
         "StateKey",
         "mutates",
-        "mutation_scope",
         "LoadContext",
         "enable_reactive_dev",
         "disable_reactive_dev",

--- a/tests/38_reactive_render_test.py
+++ b/tests/38_reactive_render_test.py
@@ -3,8 +3,9 @@ import json
 from markupsafe import Markup
 
 from pyjinhx import PJX_MOUNTED_HEADER, oob_swaps
+from tests.reactive_test_support import reactive_client, record_mutation
 from tests.ui.reactive import store
-from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401 (used by Task 2 tests)
+from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401
 from tests.ui.reactive.reactive_clear_button import ReactiveClearButton  # noqa: F401
 from tests.ui.reactive.reactive_panel import ReactivePanel  # noqa: F401
 
@@ -18,8 +19,6 @@ class _FakeHeaders:
 
 
 class _FakeRequest:
-    """Minimal request-like object: exposes .headers.get(), no FastAPI import."""
-
     def __init__(self, headers):
         self.headers = _FakeHeaders(headers)
 
@@ -43,12 +42,12 @@ def test_oob_swaps_accepts_request_like_object():
 
 
 def test_oob_swaps_request_without_header_is_empty():
-    request = _FakeRequest({})  # header absent -> headers.get returns None
+    request = _FakeRequest({})
     assert str(oob_swaps({"todos"}, request)) == ""
 
 
 def test_oob_swaps_non_request_object_is_ignored():
-    out = oob_swaps({"todos"}, object())  # not str/list/None/request-like
+    out = oob_swaps({"todos"}, object())
     assert isinstance(out, Markup)
     assert str(out) == ""
 
@@ -77,44 +76,44 @@ def test_reactive_render_returns_primary_plus_dependents():
         {"id": "counter", "type": "ReactiveCounter", "hash": "stale"},
         {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"},
     ]
-    out = str(primary.render(dirtied={"todos"}, mounted=manifest))
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(primary.render())
     assert "2 left" in out
     assert "outerHTML:[data-pjx-id='clear-btn']" in out
     assert "Clear (5)" in out
     assert "outerHTML:[data-pjx-id='counter']" not in out
 
 
-def test_reactive_render_with_request_object():
+def test_reactive_render_with_backend():
     store.state["completed"] = 6
     primary = ReactiveCounter(id="counter", remaining=1)
-    request = _FakeRequest(
-        {
-            PJX_MOUNTED_HEADER: _manifest_json(
-                {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
-            )
-        }
-    )
-    out = str(primary.render(dirtied={"todos"}, mounted=request))
+    manifest = [
+        {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
+    ]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(primary.render())
     assert "1 left" in out
     assert "outerHTML:[data-pjx-id='clear-btn']" in out
 
 
 def test_reactive_render_returns_markup():
     primary = ReactiveCounter(id="counter", remaining=1)
-    result = primary.render(dirtied={"todos"}, mounted=[])
+    with reactive_client([]):
+        record_mutation("todos")
+        result = primary.render()
     assert isinstance(result, Markup)
 
 
 def test_reactive_render_does_not_escape_primary_html():
     store.state["completed"] = 1
     primary = ReactiveCounter(id="counter", remaining=2)
-    out = str(
-        primary.render(
-            dirtied={"todos"},
-            mounted=[
-                {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
-            ],
-        )
-    )
+    manifest = [
+        {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
+    ]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(primary.render())
     assert "&lt;span" not in out and "&#34;" not in out
     assert '<span class="counter" data-pjx-id="counter"' in out

--- a/tests/40_load_cache_integration_test.py
+++ b/tests/40_load_cache_integration_test.py
@@ -20,18 +20,16 @@ def test_oob_swaps_invalidates_dirtied_before_loading():
 
 
 def test_reactive_render_invalidates_dirtied():
+    from tests.reactive_test_support import reactive_client, record_mutation
+
     store.state["completed"] = 2
     warm = ReactiveClearButton.load()
     assert warm.completed == 2
     store.state["completed"] = 9
     primary = ReactiveCounter(id="counter", remaining=0)
-    out = str(
-        primary.render(
-            dirtied={"todos"},
-            mounted=[
-                {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
-            ],
-        )
-    )
+    manifest = [{"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(primary.render())
     assert "Clear (9)" in out
     assert "Clear (2)" not in out

--- a/tests/41_reactive_render_defaults_test.py
+++ b/tests/41_reactive_render_defaults_test.py
@@ -1,47 +1,43 @@
-from pyjinhx import oob_swaps  # noqa: F401  (ensures package import side effects)
+from pyjinhx import oob_swaps  # noqa: F401
+from tests.reactive_test_support import reactive_client, record_mutation
 from tests.ui.reactive import store
 from tests.ui.reactive.reactive_counter import ReactiveCounter
 from tests.ui.reactive.reactive_clear_button import ReactiveClearButton  # noqa: F401
 from tests.ui.unified_component import UnifiedComponent
 
 
-def test_dirtied_defaults_to_primary_reacts_to():
+def test_pending_mutations_drive_oob_swaps():
     store.state["completed"] = 4
     primary = ReactiveCounter(id="counter", remaining=0)
-    out = str(
-        primary.render(
-            mounted=[
-                {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
-            ]
-        )
-    )
+    manifest = [
+        {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
+    ]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(primary.render())
     assert "outerHTML:[data-pjx-id='clear-btn']" in out
     assert "Clear (4)" in out
 
 
-def test_explicit_empty_dirtied_is_respected():
+def test_no_pending_mutations_skips_oob():
     store.state["completed"] = 4
     primary = ReactiveCounter(id="counter", remaining=0)
-    out = str(
-        primary.render(
-            dirtied=set(),
-            mounted=[
-                {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
-            ],
-        )
-    )
+    manifest = [
+        {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
+    ]
+    with reactive_client(manifest):
+        out = str(primary.render())
     assert "outerHTML:[data-pjx-id='clear-btn']" not in out
 
 
 def test_non_reactive_primary_defaults_to_no_swaps():
     store.state["completed"] = 4
     primary = UnifiedComponent(id="u1", text="hi")
-    out = str(
-        primary.render(
-            mounted=[
-                {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
-            ]
-        )
-    )
+    manifest = [
+        {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
+    ]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(primary.render())
     assert "outerHTML:[data-pjx-id='clear-btn']" not in out
     assert "hi" in out

--- a/tests/43_instance_key_cache_test.py
+++ b/tests/43_instance_key_cache_test.py
@@ -1,18 +1,19 @@
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
-from pyjinhx import LoadCache, ReactiveComponent
+from pyjinhx import LoadCache, PjxLoad, ReactiveComponent
 
 load_calls = {"n": 0}
 
 
 class Row(ReactiveComponent):
+    row_key: Annotated[str, PjxLoad()]
     title: str = ""
     reacts_to: ClassVar[set[str]] = {"row", "rows"}
 
     @classmethod
     def load(cls, key: str | int) -> "Row":
         load_calls["n"] += 1
-        return cls(title=f"row {key}")
+        return cls(row_key=str(key), title=f"row {key}")
 
 
 def _reset():
@@ -34,7 +35,7 @@ def test_keyed_id_and_key_stashed():
 
 def test_key_is_coerced_to_string():
     _reset()
-    r = Row.load(42)  # int in
+    r = Row.load(42)
     assert r.id == "row-42" and r._pjx_key == "42"
 
 
@@ -42,21 +43,11 @@ def test_cache_is_per_key():
     _reset()
     Row.load("1")
     Row.load("2")
-    Row.load("1")  # hit
+    Row.load("1")
     assert load_calls["n"] == 2
 
 
-def test_instance_invalidation_evicts_one_row():
-    _reset()
-    Row.load("1")
-    Row.load("2")
-    LoadCache.invalidate({"row:1"})
-    Row.load("1")  # miss -> reload
-    Row.load("2")  # still cached
-    assert load_calls["n"] == 3
-
-
-def test_stem_invalidation_evicts_matching_instance_keys():
+def test_row_stem_invalidation_evicts_all_rows():
     _reset()
     Row.load("1")
     Row.load("2")
@@ -70,7 +61,15 @@ def test_collection_invalidation_evicts_all_rows():
     _reset()
     Row.load("1")
     Row.load("2")
-    LoadCache.invalidate({"rows"})  # both rows declare "rows"
+    LoadCache.invalidate({"rows"})
     Row.load("1")
     Row.load("2")
     assert load_calls["n"] == 4
+
+
+def test_unrelated_key_does_not_evict():
+    _reset()
+    Row.load("1")
+    LoadCache.invalidate({"other"})
+    Row.load("1")
+    assert load_calls["n"] == 1

--- a/tests/44_instance_key_render_test.py
+++ b/tests/44_instance_key_render_test.py
@@ -1,33 +1,36 @@
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
-from pyjinhx import ReactiveComponent
+from pyjinhx import PjxLoad, ReactiveComponent
 from pyjinhx.utils import read_client_runtime
 
 
 class KeyedCard(ReactiveComponent):
+    card_key: Annotated[str, PjxLoad()]
     title: str = ""
     reacts_to: ClassVar[set[str]] = {"card"}
 
     @classmethod
     def load(cls, key: str | int) -> "KeyedCard":
-        return cls(title=f"card {key}")
+        return cls(card_key=str(key), title=f"card {key}")
 
 
-def test_keyed_root_is_stamped_with_data_pjx_key():
+def test_keyed_root_is_stamped_with_data_pjx_load():
     html = str(KeyedCard.load("7")._render(source="<div>{{ title }}</div>"))
     assert 'data-pjx-id="keyed-card-7"' in html
-    assert 'data-pjx-key="7"' in html
+    assert 'data-pjx-load="7"' in html
     assert 'data-pjx-type="KeyedCard"' in html
 
 
-def test_key_is_available_in_template_context():
+def test_pjx_load_field_is_available_in_template_context():
     html = str(
-        KeyedCard.load("7")._render(source="<a href='/cards/{{ key }}'>{{ title }}</a>")
+        KeyedCard.load("7")._render(
+            source="<a href='/cards/{{ card_key }}'>{{ title }}</a>"
+        )
     )
     assert "/cards/7" in html
 
 
-def test_runtime_reports_key_in_manifest():
+def test_runtime_reports_load_in_manifest():
     src = read_client_runtime()
-    assert "data-pjx-key" in src or "pjxKey" in src
-    assert "key:" in src
+    assert "data-pjx-load" in src or "pjxLoad" in src
+    assert "load:" in src or "entry.load" in src

--- a/tests/45_instance_key_walk_test.py
+++ b/tests/45_instance_key_walk_test.py
@@ -1,27 +1,17 @@
-from pyjinhx import oob_swaps
-from pyjinhx import LoadCache
+from pyjinhx import LoadCache, oob_swaps
 
 from tests.ui.reactive.user_row import UserRow  # noqa: F401
 
 
 def _manifest():
     return [
-        {"id": "user-row-1", "type": "UserRow", "key": "1", "hash": "stale"},
-        {"id": "user-row-2", "type": "UserRow", "key": "2", "hash": "stale"},
-        {"id": "user-row-3", "type": "UserRow", "key": "3", "hash": "stale"},
+        {"id": "user-row-1", "type": "UserRow", "load": "1", "hash": "stale"},
+        {"id": "user-row-2", "type": "UserRow", "load": "2", "hash": "stale"},
+        {"id": "user-row-3", "type": "UserRow", "load": "3", "hash": "stale"},
     ]
 
 
-def test_instance_dirty_swaps_only_that_row():
-    LoadCache.clear()
-    out = str(oob_swaps({"user:2"}, _manifest()))
-    assert "outerHTML:[data-pjx-id='user-row-2']" in out
-    assert "outerHTML:[data-pjx-id='user-row-1']" not in out
-    assert "outerHTML:[data-pjx-id='user-row-3']" not in out
-    assert "Bob" in out
-
-
-def test_collection_dirty_swaps_all_rows():
+def test_users_dirty_swaps_all_rows():
     LoadCache.clear()
     out = str(oob_swaps({"users"}, _manifest()))
     for rid in ("user-row-1", "user-row-2", "user-row-3"):
@@ -33,7 +23,10 @@ def test_unrelated_dirty_swaps_nothing():
     assert str(oob_swaps({"todos"}, _manifest())) == ""
 
 
-def test_each_row_reloads_with_its_own_key():
+def test_missing_keyed_entity_emits_delete_oob():
     LoadCache.clear()
-    out = str(oob_swaps({"user:1", "user:3"}, _manifest()))
-    assert "Alice" in out and "Carol" in out and "Bob" not in out
+    manifest = [{"id": "user-row-9", "type": "UserRow", "load": "9", "hash": "stale"}]
+    out = str(oob_swaps({"users"}, manifest))
+    assert "delete:[data-pjx-id='user-row-9']" in out
+    assert "outerHTML:[data-pjx-id='user-row-9']" not in out
+

--- a/tests/46_reactive_render_classform_test.py
+++ b/tests/46_reactive_render_classform_test.py
@@ -1,15 +1,16 @@
 """
 Class-form render(): the auto-loading route entry point.
 
-`Cls.render(key, dirtied=, mounted=)` loads the primary itself (no developer
-`load()` call), renders it, and appends OOB swaps for dependents — while
-`instance.render(...)` keeps the original instance-render contract.
+``Cls.render(*args)`` loads the primary itself (no developer ``load()`` call),
+renders it, and appends OOB swaps for dependents when a ``ClientBackend`` is
+active and mutations are pending.
 """
 
 import pytest
 from markupsafe import Markup
 
-from pyjinhx import oob_swaps  # noqa: F401 (package import side effects)
+from pyjinhx import oob_swaps  # noqa: F401
+from tests.reactive_test_support import reactive_client, record_mutation
 from tests.ui.reactive import store
 from tests.ui.reactive.reactive_counter import ReactiveCounter
 from tests.ui.reactive.reactive_clear_button import ReactiveClearButton  # noqa: F401
@@ -17,23 +18,16 @@ from tests.ui.reactive.user_row import UserRow
 
 
 def _row(i):
-    return {"id": f"user-row-{i}", "type": "UserRow", "key": str(i), "hash": "stale"}
-
-
-# --- singleton class form -----------------------------------------------------
+    return {"id": f"user-row-{i}", "type": "UserRow", "load": str(i), "hash": "stale"}
 
 
 def test_singleton_class_form_loads_primary_and_swaps_dependents():
     store.state["remaining"] = 2
     store.state["completed"] = 5
-    out = str(
-        ReactiveCounter.render(
-            dirtied={"todos"},
-            mounted=[
-                {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}
-            ],
-        )
-    )
+    manifest = [{"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(ReactiveCounter.render())
     assert "2 left" in out
     assert 'data-pjx-id="counter"' in out
     assert "outerHTML:[data-pjx-id='clear-btn']" in out
@@ -42,87 +36,50 @@ def test_singleton_class_form_loads_primary_and_swaps_dependents():
 
 def test_singleton_class_form_excludes_primary_from_oob():
     store.state["remaining"] = 1
-    out = str(
-        ReactiveCounter.render(
-            dirtied={"todos"},
-            mounted=[{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}],
-        )
-    )
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(ReactiveCounter.render())
     assert "1 left" in out
     assert "outerHTML:[data-pjx-id='counter']" not in out
 
 
-# --- keyed class form ---------------------------------------------------------
-
-
 def test_keyed_class_form_renders_keyed_primary():
-    out = str(UserRow.render("1", dirtied={"user:1"}, mounted=[]))
+    with reactive_client([]):
+        record_mutation("users")
+        out = str(UserRow.render("1"))
     assert "Alice" in out
     assert 'data-pjx-id="user-row-1"' in out
-    assert 'data-pjx-key="1"' in out
+    assert 'data-pjx-load="1"' in out
     assert 'data-pjx-type="UserRow"' in out
 
 
-def test_keyed_class_form_swaps_only_dirtied_siblings():
-    out = str(
-        UserRow.render(
-            "1",
-            dirtied={"user:1"},
-            mounted=[_row(1), _row(2), _row(3)],
-        )
-    )
+def test_keyed_class_form_swaps_siblings_on_collection_dirty():
+    manifest = [_row(1), _row(2), _row(3)]
+    with reactive_client(manifest, trigger_id="user-row-1"):
+        record_mutation("users")
+        out = str(UserRow.render("1"))
     assert 'data-pjx-id="user-row-1"' in out
-    assert "outerHTML:[data-pjx-id='user-row-1']" not in out
-    assert "outerHTML:[data-pjx-id='user-row-2']" not in out
-    assert "outerHTML:[data-pjx-id='user-row-3']" not in out
-
-
-def test_keyed_collection_tier_swaps_siblings_out_of_band():
-    out = str(
-        UserRow.render(
-            "1",
-            dirtied={"users"},
-            mounted=[_row(1), _row(2), _row(3)],
-        )
-    )
     assert "outerHTML:[data-pjx-id='user-row-1']" not in out
     assert "outerHTML:[data-pjx-id='user-row-2']" in out and "Bob" in out
     assert "outerHTML:[data-pjx-id='user-row-3']" in out and "Carol" in out
 
 
-def test_keyed_dirtied_defaults_to_interpolated_reacts_to():
-    out = str(UserRow.render("1", mounted=[_row(1), _row(2)]))
-    assert "outerHTML:[data-pjx-id='user-row-2']" in out
-
-
-# --- guards -------------------------------------------------------------------
-
-
-def test_keyed_without_key_raises():
+def test_keyed_without_load_arg_raises():
     with pytest.raises(TypeError, match="instance-keyed"):
-        UserRow.render(dirtied={"users"}, mounted=[])
+        UserRow.render()
 
 
 def test_singleton_with_key_raises():
     with pytest.raises(TypeError, match="type-singleton"):
-        ReactiveCounter.render("99", mounted=[])
-
-
-# --- contract preservation ----------------------------------------------------
-
-
-def test_class_form_equals_load_then_render():
-    store.state["remaining"] = 3
-    store.state["completed"] = 2
-    manifest = [{"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}]
-    via_class = str(ReactiveCounter.render(dirtied={"todos"}, mounted=manifest))
-    via_load = str(ReactiveCounter.load().render(dirtied={"todos"}, mounted=manifest))
-    assert via_class == via_load
+        ReactiveCounter.render("99")
 
 
 def test_class_form_returns_markup_and_does_not_escape():
     store.state["remaining"] = 2
-    result = ReactiveCounter.render(dirtied={"todos"}, mounted=[])
+    with reactive_client([]):
+        record_mutation("todos")
+        result = ReactiveCounter.render()
     assert isinstance(result, Markup)
     assert "&lt;" not in str(result)
 

--- a/tests/47_reactive_keys_and_enum_load_test.py
+++ b/tests/47_reactive_keys_and_enum_load_test.py
@@ -1,37 +1,17 @@
 from enum import Enum
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
-from pyjinhx import ReactiveComponent, LoadCache, oob_swaps
+from pyjinhx import LoadCache, PjxLoad, ReactiveComponent, oob_swaps
 from pyjinhx.reactive.keys import (
     coerce_load_key_str,
     coerce_reactive_key,
     coerce_reactive_keys,
-    interpolate_reactive_keys,
 )
 
 
 class StateKey(str, Enum):
     TODOS = "todos"
     ROW = "row"
-
-
-def test_singleton_keys_pass_through():
-    assert interpolate_reactive_keys({"todos"}, None) == {"todos"}
-
-
-def test_keyed_single_stem_expands():
-    assert interpolate_reactive_keys({"todo"}, "42", keyed=True) == {"todo:42"}
-
-
-def test_keyed_plural_sibling_splits_instance_and_collection():
-    assert interpolate_reactive_keys({"user", "users"}, "2", keyed=True) == {
-        "user:2",
-        "users",
-    }
-
-
-def test_legacy_key_placeholder_still_works():
-    assert interpolate_reactive_keys({"todo:{key}"}, "7", keyed=True) == {"todo:7"}
 
 
 def test_coerce_reactive_key_unwraps_enum():
@@ -45,12 +25,13 @@ class TodoId(Enum):
 
 
 class EnumRow(ReactiveComponent):
+    row_key: Annotated[str, PjxLoad()]
     label: str = ""
     reacts_to: ClassVar[set[str | StateKey]] = {StateKey.ROW}
 
     @classmethod
     def load(cls, key: str) -> "EnumRow":
-        return cls(label=f"row {key}")
+        return cls(row_key=str(key), label=f"row {key}")
 
 
 def test_reacts_to_coerces_enums_at_class_definition():

--- a/tests/48_reactive_keys_helpers_test.py
+++ b/tests/48_reactive_keys_helpers_test.py
@@ -1,15 +1,14 @@
-from pyjinhx.reactive.keys import StateKey
+from pyjinhx.reactive.keys import StateKey, coerce_reactive_key, coerce_reactive_keys
 
 
 class TodoKeys(StateKey):
     TODOS = "todos"
 
 
-def test_instance_key_formats_stem_and_key():
-    assert StateKey.instance_key("todo", 42) == "todo:42"
-    assert StateKey.instance_key("todo", "abc") == "todo:abc"
+def test_state_key_enum_values_are_strings():
+    assert TodoKeys.TODOS == "todos"
+    assert coerce_reactive_key(TodoKeys.TODOS) == "todos"
 
 
-def test_dirty_keys_builds_two_tier_set():
-    assert StateKey.dirty_keys("todo", 42, "todos") == {"todo:42", "todos"}
-    assert StateKey.dirty_keys("todo", 42, TodoKeys.TODOS) == {"todo:42", "todos"}
+def test_coerce_reactive_keys_accepts_enums():
+    assert coerce_reactive_keys({TodoKeys.TODOS, "users"}) == {"todos", "users"}

--- a/tests/49_mutations_test.py
+++ b/tests/49_mutations_test.py
@@ -1,9 +1,8 @@
 from pathlib import Path
 
-import pytest
-
-from pyjinhx import LoadCache, Registry, Renderer, mutates, mutation_scope
+from pyjinhx import LoadCache, Registry, Renderer, mutates
 from pyjinhx.reactive.mutations import MutationTracker
+from tests.reactive_test_support import reactive_client
 from tests.ui.reactive.reactive_clear_button import ReactiveClearButton
 from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401
 from tests.ui.reactive.store import state
@@ -22,43 +21,33 @@ def test_mutates_accumulates_pending_dirtied():
     assert MutationTracker.pending() == {"todos"}
 
 
-def test_resolve_effective_dirtied_merges_pending():
-    MutationTracker.clear()
-    _mutate_todos()
-    effective = MutationTracker.resolve_effective_dirtied(
-        dirtied=None,
-        mounted=[],
-        own_keys={"todos"},
-    )
-    assert effective == {"todos"}
-
-
-def test_render_merges_pending_dirtied_when_omitted():
+def test_render_consumes_pending_dirtied():
     LoadCache.clear()
     MutationTracker.clear()
     prev = Renderer.peek_default_environment()
     Renderer.set_default_environment(UI_ROOT)
     try:
-        _mutate_todos()
         manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
         with Registry.request_scope():
-            out = str(ReactiveClearButton.render(mounted=manifest))
+            _mutate_todos()
+            with reactive_client(manifest):
+                out = str(ReactiveClearButton.render())
         assert "outerHTML:[data-pjx-id='counter']" in out
         assert MutationTracker.pending() == set()
     finally:
         Renderer.set_default_environment(prev)
 
 
-def test_explicit_dirtied_overrides_pending():
+def test_render_without_pending_skips_oob():
     LoadCache.clear()
     MutationTracker.clear()
     prev = Renderer.peek_default_environment()
     Renderer.set_default_environment(UI_ROOT)
     try:
-        _mutate_todos()
         manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
         with Registry.request_scope():
-            out = str(ReactiveClearButton.render(dirtied=set(), mounted=manifest))
+            with reactive_client(manifest):
+                out = str(ReactiveClearButton.render())
         assert "outerHTML:[data-pjx-id='counter']" not in out
     finally:
         Renderer.set_default_environment(prev)
@@ -70,35 +59,3 @@ def test_request_scope_isolates_mutations():
         _mutate_todos()
         assert MutationTracker.pending() == {"todos"}
     assert MutationTracker.pending() == set()
-
-
-def test_mutation_scope_records_on_success():
-    LoadCache.clear()
-    MutationTracker.clear()
-    with mutation_scope("todos"):
-        state["remaining"] -= 1
-    assert MutationTracker.pending() == {"todos"}
-
-
-def test_mutation_scope_does_not_record_on_exception():
-    LoadCache.clear()
-    MutationTracker.clear()
-    with pytest.raises(ValueError):
-        with mutation_scope("todos"):
-            raise ValueError("mutation failed")
-    assert MutationTracker.pending() == set()
-
-
-def test_mutation_scope_and_mutates_parity_on_success():
-    LoadCache.clear()
-    MutationTracker.clear()
-    with mutation_scope("todos"):
-        pass
-    scope_pending = MutationTracker.pending()
-
-    LoadCache.clear()
-    MutationTracker.clear()
-    _mutate_todos()
-    mutates_pending = MutationTracker.pending()
-
-    assert scope_pending == mutates_pending == {"todos"}

--- a/tests/50_asset_reference_mode_test.py
+++ b/tests/50_asset_reference_mode_test.py
@@ -180,8 +180,12 @@ def test_resolver_with_hash_embeds_digest():
 
 
 def test_reactive_partial_render_suppresses_assets():
+    from tests.reactive_test_support import reactive_client, record_mutation
+
     manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
-    rendered = str(ReactiveCounter.render(dirtied={"todos"}, mounted=manifest))
+    with reactive_client(manifest):
+        record_mutation("todos")
+        rendered = str(ReactiveCounter.render())
 
     assert "<style>" not in rendered
     assert "<script" not in rendered

--- a/tests/50_load_context_test.py
+++ b/tests/50_load_context_test.py
@@ -1,8 +1,13 @@
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
-from pyjinhx import LoadCache, ReactiveComponent, Registry
-from pyjinhx.reactive.context import LoadContext
+import pytest
+
+from pyjinhx import LoadCache, PjxLoad, ReactiveComponent, Registry
+from pyjinhx.reactive.context import (
+    LoadContext,
+    resolve_load_context_param,
+)
 
 
 @dataclass(frozen=True)
@@ -15,17 +20,18 @@ class CtxSingleton(ReactiveComponent):
     reacts_to: ClassVar[set[str]] = {"widgets"}
 
     @classmethod
-    def load(cls, *, ctx: AppLoadContext | None = None) -> "CtxSingleton":
-        return cls(id="ctx-singleton", value=ctx.value if ctx else -1)
+    def load(cls, *, app: AppLoadContext | None = None) -> "CtxSingleton":
+        return cls(id="ctx-singleton", value=app.value if app else -1)
 
 
 class CtxKeyed(ReactiveComponent):
+    row_key: Annotated[str, PjxLoad()]
     label: str = ""
     reacts_to: ClassVar[set[str]] = {"row"}
 
     @classmethod
-    def load(cls, key: str, *, ctx: AppLoadContext | None = None) -> "CtxKeyed":
-        return cls(label=f"{key}:{ctx.value if ctx else 'none'}")
+    def load(cls, key: str, app_ctx: AppLoadContext) -> "CtxKeyed":
+        return cls(row_key=key, label=f"{key}:{app_ctx.value}")
 
 
 class CtxPlain(ReactiveComponent):
@@ -50,7 +56,7 @@ def test_load_context_bind_sets_context():
     assert LoadContext.current() is None
 
 
-def test_load_receives_ctx_kwarg():
+def test_load_receives_context_by_type_not_name():
     LoadCache.clear()
     ctx = AppLoadContext(value=42)
     with LoadContext.bind(ctx):
@@ -58,7 +64,7 @@ def test_load_receives_ctx_kwarg():
     assert instance.value == 42
 
 
-def test_keyed_load_with_ctx_kwarg_stays_keyed():
+def test_keyed_load_injects_context_positionally():
     assert CtxKeyed._pjx_keyed is True
     LoadCache.clear()
     ctx = AppLoadContext(value=9)
@@ -68,7 +74,7 @@ def test_keyed_load_with_ctx_kwarg_stays_keyed():
     assert row.id == "ctx-keyed-a"
 
 
-def test_load_contextvar_when_no_ctx_param():
+def test_load_contextvar_when_no_context_param():
     LoadCache.clear()
     ctx = AppLoadContext(value=5)
     with LoadContext.bind(ctx):
@@ -84,12 +90,27 @@ def test_request_scope_accepts_load_context():
     assert instance.value == 11
 
 
-def test_load_context_accepts_ctx_detects_keyword_only():
-    def with_ctx(cls, *, ctx=None):
+def test_resolve_load_context_param_detects_subclass_annotation():
+    def with_context(cls, *, app: AppLoadContext | None = None):
         pass
 
-    def without_ctx(cls):
+    def without_context(cls):
         pass
 
-    assert LoadContext.accepts_ctx(with_ctx) is True
-    assert LoadContext.accepts_ctx(without_ctx) is False
+    assert resolve_load_context_param(with_context).name == "app"
+    assert resolve_load_context_param(without_context) is None
+
+
+def test_duplicate_load_context_params_raise_at_class_definition():
+    with pytest.raises(TypeError, match="multiple LoadContext parameters"):
+
+        class DuplicateCtxLoad(ReactiveComponent):
+            reacts_to: ClassVar[set[str]] = {"dup"}
+
+            @classmethod
+            def load(
+                cls,
+                first: AppLoadContext,
+                second: LoadContext,
+            ) -> "DuplicateCtxLoad":
+                return cls(id="dup")

--- a/tests/51_client_asset_manifest_test.py
+++ b/tests/51_client_asset_manifest_test.py
@@ -173,11 +173,6 @@ def test_reactive_partial_still_emits_no_assets_with_client_header():
     Renderer.set_default_asset_dedup(True)
 
     manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
-    client = _Client(
-        {
-            PJX_ASSETS_HEADER: json.dumps(["/static/components/counter.js"]),
-        }
-    )
     from tests.reactive_test_support import reactive_client, record_mutation
 
     with reactive_client(

--- a/tests/51_client_asset_manifest_test.py
+++ b/tests/51_client_asset_manifest_test.py
@@ -178,11 +178,16 @@ def test_reactive_partial_still_emits_no_assets_with_client_header():
             PJX_ASSETS_HEADER: json.dumps(["/static/components/counter.js"]),
         }
     )
-    rendered = str(
-        ReactiveCounter.load().render(
-            dirtied={"todos"}, mounted=manifest, client=client
-        )
-    )
+    from tests.reactive_test_support import reactive_client, record_mutation
+
+    with reactive_client(
+        manifest,
+        extra_headers={
+            PJX_ASSETS_HEADER: json.dumps(["/static/components/counter.js"]),
+        },
+    ):
+        record_mutation("todos")
+        rendered = str(ReactiveCounter.load().render())
 
     assert "<link" not in rendered
     assert "<script" not in rendered

--- a/tests/51_reactive_dev_test.py
+++ b/tests/51_reactive_dev_test.py
@@ -51,17 +51,16 @@ def test_strict_mutations_without_render_raises():
             _orphan_mutation()
 
 
-def test_warn_render_without_mounted(caplog):
-    from pyjinhx.reactive.dev import warn_reactive_render_without_mounted
+def test_warn_render_without_client(caplog):
+    from pyjinhx.reactive.dev import warn_reactive_render_without_client
+    from pyjinhx.reactive.mutations import MutationTracker
 
     enable_reactive_dev()
+    MutationTracker.clear()
+    MutationTracker.record({"todos"})
     with caplog.at_level(logging.WARNING, logger="pyjinhx"):
-        warn_reactive_render_without_mounted(
-            dirtied={"todos"},
-            mounted=None,
-            own_keys={"todos"},
-        )
-    assert "mounted was not passed" in caplog.text.lower()
+        warn_reactive_render_without_client(backend=None)
+    assert "clientbackend" in caplog.text.lower()
 
 
 def test_dependency_graph_includes_reactive_components():

--- a/tests/61_depends_on_test.py
+++ b/tests/61_depends_on_test.py
@@ -33,7 +33,7 @@ def teardown_function():
     disable_reactive_dev()
 
 
-def test_oob_skips_when_runtime_deps_do_not_intersect_dirtied():
+def test_oob_skips_when_static_reacts_to_does_not_intersect_dirtied():
     manifest = [
         {
             "id": "panel",
@@ -41,11 +41,11 @@ def test_oob_skips_when_runtime_deps_do_not_intersect_dirtied():
             "hash": "stale",
         }
     ]
-    out = str(oob_swaps({"user"}, manifest))
+    out = str(oob_swaps({"todos"}, manifest))
     assert "outerHTML:[data-pjx-id='panel']" not in out
 
 
-def test_oob_swaps_when_runtime_deps_intersect_dirtied():
+def test_oob_swaps_when_static_reacts_to_intersects_dirtied():
     prev = Renderer.peek_default_environment()
     Renderer.set_default_environment(UI_ROOT)
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def _suppress_pjx_runtime_injection(request: pytest.FixtureRequest, monkeypatch:
     if request.node.get_closest_marker("pjx_runtime"):
         return
     monkeypatch.setattr(
-        "pyjinhx.core.renderer.inject_runtime",
+        "pyjinhx.core.render_assets.inject_runtime",
         _noop_inject_runtime,
     )
 

--- a/tests/integration/test_instance_keyed.py
+++ b/tests/integration/test_instance_keyed.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from examples.reactive_todo import store
+from examples.reactive_todo.components import ItemRow
 from pyjinhx import PJX_MOUNTED_HEADER, Renderer
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -27,8 +28,8 @@ def _rows(*ids):
         {
             "id": f"row-{i}",
             "type": "ItemRow",
-            "key": str(i),
-            "hash": "stale",
+            "load": str(i),
+            "hash": ItemRow.load(i).state_hash(),
         }
         for i in ids
     ]
@@ -38,7 +39,7 @@ def test_index_renders_instance_keyed_rows(client):
     body = client.get("/").text
     for i in (1, 2, 3):
         assert f'data-pjx-id="row-{i}"' in body
-        assert f'data-pjx-key="{i}"' in body
+        assert f'data-pjx-load="{i}"' in body
     assert 'data-pjx-type="ItemRow"' in body
 
 
@@ -47,7 +48,7 @@ def test_toggle_row_swaps_only_that_row(client):
     body = client.post("/rows/1/toggle", headers=headers).text
 
     assert 'data-pjx-id="row-1"' in body
-    assert 'data-pjx-key="1"' in body
+    assert 'data-pjx-load="1"' in body
 
     assert "outerHTML:[data-pjx-id='row-1']" not in body
     assert "outerHTML:[data-pjx-id='row-2']" not in body
@@ -59,6 +60,6 @@ def test_toggle_row_does_not_resurrect_other_rows_as_oob(client):
     body = client.post("/rows/2/toggle", headers=headers).text
 
     assert 'data-pjx-id="row-2"' in body
-    assert 'data-pjx-key="2"' in body
+    assert 'data-pjx-load="2"' in body
     assert "outerHTML:[data-pjx-id='row-1']" not in body
     assert "outerHTML:[data-pjx-id='row-3']" not in body

--- a/tests/integration/test_reactive_todo.py
+++ b/tests/integration/test_reactive_todo.py
@@ -58,6 +58,18 @@ def test_toggle_hash_gates_unchanged_total(client):
     assert "outerHTML:[data-pjx-id='total']" not in body
 
 
+def test_clear_completed_with_stale_row_manifest(client):
+    client.post("/rows/1/toggle", headers=_manifest())
+    headers = _manifest(
+        {"id": "row-1", "type": "ItemRow", "load": "1", "hash": "stale"},
+        {"id": "list", "type": "ItemList", "hash": "stale"},
+    )
+    body = client.post("/todos/clear-completed", headers=headers).text
+    assert 'id="list"' in body
+    assert "row-1" not in body.split("hx-swap-oob")[0]
+    assert "delete:[data-pjx-id='row-1']" in body
+
+
 def test_clear_completed_hash_gates_unchanged_counter(client):
     client.post("/rows/1/toggle", headers=_manifest())
     fresh_counter = Counter.load()

--- a/tests/reactive_test_support.py
+++ b/tests/reactive_test_support.py
@@ -1,0 +1,37 @@
+"""Shared helpers for reactive render tests."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from pyjinhx import FastAPIClientBackend
+from pyjinhx.reactive.backend import ClientBackend
+from pyjinhx.reactive.mutations import MutationTracker
+
+
+class FakeRequest:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self.headers = headers or {}
+
+
+@contextmanager
+def reactive_client(
+    manifest: list[dict[str, object]] | None = None,
+    *,
+    extra_headers: dict[str, str] | None = None,
+    trigger_id: str | None = None,
+) -> Iterator[FastAPIClientBackend]:
+    headers = dict(extra_headers or {})
+    if manifest is not None:
+        headers["X-PJX-Mounted"] = json.dumps(manifest)
+    if trigger_id is not None:
+        headers["X-PJX-Trigger"] = json.dumps({"id": trigger_id})
+    backend = FastAPIClientBackend(FakeRequest(headers))
+    with ClientBackend.scope(backend):
+        yield backend
+
+
+def record_mutation(*keys: str) -> None:
+    MutationTracker.record(keys)

--- a/tests/ui/reactive/user_row.py
+++ b/tests/ui/reactive/user_row.py
@@ -1,14 +1,15 @@
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
-from pyjinhx import ReactiveComponent
+from pyjinhx import PjxLoad, ReactiveComponent
 
 names = {"1": "Alice", "2": "Bob", "3": "Carol"}
 
 
 class UserRow(ReactiveComponent):
+    user_key: Annotated[str, PjxLoad()]
     name: str = ""
-    reacts_to: ClassVar[set[str]] = {"user", "users"}
+    reacts_to: ClassVar[set[str]] = {"users"}
 
     @classmethod
     def load(cls, key: str) -> "UserRow":
-        return cls(name=names[key])
+        return cls(user_key=key, name=names[key])


### PR DESCRIPTION
## Summary
- Replace `data-pjx-key` / `{{ key }}` with `PjxLoad` annotated fields stamped as `data-pjx-load`; manifest uses `load` for OOB reload args.
- Streamline mutations to state-key-only `@mutates`; class `render(*args)` auto-loads primary + OOB via `ClientBackend` and `X-PJX-Trigger`.
- Fix reactive todo demo: registry `setdefault` prevents id/field collision on `Total`, and delete OOB for keyed rows whose entity was removed (clear completed).

## Test plan
- [x] `uv run pytest` (303 passed)
- [ ] Manual: `uv run uvicorn examples.reactive_todo.app:app --reload` — toggle, clear completed, verify footer counts

Made with [Cursor](https://cursor.com)