### PR TITLE
Reactive in-flight loading indicators (skeleton + spinner) + demo design system

### DIFF
--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -387,6 +387,26 @@ setup(
 
 Requires `pip install pyjinhx[redis]`. See [Redis integration](api/integrations-redis.md).
 
+## Loading shimmer (in-flight)
+
+A reactive region can shimmer over its current content while a reactive update is in
+flight, then swap in the fresh HTML when the response arrives. Opt in per component:
+
+```python
+class TodoCounter(ReactiveComponent):
+    remaining: int
+    reacts_to: ClassVar[set[str]] = {"todos"}
+    loading_skeleton: ClassVar[bool] = True   # shimmer while reloading
+```
+
+How it works: every reactive root is stamped with `data-pjx-reacts` (its state keys), and
+opted-in roots also get `data-pjx-skeleton`. When an htmx request starts, `pjx.js` reads
+the target region's `data-pjx-reacts` as the predicted dirtied set and adds a `.pjx-loading`
+shimmer class to every mounted opted-in region whose keys intersect it — the swap target
+*and* its out-of-band dependents. The class is removed when the response arrives (swapped
+regions replace themselves; hash-gated/unchanged regions are cleared). It is purely a
+client affordance: no server reactive semantics change, and it is off unless you opt in.
+
 ## Boundaries
 
 - **Hash gating is a skip-hint, not correctness authority**: a matching client hash

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -391,37 +391,75 @@ Requires `pip install pyjinhx[redis]`. See [Redis integration](api/integrations-
 
 ## Loading indicators (in-flight)
 
-A reactive region can show a loading indicator while a reactive update is in flight, then
-swap in the fresh HTML when the response arrives. Opt in per component with `loading`:
+A reactive region can show a loading indicator while an update is in flight, then swap in the
+fresh HTML when the response arrives. You opt in **in the template** by adding a
+`data-pjx-loading` attribute to whichever element(s) should show the effect — the component
+root, or any element inside it:
 
-```python
-class TodoCounter(ReactiveComponent):
-    remaining: int
-    reacts_to: ClassVar[set[str]] = {"todos"}
-    loading: ClassVar[str] = "skeleton"   # or "spinner"
+```html
+<!-- item_row.html: shimmer the whole row while it reloads -->
+<li class="todo" data-pjx-loading="skeleton">…</li>
+
+<!-- clear_button.html: spin just this button -->
+<button class="clear" data-pjx-loading="spinner">Clear completed ({{ completed }})</button>
 ```
 
-Two styles:
+Two built-in styles:
 
-- **`"skeleton"`** — a silhouette shimmer in place of the region's content (the box keeps
-  its shape; the content is hidden while it shimmers).
-- **`"spinner"`** — a dim overlay with a centered circular progress indicator; the content
-  stays visible underneath and the region is non-interactive while loading. Good for
-  buttons (e.g. a "Clear completed" button).
+- **`"skeleton"`** — a silhouette shimmer in place of the element's content (the box keeps its
+  shape; the content is hidden while it shimmers).
+- **`"spinner"`** — a dim, blurred overlay with a centered circular progress indicator; the
+  content stays underneath and the element is non-interactive while loading.
 
-How it works: every reactive root is stamped with `data-pjx-reacts` (its state keys), and
-opted-in roots also get `data-pjx-loading="<style>"`. When an htmx request starts, `pjx.js`
-reads the target region's `data-pjx-reacts` as the predicted dirtied set and adds a
-`.pjx-loading--<style>` class to every mounted opted-in region whose keys intersect it — the
-swap target *and* its out-of-band dependents. The class is removed when the response arrives
-(swapped regions replace themselves; hash-gated/unchanged and aborted/errored regions are
-cleared). It is purely a client affordance: no server reactive semantics change, and it is
-off unless you opt in.
+**Auto-triggered — no per-route wiring.** Every reactive root is stamped with `data-pjx-reacts`
+(its `reacts_to` keys). When an htmx request starts, `pjx.js` reads the triggering region's
+`data-pjx-reacts` as the predicted dirtied set, then lights the `data-pjx-loading` elements of
+**every mounted region whose keys intersect it** — the swap target *and* its out-of-band
+dependents. Declaring `reacts_to` is all it takes for a component's loading elements to fire on
+the right mutations; routes don't change.
 
-A trigger can also carry `data-pjx-loading-extra="<css-selector>"` to flag regions the
-dependency walk can't predict on its own — e.g. the specific rows a bulk action like
-"clear completed" is about to remove. Matched elements use their own `data-pjx-loading`
-style and are cleared on response like any other.
+- A loading element is matched through its **enclosing reactive root**, so it can sit on the
+  root or any inner element; the root supplies the reactivity and the instance key.
+- **Instance-keyed rows stay scoped:** the template renders per instance, so each instance
+  carries the attribute, but only the instance whose `data-pjx-load` matches the trigger (plus
+  singleton dependents) lights up — clicking one row doesn't shimmer its siblings.
+- Indicators are **ref-counted across overlapping requests** and re-applied across swaps, so a
+  shared dependent stays lit until the *last* in-flight request finishes.
+- The class clears once the response settles (swapped regions replace themselves; hash-gated,
+  aborted, and errored requests are released too). Purely a client affordance — no server
+  reactive semantics change, and it is off unless an element opts in.
+
+A trigger can also carry `data-pjx-loading-extra="<css-selector>"` to light regions the
+dependency walk can't predict — e.g. the specific rows a bulk action like "clear completed" is
+about to remove. Matched regions use their own `data-pjx-loading` style.
+
+### Styling and overrides
+
+Both styles read overridable CSS custom properties (with sensible defaults), so you can restyle
+them from your own CSS without touching the runtime — set the tokens on `:root`, a theme
+wrapper, or a specific element:
+
+```css
+:root {
+  /* spinner */
+  --pjx-spinner-color: #b8ff4d;             /* the moving arc */
+  --pjx-spinner-track: rgba(255, 255, 255, 0.4);
+  --pjx-spinner-overlay: rgba(0, 0, 0, 0.45); /* dim/scrim behind it */
+  --pjx-spinner-blur: 2px;
+  --pjx-spinner-size: 1.1em;
+  --pjx-spinner-thickness: 2px;
+  --pjx-spinner-speed: 0.6s;
+  /* skeleton */
+  --pjx-skeleton-color: rgba(127, 127, 127, 0.12);     /* base */
+  --pjx-skeleton-highlight: rgba(127, 127, 127, 0.30); /* shimmer sweep */
+  --pjx-skeleton-radius: 6px;
+  --pjx-skeleton-speed: 1.2s;
+}
+```
+
+Want a different effect entirely? Use your own value (e.g. `data-pjx-loading="pulse"`) and
+style `.pjx-loading--pulse` yourself — `pjx.js` applies `.pjx-loading--<value>` regardless of
+the name.
 
 ## Boundaries
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -389,8 +389,9 @@ Requires `pip install pyjinhx[redis]`. See [Redis integration](api/integrations-
 
 ## Loading shimmer (in-flight)
 
-A reactive region can shimmer over its current content while a reactive update is in
-flight, then swap in the fresh HTML when the response arrives. Opt in per component:
+A reactive region can show a shimmer in place of its current content while a reactive
+update is in flight, then swap in the fresh HTML when the response arrives. Opt in per
+component:
 
 ```python
 class TodoCounter(ReactiveComponent):

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -418,6 +418,11 @@ swap target *and* its out-of-band dependents. The class is removed when the resp
 cleared). It is purely a client affordance: no server reactive semantics change, and it is
 off unless you opt in.
 
+A trigger can also carry `data-pjx-loading-extra="<css-selector>"` to flag regions the
+dependency walk can't predict on its own — e.g. the specific rows a bulk action like
+"clear completed" is about to remove. Matched elements use their own `data-pjx-loading`
+style and are cleared on response like any other.
+
 ## Boundaries
 
 - **Hash gating is a skip-hint, not correctness authority**: a matching client hash

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -389,26 +389,34 @@ setup(
 
 Requires `pip install pyjinhx[redis]`. See [Redis integration](api/integrations-redis.md).
 
-## Loading shimmer (in-flight)
+## Loading indicators (in-flight)
 
-A reactive region can show a shimmer in place of its current content while a reactive
-update is in flight, then swap in the fresh HTML when the response arrives. Opt in per
-component:
+A reactive region can show a loading indicator while a reactive update is in flight, then
+swap in the fresh HTML when the response arrives. Opt in per component with `loading`:
 
 ```python
 class TodoCounter(ReactiveComponent):
     remaining: int
     reacts_to: ClassVar[set[str]] = {"todos"}
-    loading_skeleton: ClassVar[bool] = True   # shimmer while reloading
+    loading: ClassVar[str] = "skeleton"   # or "spinner"
 ```
 
+Two styles:
+
+- **`"skeleton"`** — a silhouette shimmer in place of the region's content (the box keeps
+  its shape; the content is hidden while it shimmers).
+- **`"spinner"`** — a dim overlay with a centered circular progress indicator; the content
+  stays visible underneath and the region is non-interactive while loading. Good for
+  buttons (e.g. a "Clear completed" button).
+
 How it works: every reactive root is stamped with `data-pjx-reacts` (its state keys), and
-opted-in roots also get `data-pjx-skeleton`. When an htmx request starts, `pjx.js` reads
-the target region's `data-pjx-reacts` as the predicted dirtied set and adds a `.pjx-loading`
-shimmer class to every mounted opted-in region whose keys intersect it — the swap target
-*and* its out-of-band dependents. The class is removed when the response arrives (swapped
-regions replace themselves; hash-gated/unchanged regions are cleared). It is purely a
-client affordance: no server reactive semantics change, and it is off unless you opt in.
+opted-in roots also get `data-pjx-loading="<style>"`. When an htmx request starts, `pjx.js`
+reads the target region's `data-pjx-reacts` as the predicted dirtied set and adds a
+`.pjx-loading--<style>` class to every mounted opted-in region whose keys intersect it — the
+swap target *and* its out-of-band dependents. The class is removed when the response arrives
+(swapped regions replace themselves; hash-gated/unchanged and aborted/errored regions are
+cleared). It is purely a client affordance: no server reactive semantics change, and it is
+off unless you opt in.
 
 ## Boundaries
 

--- a/examples/reactive_todo/README.md
+++ b/examples/reactive_todo/README.md
@@ -17,12 +17,14 @@ What to watch (open the network tab):
 - **Clear completed** → the list and total update; the **"N left"** counter is skipped
   (remaining is unchanged).
 
-**Loading indicators:** components opt in with `loading`. `ItemRow` uses
-`loading = "skeleton"` (a silhouette shimmer while a row reloads); `ClearButton` uses
-`loading = "spinner"` (a dim overlay + circular progress, content kept visible). Toggling
-a row or clearing shows the indicator until the fresh HTML swaps in. The toggle/clear
-routes `time.sleep` briefly so this is visible on a fast local server — adding a todo stays
-instant (it shows no indicator). Set `PJX_DEMO_LATENCY=0` to disable.
+**Loading indicators:** opt in *in the template* with `data-pjx-loading`. `item_row.html`
+puts `data-pjx-loading="skeleton"` on the row (a silhouette shimmer while it reloads);
+`clear_button.html` puts `data-pjx-loading="spinner"` on the button (a dim, blurred overlay +
+circular progress). The element auto-triggers off its component's `reacts_to`, so toggling a
+row or clearing shows the indicator until the fresh HTML swaps in. The toggle/clear routes
+`time.sleep` briefly so this is visible on a fast local server — adding a todo stays instant
+(no indicator). Set `PJX_DEMO_LATENCY=0` to disable; restyle via the `--pjx-*` CSS tokens
+(see [Loading indicators](../../docs/reactivity.md)).
 
 The routes never mention the counter/total/clear button — `@mutates` and
 `@mutates` accumulates dirtied keys automatically, and `setup()` wires

--- a/examples/reactive_todo/README.md
+++ b/examples/reactive_todo/README.md
@@ -17,10 +17,12 @@ What to watch (open the network tab):
 - **Clear completed** → the list and total update; the **"N left"** counter is skipped
   (remaining is unchanged).
 
-**Loading shimmer:** `Counter` and `Total` set `loading_skeleton = True`, so when you
-toggle/add a todo they show a shimmer over their current value until the server's fresh
-value swaps in. (Each `load()` has a small artificial `time.sleep` so the effect is
-visible on a fast local server — remove it in real apps.)
+**Loading indicators:** components opt in with `loading`. `ItemList`, `Counter`, and
+`Total` use `loading = "skeleton"` (a silhouette shimmer in place of their content);
+`ClearButton` uses `loading = "spinner"` (a dim overlay + circular progress, content kept
+visible). When you toggle/add/clear a todo, the affected regions show their indicator until
+the server's fresh HTML swaps in. (`Counter`/`Total` `load()` have a small artificial
+`time.sleep` so the effect is visible on a fast local server — remove it in real apps.)
 
 The routes never mention the counter/total/clear button — `@mutates` and
 `@mutates` accumulates dirtied keys automatically, and `setup()` wires

