### PR TITLE
Reduce engine footprint: drop legacy asset API, bundle AssetPolicy, tidy internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ pip install pyjinhx
 
 Import from the top level only — `from pyjinhx import BaseComponent, ReactiveComponent, setup, ...`. Internal module paths are not a stable API.
 
-| Folder | Role |
+| Area | Modules |
 |--------|------|
-| `pyjinhx/core/` | Components, render pipeline, registry, assets (usage tiers 1–2). Flat modules: `renderer` (orchestration), `render_assets`, `tag_expand`, `autodiscover`, `base`, `registry`, `finder`, `parser`, `assets` |
-| `pyjinhx/reactive/` | Cache, invalidation, mutations, OOB client helpers, `ReactiveComponent` (tier 3+) |
-| `pyjinhx/config/` | `setup()`, `PyJinhxSettings`, lifespan helpers |
+| Render engine (tiers 1–2) | `base`, `renderer`, `assets`, `tags`, `finder`, `registry` |
+| Reactivity (tier 3+) | `reactive`, `client`, `cache`, `mutations`, `keys`, `context`, `dev` |
+| Setup | `config` — `setup()`, `PyJinhxSettings`, lifespan helpers |
 | `pyjinhx/integrations/` | FastAPI wiring, Redis invalidation backend |
 | `pyjinhx/builtins/` | Optional UI kit |
 | `pyjinhx/runtime/` | Client runtime (`pjx.js`) |
@@ -200,7 +200,7 @@ Each asset is included once per render session. Output order: `<style>` tags, HT
 
 - **INLINE** (default): zero-config demos — assets are inlined as `<style>` / `<script>` blocks.
 - **REFERENCE**: production — emits `<link href="...">` / `<script src="...">` from a per-render manifest; configure `Renderer.set_asset_url_resolver()`.
-- **NONE**: no asset tags (legacy `set_default_inline_js(False)` behavior).
+- **NONE**: no asset tags.
 
 Reactive partial responses (when `mounted` is set) and OOB swaps never emit assets. Full-page layout renders emit them once. For boosted navigation in REFERENCE mode, enable client asset dedup so root renders skip URLs the browser already has (`X-PJX-Assets` via `ClientBackend` in middleware, or `render(client=request)`).
 

--- a/docs/api/renderer.md
+++ b/docs/api/renderer.md
@@ -21,8 +21,6 @@ def __init__(
     environment: Environment,
     *,
     auto_id: bool = True,
-    inline_js: bool | None = None,
-    inline_css: bool | None = None,
     js_mode: AssetMode | None = None,
     css_mode: AssetMode | None = None,
 ) -> None
@@ -33,8 +31,6 @@ Initialize a Renderer with the given Jinja environment.
 **Parameters:**
 - `environment` (Environment): The Jinja2 Environment to use for template rendering
 - `auto_id` (bool): If True (default), generate UUIDs for components without explicit IDs
-- `inline_js` (bool | None): Deprecated bool shim; maps to `AssetMode.INLINE` or `AssetMode.NONE`
-- `inline_css` (bool | None): Deprecated bool shim; maps to `AssetMode.INLINE` or `AssetMode.NONE`
 - `js_mode` (AssetMode | None): JavaScript delivery mode. Defaults to the class-level setting
 - `css_mode` (AssetMode | None): CSS delivery mode. Defaults to the class-level setting
 
@@ -47,8 +43,6 @@ Initialize a Renderer with the given Jinja environment.
 def get_default_renderer(
     *,
     auto_id: bool = True,
-    inline_js: bool | None = None,
-    inline_css: bool | None = None,
     js_mode: AssetMode | None = None,
     css_mode: AssetMode | None = None,
 ) -> Renderer
@@ -58,8 +52,6 @@ Return a cached default renderer instance.
 
 **Parameters:**
 - `auto_id` (bool): If True, generate UUIDs for components without explicit IDs
-- `inline_js` (bool | None): Deprecated bool shim for JavaScript delivery
-- `inline_css` (bool | None): Deprecated bool shim for CSS delivery
 - `js_mode` (AssetMode | None): JavaScript delivery mode
 - `css_mode` (AssetMode | None): CSS delivery mode
 
