### PR TITLE
Fix: don't exclude the htmx trigger from out-of-band swaps

### DIFF
--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -126,7 +126,9 @@ With `@mutates` on the store method, pending dirtied keys drive OOB swaps automa
 `Cls.render(*args)` loads the primary (`load(*args)` for keyed types, `load()` for
 singletons), renders it as the main-target response, then appends OOB swaps for every
 *other* mounted reactive region whose `reacts_to` intersects pending mutations from
-`@mutates`. The trigger region (`X-PJX-Trigger`) and primary id are excluded.
+`@mutates`. Only the primary id is excluded (htmx swaps it as the main-target response);
+the region that *initiated* the request still updates out-of-band if it depends on the
+dirtied keys — e.g. a "Clear completed (N)" button updates its own count.
 
 A **plain, non-reactive** primary has no `load()` to call, so you build it and render
 the instance: `MyFragment(id=..., ...).render()`.

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -25,7 +25,7 @@ from pyjinhx.utils import (
 )
 
 from .cache import LoadCache
-from .client import ClientBackend, MountedManifest, TriggerManifest
+from .client import ClientBackend, MountedManifest
 from .dev import warn_reactive_render_without_client
 from .keys import ReactiveKey, coerce_load_key_str, coerce_reactive_keys
 from .mutations import MutationTracker
@@ -295,10 +295,10 @@ def reactive_render_bundle(
     primary = primary_html() if callable(primary_html) else primary_html
     MutationTracker.mark_render_consumed()
 
+    # Exclude only the primary (htmx swaps it as the main response). The trigger is
+    # NOT excluded: a clicked region that depends on the dirtied keys must update
+    # out-of-band like any other dependent (e.g. a "Clear (N)" button updating itself).
     resolved_exclude = set(exclude_ids() if callable(exclude_ids) else exclude_ids)
-    trigger = TriggerManifest.parse(backend) if backend is not None else None
-    if trigger and trigger.get("id"):
-        resolved_exclude.add(str(trigger["id"]))
 
     swaps = oob_swaps(
         effective_dirtied,

--- a/tests/46_reactive_render_classform_test.py
+++ b/tests/46_reactive_render_classform_test.py
@@ -87,3 +87,16 @@ def test_class_form_returns_markup_and_does_not_escape():
 def test_instance_form_still_renders_self():
     counter = ReactiveCounter(id="counter", remaining=99)
     assert "99 left" in str(counter.render())
+
+
+def test_dependent_trigger_still_swaps_oob():
+    # Regression: the clicked element (X-PJX-Trigger) is a dependent distinct from
+    # the primary, so it must still OOB-update -- it was wrongly excluded before.
+    store.state["remaining"] = 2
+    store.state["completed"] = 5
+    manifest = [{"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}]
+    with reactive_client(manifest, trigger_id="clear-btn"):
+        record_mutation("todos")
+        out = str(ReactiveCounter.render())
+    assert "outerHTML:[data-pjx-id='clear-btn']" in out
+    assert "Clear (5)" in out


### PR DESCRIPTION
## Bug
In the `reactive_todo` demo, clicking **Clear completed** didn't update its own `(N)` count.

## Root cause (library, not the demo)
`reactive_render_bundle` added the htmx **trigger** id (`X-PJX-Trigger`) to the OOB exclusion set alongside the primary. That's:
- **redundant** when the trigger *is* the primary (e.g. toggling a row re-renders that same row), but
- **wrong** when the trigger is a *distinct* dependent: the "Clear completed" button is its own reactive root (`data-pjx-id="clear"`) while the primary is the list (`"list"`), so `"clear"` got excluded and the button could never update itself.

Confirmed empirically: with `trigger="clear"` the `ClearButton` was absent from the OOB response; with no trigger it updated correctly.

## Fix
Exclude **only the primary** (htmx swaps it as the main-target response). The trigger updates out-of-band like any other dependent, still hash-gated. A region updating in response to state it depends on shouldn't be exempted just because it was the clicked element.

- No test relied on the old behavior — the one trigger test (`test_keyed_class_form_swaps_siblings_on_collection_dirty`) has trigger == primary, covered by the primary exclusion.
- Added a regression test (`test_dependent_trigger_still_swaps_oob`): trigger = a dependent ≠ primary → it must still OOB-swap.
- `TriggerManifest` / `PJX_TRIGGER_HEADER` remain exported (public API) and `pjx.js` still sends the header; the core flow simply no longer consumes it.

## Test plan
- [x] `uv run pytest tests/` → 304 passed (303 + 1 regression)
- [x] `uv run ruff check .` → clean
- [x] `uv run mkdocs build --strict` → builds
- [x] End-to-end demo repro: clicking Clear (trigger=`"clear"`) now updates to `(0)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)