--- a/examples/reactive_todo/README.md
+++ b/examples/reactive_todo/README.md
@@ -17,6 +17,11 @@ What to watch (open the network tab):
 - **Clear completed** → the list and total update; the **"N left"** counter is skipped
   (remaining is unchanged).
 
+**Loading shimmer:** `Counter` and `Total` set `loading_skeleton = True`, so when you
+toggle/add a todo they show a shimmer over their current value until the server's fresh
+value swaps in. (Each `load()` has a small artificial `time.sleep` so the effect is
+visible on a fast local server — remove it in real apps.)
+
 The routes never mention the counter/total/clear button — `@mutates` and
 `@mutates` accumulates dirtied keys automatically, and `setup()` wires
 `ClientBackend` so `render()` reads `X-PJX-Mounted` from the request.

--- a/examples/reactive_todo/README.md
+++ b/examples/reactive_todo/README.md
@@ -17,12 +17,12 @@ What to watch (open the network tab):
 - **Clear completed** → the list and total update; the **"N left"** counter is skipped
   (remaining is unchanged).
 
-**Loading indicators:** components opt in with `loading`. `ItemList`, `Counter`, and
-`Total` use `loading = "skeleton"` (a silhouette shimmer in place of their content);
-`ClearButton` uses `loading = "spinner"` (a dim overlay + circular progress, content kept
-visible). When you toggle/add/clear a todo, the affected regions show their indicator until
-the server's fresh HTML swaps in. (`Counter`/`Total` `load()` have a small artificial
-`time.sleep` so the effect is visible on a fast local server — remove it in real apps.)
+**Loading indicators:** components opt in with `loading`. `ItemRow` uses
+`loading = "skeleton"` (a silhouette shimmer while a row reloads); `ClearButton` uses
+`loading = "spinner"` (a dim overlay + circular progress, content kept visible). Toggling
+a row or clearing shows the indicator until the fresh HTML swaps in. The toggle/clear
+routes `time.sleep` briefly so this is visible on a fast local server — adding a todo stays
+instant (it shows no indicator). Set `PJX_DEMO_LATENCY=0` to disable.
 
 The routes never mention the counter/total/clear button — `@mutates` and
 `@mutates` accumulates dirtied keys automatically, and `setup()` wires

--- a/examples/reactive_todo/app.html
+++ b/examples/reactive_todo/app.html
@@ -2,29 +2,271 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>pyjinhx · reactive todos</title>
     <script src="https://unpkg.com/htmx.org@2.0.3"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
     <style>