@@ -136,24 +128,6 @@ Set or clear the process-wide default Jinja environment.
 
 **Parameters:**
 - `environment` (Environment | str | os.PathLike[str] | None): A Jinja Environment instance, a path to a template directory, or None to clear the default and reset to auto-detection
-
-##### set_default_inline_js()
-
-```python
-@classmethod
-def set_default_inline_js(inline_js: bool) -> None
-```
-
-Deprecated bool shim. Maps to `AssetMode.INLINE` (True) or `AssetMode.NONE` (False).
-
-##### set_default_inline_css()
-
-```python
-@classmethod
-def set_default_inline_css(inline_css: bool) -> None
-```
-
-Deprecated bool shim. Maps to `AssetMode.INLINE` (True) or `AssetMode.NONE` (False).
 
 ##### peek_default_environment()
 

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -156,8 +156,6 @@ Renderer.set_default_js_mode(AssetMode.NONE)
 Renderer.set_default_css_mode(AssetMode.NONE)
 ```
 
-Legacy bool shims still work: `Renderer.set_default_inline_js(False)`.
-
 When disabled, no asset tags are emitted. Use `Finder.collect_javascript_files()` and `Finder.collect_css_files()` to discover files for fully manual static serving.
 
 ## Static File Serving

--- a/docs/guide/usage-tiers.md
+++ b/docs/guide/usage-tiers.md
@@ -2,7 +2,7 @@
 
 PyJinHx is one library with optional layers. Adopt each tier only when you need it.
 
-**Source layout:** tiers 1–2 live under `pyjinhx/core/`; tier 3+ under `pyjinhx/reactive/`; process setup under `pyjinhx/config/`. Public imports stay on `from pyjinhx import ...`.
+**Source layout:** the engine is a flat package — modules live directly under `pyjinhx/` (e.g. `base`, `renderer`, `reactive`, `cache`, `config`). Public imports stay on `from pyjinhx import ...`.
 
 ## Tier 1 — Components
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -113,7 +113,7 @@ Each component gets its own `<script>`/`<style>` tag (errors in one don't break 
 widget = MyWidget(id="w1", js=["path/to/extra.js"], css=["path/to/theme.css"])
 ```
 
-Missing extra files emit a warning (check `pyjinhx` logger). For production, use `AssetMode.REFERENCE` with `Renderer.set_asset_url_resolver()`. Disable assets with `AssetMode.NONE` or legacy `Renderer.set_default_inline_js(False)` / `Renderer.set_default_inline_css(False)`. Use `Finder(root).collect_javascript_files()` / `Finder(root).collect_css_files()` or `layout_asset_tags()` for layout preload.
+Missing extra files emit a warning (check `pyjinhx` logger). For production, use `AssetMode.REFERENCE` with `Renderer.set_asset_url_resolver()`. Disable assets with `AssetMode.NONE`. Use `Finder(root).collect_javascript_files()` / `Finder(root).collect_css_files()` or `layout_asset_tags()` for layout preload.
 
 **Kebab vs snake for co-located assets:** `pascal_case_to_kebab_case(ClassName) + ".js"|".css"` (e.g. `TabGroup` → `tab-group.js`, `LoadingOverlay` → `loading-overlay.js`). Wrong stem (e.g. `tab_group.js`) is **not** collected.
 

--- a/pyjinhx/assets.py
+++ b/pyjinhx/assets.py
@@ -82,10 +82,6 @@ def runtime_asset_path() -> str:
     )
 
 
-def asset_mode_from_inline(inline: bool) -> AssetMode:
-    return AssetMode.INLINE if inline else AssetMode.NONE
-
-
 def default_asset_url(path: str, *, root: str) -> str:
     normalized_path = os.path.normpath(path)
     if normalized_path == os.path.normpath(runtime_asset_path()):

--- a/pyjinhx/assets.py
+++ b/pyjinhx/assets.py
@@ -75,6 +75,20 @@ class AssetManifest:
     scripts: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class AssetPolicy:
+    """How a render emits assets: per-kind mode, URL resolution, and dedup."""
+
+    js_mode: AssetMode
+    css_mode: AssetMode
+    resolve_url: AssetUrlResolver
+    loaded_assets: frozenset[str] = frozenset()
+    dedup_enabled: bool = False
+
+    def mode(self, kind: AssetKind) -> AssetMode:
+        return self.js_mode if kind == "js" else self.css_mode
+
+
 def runtime_asset_path() -> str:
     """Return the absolute path to the bundled pyjinhx client runtime."""
     return os.path.normpath(
@@ -147,10 +161,6 @@ def normalize_asset_path(path: str) -> str:
     return os.path.normpath(path).replace("\\", "/")
 
 
-def asset_mode(js_mode: AssetMode, css_mode: AssetMode, kind: AssetKind) -> AssetMode:
-    return js_mode if kind == "js" else css_mode
-
-
 def register_asset(
     session: RenderSession,
     path: str,
@@ -187,12 +197,11 @@ def collect_component_asset(
     session: RenderSession,
     kind: AssetKind,
     *,
-    js_mode: AssetMode,
-    css_mode: AssetMode,
+    policy: AssetPolicy,
     component_dir: str | None = None,
     asset_name: str | None = None,
 ) -> None:
-    mode = asset_mode(js_mode, css_mode, kind)
+    mode = policy.mode(kind)
     if mode == AssetMode.NONE:
         return
 
@@ -211,10 +220,9 @@ def collect_extra_assets(
     session: RenderSession,
     kind: AssetKind,
     *,
-    js_mode: AssetMode,
-    css_mode: AssetMode,
+    policy: AssetPolicy,
 ) -> None:
-    mode = asset_mode(js_mode, css_mode, kind)
+    mode = policy.mode(kind)
     if mode == AssetMode.NONE:
         return
 
@@ -237,7 +245,7 @@ def collect_extra_assets(
 def inject_runtime(
     session: RenderSession,
     *,
-    js_mode: AssetMode,
+    policy: AssetPolicy,
     client: object | None = None,
 ) -> None:
     from pyjinhx.client import MountedManifest
@@ -246,9 +254,9 @@ def inject_runtime(
         return
     if MountedManifest.is_present(client):
         return
-    if js_mode == AssetMode.INLINE:
+    if policy.js_mode == AssetMode.INLINE:
         session.scripts.insert(0, read_client_runtime())
-    elif js_mode == AssetMode.REFERENCE:
+    elif policy.js_mode == AssetMode.REFERENCE:
         runtime_path = normalize_asset_path(runtime_asset_path())
         if runtime_path not in session.collected_paths:
             session.collected_paths.add(runtime_path)
@@ -269,17 +277,8 @@ def should_emit_reference_url(
     return url not in loaded_assets
 
 
-def render_assets(
-    session: RenderSession,
-    kind: AssetKind,
-    *,
-    js_mode: AssetMode,
-    css_mode: AssetMode,
-    resolve_url: Callable[[str], str],
-    loaded_assets: frozenset[str] = frozenset(),
-    dedup_enabled: bool = False,
-) -> str:
-    mode = asset_mode(js_mode, css_mode, kind)
+def render_assets(session: RenderSession, kind: AssetKind, *, policy: AssetPolicy) -> str:
+    mode = policy.mode(kind)
     if mode == AssetMode.INLINE:
         items = session.scripts if kind == "js" else session.styles
         if not items:
@@ -293,9 +292,9 @@ def render_assets(
             return ""
         tags: list[str] = []
         for asset in kind_assets:
-            url = resolve_url(asset.path)
+            url = policy.resolve_url(asset.path)
             if should_emit_reference_url(
-                url, loaded_assets, dedup_enabled=dedup_enabled
+                url, policy.loaded_assets, dedup_enabled=policy.dedup_enabled
             ):
                 if kind == "js":
                     tags.append(f'<script src="{url}"></script>')
@@ -313,11 +312,7 @@ def apply_component_render_assets(
     template_path: str | None,
     is_root: bool,
     collect_component_js: bool,
-    js_mode: AssetMode,
-    css_mode: AssetMode,
-    resolve_url: Callable[[str], str],
-    loaded_assets: frozenset[str],
-    dedup_enabled: bool,
+    policy: AssetPolicy,
     client: object | None,
 ) -> str:
     if template_path is not None and type(component).__name__ == "BaseComponent":
@@ -331,86 +326,31 @@ def apply_component_render_assets(
 
     if collect_component_js:
         collect_component_asset(
-            component,
-            session,
-            "js",
-            js_mode=js_mode,
-            css_mode=css_mode,
-            component_dir=asset_dir,
-            asset_name=asset_name,
+            component, session, "js",
+            policy=policy, component_dir=asset_dir, asset_name=asset_name,
         )
         collect_component_asset(
-            component,
-            session,
-            "css",
-            js_mode=js_mode,
-            css_mode=css_mode,
-            component_dir=asset_dir,
-            asset_name=asset_name,
+            component, session, "css",
+            policy=policy, component_dir=asset_dir, asset_name=asset_name,
         )
 
     if not is_root:
         return rendered_markup
 
-    if css_mode != AssetMode.NONE:
-        collect_extra_assets(
-            component,
-            session,
-            "css",
-            js_mode=js_mode,
-            css_mode=css_mode,
-        )
-    if js_mode != AssetMode.NONE:
-        inject_runtime(session, js_mode=js_mode, client=client)
-        collect_extra_assets(
-            component,
-            session,
-            "js",
-            js_mode=js_mode,
-            css_mode=css_mode,
-        )
-    if css_mode == AssetMode.NONE and js_mode == AssetMode.NONE:
+    if policy.css_mode != AssetMode.NONE:
+        collect_extra_assets(component, session, "css", policy=policy)
+    if policy.js_mode != AssetMode.NONE:
+        inject_runtime(session, policy=policy, client=client)
+        collect_extra_assets(component, session, "js", policy=policy)
+    if policy.css_mode == AssetMode.NONE and policy.js_mode == AssetMode.NONE:
         return rendered_markup
 
-    return inject_assets(
-        rendered_markup,
-        session,
-        js_mode=js_mode,
-        css_mode=css_mode,
-        resolve_url=resolve_url,
-        loaded_assets=loaded_assets,
-        dedup_enabled=dedup_enabled,
-    )
+    return inject_assets(rendered_markup, session, policy=policy)
 
 
-def inject_assets(
-    markup: str,
-    session: RenderSession,
-    *,
-    js_mode: AssetMode,
-    css_mode: AssetMode,
-    resolve_url: Callable[[str], str],
-    loaded_assets: frozenset[str] = frozenset(),
-    dedup_enabled: bool = False,
-) -> str:
-    css_markup = render_assets(
-        session,
-        "css",
-        js_mode=js_mode,
-        css_mode=css_mode,
-        resolve_url=resolve_url,
-        loaded_assets=loaded_assets,
-        dedup_enabled=dedup_enabled,
-    )
-    js_markup = render_assets(
-        session,
-        "js",
-        js_mode=js_mode,
-        css_mode=css_mode,
-        resolve_url=resolve_url,
-        loaded_assets=loaded_assets,
-        dedup_enabled=dedup_enabled,
-    )
+def inject_assets(markup: str, session: RenderSession, *, policy: AssetPolicy) -> str:
+    css_markup = render_assets(session, "css", policy=policy)
+    js_markup = render_assets(session, "js", policy=policy)
     if css_markup:
         markup = f"{css_markup}\n{markup}"
     if js_markup:

--- a/pyjinhx/cache.py
+++ b/pyjinhx/cache.py
@@ -170,18 +170,26 @@ class LoadCache:
         return set(getattr(instance.__class__, "_pjx_reacts_to", frozenset()))
 
     @classmethod
-    def _unindex_cache_key(
-        cls, state: _CacheState, cache_key: tuple[type, str | None]
+    def _drop_reverse(
+        cls,
+        state: _CacheState,
+        cache_key: tuple[type, str | None],
+        instance: BaseComponent,
     ) -> None:
-        existing = state._cache.get(cache_key)
-        if existing is None:
-            return
-        for reactive_key in cls._indexed_keys(existing):
+        for reactive_key in cls._indexed_keys(instance):
             bucket = state._reverse.get(reactive_key)
             if bucket is not None:
                 bucket.discard(cache_key)
                 if not bucket:
                     state._reverse.pop(reactive_key, None)
+
+    @classmethod
+    def _unindex_cache_key(
+        cls, state: _CacheState, cache_key: tuple[type, str | None]
+    ) -> None:
+        existing = state._cache.get(cache_key)
+        if existing is not None:
+            cls._drop_reverse(state, cache_key, existing)
 
     @classmethod
     def _evict_from_state(cls, state: _CacheState, keys: set[str]) -> None:
@@ -192,14 +200,8 @@ class LoadCache:
             to_evict |= state._reverse.get(key, set())
         for cache_key in to_evict:
             cached = state._cache.pop(cache_key, None)
-            if cached is None:
-                continue
-            for reactive_key in cls._indexed_keys(cached):
-                bucket = state._reverse.get(reactive_key)
-                if bucket is not None:
-                    bucket.discard(cache_key)
-                    if not bucket:
-                        state._reverse.pop(reactive_key, None)
+            if cached is not None:
+                cls._drop_reverse(state, cache_key, cached)
 
     @classmethod
     def _evict_local(cls, keys: set[str]) -> None:

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -58,6 +58,8 @@ def pjx_load_field_names(model_cls: type[Any]) -> list[str]:
             names.append(name)
     if names:
         return names
+    # During __init_subclass__ pydantic has not yet populated model_fields, so
+    # fall back to the raw annotations to detect the PjxLoad marker at definition.
     for name, annotation in getattr(model_cls, "__annotations__", {}).items():
         if _annotation_has_pjx_load(annotation):
             names.append(name)

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -91,12 +91,6 @@ def load_template_for_component(
     )
 
 
-def find_template_for_tag(renderer: Renderer, tag_name: str) -> str:
-    loader_root = get_loader_root(renderer.environment)
-    finder = get_finder_for_root(renderer, loader_root)
-    return finder.find_template_for_tag(tag_name)
-
-
 def build_render_context(context: dict[str, Any]) -> dict[str, Any]:
     render_context = dict(context)
     for instance in Registry.get_instances().values():
@@ -249,22 +243,10 @@ class Renderer:
     def new_session(self) -> RenderSession:
         return RenderSession()
 
-    def _load_template_for_component(
-        self,
-        component: BaseComponent,
-        *,
-        template_source: str | None,
-        template_path: str | None,
-    ):
-        return load_template_for_component(
-            self,
-            component,
-            template_source=template_source,
-            template_path=template_path,
-        )
-
     def _find_template_for_tag(self, tag_name: str) -> str:
-        return find_template_for_tag(self, tag_name)
+        loader_root = get_loader_root(self._environment)
+        finder = get_finder_for_root(self, loader_root)
+        return finder.find_template_for_tag(tag_name)
 
     def render_component_with_context(
         self,
@@ -280,8 +262,8 @@ class Renderer:
         loaded_assets: frozenset[str] = frozenset(),
         client: object | None = None,
     ) -> Markup:
-        template = self._load_template_for_component(
-            component, template_source=template_source, template_path=template_path
+        template = load_template_for_component(
+            self, component, template_source=template_source, template_path=template_path
         )
 
         render_context = build_render_context(context)

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -10,6 +10,7 @@ from markupsafe import Markup
 from .assets import (
     DEFAULT_RUNTIME_URL as _DEFAULT_RUNTIME_URL,
     AssetMode,
+    AssetPolicy,
     AssetUrlResolver,
     RenderSession,
     apply_component_render_assets,
@@ -297,6 +298,13 @@ class Renderer:
         if not emit_assets:
             return Markup(rendered_markup).unescape()
 
+        policy = AssetPolicy(
+            js_mode=self._js_mode,
+            css_mode=self._css_mode,
+            resolve_url=self._resolve_asset_url,
+            loaded_assets=loaded_assets,
+            dedup_enabled=Renderer._default_asset_dedup,
+        )
         rendered_markup = apply_component_render_assets(
             component,
             rendered_markup,
@@ -304,11 +312,7 @@ class Renderer:
             template_path=template_path,
             is_root=is_root,
             collect_component_js=collect_component_js,
-            js_mode=self._js_mode,
-            css_mode=self._css_mode,
-            resolve_url=self._resolve_asset_url,
-            loaded_assets=loaded_assets,
-            dedup_enabled=Renderer._default_asset_dedup,
+            policy=policy,
             client=client,
         )
         return Markup(rendered_markup).unescape()
@@ -330,12 +334,11 @@ class Renderer:
             for node in parser.root_nodes
         )
         if self._css_mode != AssetMode.NONE or self._js_mode != AssetMode.NONE:
-            rendered_markup = inject_assets(
-                rendered_markup,
-                session,
+            policy = AssetPolicy(
                 js_mode=self._js_mode,
                 css_mode=self._css_mode,
                 resolve_url=self._resolve_asset_url,
                 dedup_enabled=Renderer._default_asset_dedup,
             )
+            rendered_markup = inject_assets(rendered_markup, session, policy=policy)
         return rendered_markup.strip()

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -13,7 +13,6 @@ from .assets import (
     AssetUrlResolver,
     RenderSession,
     apply_component_render_assets,
-    asset_mode_from_inline,
     inject_assets,
     make_default_asset_url_resolver,
     normalize_asset_path,
@@ -168,14 +167,6 @@ class Renderer:
         cls._default_renderers.clear()
 
     @classmethod
-    def set_default_inline_js(cls, inline_js: bool) -> None:
-        cls.set_default_js_mode(asset_mode_from_inline(inline_js))
-
-    @classmethod
-    def set_default_inline_css(cls, inline_css: bool) -> None:
-        cls.set_default_css_mode(asset_mode_from_inline(inline_css))
-
-    @classmethod
     def set_default_runtime_url(cls, url: str) -> None:
         cls._default_runtime_url = url
         cls._default_renderers.clear()
@@ -201,30 +192,12 @@ class Renderer:
         cls,
         *,
         auto_id: bool = True,
-        inline_js: bool | None = None,
-        inline_css: bool | None = None,
         js_mode: AssetMode | None = None,
         css_mode: AssetMode | None = None,
     ):
         environment = cls.get_default_environment()
-        effective_js_mode = (
-            js_mode
-            if js_mode is not None
-            else (
-                asset_mode_from_inline(inline_js)
-                if inline_js is not None
-                else cls._default_js_mode
-            )
-        )
-        effective_css_mode = (
-            css_mode
-            if css_mode is not None
-            else (
-                asset_mode_from_inline(inline_css)
-                if inline_css is not None
-                else cls._default_css_mode
-            )
-        )
+        effective_js_mode = js_mode if js_mode is not None else cls._default_js_mode
+        effective_css_mode = css_mode if css_mode is not None else cls._default_css_mode
         resolver_id = id(cls._asset_url_resolver)
         cache_key = (
             id(environment),
@@ -249,25 +222,13 @@ class Renderer:
         environment: Environment,
         *,
         auto_id: bool = True,
-        inline_js: bool | None = None,
-        inline_css: bool | None = None,
         js_mode: AssetMode | None = None,
         css_mode: AssetMode | None = None,
     ) -> None:
         self._environment = environment
         self._auto_id = auto_id
-        if js_mode is not None:
-            self._js_mode = js_mode
-        elif inline_js is not None:
-            self._js_mode = asset_mode_from_inline(inline_js)
-        else:
-            self._js_mode = Renderer._default_js_mode
-        if css_mode is not None:
-            self._css_mode = css_mode
-        elif inline_css is not None:
-            self._css_mode = asset_mode_from_inline(inline_css)
-        else:
-            self._css_mode = Renderer._default_css_mode
+        self._js_mode = js_mode if js_mode is not None else Renderer._default_js_mode
+        self._css_mode = css_mode if css_mode is not None else Renderer._default_css_mode
         self._template_finder_cache: dict[str, object] = {}
 
     @property

--- a/tests/25_css_collection_test.py
+++ b/tests/25_css_collection_test.py
@@ -1,4 +1,4 @@
-from pyjinhx import Renderer
+from pyjinhx import AssetMode, Renderer
 from tests.ui.unified_component import UnifiedComponent
 
 
@@ -72,8 +72,8 @@ def test_missing_extra_css_warns(caplog):
     assert any("nonexistent.css" in record.message for record in caplog.records)
 
 
-def test_inline_css_false_disables_injection():
-    renderer = Renderer.get_default_renderer(inline_css=False)
+def test_css_mode_none_disables_injection():
+    renderer = Renderer.get_default_renderer(css_mode=AssetMode.NONE)
     component = UnifiedComponent(id="css-off-1", text="No CSS")
 
     rendered = str(component._render(_renderer=renderer))

--- a/tests/50_asset_reference_mode_test.py
+++ b/tests/50_asset_reference_mode_test.py
@@ -117,8 +117,8 @@ def test_none_mode_stays_silent():
     assert "<link" not in rendered
 
 
-def test_set_default_inline_js_false_maps_to_none():
-    Renderer.set_default_inline_js(False)
+def test_set_default_js_mode_none():
+    Renderer.set_default_js_mode(AssetMode.NONE)
     renderer = Renderer.get_default_renderer()
     assert renderer._js_mode == AssetMode.NONE
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from pyjinhx.cache import InvalidationHub
 def _noop_inject_runtime(
     session: RenderSession,
     *,
-    js_mode: Any,
+    policy: Any,
     client: object | None = None,
 ) -> None:
     return


### PR DESCRIPTION
Follow-up to #33 (stacked on `refactor/flatten-engine`). A behavior-preserving footprint sweep — engine **3,564 → 3,450 lines**, all 303 tests green at every commit.

## What changed
- **Drop the legacy `inline_js`/`inline_css` asset API.** Superseded by `AssetMode` (`js_mode`/`css_mode`). Removes the boolean kwargs, `set_default_inline_js`/`set_default_inline_css`, `asset_mode_from_inline`, and the precedence ternaries; the two tests use `AssetMode.NONE` directly.
- **Bundle the asset-pipeline config into a frozen `AssetPolicy`.** Replaces `js_mode/css_mode/resolve_url/loaded_assets/dedup_enabled` threaded through six functions; drops the `asset_mode()` dispatcher. `assets.py`: 422 → 358.
- **De-dup the load-cache reverse-index removal** (`LoadCache._drop_reverse`) and **drop the template-loader wrapper indirection** in `renderer.py`.
- **Documented** (not removed) why `pjx_load_field_names` falls back to `__annotations__`: it's load-bearing — during `__init_subclass__` pydantic hasn't populated `model_fields` yet, so PjxLoad detection needs the raw annotations. (The audit flagged it as possibly-dead; the test gate proved otherwise, so it stays.)
- **Docs:** updated README package-layout table + `usage-tiers` for the flat module structure, and removed the legacy `inline_*` API from the Renderer API docs, assets guide, and claude-code notes.

## Not done (deliberately)
All Tier-3 features kept per your call: the `builtins/` UI kit, REFERENCE asset mode + hashing/dedup, and PROCESS scope + Redis invalidation. The remaining large footprint is genuine feature surface, not dead code.

## Test plan
- [x] `uv run pytest tests/` → 303 passed (unit + integration)
- [x] `uv run ruff check .` → clean
- [x] `uv run mkdocs build --strict` → builds (clean-checkout state)
- [x] public API unchanged except the intentionally-removed legacy `inline_*` shims

🤖 Generated with [Claude Code](https://claude.com/claude-code)