-      body { font-family: system-ui, sans-serif; max-width: 32rem; margin: 2rem auto; }
-      ul { list-style: none; padding: 0; }
-      li { display: flex; gap: .5rem; align-items: center; padding: .25rem 0; }
-      li.done span { text-decoration: line-through; opacity: .55; }
-      .meta { margin-top: 1rem; display: flex; gap: 1rem; align-items: center; }
-      button { cursor: pointer; }
+      /* design tokens */
+      :root {
+        --bg: #0b0c0f;
+        --panel: #111318;
+        --panel-2: #0e1014;
+        --edge: #1e212a;
+        --row: #15171d;
+        --row-hover: #1a1d25;
+        --line: rgba(255, 255, 255, 0.07);
+        --line-2: rgba(255, 255, 255, 0.13);
+        --text: #e8eaef;
+        --muted: #828897;
+        --faint: #555c6b;
+        --accent: #b8ff4d;
+        --accent-ink: #0b0c0f;
+        --danger: #ff7d7d;
+        --radius: 12px;
+        --mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+      }
+
+      * { box-sizing: border-box; }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 7vh 1.25rem 4rem;
+        font-family: var(--mono);
+        font-size: 15px;
+        line-height: 1.5;
+        letter-spacing: 0.01em;
+        color: var(--text);
+        background: radial-gradient(130% 90% at 50% -20%, #181b23 0%, var(--bg) 60%) fixed;
+        -webkit-font-smoothing: antialiased;
+      }
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        z-index: 0;
+        pointer-events: none;
+        background-image: radial-gradient(rgba(255, 255, 255, 0.022) 1px, transparent 1px);
+        background-size: 22px 22px;
+      }
+
+      /* panel */
+      .panel {
+        position: relative;
+        z-index: 1;
+        width: 100%;
+        max-width: 33rem;
+        overflow: hidden;
+        background: linear-gradient(180deg, var(--panel) 0%, var(--panel-2) 100%);
+        border: 1px solid var(--edge);
+        border-radius: var(--radius);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.05),
+          0 30px 70px -28px rgba(0, 0, 0, 0.8);
+        animation: panel-in 0.55s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+      }
+
+      .bar {
+        display: flex;
+        align-items: center;
+        padding: 0.85rem 1.15rem;
+        border-bottom: 1px solid var(--line);
+        background: rgba(255, 255, 255, 0.015);
+      }
+      .bar__title { font-weight: 600; letter-spacing: 0.05em; }
+      .bar__title::before { content: "› "; color: var(--accent); }
+      .bar__dot {
+        margin-left: auto;
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 50%;
+        background: var(--accent);
+        animation: pulse 2.8s ease-out infinite;
+      }
+
+      /* add form */
+      .composer {
+        display: flex;
+        align-items: center;
+        gap: 0.55rem;
+        padding: 0.65rem 1.15rem;
+        border-bottom: 1px solid var(--line);
+        transition: background 0.2s ease;
+      }
+      .composer:focus-within { background: rgba(184, 255, 77, 0.035); }
+      .composer__prompt { color: var(--accent); font-weight: 600; }
+      .composer__input {
+        flex: 1;
+        min-width: 0;
+        padding: 0.4rem 0;
+        font: inherit;
+        color: var(--text);
+        background: transparent;
+        border: 0;
+        outline: none;
+        caret-color: var(--accent);
+      }
+      .composer__input::placeholder { color: var(--faint); }
+      .composer__add {
+        flex: none;
+        display: grid;
+        place-items: center;
+        width: 2.1rem;
+        height: 2.1rem;
+        font: inherit;
+        font-size: 1.25rem;
+        line-height: 1;
+        color: var(--accent-ink);
+        background: var(--accent);
+        border: 0;
+        border-radius: 8px;
+        cursor: pointer;
+        transition: box-shadow 0.2s ease, transform 0.1s ease;
+      }
+      .composer__add:hover { box-shadow: 0 0 20px -2px var(--accent); }
+      .composer__add:active { transform: scale(0.94); }
+
+      /* list + rows (#list is ItemList, li.todo is ItemRow) */
+      #list {
+        list-style: none;
+        margin: 0;
+        padding: 0.55rem 0.7rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.3rem;
+        min-height: 3.5rem;
+      }
+      #list:empty::after {
+        content: "no todos — add one above ↑";
+        display: block;
+        padding: 1.1rem 0.5rem;
+        text-align: center;
+        font-size: 0.85rem;
+        color: var(--faint);
+      }
+      .todo {
+        display: flex;
+        align-items: center;
+        gap: 0.7rem;
+        padding: 0.55rem 0.65rem;
+        border-radius: 9px;
+        background: var(--row);
+        border: 1px solid transparent;
+        transition: background 0.15s ease, border-color 0.15s ease;
+        animation: row-in 0.3s ease both;
+      }
+      .todo:hover { background: var(--row-hover); border-color: var(--line); }
+      .todo > button {
+        flex: none;
+        display: grid;
+        place-items: center;
+        width: 1.55rem;
+        height: 1.55rem;
+        font: inherit;
+        font-size: 0.95rem;
+        line-height: 1;
+        color: var(--muted);
+        background: transparent;
+        border: 1px solid var(--line-2);
+        border-radius: 7px;
+        cursor: pointer;
+        transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+      }
+      .todo > button:hover { color: var(--accent); border-color: var(--accent); }
+      .todo.done > button {
+        color: var(--accent-ink);
+        background: var(--accent);
+        border-color: var(--accent);
+      }
+      .todo > span { flex: 1; min-width: 0; }
+      .todo.done > span {
+        color: var(--muted);
+        text-decoration: line-through;
+        text-decoration-color: var(--faint);
+      }
+
+      /* status bar (counter / total / clear) */
+      .meta {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.7rem 1.15rem;
+        border-top: 1px solid var(--line);
+        background: rgba(0, 0, 0, 0.22);
+        font-size: 0.85rem;
+        color: var(--muted);
+      }
+      .meta .counter { color: var(--text); }
+      .meta__sep { color: var(--faint); }
+      .clear {
+        margin-left: auto;
+        padding: 0.32rem 0.7rem;
+        font: inherit;
+        font-size: 0.82rem;
+        color: var(--muted);
+        background: transparent;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        cursor: pointer;
+        transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+      }
+      .clear:hover {
+        color: var(--danger);
+        border-color: var(--danger);
+        background: rgba(255, 125, 125, 0.08);
+      }
+
+      .credit {
+        position: relative;
+        z-index: 1;
+        margin: 1.1rem 0 0;
+        font-size: 0.75rem;
+        letter-spacing: 0.04em;
+        color: var(--faint);
+      }
+      .credit b { color: var(--muted); font-weight: 600; }
+
+      /* focus + motion */
+      :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 6px; }
+      @keyframes panel-in { from { opacity: 0; transform: translateY(12px) scale(0.99); } to { opacity: 1; transform: none; } }
+      @keyframes row-in { from { opacity: 0; } to { opacity: 1; } }
+      @keyframes pulse { 0% { box-shadow: 0 0 0 0 rgba(184, 255, 77, 0.5); } 70%, 100% { box-shadow: 0 0 0 7px rgba(184, 255, 77, 0); } }
+      @media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; } }
     </style>
   </head>
   <body>
-    <h1>Todos</h1>
-    <form hx-post="/todos" hx-target="#list" hx-swap="beforeend"
-          hx-on::after-request="this.reset()">
-      <input name="text" placeholder="Add a todo…" autocomplete="off" required />
-      <button type="submit">Add</button>
-    </form>
-    {{ item_list }}
-    <div class="meta">
-      {{ remaining }}
-      {{ total_count }}
-      {{ clear_button }}
-    </div>
+    <main class="panel">
+      <header class="bar">
+        <span class="bar__title">todos</span>
+        <span class="bar__dot" aria-hidden="true"></span>
+      </header>
+
+      <form class="composer" hx-post="/todos" hx-target="#list" hx-swap="beforeend"
+            hx-on::after-request="this.reset()">
+        <span class="composer__prompt" aria-hidden="true">›</span>
+        <input class="composer__input" name="text" placeholder="add a todo…" autocomplete="off" required />
+        <button class="composer__add" type="submit" aria-label="add todo">+</button>
+      </form>
+
+      {{ item_list }}
+
+      <footer class="meta">
+        {{ remaining }}
+        <span class="meta__sep" aria-hidden="true">·</span>
+        {{ total_count }}
+        {{ clear_button }}
+      </footer>
+    </main>
+
+    <p class="credit"><b>pyjinhx</b> · reactive components over htmx</p>
   </body>
 </html>

--- a/examples/reactive_todo/app.py
+++ b/examples/reactive_todo/app.py
@@ -33,6 +33,10 @@ setup(
 )
 
 
+def _demo_latency() -> float:
+    return float(os.environ.get("PJX_DEMO_LATENCY", "0.5"))
+
+
 @app.get("/", response_class=HTMLResponse)
 def index() -> str:
     return App(
@@ -48,12 +52,6 @@ def index() -> str:
 def add(text: str = Form(...)) -> str:
     store.add(text)
     return ItemRow.render(store.all_todos()[-1].id)
-
-
-def _demo_latency() -> float:
-    # demo-only pause on the actions that show a loading state, so the skeleton/
-    # spinner are visible on a fast local server; set PJX_DEMO_LATENCY=0 to disable.
-    return float(os.environ.get("PJX_DEMO_LATENCY", "0.5"))
 
 
 @app.post("/rows/{todo_id}/toggle", response_class=HTMLResponse)

--- a/examples/reactive_todo/app.py
+++ b/examples/reactive_todo/app.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import sys
+import time
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
@@ -48,15 +50,23 @@ def add(text: str = Form(...)) -> str:
     return ItemRow.render(store.all_todos()[-1].id)
 
 
+def _demo_latency() -> float:
+    # demo-only pause on the actions that show a loading state, so the skeleton/
+    # spinner are visible on a fast local server; set PJX_DEMO_LATENCY=0 to disable.
+    return float(os.environ.get("PJX_DEMO_LATENCY", "0.5"))
+
+
 @app.post("/rows/{todo_id}/toggle", response_class=HTMLResponse)
 def toggle_row(todo_id: int) -> str:
     store.toggle(todo_id)
+    time.sleep(_demo_latency())
     return ItemRow.render(todo_id)
 
 
 @app.post("/todos/clear-completed", response_class=HTMLResponse)
 def clear_completed() -> str:
     store.clear_completed()
+    time.sleep(_demo_latency())
     return ItemList.render()
 
 

--- a/examples/reactive_todo/clear_button.html
+++ b/examples/reactive_todo/clear_button.html
@@ -1,4 +1,4 @@
 <button class="clear" hx-post="/todos/clear-completed" hx-target="#list" hx-swap="outerHTML"
-        data-pjx-loading-extra=".todo.done">
+        data-pjx-loading="spinner" data-pjx-loading-extra=".todo.done">
   Clear completed ({{ completed }})
 </button>

--- a/examples/reactive_todo/clear_button.html
+++ b/examples/reactive_todo/clear_button.html
@@ -1,3 +1,4 @@
-<button class="clear" hx-post="/todos/clear-completed" hx-target="#list" hx-swap="outerHTML">
+<button class="clear" hx-post="/todos/clear-completed" hx-target="#list" hx-swap="outerHTML"
+        data-pjx-loading-extra=".todo.done">
   Clear completed ({{ completed }})
 </button>

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -1,3 +1,4 @@
+import time
 from dataclasses import dataclass
 from typing import Annotated, ClassVar, Optional
 
@@ -57,18 +58,22 @@ class ItemList(ReactiveComponent):
 class Counter(ReactiveComponent):
     remaining: int = 0
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}
+    loading_skeleton: ClassVar[bool] = True
 
     @classmethod
     def load(cls) -> "Counter":
+        time.sleep(0.4)  # demo only: artificial latency so the loading shimmer is visible
         return cls(remaining=_store().remaining())
 
 
 class Total(ReactiveComponent):
     count: int = 0
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}
+    loading_skeleton: ClassVar[bool] = True
 
     @classmethod
     def load(cls) -> "Total":
+        time.sleep(0.4)  # demo only: artificial latency so the loading shimmer is visible
         return cls(count=_store().total())
 
 

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -45,6 +45,7 @@ class ItemRow(ReactiveComponent):
 class ItemList(ReactiveComponent):
     items: list[ItemRow] = []
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}
+    loading: ClassVar[str] = "skeleton"
 
     @classmethod
     def load(cls) -> "ItemList":
@@ -58,28 +59,33 @@ class ItemList(ReactiveComponent):
 class Counter(ReactiveComponent):
     remaining: int = 0
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}
-    loading_skeleton: ClassVar[bool] = True
+    loading: ClassVar[str] = "skeleton"
 
     @classmethod
     def load(cls) -> "Counter":
-        time.sleep(0.4)  # demo only: artificial latency so the loading shimmer is visible
+        time.sleep(
+            0.4
+        )  # demo only: artificial latency so the loading shimmer is visible
         return cls(remaining=_store().remaining())
 
 
 class Total(ReactiveComponent):
     count: int = 0
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}
-    loading_skeleton: ClassVar[bool] = True
+    loading: ClassVar[str] = "skeleton"
 
     @classmethod
     def load(cls) -> "Total":
-        time.sleep(0.4)  # demo only: artificial latency so the loading shimmer is visible
+        time.sleep(
+            0.4
+        )  # demo only: artificial latency so the loading shimmer is visible
         return cls(count=_store().total())
 
 
 class ClearButton(ReactiveComponent):
     completed: int = 0
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}
+    loading: ClassVar[str] = "spinner"
 
     @classmethod
     def load(cls) -> "ClearButton":

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -28,6 +28,7 @@ class ItemRow(ReactiveComponent):
     title: str = ""
     done: bool = False
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}
+    loading: ClassVar[str] = "skeleton"
 
     @classmethod
     def load(cls, todo_id: int | str) -> "ItemRow":
@@ -44,8 +45,7 @@ class ItemRow(ReactiveComponent):
 
 class ItemList(ReactiveComponent):
     items: list[ItemRow] = []
-    reacts_to: ClassVar[set[str]] = {Keys.TODOS}
-    loading: ClassVar[str] = "skeleton"
+    reacts_to: ClassVar[set[str]] = {Keys.TODO_LIST}
 
     @classmethod
     def load(cls) -> "ItemList":
@@ -59,7 +59,6 @@ class ItemList(ReactiveComponent):
 class Counter(ReactiveComponent):
     remaining: int = 0
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}
-    loading: ClassVar[str] = "skeleton"
 
     @classmethod
     def load(cls) -> "Counter":
@@ -72,7 +71,6 @@ class Counter(ReactiveComponent):
 class Total(ReactiveComponent):
     count: int = 0
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}
-    loading: ClassVar[str] = "skeleton"
 
     @classmethod
     def load(cls) -> "Total":

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -1,4 +1,3 @@
-import time
 from dataclasses import dataclass
 from typing import Annotated, ClassVar, Optional
 
@@ -62,9 +61,6 @@ class Counter(ReactiveComponent):
 
     @classmethod
     def load(cls) -> "Counter":
-        time.sleep(
-            0.4
-        )  # demo only: artificial latency so the loading shimmer is visible
         return cls(remaining=_store().remaining())
 
 
@@ -74,9 +70,6 @@ class Total(ReactiveComponent):
 
     @classmethod
     def load(cls) -> "Total":
-        time.sleep(
-            0.4
-        )  # demo only: artificial latency so the loading shimmer is visible
         return cls(count=_store().total())
 
 

--- a/examples/reactive_todo/item_row.html
+++ b/examples/reactive_todo/item_row.html
@@ -1,4 +1,4 @@
-<li class="todo{% if done %} done{% endif %}">
+<li class="todo{% if done %} done{% endif %}" data-pjx-loading="skeleton">
   <button hx-post="/rows/{{ todo_id }}/toggle" hx-target="closest [data-pjx-id]" hx-swap="outerHTML"
           aria-label="toggle">{% if done %}✓{% else %}○{% endif %}</button>
   <span>{{ title }}</span>

--- a/examples/reactive_todo/keys.py
+++ b/examples/reactive_todo/keys.py
@@ -3,3 +3,4 @@ from pyjinhx import StateKey
 
 class Keys(StateKey):
     TODOS = "todos"
+    TODO_LIST = "todo-list"

--- a/examples/reactive_todo/store.py
+++ b/examples/reactive_todo/store.py
@@ -41,7 +41,7 @@ def toggle(todo_id: int) -> Todo:
     return _todos[todo_id]
 
 
-@mutates(Keys.TODOS)
+@mutates(Keys.TODOS, Keys.TODO_LIST)
 def clear_completed() -> None:
     for todo_id in [tid for tid, t in _todos.items() if t.done]:
         del _todos[todo_id]

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -183,9 +183,7 @@ class ReactiveComponent(BaseComponent):
 
     reacts_to: ClassVar[set[str]] = set()
     state_hash_exclude: ClassVar[frozenset[str]] = frozenset({"id"})
-    # In-flight loading indicator while this region reloads: "skeleton" (silhouette
-    # shimmer) or "spinner" (dim overlay + circular progress). None = no indicator.
-    loading: ClassVar[str | None] = None
+    loading: ClassVar[str | None] = None  # "skeleton" | "spinner"
 
     _pjx_key: str | None = PrivateAttr(default=None)
 

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -183,7 +183,6 @@ class ReactiveComponent(BaseComponent):
 
     reacts_to: ClassVar[set[str]] = set()
     state_hash_exclude: ClassVar[frozenset[str]] = frozenset({"id"})
-    loading: ClassVar[str | None] = None  # "skeleton" | "spinner"
 
     _pjx_key: str | None = PrivateAttr(default=None)
 

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -183,7 +183,9 @@ class ReactiveComponent(BaseComponent):
 
     reacts_to: ClassVar[set[str]] = set()
     state_hash_exclude: ClassVar[frozenset[str]] = frozenset({"id"})
-    loading_skeleton: ClassVar[bool] = False
+    # In-flight loading indicator while this region reloads: "skeleton" (silhouette
+    # shimmer) or "spinner" (dim overlay + circular progress). None = no indicator.
+    loading: ClassVar[str | None] = None
 
     _pjx_key: str | None = PrivateAttr(default=None)
 

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -183,6 +183,7 @@ class ReactiveComponent(BaseComponent):
 
     reacts_to: ClassVar[set[str]] = set()
     state_hash_exclude: ClassVar[frozenset[str]] = frozenset({"id"})
+    loading_skeleton: ClassVar[bool] = False
 
     _pjx_key: str | None = PrivateAttr(default=None)
 

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -115,8 +115,9 @@ def stamp_reactive_markup(markup: str, component: BaseComponent) -> str:
     reacts = getattr(type(component), "_pjx_reacts_to", frozenset())
     if reacts:
         attrs["data-pjx-reacts"] = " ".join(sorted(reacts))
-    if getattr(type(component), "loading_skeleton", False):
-        attrs["data-pjx-skeleton"] = "true"
+    loading = getattr(type(component), "loading", None)
+    if loading:
+        attrs["data-pjx-loading"] = str(loading)
     return stamp_root_attributes(markup, attrs)
 
 

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -115,9 +115,6 @@ def stamp_reactive_markup(markup: str, component: BaseComponent) -> str:
     reacts = getattr(type(component), "_pjx_reacts_to", frozenset())
     if reacts:
         attrs["data-pjx-reacts"] = " ".join(sorted(reacts))
-    loading = getattr(type(component), "loading", None)
-    if loading:
-        attrs["data-pjx-loading"] = str(loading)
     return stamp_root_attributes(markup, attrs)
 
 

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -112,6 +112,11 @@ def stamp_reactive_markup(markup: str, component: BaseComponent) -> str:
     load_value = pjx_load_value(component)
     if load_value is not None:
         attrs["data-pjx-load"] = load_value
+    reacts = getattr(type(component), "_pjx_reacts_to", frozenset())
+    if reacts:
+        attrs["data-pjx-reacts"] = " ".join(sorted(reacts))
+    if getattr(type(component), "loading_skeleton", False):
+        attrs["data-pjx-skeleton"] = "true"
     return stamp_root_attributes(markup, attrs)
 
 

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -58,12 +58,21 @@
     var style = document.createElement("style");
     style.id = "pjx-style";
     style.textContent =
-      ".pjx-loading{color:transparent !important;border-radius:6px;" +
+      ".pjx-loading--skeleton,.pjx-loading--spinner{pointer-events:none}" +
+      ".pjx-loading--skeleton{color:transparent !important;border-radius:6px;" +
       "background-image:linear-gradient(90deg," +
       "rgba(127,127,127,.12),rgba(127,127,127,.30) 50%,rgba(127,127,127,.12));" +
       "background-size:200% 100%;animation:pjx-shimmer 1.2s ease-in-out infinite}" +
-      ".pjx-loading *{visibility:hidden}" +
-      "@keyframes pjx-shimmer{from{background-position:100% 0}to{background-position:-100% 0}}";
+      ".pjx-loading--skeleton *{visibility:hidden}" +
+      ".pjx-loading--spinner{position:relative}" +
+      ".pjx-loading--spinner::before{content:'';position:absolute;inset:0;" +
+      "background:rgba(127,127,127,.35);border-radius:inherit}" +
+      ".pjx-loading--spinner::after{content:'';position:absolute;top:50%;left:50%;" +
+      "width:1.1em;height:1.1em;margin:-.55em 0 0 -.55em;box-sizing:border-box;" +
+      "border:2px solid rgba(0,0,0,.2);border-top-color:rgba(0,0,0,.65);" +
+      "border-radius:50%;animation:pjx-spin .6s linear infinite}" +
+      "@keyframes pjx-shimmer{from{background-position:100% 0}to{background-position:-100% 0}}" +
+      "@keyframes pjx-spin{to{transform:rotate(360deg)}}";
     document.head.appendChild(style);
   }
 
@@ -87,14 +96,15 @@
     });
     var marked = [];
     Array.prototype.forEach.call(
-      document.querySelectorAll("[data-pjx-skeleton][data-pjx-reacts]"),
+      document.querySelectorAll("[data-pjx-loading][data-pjx-reacts]"),
       function (el) {
         var hit = pjxReacts(el).some(function (key) {
           return dirty[key];
         });
         if (hit) {
-          el.classList.add("pjx-loading");
-          marked.push(el);
+          var cls = "pjx-loading--" + (el.getAttribute("data-pjx-loading") || "skeleton");
+          el.classList.add(cls);
+          marked.push([el, cls]);
         }
       }
     );
@@ -109,8 +119,8 @@
     if (!marked) {
       return;
     }
-    marked.forEach(function (el) {
-      el.classList.remove("pjx-loading");
+    marked.forEach(function (pair) {
+      pair[0].classList.remove(pair[1]);
     });
     pjxLoadingByXhr.delete(xhr);
   }

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -58,11 +58,11 @@
     var style = document.createElement("style");
     style.id = "pjx-style";
     style.textContent =
-      ".pjx-loading{position:relative;overflow:hidden}" +
-      ".pjx-loading>*{opacity:.55;transition:opacity .15s ease}" +
-      ".pjx-loading::after{content:'';position:absolute;inset:0;pointer-events:none;" +
-      "background:linear-gradient(90deg,transparent,rgba(127,127,127,.18) 50%,transparent);" +
+      ".pjx-loading{color:transparent !important;border-radius:6px;" +
+      "background-image:linear-gradient(90deg," +
+      "rgba(127,127,127,.12),rgba(127,127,127,.30) 50%,rgba(127,127,127,.12));" +
       "background-size:200% 100%;animation:pjx-shimmer 1.2s ease-in-out infinite}" +
+      ".pjx-loading *{visibility:hidden}" +
       "@keyframes pjx-shimmer{from{background-position:100% 0}to{background-position:-100% 0}}";
     document.head.appendChild(style);
   }

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -95,18 +95,25 @@
     pjxReacts(root).forEach(function (key) {
       dirty[key] = true;
     });
+    var triggerLoad = root.getAttribute("data-pjx-load");
     var marked = [];
     Array.prototype.forEach.call(
       document.querySelectorAll("[data-pjx-loading][data-pjx-reacts]"),
       function (el) {
-        var hit = pjxReacts(el).some(function (key) {
-          return dirty[key];
-        });
-        if (hit) {
-          var cls = "pjx-loading--" + (el.getAttribute("data-pjx-loading") || "skeleton");
-          el.classList.add(cls);
-          marked.push([el, cls]);
+        if (!pjxReacts(el).some(function (key) { return dirty[key]; })) {
+          return;
         }
+        // Instance-keyed regions (data-pjx-load) share reacts_to across every instance,
+        // so reacts-matching alone can't tell which one will change. Flag only the keyed
+        // instance whose load key matches the trigger's; singletons (no data-pjx-load)
+        // are flagged by reacts_to as usual.
+        var elLoad = el.getAttribute("data-pjx-load");
+        if (elLoad !== null && elLoad !== triggerLoad) {
+          return;
+        }
+        var cls = "pjx-loading--" + (el.getAttribute("data-pjx-loading") || "skeleton");
+        el.classList.add(cls);
+        marked.push([el, cls]);
       }
     );
     if (marked.length) {

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -77,11 +77,20 @@
     document.head.appendChild(style);
   }
 
-  var pjxLoadingByXhr = new Map();
+  var pjxLoadingByXhr = new Map();  // xhr -> [region id, ...]
+  var pjxLoading = {};              // region id -> in-flight request count (ref-count)
 
   function pjxReacts(el) {
     var value = el.getAttribute("data-pjx-reacts");
     return value ? value.split(" ").filter(Boolean) : [];
+  }
+
+  function pjxLoadingClass(el) {
+    return "pjx-loading--" + (el.getAttribute("data-pjx-loading") || "skeleton");
+  }
+
+  function pjxRegion(id) {
+    return document.querySelector('[data-pjx-id="' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '"]');
   }
 
   function pjxBeginLoading(evt) {
@@ -96,11 +105,15 @@
       dirty[key] = true;
     });
     var triggerLoad = root.getAttribute("data-pjx-load");
-    var marked = [];
+    var ids = [];
     function mark(el) {
-      var cls = "pjx-loading--" + (el.getAttribute("data-pjx-loading") || "skeleton");
-      el.classList.add(cls);
-      marked.push([el, cls]);
+      var id = el.getAttribute("data-pjx-id");
+      if (!id) {
+        return;
+      }
+      el.classList.add(pjxLoadingClass(el));
+      pjxLoading[id] = (pjxLoading[id] || 0) + 1;
+      ids.push(id);
     }
     Array.prototype.forEach.call(
       document.querySelectorAll("[data-pjx-loading][data-pjx-reacts]"),
@@ -120,25 +133,48 @@
     if (extra) {
       Array.prototype.forEach.call(document.querySelectorAll(extra), mark);
     }
-    if (marked.length) {
-      pjxLoadingByXhr.set(xhr, marked);
+    if (ids.length) {
+      pjxLoadingByXhr.set(xhr, ids);
+      // loadend always fires (load/error/abort), even when htmx discards the
+      // response of a superseded request -- a reliable cue to release the refs
+      xhr.addEventListener("loadend", function () {
+        pjxEndLoading(xhr);
+      });
     }
   }
 
-  function pjxEndLoading(evt) {
-    var xhr = evt.detail && evt.detail.xhr;
-    var marked = xhr && pjxLoadingByXhr.get(xhr);
-    if (!marked) {
+  function pjxEndLoading(xhrOrEvt) {
+    var xhr = xhrOrEvt && xhrOrEvt.detail ? xhrOrEvt.detail.xhr : xhrOrEvt;
+    var ids = xhr && pjxLoadingByXhr.get(xhr);
+    if (!ids) {
       return;
     }
-    marked.forEach(function (pair) {
-      pair[0].classList.remove(pair[1]);
-    });
     pjxLoadingByXhr.delete(xhr);
+    ids.forEach(function (id) {
+      pjxLoading[id] -= 1;
+      if (pjxLoading[id] <= 0) {
+        delete pjxLoading[id];
+        var el = pjxRegion(id);
+        if (el) {
+          el.classList.remove(pjxLoadingClass(el));
+        }
+      }
+    });
+  }
+
+  // a swap can replace a region another in-flight request still needs lit
+  function pjxReapplyLoading() {
+    Object.keys(pjxLoading).forEach(function (id) {
+      var el = pjxRegion(id);
+      if (el) {
+        el.classList.add(pjxLoadingClass(el));
+      }
+    });
   }
 
   pjxInjectStyle();
   document.body.addEventListener("htmx:beforeRequest", pjxBeginLoading);
+  document.body.addEventListener("htmx:afterSettle", pjxReapplyLoading);
   document.body.addEventListener("htmx:afterOnLoad", pjxEndLoading);
   document.body.addEventListener("htmx:responseError", pjxEndLoading);
   document.body.addEventListener("htmx:timeout", pjxEndLoading);

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -66,7 +66,8 @@
       ".pjx-loading--skeleton *{visibility:hidden}" +
       ".pjx-loading--spinner{position:relative}" +
       ".pjx-loading--spinner::before{content:'';position:absolute;inset:0;" +
-      "background:rgba(0,0,0,.45);border-radius:inherit}" +
+      "background:rgba(0,0,0,.45);backdrop-filter:blur(2px);" +
+      "-webkit-backdrop-filter:blur(2px);border-radius:inherit}" +
       ".pjx-loading--spinner::after{content:'';position:absolute;top:50%;left:50%;" +
       "width:1.1em;height:1.1em;margin:-.55em 0 0 -.55em;box-sizing:border-box;" +
       "border:2px solid rgba(255,255,255,.4);border-top-color:rgba(255,255,255,.95);" +

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -57,21 +57,28 @@
     }
     var style = document.createElement("style");
     style.id = "pjx-style";
+    // styles read overridable --pjx-* custom properties (set them in your own CSS)
     style.textContent =
       ".pjx-loading--skeleton,.pjx-loading--spinner{pointer-events:none}" +
-      ".pjx-loading--skeleton{color:transparent !important;border-radius:6px;" +
-      "background-image:linear-gradient(90deg," +
-      "rgba(127,127,127,.12),rgba(127,127,127,.30) 50%,rgba(127,127,127,.12));" +
-      "background-size:200% 100%;animation:pjx-shimmer 1.2s ease-in-out infinite}" +
+      ".pjx-loading--skeleton{color:transparent !important;" +
+      "border-radius:var(--pjx-skeleton-radius,6px);background-image:linear-gradient(90deg," +
+      "var(--pjx-skeleton-color,rgba(127,127,127,.12))," +
+      "var(--pjx-skeleton-highlight,rgba(127,127,127,.30)) 50%," +
+      "var(--pjx-skeleton-color,rgba(127,127,127,.12)));background-size:200% 100%;" +
+      "animation:pjx-shimmer var(--pjx-skeleton-speed,1.2s) ease-in-out infinite}" +
       ".pjx-loading--skeleton *{visibility:hidden}" +
       ".pjx-loading--spinner{position:relative}" +
       ".pjx-loading--spinner::before{content:'';position:absolute;inset:0;" +
-      "background:rgba(0,0,0,.45);backdrop-filter:blur(2px);" +
-      "-webkit-backdrop-filter:blur(2px);border-radius:inherit}" +
+      "background:var(--pjx-spinner-overlay,rgba(0,0,0,.45));" +
+      "backdrop-filter:blur(var(--pjx-spinner-blur,2px));" +
+      "-webkit-backdrop-filter:blur(var(--pjx-spinner-blur,2px));border-radius:inherit}" +
       ".pjx-loading--spinner::after{content:'';position:absolute;top:50%;left:50%;" +
-      "width:1.1em;height:1.1em;margin:-.55em 0 0 -.55em;box-sizing:border-box;" +
-      "border:2px solid rgba(255,255,255,.4);border-top-color:rgba(255,255,255,.95);" +
-      "border-radius:50%;animation:pjx-spin .6s linear infinite}" +
+      "width:var(--pjx-spinner-size,1.1em);height:var(--pjx-spinner-size,1.1em);" +
+      "margin:calc(var(--pjx-spinner-size,1.1em)/-2) 0 0 calc(var(--pjx-spinner-size,1.1em)/-2);" +
+      "box-sizing:border-box;border:var(--pjx-spinner-thickness,2px) solid " +
+      "var(--pjx-spinner-track,rgba(255,255,255,.4));" +
+      "border-top-color:var(--pjx-spinner-color,rgba(255,255,255,.95));" +
+      "border-radius:50%;animation:pjx-spin var(--pjx-spinner-speed,.6s) linear infinite}" +
       "@keyframes pjx-shimmer{from{background-position:100% 0}to{background-position:-100% 0}}" +
       "@keyframes pjx-spin{to{transform:rotate(360deg)}}";
     document.head.appendChild(style);
@@ -93,6 +100,21 @@
     return document.querySelector('[data-pjx-id="' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '"]');
   }
 
+  // the [data-pjx-loading] elements belonging to a region (itself and/or inner
+  // elements, but not those owned by a nested reactive region)
+  function pjxLoadingTargets(region) {
+    var targets = [];
+    if (region.getAttribute("data-pjx-loading")) {
+      targets.push(region);
+    }
+    Array.prototype.forEach.call(region.querySelectorAll("[data-pjx-loading]"), function (el) {
+      if (el.closest("[data-pjx-id][data-pjx-reacts]") === region) {
+        targets.push(el);
+      }
+    });
+    return targets;
+  }
+
   function pjxBeginLoading(evt) {
     var xhr = evt.detail && evt.detail.xhr;
     var elt = evt.detail && evt.detail.elt;
@@ -106,32 +128,38 @@
     });
     var triggerLoad = root.getAttribute("data-pjx-load");
     var ids = [];
-    function mark(el) {
-      var id = el.getAttribute("data-pjx-id");
-      if (!id) {
+    function light(region) {
+      var id = region.getAttribute("data-pjx-id");
+      if (!id || ids.indexOf(id) !== -1) {
         return;
       }
-      el.classList.add(pjxLoadingClass(el));
+      var targets = pjxLoadingTargets(region);
+      if (!targets.length) {
+        return;
+      }
+      targets.forEach(function (t) { t.classList.add(pjxLoadingClass(t)); });
       pjxLoading[id] = (pjxLoading[id] || 0) + 1;
       ids.push(id);
     }
+    // light every reactive region reacting to the predicted keys; the template
+    // decides which element(s) inside each region carry data-pjx-loading
     Array.prototype.forEach.call(
-      document.querySelectorAll("[data-pjx-loading][data-pjx-reacts]"),
-      function (el) {
-        if (!pjxReacts(el).some(function (key) { return dirty[key]; })) {
+      document.querySelectorAll("[data-pjx-id][data-pjx-reacts]"),
+      function (region) {
+        if (!pjxReacts(region).some(function (key) { return dirty[key]; })) {
           return;
         }
         // keyed regions: flag only the instance matching the trigger's load key
-        var elLoad = el.getAttribute("data-pjx-load");
-        if (elLoad === null || elLoad === triggerLoad) {
-          mark(el);
+        var regionLoad = region.getAttribute("data-pjx-load");
+        if (regionLoad === null || regionLoad === triggerLoad) {
+          light(region);
         }
       }
     );
     // a trigger may name extra regions to flag (e.g. rows a bulk action removes)
     var extra = root.getAttribute("data-pjx-loading-extra");
     if (extra) {
-      Array.prototype.forEach.call(document.querySelectorAll(extra), mark);
+      Array.prototype.forEach.call(document.querySelectorAll(extra), light);
     }
     if (ids.length) {
       pjxLoadingByXhr.set(xhr, ids);
@@ -154,9 +182,11 @@
       pjxLoading[id] -= 1;
       if (pjxLoading[id] <= 0) {
         delete pjxLoading[id];
-        var el = pjxRegion(id);
-        if (el) {
-          el.classList.remove(pjxLoadingClass(el));
+        var region = pjxRegion(id);
+        if (region) {
+          pjxLoadingTargets(region).forEach(function (t) {
+            t.classList.remove(pjxLoadingClass(t));
+          });
         }
       }
     });
@@ -165,9 +195,11 @@
   // a swap can replace a region another in-flight request still needs lit
   function pjxReapplyLoading() {
     Object.keys(pjxLoading).forEach(function (id) {
-      var el = pjxRegion(id);
-      if (el) {
-        el.classList.add(pjxLoadingClass(el));
+      var region = pjxRegion(id);
+      if (region) {
+        pjxLoadingTargets(region).forEach(function (t) {
+          t.classList.add(pjxLoadingClass(t));
+        });
       }
     });
   }

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -103,10 +103,7 @@
         if (!pjxReacts(el).some(function (key) { return dirty[key]; })) {
           return;
         }
-        // Instance-keyed regions (data-pjx-load) share reacts_to across every instance,
-        // so reacts-matching alone can't tell which one will change. Flag only the keyed
-        // instance whose load key matches the trigger's; singletons (no data-pjx-load)
-        // are flagged by reacts_to as usual.
+        // keyed regions: flag only the instance matching the trigger's load key
         var elLoad = el.getAttribute("data-pjx-load");
         if (elLoad !== null && elLoad !== triggerLoad) {
           return;

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -97,6 +97,11 @@
     });
     var triggerLoad = root.getAttribute("data-pjx-load");
     var marked = [];
+    function mark(el) {
+      var cls = "pjx-loading--" + (el.getAttribute("data-pjx-loading") || "skeleton");
+      el.classList.add(cls);
+      marked.push([el, cls]);
+    }
     Array.prototype.forEach.call(
       document.querySelectorAll("[data-pjx-loading][data-pjx-reacts]"),
       function (el) {
@@ -105,14 +110,16 @@
         }
         // keyed regions: flag only the instance matching the trigger's load key
         var elLoad = el.getAttribute("data-pjx-load");
-        if (elLoad !== null && elLoad !== triggerLoad) {
-          return;
+        if (elLoad === null || elLoad === triggerLoad) {
+          mark(el);
         }
-        var cls = "pjx-loading--" + (el.getAttribute("data-pjx-loading") || "skeleton");
-        el.classList.add(cls);
-        marked.push([el, cls]);
       }
     );
+    // a trigger may name extra regions to flag (e.g. rows a bulk action removes)
+    var extra = root.getAttribute("data-pjx-loading-extra");
+    if (extra) {
+      Array.prototype.forEach.call(document.querySelectorAll(extra), mark);
+    }
     if (marked.length) {
       pjxLoadingByXhr.set(xhr, marked);
     }

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -50,4 +50,76 @@
       evt.detail.headers["X-PJX-Trigger"] = JSON.stringify(trigger);
     }
   });
+
+  function pjxInjectStyle() {
+    if (document.getElementById("pjx-style")) {
+      return;
+    }
+    var style = document.createElement("style");
+    style.id = "pjx-style";
+    style.textContent =
+      ".pjx-loading{position:relative;overflow:hidden}" +
+      ".pjx-loading>*{opacity:.55;transition:opacity .15s ease}" +
+      ".pjx-loading::after{content:'';position:absolute;inset:0;pointer-events:none;" +
+      "background:linear-gradient(90deg,transparent,rgba(127,127,127,.18) 50%,transparent);" +
+      "background-size:200% 100%;animation:pjx-shimmer 1.2s ease-in-out infinite}" +
+      "@keyframes pjx-shimmer{from{background-position:100% 0}to{background-position:-100% 0}}";
+    document.head.appendChild(style);
+  }
+
+  var pjxLoadingByXhr = new Map();
+
+  function pjxReacts(el) {
+    var value = el.getAttribute("data-pjx-reacts");
+    return value ? value.split(" ").filter(Boolean) : [];
+  }
+
+  function pjxBeginLoading(evt) {
+    var xhr = evt.detail && evt.detail.xhr;
+    var elt = evt.detail && evt.detail.elt;
+    var root = elt && elt.closest ? elt.closest("[data-pjx-id][data-pjx-reacts]") : null;
+    if (!xhr || !root) {
+      return;
+    }
+    var dirty = {};
+    pjxReacts(root).forEach(function (key) {
+      dirty[key] = true;
+    });
+    var marked = [];
+    Array.prototype.forEach.call(
+      document.querySelectorAll("[data-pjx-skeleton][data-pjx-reacts]"),
+      function (el) {
+        var hit = pjxReacts(el).some(function (key) {
+          return dirty[key];
+        });
+        if (hit) {
+          el.classList.add("pjx-loading");
+          marked.push(el);
+        }
+      }
+    );
+    if (marked.length) {
+      pjxLoadingByXhr.set(xhr, marked);
+    }
+  }
+
+  function pjxEndLoading(evt) {
+    var xhr = evt.detail && evt.detail.xhr;
+    var marked = xhr && pjxLoadingByXhr.get(xhr);
+    if (!marked) {
+      return;
+    }
+    marked.forEach(function (el) {
+      el.classList.remove("pjx-loading");
+    });
+    pjxLoadingByXhr.delete(xhr);
+  }
+
+  pjxInjectStyle();
+  document.body.addEventListener("htmx:beforeRequest", pjxBeginLoading);
+  document.body.addEventListener("htmx:afterOnLoad", pjxEndLoading);
+  document.body.addEventListener("htmx:responseError", pjxEndLoading);
+  document.body.addEventListener("htmx:timeout", pjxEndLoading);
+  document.body.addEventListener("htmx:sendError", pjxEndLoading);
+  document.body.addEventListener("htmx:abort", pjxEndLoading);
 })();

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -66,10 +66,10 @@
       ".pjx-loading--skeleton *{visibility:hidden}" +
       ".pjx-loading--spinner{position:relative}" +
       ".pjx-loading--spinner::before{content:'';position:absolute;inset:0;" +
-      "background:rgba(127,127,127,.35);border-radius:inherit}" +
+      "background:rgba(0,0,0,.45);border-radius:inherit}" +
       ".pjx-loading--spinner::after{content:'';position:absolute;top:50%;left:50%;" +
       "width:1.1em;height:1.1em;margin:-.55em 0 0 -.55em;box-sizing:border-box;" +
-      "border:2px solid rgba(0,0,0,.2);border-top-color:rgba(0,0,0,.65);" +
+      "border:2px solid rgba(255,255,255,.4);border-top-color:rgba(255,255,255,.95);" +
       "border-radius:50%;animation:pjx-spin .6s linear infinite}" +
       "@keyframes pjx-shimmer{from{background-position:100% 0}to{background-position:-100% 0}}" +
       "@keyframes pjx-spin{to{transform:rotate(360deg)}}";

--- a/tests/62_reactive_loading_skeleton_test.py
+++ b/tests/62_reactive_loading_skeleton_test.py
@@ -60,3 +60,4 @@ def test_runtime_has_loading_indicator_logic():
     assert "pjx-spin" in source
     assert "data-pjx-reacts" in source
     assert "triggerLoad" in source
+    assert "data-pjx-loading-extra" in source

--- a/tests/62_reactive_loading_skeleton_test.py
+++ b/tests/62_reactive_loading_skeleton_test.py
@@ -59,5 +59,4 @@ def test_runtime_has_loading_indicator_logic():
     assert "pjx-loading--spinner" in source
     assert "pjx-spin" in source
     assert "data-pjx-reacts" in source
-    # instance-keyed regions are scoped by load key, not flagged indiscriminately
     assert "triggerLoad" in source

--- a/tests/62_reactive_loading_skeleton_test.py
+++ b/tests/62_reactive_loading_skeleton_test.py
@@ -1,6 +1,7 @@
 from typing import ClassVar
 
 from pyjinhx import ReactiveComponent
+from pyjinhx.utils import read_client_runtime
 
 
 class ShimmerCounter(ReactiveComponent):
@@ -32,3 +33,11 @@ def test_default_component_stamps_reacts_but_not_skeleton():
     html = str(PlainCounter(id="c2", remaining=2)._render(source="<span>{{ remaining }}</span>"))
     assert 'data-pjx-reacts="todos"' in html
     assert "data-pjx-skeleton" not in html
+
+
+def test_runtime_has_loading_shimmer_logic():
+    source = read_client_runtime()
+    assert "htmx:beforeRequest" in source
+    assert "pjx-loading" in source
+    assert "data-pjx-skeleton" in source
+    assert "data-pjx-reacts" in source

--- a/tests/62_reactive_loading_skeleton_test.py
+++ b/tests/62_reactive_loading_skeleton_test.py
@@ -1,0 +1,34 @@
+from typing import ClassVar
+
+from pyjinhx import ReactiveComponent
+
+
+class ShimmerCounter(ReactiveComponent):
+    remaining: int = 0
+    reacts_to: ClassVar[set[str]] = {"todos"}
+    loading_skeleton: ClassVar[bool] = True
+
+    @classmethod
+    def load(cls) -> "ShimmerCounter":
+        return cls(id="shimmer-counter", remaining=0)
+
+
+class PlainCounter(ReactiveComponent):
+    remaining: int = 0
+    reacts_to: ClassVar[set[str]] = {"todos"}
+
+    @classmethod
+    def load(cls) -> "PlainCounter":
+        return cls(id="plain-counter", remaining=0)
+
+
+def test_opted_in_component_stamps_skeleton_and_reacts():
+    html = str(ShimmerCounter(id="c1", remaining=2)._render(source="<span>{{ remaining }}</span>"))
+    assert 'data-pjx-skeleton="true"' in html
+    assert 'data-pjx-reacts="todos"' in html
+
+
+def test_default_component_stamps_reacts_but_not_skeleton():
+    html = str(PlainCounter(id="c2", remaining=2)._render(source="<span>{{ remaining }}</span>"))
+    assert 'data-pjx-reacts="todos"' in html
+    assert "data-pjx-skeleton" not in html

--- a/tests/62_reactive_loading_skeleton_test.py
+++ b/tests/62_reactive_loading_skeleton_test.py
@@ -4,14 +4,24 @@ from pyjinhx import ReactiveComponent
 from pyjinhx.utils import read_client_runtime
 
 
-class ShimmerCounter(ReactiveComponent):
+class SkeletonCounter(ReactiveComponent):
     remaining: int = 0
     reacts_to: ClassVar[set[str]] = {"todos"}
-    loading_skeleton: ClassVar[bool] = True
+    loading: ClassVar[str] = "skeleton"
 
     @classmethod
-    def load(cls) -> "ShimmerCounter":
-        return cls(id="shimmer-counter", remaining=0)
+    def load(cls) -> "SkeletonCounter":
+        return cls(id="skeleton-counter", remaining=0)
+
+
+class SpinnerButton(ReactiveComponent):
+    completed: int = 0
+    reacts_to: ClassVar[set[str]] = {"todos"}
+    loading: ClassVar[str] = "spinner"
+
+    @classmethod
+    def load(cls) -> "SpinnerButton":
+        return cls(id="spin-btn", completed=0)
 
 
 class PlainCounter(ReactiveComponent):
@@ -23,21 +33,29 @@ class PlainCounter(ReactiveComponent):
         return cls(id="plain-counter", remaining=0)
 
 
-def test_opted_in_component_stamps_skeleton_and_reacts():
-    html = str(ShimmerCounter(id="c1", remaining=2)._render(source="<span>{{ remaining }}</span>"))
-    assert 'data-pjx-skeleton="true"' in html
+def test_skeleton_component_stamps_loading_and_reacts():
+    html = str(SkeletonCounter(id="c1", remaining=2)._render(source="<span>{{ remaining }}</span>"))
+    assert 'data-pjx-loading="skeleton"' in html
     assert 'data-pjx-reacts="todos"' in html
 
 
-def test_default_component_stamps_reacts_but_not_skeleton():
+def test_spinner_component_stamps_loading_spinner():
+    html = str(SpinnerButton(id="b1", completed=1)._render(source="<button>{{ completed }}</button>"))
+    assert 'data-pjx-loading="spinner"' in html
+    assert 'data-pjx-reacts="todos"' in html
+
+
+def test_default_component_stamps_reacts_but_no_loading():
     html = str(PlainCounter(id="c2", remaining=2)._render(source="<span>{{ remaining }}</span>"))
     assert 'data-pjx-reacts="todos"' in html
-    assert "data-pjx-skeleton" not in html
+    assert "data-pjx-loading" not in html
 
 
-def test_runtime_has_loading_shimmer_logic():
+def test_runtime_has_loading_indicator_logic():
     source = read_client_runtime()
     assert "htmx:beforeRequest" in source
-    assert "pjx-loading" in source
-    assert "data-pjx-skeleton" in source
+    assert "data-pjx-loading" in source
+    assert "pjx-loading--skeleton" in source
+    assert "pjx-loading--spinner" in source
+    assert "pjx-spin" in source
     assert "data-pjx-reacts" in source

--- a/tests/62_reactive_loading_skeleton_test.py
+++ b/tests/62_reactive_loading_skeleton_test.py
@@ -59,3 +59,5 @@ def test_runtime_has_loading_indicator_logic():
     assert "pjx-loading--spinner" in source
     assert "pjx-spin" in source
     assert "data-pjx-reacts" in source
+    # instance-keyed regions are scoped by load key, not flagged indiscriminately
+    assert "triggerLoad" in source

--- a/tests/62_reactive_loading_skeleton_test.py
+++ b/tests/62_reactive_loading_skeleton_test.py
@@ -4,49 +4,39 @@ from pyjinhx import ReactiveComponent
 from pyjinhx.utils import read_client_runtime
 
 
-class SkeletonCounter(ReactiveComponent):
-    remaining: int = 0
-    reacts_to: ClassVar[set[str]] = {"todos"}
-    loading: ClassVar[str] = "skeleton"
-
-    @classmethod
-    def load(cls) -> "SkeletonCounter":
-        return cls(id="skeleton-counter", remaining=0)
-
-
-class SpinnerButton(ReactiveComponent):
-    completed: int = 0
-    reacts_to: ClassVar[set[str]] = {"todos"}
-    loading: ClassVar[str] = "spinner"
-
-    @classmethod
-    def load(cls) -> "SpinnerButton":
-        return cls(id="spin-btn", completed=0)
-
-
-class PlainCounter(ReactiveComponent):
-    remaining: int = 0
+class LoadingProbe(ReactiveComponent):
+    value: int = 0
     reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod
-    def load(cls) -> "PlainCounter":
-        return cls(id="plain-counter", remaining=0)
+    def load(cls) -> "LoadingProbe":
+        return cls(id="probe", value=0)
 
 
-def test_skeleton_component_stamps_loading_and_reacts():
-    html = str(SkeletonCounter(id="c1", remaining=2)._render(source="<span>{{ remaining }}</span>"))
+def test_loading_authored_on_root_is_preserved():
+    html = str(
+        LoadingProbe(id="p", value=2)._render(
+            source='<span data-pjx-loading="skeleton">{{ value }}</span>'
+        )
+    )
     assert 'data-pjx-loading="skeleton"' in html
     assert 'data-pjx-reacts="todos"' in html
+    # stamping must not duplicate the author's attribute
+    assert html.count('data-pjx-loading="') == 1
 
 
-def test_spinner_component_stamps_loading_spinner():
-    html = str(SpinnerButton(id="b1", completed=1)._render(source="<button>{{ completed }}</button>"))
+def test_loading_authored_on_inner_element_is_preserved():
+    html = str(
+        LoadingProbe(id="p", value=2)._render(
+            source='<div><button data-pjx-loading="spinner">x</button></div>'
+        )
+    )
     assert 'data-pjx-loading="spinner"' in html
-    assert 'data-pjx-reacts="todos"' in html
+    assert 'data-pjx-reacts="todos"' in html  # reactivity stays on the root <div>
 
 
-def test_default_component_stamps_reacts_but_no_loading():
-    html = str(PlainCounter(id="c2", remaining=2)._render(source="<span>{{ remaining }}</span>"))
+def test_no_loading_attribute_when_template_omits_it():
+    html = str(LoadingProbe(id="p", value=2)._render(source="<span>{{ value }}</span>"))
     assert 'data-pjx-reacts="todos"' in html
     assert "data-pjx-loading" not in html
 
@@ -54,11 +44,15 @@ def test_default_component_stamps_reacts_but_no_loading():
 def test_runtime_has_loading_indicator_logic():
     source = read_client_runtime()
     assert "htmx:beforeRequest" in source
+    assert "htmx:afterSettle" in source
+    assert "loadend" in source
     assert "data-pjx-loading" in source
+    assert "data-pjx-loading-extra" in source
+    assert "data-pjx-reacts" in source
+    assert "triggerLoad" in source
     assert "pjx-loading--skeleton" in source
     assert "pjx-loading--spinner" in source
     assert "pjx-spin" in source
-    assert "data-pjx-reacts" in source
-    assert "triggerLoad" in source
-    assert "data-pjx-loading-extra" in source
-    assert "loadend" in source
+    # overridable style tokens
+    assert "--pjx-spinner-color" in source
+    assert "--pjx-skeleton-color" in source

--- a/tests/62_reactive_loading_skeleton_test.py
+++ b/tests/62_reactive_loading_skeleton_test.py
@@ -61,3 +61,4 @@ def test_runtime_has_loading_indicator_logic():
     assert "data-pjx-reacts" in source
     assert "triggerLoad" in source
     assert "data-pjx-loading-extra" in source
+    assert "loadend" in source

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,11 @@ from fastapi.testclient import TestClient
 from examples.reactive_todo.app import app
 
 
+@pytest.fixture(autouse=True)
+def _no_demo_latency(monkeypatch):
+    monkeypatch.setenv("PJX_DEMO_LATENCY", "0")
+
+
 @pytest.fixture
 def client():
     with TestClient(app) as test_client:

--- a/tests/integration/test_reactive_todo.py
+++ b/tests/integration/test_reactive_todo.py
@@ -47,6 +47,18 @@ def test_toggle_swaps_changed_dependents(client):
     )
 
 
+def test_toggle_does_not_reswap_whole_list(client):
+    # regression: a full-list swap on toggle detaches a concurrent row's target
+    headers = _manifest(
+        {"id": "list", "type": "ItemList", "hash": "stale"},
+        {"id": "row-1", "type": "ItemRow", "load": "1", "hash": "stale"},
+        {"id": "row-2", "type": "ItemRow", "load": "2", "hash": "stale"},
+    )
+    body = client.post("/rows/1/toggle", headers=headers).text
+    assert 'data-pjx-id="row-1"' in body
+    assert "outerHTML:[data-pjx-id='list']" not in body
+
+
 def test_toggle_hash_gates_unchanged_total(client):
     fresh_total = Total.load()
     headers = _manifest(


### PR DESCRIPTION
## Summary

In-flight **loading indicators** for reactive regions — a fully client-side, auto-triggered affordance that shows a skeleton or spinner while a reactive update is on the wire, then clears when the fresh HTML swaps in. No per-route wiring: a region's `reacts_to` drives when its loading elements fire.

## Highlights

- **Two styles, declared in the template.** Put `data-pjx-loading="skeleton"` or `"spinner"` on any element (the component root *or* an inner element). `pjx.js` matches it via its enclosing reactive root, so it auto-triggers off `reacts_to` and can target specific elements.
  - **skeleton** — silhouette shimmer (content hidden, the box shimmers).
  - **spinner** — dim, blurred overlay + centered circular progress; content stays, region non-interactive.
- **Overridable styling.** Both styles read `--pjx-*` CSS custom properties (color, track, overlay, blur, size, thickness, speed, radius) with sane defaults — restyle from your own CSS, or use a custom `data-pjx-loading="…"` value and style `.pjx-loading--…` yourself.
- **OOB-aware + instance-scoped.** Lights the swap target *and* its out-of-band dependents (predicted from the dependency graph). Instance-keyed rows are scoped by the triggering instance's load key — clicking one row doesn't shimmer its siblings.
- **`data-pjx-loading-extra="<selector>"`** lets a trigger flag regions the dependency walk can't predict — e.g. the rows a bulk "clear completed" is about to remove.
- **Robust lifecycle.** Loading is ref-counted per region across overlapping requests, re-applied across swaps, and released on the xhr's `loadend` (reliable even when htmx discards a superseded response) — a shared indicator stays lit until the *last* in-flight request finishes.

## Demo (`examples/reactive_todo`)

- A **terminal/mono design system** (IBM Plex Mono, dark panel, lime accent) showcasing the loading states.
- Correctness fixes surfaced while building:
  - Toggling one row no longer re-renders the whole list (the list reacts to a composition key, not the per-item key) — fixes a detach race between overlapping toggles.
  - Adding a todo stays instant; the artificial demo latency lives on the toggle/clear routes (env-gated via `PJX_DEMO_LATENCY`), the actions that actually show an indicator.

> The OOB trigger-exclusion fix (a clicked region that depends on the dirtied keys now updates itself) shipped separately as #37 and is merged in here.

## Test plan

- [x] `uv run pytest tests/` — 309 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run mkdocs build --strict` — builds
- [x] `node --check pyjinhx/runtime/pjx.js` — valid
- [x] Browser (Playwright): template-authored skeleton/spinner fire; instance scoping; overlapping requests keep a shared indicator lit until the last finishes; `--pjx-*` token override flows through.

Docs: **Loading indicators** section in `docs/reactivity.md` (mechanism, scoping, `data-pjx-loading-extra`, and a Styling/overrides subsection for the tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)