### PR TITLE
docs: audit sweep — fix mistakes, fill gaps, compress (+2 code bugs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,26 +129,25 @@ flowchart TB
     B --> A
 ```
 
-You can also start from an HTML string — `Renderer.render("<Card ...><Button .../></Card>")` — same order and tag rules.
+You can also start from an HTML string — `Renderer.get_default_renderer().render("<Card ...><Button .../></Card>")` — same order and tag rules.
 
 ## Reactivity
 
 Declare what state each component depends on. After a mutation, return `Cls.render()`; PyJinHx appends out-of-band swaps for other mounted regions whose dependencies overlap.
 
 ```python
-from enum import Enum
 from typing import ClassVar
 
-from pyjinhx import ReactiveComponent
+from pyjinhx import ReactiveComponent, StateKey
 
 
-class StateKey(str, Enum):
+class Keys(StateKey):
     TODOS = "todos"
 
 
 class Counter(ReactiveComponent):
     remaining: int
-    reacts_to: ClassVar[set[StateKey]] = {StateKey.TODOS}
+    reacts_to: ClassVar[set[str]] = {Keys.TODOS}
 
     @classmethod
     def load(cls) -> "Counter":
@@ -161,19 +160,13 @@ def toggle():
     return Counter.render()
 ```
 
-Wire `setup(app, ...)` once — lifespan and registry middleware handle cache scope, optional invalidation, `LoadContext`, and `ClientBackend` for header auto-resolution. Mutation routes call `Cls.render(*args)` with no framework kwargs; `pjx.js` is injected on root full-page renders unless `X-PJX-Mounted` is already present.
+Call `setup(app, ...)` once: it installs the lifespan and registry middleware that handle cache scope, optional invalidation, `LoadContext`, and the `ClientBackend` that resolves the `X-PJX-*` headers — so mutation routes call `Cls.render(*args)` with no framework kwargs. The client runtime (`pjx.js`) is injected on root full-page renders unless `X-PJX-Mounted` is already present.
 
-**Reactive ergonomics:** use `StateKey` enums for typed keys; `@mutates` on store methods to accumulate pending dirtied keys for the next reactive `render()`; `PjxLoad` on one model field per keyed component for `data-pjx-load` round-trip; `LoadContext.bind()` / `LoadContext.current()` to inject dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
+**Reactive ergonomics:** `StateKey` enums for typed keys; `@mutates` on store methods to accumulate pending dirtied keys for the next reactive `render()`; one `PjxLoad`-annotated field per keyed component for the `data-pjx-load` round-trip; `LoadContext` to inject request-scoped dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
 
-**Reactive design decisions:**
-- **Three identities:** `data-pjx-id` (HTMX swap target), `data-pjx-load` (round-trip `load()` arg from a `PjxLoad` field), and state keys in `reacts_to` / `@mutates` (pub-sub only).
-- **Pub-sub OOB:** every mounted region whose `reacts_to` intersects pending mutations may OOB-reload via `load(manifest.load)`; the trigger region and primary are excluded via `X-PJX-Trigger` + primary id.
-- **`depends_on()`:** optional runtime narrowing for load-cache indexing; `oob_swaps` matches on static `reacts_to` only.
-- **`state_hash()`:** canonical sorted JSON from `model_dump(mode="json")` with `id` excluded by default (`state_hash_exclude` to omit more fields). Override `state_hash()` for custom hashing.
+**Loading indicators:** a reactive region can show an in-flight indicator while it reloads — add `data-pjx-loading="skeleton"` (or `"spinner"`) to a template element, and `pjx.js` lights it automatically off the region's `reacts_to`. Themeable via `--pjx-*` CSS variables. See the [reactivity guide](docs/reactivity.md#loading-indicators-in-flight).
 
-**Load cache scope** (default `CacheScope.REQUEST`): `load()` results are cached within each HTTP request via `LoadCache`. Use `LoadCache.invalidate()` to evict entries; `MutationTracker` accumulates dirtied keys from `@mutates` for the next reactive render. Use `Registry.request_scope()` on every request for instance registry isolation (included in `setup(app, ...)`). For cross-request caching per worker, pass `cache_scope=CacheScope.PROCESS` to `setup()` and pair with an `InvalidationBackend` + `InvalidationHub` ([Redis reference](pyjinhx/integrations/redis.py), `pip install pyjinhx[redis]`).
-
-**API shape:** reactive internals expose class methods directly (`LoadCache`, `MutationTracker`, `InvalidationHub`, `MountedManifest`, `LoadedAssets`) — no thin module-level wrapper functions.
+The cache, hashing, `depends_on()`, `MutationTracker`/`InvalidationHub`, and the `oob_swaps` walk are all covered in the [reactivity guide](docs/reactivity.md). Load results are cached per request by default (`CacheScope.REQUEST`); pass `cache_scope=CacheScope.PROCESS` to `setup()` plus a Redis `InvalidationBackend` ([reference](pyjinhx/integrations/redis.py), `pip install pyjinhx[redis]`) for cross-request caching across workers.
 
 Details: [usage tiers](docs/guide/usage-tiers.md) · [reactivity guide](docs/reactivity.md) · [Build an App](docs/getting-started/build-an-app.md) · [examples/reactive_todo/](examples/reactive_todo/).
 
@@ -217,72 +210,72 @@ Details: [asset collection guide](docs/guide/assets.md). Optional UI kit: [pyjin
 
 ## FastAPI + HTMX (reactive)
 
-Root full-page renders inject the client runtime (`pjx.js`) automatically unless the request already sent `X-PJX-Mounted`. A toggle route returns the row as the primary swap; the counter updates out-of-band because both declare `reacts_to={StateKey.TODOS}`.
+A toggle route returns the row as the primary swap; the counter updates out-of-band because both declare `reacts_to={Keys.TODOS}`. (Matches [examples/reactive_todo/](examples/reactive_todo/).)
 
 ```python
-# components/todo_row.py
-from enum import Enum
-from typing import ClassVar
+# components.py
+from typing import Annotated, ClassVar
 
-from pyjinhx import BaseComponent, ReactiveComponent
+from pyjinhx import BaseComponent, PjxLoad, ReactiveComponent, StateKey
 
 
-class StateKey(str, Enum):
+class Keys(StateKey):
     TODOS = "todos"
 
 
-class TodoRow(ReactiveComponent):
-    title: str
+class ItemRow(ReactiveComponent):
+    todo_id: Annotated[int, PjxLoad()]
+    title: str = ""
     done: bool = False
-    reacts_to: ClassVar[set[StateKey]] = {StateKey.TODOS}
+    reacts_to: ClassVar[set[str]] = {Keys.TODOS}
 
     @classmethod
-    def load(cls, key: int) -> "TodoRow":
-        todo = db.get(key)
-        return cls(id=f"row-{key}", title=todo.text, done=todo.done)
+    def load(cls, todo_id: int) -> "ItemRow":
+        todo = db.get(todo_id)
+        return cls(id=f"row-{todo_id}", todo_id=todo_id, title=todo.text, done=todo.done)
 
 
-class TodoCounter(ReactiveComponent):
-    remaining: int
-    reacts_to: ClassVar[set[StateKey]] = {StateKey.TODOS}
+class Counter(ReactiveComponent):
+    remaining: int = 0
+    reacts_to: ClassVar[set[str]] = {Keys.TODOS}
 
     @classmethod
-    def load(cls) -> "TodoCounter":
-        return cls(id="counter", remaining=db.remaining())
+    def load(cls) -> "Counter":  # id defaults to "counter"
+        return cls(remaining=db.remaining())
 
 
-class TodoList(BaseComponent):
-    items: list[TodoRow] = []
+class ItemList(BaseComponent):
+    items: list[ItemRow] = []
 
 
-class TodoApp(BaseComponent):
-    todo_list: TodoList | None = None
-    counter: TodoCounter | None = None
+class App(BaseComponent):
+    item_list: ItemList | None = None
+    remaining: Counter | None = None
 ```
 
 ```html
-<!-- todo_list.html -->
+<!-- item_list.html -->
 <ul id="{{ id }}">
   {% for item in items %}{{ item }}{% endfor %}
 </ul>
 ```
 
 ```html
-<!-- todo_row.html -->
+<!-- item_row.html -->
 <li>
-  <button hx-post="/rows/{{ key }}/toggle"
+  <button hx-post="/rows/{{ todo_id }}/toggle"
           hx-target="closest [data-pjx-id]" hx-swap="outerHTML">toggle</button>
   <span>{{ title }}</span>
 </li>
 ```
 
 ```html
-<!-- todo_counter.html -->
+<!-- counter.html -->
 <span>{{ remaining }} left</span>
 ```
 
 ```html
-<!-- todo_app.html -->
+<!-- app.html -->
 <!doctype html>
 <html lang="en">
   <head>
@@ -290,8 +283,8 @@ class TodoApp(BaseComponent):
   </head>
   <body>
     <h1>Todos</h1>
-    {{ todo_list }}
-    {{ counter }}
+    {{ item_list }}
+    {{ remaining }}
   </body>
 </html>
 ```
@@ -299,40 +292,26 @@ class TodoApp(BaseComponent):
 ```python
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
-from pyjinhx import FastAPIClientBackend, Registry, Renderer
-from starlette.middleware.base import BaseHTTPMiddleware
+from pyjinhx import Renderer, setup
 
 Renderer.set_default_environment("./components")
 app = FastAPI()
-
-
-class RegistryScopeMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request, call_next):
-        with Registry.request_scope(client_backend=FastAPIClientBackend(request)):
-            return await call_next(request)
-
-
-app.add_middleware(RegistryScopeMiddleware)
+setup(app)  # installs the lifespan + registry/ClientBackend middleware
 
 
 @app.get("/", response_class=HTMLResponse)
 def index():
-    return str(
-        TodoApp(
-            id="todo-app",
-            todo_list=TodoList(
-                id="todo-list",
-                items=[TodoRow.load(t.id) for t in db.all()],
-            ),
-            counter=TodoCounter.load(),
-        ).render()
-    )
+    return App(
+        id="app",
+        item_list=ItemList(id="list", items=[ItemRow.load(t.id) for t in db.all()]),
+        remaining=Counter.load(),
+    ).render()
 
 
 @app.post("/rows/{todo_id}/toggle", response_class=HTMLResponse)
 def toggle_row(todo_id: int):
     db.toggle(todo_id)
-    return TodoRow.render(todo_id)
+    return ItemRow.render(todo_id)
 ```
 
 Run the full app: `uv run uvicorn examples.reactive_todo.app:app --reload` — see [examples/reactive_todo/README.md](examples/reactive_todo/README.md).

--- a/docs/api/assets-api.md
+++ b/docs/api/assets-api.md
@@ -46,7 +46,7 @@ app.mount(
 ## default_asset_url
 
 ```python
-def default_asset_url(path: str, *, kind: AssetKind, root: str) -> str
+def default_asset_url(path: str, *, root: str) -> str
 ```
 
 Map an absolute asset path to a default public URL under `/static/components/`. The runtime path maps to `DEFAULT_RUNTIME_URL`.
@@ -95,20 +95,18 @@ def asset_manifest(session: RenderSession, *, resolver: AssetUrlResolver) -> Ass
 
 Build an `AssetManifest` from a `RenderSession` and a URL resolver. Equivalent to `session.manifest(resolver=resolver)`.
 
-## layout_asset_tags
+## Finder.layout_asset_tags
 
 ```python
-def layout_asset_tags(finder: Finder, *, resolver: AssetUrlResolver) -> Markup
+def layout_asset_tags(self, *, resolver: AssetUrlResolver) -> Markup
 ```
 
-Emit `<link>` and `<script src>` tags for every component asset discovered by a `Finder`. Use in layout shells to preload all component assets instead of per-page discovery.
+Instance method on [`Finder`](finder.md). Emit `<link>` and `<script src>` tags for every component asset discovered under the finder's root. Use in layout shells to preload all component assets instead of per-page discovery.
 
 ```python
-from pyjinhx import Finder, layout_asset_tags, make_default_asset_url_resolver
+from pyjinhx import Finder, make_default_asset_url_resolver
 
 finder = Finder(root="./components")
 resolver = make_default_asset_url_resolver("./components")
-head_tags = layout_asset_tags(finder, resolver=resolver)
+head_tags = finder.layout_asset_tags(resolver=resolver)
 ```
-
-Defined in `pyjinhx.finder` and re-exported from the top-level package.

--- a/docs/api/base-component.md
+++ b/docs/api/base-component.md
@@ -23,25 +23,14 @@ Components accept extra fields beyond those defined in the class (`extra="allow"
 ##### render()
 
 ```python
-def render(
-    *,
-    dirtied: set[ReactiveKey] | None = None,
-    mounted: object | None = None,
-    client: object | None = None,
-) -> Markup
+def render() -> Markup
 ```
 
 Render this component to HTML using its associated Jinja template.
 
 The template is auto-discovered based on the component class name (e.g., `MyButton` looks for `my_button.html` or `my_button.jinja`). All component fields are available in the template context, and nested components are rendered recursively.
 
-With no arguments this is a plain render. Passing `dirtied` and/or `mounted` opts into dependency-aware reactivity: this component is the primary response, and OOB swaps are appended for other mounted reactive regions whose `reacts_to` intersects `dirtied`. See [Reactivity](../reactivity.md).
-
-| Parameter | Description |
-|-----------|-------------|
-| `dirtied` | State keys the route mutated (e.g. `{"todos"}`). Defaults to the primary's `reacts_to`. |
-| `mounted` | Client manifest — request-like object, raw `X-PJX-Mounted` string, or parsed list. When omitted, uses the request-scoped `ClientBackend` after mutations. |
-| `client` | Request-like object or raw `X-PJX-Assets` JSON for REFERENCE-mode asset dedup on root renders. When omitted, uses the request-scoped `ClientBackend`. |
+This is a plain, zero-argument render. The dependency-aware reactive behavior (`dirtied` / `mounted` / `client`) lives on `ReactiveComponent` — see [Reactive API](reactive-api.md).
 
 **Returns:** The rendered HTML as a Markup object (safe for direct use in templates).
 
@@ -73,7 +62,7 @@ A wrapper for nested components. Enables access to the component's properties an
 ##### __str__()
 
 ```python
-def __str__() -> Markup
+def __str__() -> str
 ```
 
-Returns the rendered HTML when the wrapper is used in a template context.
+Returns the wrapper's `html` field (a plain string) when used in a template context.

--- a/docs/api/client-backend.md
+++ b/docs/api/client-backend.md
@@ -1,6 +1,6 @@
 # Client Backend
 
-Per-request HTTP header access for reactive rendering. Wire once in your app's middleware; `render()` reads `X-PJX-Mounted`, `X-PJX-Assets`, and `X-PJX-Trigger` from the active backend.
+Per-request HTTP header access for reactive rendering. Wire once in your app's middleware; `render()` reads `X-PJX-Mounted` and `X-PJX-Assets` from the active backend. `X-PJX-Trigger` is client-only — consumed by pjx.js for loading indicators, not by the server render walk.
 
 PyJinHx does **not** ship middleware — you define a thin wrapper (see [FastAPI integration](../integrations/fastapi.md#middleware-recommended)) that calls `Registry.request_scope(client_backend=FastAPIClientBackend(request))`.
 
@@ -48,9 +48,11 @@ Default implementation for FastAPI and Starlette. Wraps `request.headers`. `setu
 When a `ClientBackend` is active (via `setup()` middleware or `ClientBackend.scope()`):
 
 - Root renders use it for asset dedup (`X-PJX-Assets`) and runtime injection gating (`X-PJX-Mounted`).
-- Reactive class/instance `render()` reads the manifest and trigger headers for OOB swaps.
+- Reactive class/instance `render()` reads the `X-PJX-Mounted` manifest for OOB swaps.
 
 Mutation routes call `Cls.render(*args)` with no framework kwargs — pending keys from `@mutates` drive the OOB walk.
+
+Without a `ClientBackend`, reactive OOB is skipped even when mutations are pending — only the primary is rendered.
 
 ## Non-FastAPI frameworks
 

--- a/docs/api/finder.md
+++ b/docs/api/finder.md
@@ -75,6 +75,21 @@ Collect all `.css` files under `root`.
 
 **Returns:** A sorted list of CSS file paths.
 
+##### layout_asset_tags()
+
+```python
+def layout_asset_tags(*, resolver: Callable[[str], str]) -> Markup
+```
+
+Emit `<link>` and `<script src>` tags for every component asset discovered under `root`. Use in layout shells to preload all component assets instead of per-page discovery.
+
+**Parameters:**
+- `resolver` (Callable[[str], str]): Maps an absolute asset path to its public URL (e.g. from `make_default_asset_url_resolver`).
+
+**Returns:** A `Markup` string of `<link>` and `<script>` tags.
+
+See also [Assets API](assets-api.md#finderlayout_asset_tags).
+
 #### Static Methods
 
 ##### get_class_directory()
@@ -143,15 +158,16 @@ Return the first search path from a Jinja `FileSystemLoader`.
 
 **Returns:** The first search path directory.
 
-##### detect_root_directory()
+## detect_root_directory
 
 ```python
-@staticmethod
 def detect_root_directory(
     start_directory: str | None = None,
     project_markers: list[str] | None = None,
 ) -> str
 ```
+
+Free function in `pyjinhx.utils` (not a `Finder` method): `from pyjinhx.utils import detect_root_directory`. Used internally to locate the project root.
 
 Find the project root by walking upward until a marker file is found.
 

--- a/docs/api/reactive-api.md
+++ b/docs/api/reactive-api.md
@@ -8,7 +8,7 @@ See [Reactivity](../reactivity.md) for conceptual documentation and usage patter
 
 ```python
 class ReactiveComponent(BaseComponent):
-    reacts_to: ClassVar[frozenset[str]]
+    reacts_to: ClassVar[set[str]]
 ```
 
 Base class for components that reload from application state via a `load()` classmethod and participate in out-of-band HTMX swaps.
@@ -36,6 +36,8 @@ Cls.render(*args, **kwargs) -> Markup
 ```
 
 Auto-`load()`s the primary, renders it, and appends OOB swaps when a `ClientBackend` is active and `@mutates` left pending keys.
+
+Raises `TypeError` if called with arguments on a type-singleton, or without the key argument on an instance-keyed type.
 
 **Instance method:**
 

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -43,6 +43,40 @@ Return a copy of all registered component classes.
 
 **Returns:** Dictionary mapping class names to component class types.
 
+### get_class()
+
+```python
+@classmethod
+def get_class(cls, name: str) -> type[BaseComponent] | None
+```
+
+Return a registered component class by name without copying the registry, or `None` if not registered.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | The component class name (e.g., `"Button"`) |
+
+**Returns:** The component class, or `None`.
+
+### has_class()
+
+```python
+@classmethod
+def has_class(cls, name: str) -> bool
+```
+
+Return whether a component class is registered under `name`.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | The component class name to check |
+
+**Returns:** `True` if registered, otherwise `False`.
+
 ### clear_classes()
 
 ```python
@@ -125,7 +159,7 @@ Remove all registered component instances from the current context.
 ```python
 @classmethod
 @contextmanager
-def request_scope(cls, *, load_context: Any | None = None, client_backend: ClientBackend | None = None)
+def request_scope(cls, *, load_context: object | None = None, client_backend: object | None = None)
 ```
 
 Context manager for request-scoped component instances, load cache, mutation tracking, optional load context, and optional client backend for HTTP headers.
@@ -154,4 +188,4 @@ with Registry.request_scope(
 - Supports nesting—each scope is independent
 - Prevents "Overwriting..." warnings when reusing component IDs across requests
 
-See the [FastAPI integration guide](../integrations/fastapi.md#request-scoped-registry) for practical examples.
+See the [FastAPI integration guide](../integrations/fastapi.md#middleware-recommended) for practical examples.

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -280,16 +280,21 @@ Template button:
 
 ## Step 8 — Reactive components
 
-Upgrade the counter:
+Upgrade the counter. It names the state it derives from with a `Keys` enum and
+reads from a `store` module — **we define both `keys.py` and `store.py` in Step 9**;
+for now just note that `Keys.TODOS` and `store` are imported from there:
 
 ```python
 from typing import ClassVar
 from pyjinhx import ReactiveComponent
 
+from .keys import Keys
+from . import store
+
 
 class TodoCounter(ReactiveComponent):
     remaining: int = 0
-    reacts_to: ClassVar[set[str]] = {"todos"}
+    reacts_to: ClassVar[set[str]] = {Keys.TODOS}
 
     @classmethod
     def load(cls) -> "TodoCounter":
@@ -314,7 +319,8 @@ class TodoApp(BaseComponent):
 
 ## Step 9 — Keys, mutations, and render()
 
-`keys.py`:
+Centralize reactive key strings in a `StateKey` enum so `reacts_to`, `@mutates`, and
+`dirtied` all share one vocabulary (no stray raw strings to typo). `keys.py`:
 
 ```python
 from pyjinhx import StateKey
@@ -342,7 +348,7 @@ def toggle(todo_id: int) -> None:
     ...
 ```
 
-Route:
+Route (the `TodoItemRow` it renders is the instance-keyed row **we define in Step 10**):
 
 ```python
 @app.post("/rows/{todo_id}/toggle", response_class=HTMLResponse)
@@ -382,10 +388,10 @@ class TodoItemRow(ReactiveComponent):
         )
 ```
 
-Template:
+Template (note `data-pjx-loading` — covered in Step 11):
 
 ```html
-<li>
+<li data-pjx-loading="skeleton">
   <button hx-post="/rows/{{ todo_id }}/toggle"
           hx-target="closest [data-pjx-id]" hx-swap="outerHTML">toggle</button>
   <span>{{ title }}</span>
@@ -397,7 +403,39 @@ Template:
 
 ---
 
-## Step 11 — LoadContext (avoid globals in load())
+## Step 11 — Loading states (in-flight indicators)
+
+While a reactive region's OOB update is in flight, it can show a built-in indicator.
+You opt in **in the template** by adding `data-pjx-loading` to any element — the
+component root or something inside it. No route or Python changes:
+
+```html
+<!-- todo_item_row.html: shimmer the whole row while it reloads -->
+<li data-pjx-loading="skeleton"> ... </li>
+
+<!-- clear_button.html: spin just this button -->
+<button data-pjx-loading="spinner">Clear completed ({{ completed }})</button>
+```
+
+Two built-in styles ship: `"skeleton"` (silhouette shimmer) and `"spinner"` (dimmed
+overlay with a circular indicator). `pjx.js` reads each reactive root's `reacts_to`
+keys and lights the matching `data-pjx-loading` elements on every mounted region a
+mutation touches — the swap target *and* its OOB dependents.
+
+???+ question "Why template-driven, and how do I theme it?"
+    Indicators are purely a client affordance — no server reactive semantics change, and
+    nothing fires unless an element opts in. Both styles read overridable `--pjx-*` CSS
+    variables (e.g. `--pjx-skeleton-color`, `--pjx-spinner-color`, `--pjx-spinner-speed`)
+    you can set on `:root` or any wrapper. Any other value (`data-pjx-loading="pulse"`)
+    just applies `.pjx-loading--pulse` for you to style.
+
+    See: [Reactivity → Loading indicators](../reactivity.md#loading-indicators-in-flight).
+
+---
+
+## Step 12 — LoadContext (avoid globals in load())
+
+The context is just a **plain frozen dataclass** — `LoadContext.current()` is duck-typed, so you don't need to subclass anything:
 
 ```python
 from dataclasses import dataclass
@@ -405,7 +443,7 @@ from pyjinhx import LoadContext
 
 
 @dataclass(frozen=True)
-class AppLoadContext(LoadContext):
+class AppLoadContext:
     store: object
 
 
@@ -425,7 +463,7 @@ setup(app, load_context_factory=lambda request: AppLoadContext(store=store))
 
 ---
 
-## Step 12 — Load cache scope and invalidation
+## Step 13 — Load cache scope and invalidation
 
 Default: **`CacheScope.REQUEST`** — `load()` results cache within each HTTP request (multi-worker safe).
 
@@ -453,11 +491,15 @@ setup(
 ???+ question "Why cache at all?"
     A single page may call `TodoCounter.load()` many times during composition and OOB walks. Caching `(class, load_arg) → component snapshot` avoids repeated store/DB work. **Invalidation** (`@mutates` or `LoadCache.invalidate`) evicts entries when state changes — cache is a performance layer, not the source of truth.
 
-    If toggles feel stale, check that mutations dirtied the **instance key** (`todo:42`), not just the stem (`todo`).
+    If toggles feel stale, check that `@mutates` dirtied a key your rows actually
+    declare in `reacts_to`. Rows here use **pub-sub** on `{Keys.TODOS}` — every mounted
+    row reloads when `todos` changes, and hash-gating skips the unchanged ones. (For
+    per-instance keys like `"todo:42"` instead of a shared stem, see
+    [Reactivity → Instance-keyed regions](../reactivity.md#instance-keyed-regions-rows).)
 
 ---
 
-## Step 13 — Production assets
+## Step 14 — Production assets
 
 ```python
 from pyjinhx import AssetMode, Renderer
@@ -479,7 +521,7 @@ TodoApp(...).render()  # client headers from middleware ClientBackend
 
 ---
 
-## Step 14 — Dev guardrails (optional)
+## Step 15 — Dev guardrails (optional)
 
 ```python
 from pyjinhx import enable_reactive_dev, dependency_graph, format_dependency_graph
@@ -493,7 +535,7 @@ print(format_dependency_graph())
 
 ---
 
-## Step 15 — Built-in UI kit (optional)
+## Step 16 — Built-in UI kit (optional)
 
 ```python
 import pyjinhx.builtins  # register templates
@@ -509,20 +551,13 @@ from pyjinhx.builtins import Alert, Button, Card
 
 ## Checklist — full app wiring
 
-| Piece | Required for reactive HTMX app |
-|-------|--------------------------------|
-| `Renderer.set_default_environment(...)` | Yes |
-| `Registry.request_scope()` middleware | Yes |
-| Root full-page render (auto `pjx.js` unless `X-PJX-Mounted` present) | Yes |
-| HTMX in layout | Yes |
-| `ReactiveComponent` + `reacts_to` + `load()` | Yes |
-| `@mutates(Keys.TODOS)` on store mutations | Yes |
-| `setup()` wires `FastAPIClientBackend` | Yes |
-| `PjxLoad` on keyed row components | Yes |
-| `LoadContext` | Recommended |
-| Assets / REFERENCE mode | Production |
-| Invalidation backend | Multi-worker + PROCESS cache |
-| `enable_reactive_dev()` | Development |
+The per-step **Why?** panels above cover the *why*; this is the at-a-glance *what*.
+
+| Tier | Pieces |
+|------|--------|
+| **Required** | `set_default_environment` · `Registry.request_scope()` middleware · root full-page render · HTMX in layout · `ReactiveComponent` (`reacts_to` + `load()`) · `@mutates(Keys.…)` on mutations · `setup()` (wires `FastAPIClientBackend`) · `PjxLoad` on keyed rows |
+| **Recommended** | `LoadContext` · `data-pjx-loading` indicators · `enable_reactive_dev()` in dev |
+| **Production** | `AssetMode.REFERENCE` + URL resolver · `InvalidationBackend` for multi-worker `PROCESS` cache |
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,13 +16,27 @@ pip install pyjinhx
 uv add pyjinhx
 ```
 
+## Optional extras
+
+The `redis` extra pulls in the dependencies for the Redis invalidation backend (used with `CacheScope.PROCESS` across multiple workers):
+
+```bash
+pip install pyjinhx[redis]
+```
+
 ## Dependencies
 
-PyJinHx automatically installs these dependencies:
+PyJinHx automatically installs these runtime dependencies:
 
 - **Jinja2** - Template engine
-- **Pydantic** - Data validation and settings
 - **MarkupSafe** - Safe HTML string handling
+- **Pydantic** - Data validation and settings
+
+PyJinHx does **not** install a web framework. FastAPI, Starlette, and uvicorn are user-supplied — install them yourself before following the FastAPI quickstart or [Build an App](build-an-app.md):
+
+```bash
+pip install fastapi uvicorn
+```
 
 ## Verify Installation
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -58,6 +58,8 @@ from pyjinhx import Renderer
 # Set the template search path
 Renderer.set_default_environment("./components")
 
+# Import components after setting the default environment so template
+# discovery is rooted at the path above.
 from components.ui.button import Button
 
 # Create and render

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -52,7 +52,7 @@ Configure how assets are delivered with `AssetMode`:
 |------|-----|----|----------|
 | `INLINE` (default) | `<style>` | inline `<script>` | Zero-config demos |
 | `REFERENCE` | `<link href>` | `<script src>` | Production monoliths with static file serving |
-| `NONE` | silence | silence | Manual static wiring (legacy `inline=False`) |
+| `NONE` | silence | silence | Manual static wiring |
 
 ```python
 from pyjinhx import AssetMode, Renderer
@@ -88,7 +88,7 @@ Partial renders ignore the asset header (no assets emitted). Dedup defaults to *
 
 In `REFERENCE` mode, root full-page renders emit `<script src="/static/pyjinhx/pjx.js">` when the request lacks `X-PJX-Mounted`. Mount the packaged file from `pyjinhx/runtime/pjx.js` or override with `Renderer.set_default_runtime_url()`.
 
-For raw Jinja shells, use `client_script(mode=AssetMode.REFERENCE)`.
+For raw Jinja shells, use `client_script(mode=AssetMode.REFERENCE)`. Pass `client_script(src=...)` to override the runtime URL (otherwise it falls back to `Renderer`'s configured URL, then `DEFAULT_RUNTIME_URL`).
 
 ### CSP
 
@@ -127,11 +127,11 @@ manifest = asset_manifest(session, resolver=resolver)
 Ship every component asset from the layout shell instead of per-page discovery:
 
 ```python
-from pyjinhx import Finder, layout_asset_tags, make_default_asset_url_resolver
+from pyjinhx import Finder, make_default_asset_url_resolver
 
 finder = Finder(root="./components")
 resolver = make_default_asset_url_resolver("./components")
-head_tags = layout_asset_tags(finder, resolver=resolver)
+head_tags = finder.layout_asset_tags(resolver=resolver)
 ```
 
 Combine with `AssetMode.REFERENCE` and reactive partial suppression so HTMX swaps never re-ship assets.
@@ -220,6 +220,6 @@ Map each absolute asset path to your `{% static %}` URL in the resolver callback
 | `hashed_filename()` | Content-hash a filename for cache-busting |
 | `resolver_with_hash()` | Resolver that embeds hashes in URLs |
 | `asset_manifest()` | Build `AssetManifest` from a `RenderSession` |
-| `layout_asset_tags()` | Preload all component assets in a layout shell |
+| `Finder.layout_asset_tags()` | Preload all component assets in a layout shell (instance method) |
 
 See [Assets API](../api/assets-api.md) for signatures and examples.

--- a/docs/guide/builtins.md
+++ b/docs/guide/builtins.md
@@ -31,9 +31,19 @@ from pyjinhx.builtins import (
 
 **Conventions:** Markup classes use the **`px-`** prefix; overrides use **`--px-`** custom properties. Builtin CSS also references **theme variables** (`--surface`, `--border`, `--text`, `--radius-md`, `--shadow-md`, `--transition`, `--brand`, …)—define those in your global CSS or map them to your design system.
 
-**Template discovery:** Builtins ship inside `site-packages`. If your Jinja loader only covers your app tree, the renderer **falls back** to adjacent package templates for `pyjinhx.builtins` classes.
+**Template discovery:** Builtins ship inside `site-packages`. If your Jinja loader only covers your app tree, the renderer **falls back** to adjacent package templates for `pyjinhx.builtins` classes. Each component's Jinja template lives next to its Python source in `pyjinhx/builtins/ui/<component>/` (e.g. `pyjinhx/builtins/ui/modal/modal.html`).
 
-Every component below inherits **`id`** (required), **`js`** / **`css`** (extra asset paths), **`render()`**, and **`__html__()`** from [`BaseComponent`](../api/base-component.md). `extra="allow"` lets you pass additional kwargs into the Jinja context.
+**Inherited fields:** Every component inherits **`id`** (required), **`js`** / **`css`** (extra asset paths), **`render()`**, and **`__html__()`** from [`BaseComponent`](../api/base-component.md). Because `id` is universal it is omitted from the per-component props tables below. `extra="allow"` lets you pass additional kwargs into the Jinja context.
+
+**Theming:** Per-component `--px-*` tokens are collected in the [Theming tokens](#theming-tokens) appendix. Each component section points there.
+
+**CSS-only components** (no bundled script): Badge, Tooltip, Progress, Skeleton, EmptyState, Divider, Spinner, Avatar, Card, Breadcrumb. (Tooltip and Popover ship CSS plus an IIFE that exports no globals.)
+
+**Children-vs-`content` tag gotcha (children-mapping components):** Several components map children to a single attribute (e.g. Tooltip `tip`, Popover `card_content`, Notification `content`, PanelTrigger `content`). If you use `Renderer.render()` with PascalCase tags, do **not** supply both child text and the corresponding attribute on the same tag—use body text as the child *or* the attribute, not both.
+
+**Backdrop click (Modal and Drawer):** Both render a native `<dialog>`; a document `click` listener treats a click whose target is the `<dialog>` root itself (the backdrop) as a close. Any native `<dialog>` clicked directly is affected—use unique ids and avoid stacking multiple dialogs unless you adjust this.
+
+**`panel.js` loading:** `panel.js` is included only when a [`Panel`](#panel) is rendered on the page. [`PanelTrigger`](#paneltrigger) does **not** load `panel.js` by asset name, so render a `Panel` on the same page (or add the script yourself) for triggers to work.
 
 ---
 
@@ -41,51 +51,14 @@ Every component below inherits **`id`** (required), **`js`** / **`css`** (extra 
 
 Small status label. **Assets:** `badge.css` only.
 
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Element id. |
 | `label` | `str` | `""` | Inner text. |
 | `color` | literal | `"neutral"` | `brand`, `error`, `neutral`, `muted` → `px-badge--{color}`. |
 | `shape` | literal | `"md"` | `square`, `sm`, `md`, `full` → `px-badge--{shape}`. |
 | `class_name` | `str` | `""` | Extra classes after the `px-badge*` classes. |
 
-
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```html
-    <span class="px-badge px-badge--{{ color }} px-badge--{{ shape }}{% if class_name %} {{ class_name }}{% endif %}">{{ label }}</span>
-    ```
-
-### JavaScript
-
-No bundled script.
-
-### Style
-
-**Classes:** `px-badge`; color modifiers `px-badge--brand`, `--error`, `--neutral`, `--muted`; shape `px-badge--square`, `--sm`, `--md`, `--full`.
-
-| Token | Default (maps to) |
-| --- | --- |
-| `--px-badge-font-size` | `var(--font-size-xs)` |
-| `--px-badge-radius-sm` | `var(--radius-sm)` |
-| `--px-badge-radius-md` | `var(--radius-md)` |
-| `--px-badge-radius-full` | `var(--radius-full)` |
-| `--px-badge-brand-bg` | `var(--brand-subtle)` |
-| `--px-badge-brand-fg` | `var(--brand-muted)` |
-| `--px-badge-brand-accent` | `var(--brand)` |
-| `--px-badge-error-bg` | `var(--error-bg)` |
-| `--px-badge-error-fg` | `var(--error)` |
-| `--px-badge-error-border` | `var(--error-border)` |
-| `--px-badge-neutral-bg` | `var(--surface-alt)` |
-| `--px-badge-neutral-fg` | `var(--text)` |
-| `--px-badge-neutral-border` | `var(--border)` |
-| `--px-badge-muted-bg` | `var(--surface)` |
-| `--px-badge-muted-fg` | `var(--text-muted)` |
-| `--px-badge-muted-border` | `var(--border)` |
+**Classes:** `px-badge`; color modifiers `px-badge--brand`, `--error`, `--neutral`, `--muted`; shape `px-badge--square`, `--sm`, `--md`, `--full`. Theming: see [appendix](#badge-1).
 
 ---
 
@@ -93,45 +66,12 @@ No bundled script.
 
 Native `<dialog>`. **Assets:** `modal.css`, `modal.js`.
 
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | `<dialog id>`; used by `openModal` / `closeModal`. |
 | `title` | `str \| BaseComponent` | `""` | Default header title when `header` is empty. |
 | `header` | `str \| BaseComponent` | `""` | If set, replaces the built-in title row. |
 | `body` | `str \| BaseComponent` | `""` | Main content; wrapper id `{{ id }}-body`. |
 | `footer` | `str \| BaseComponent` | `""` | If non-empty, renders `<footer class="px-modal__footer">`. |
-
-
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```html
-    <dialog class="px-modal" id="{{ id }}">
-        <div class="px-modal__box">
-            <header class="px-modal__header">
-                {% if header %}
-                {{ header }}
-                {% else %}
-                <span class="px-modal__title">{{ title }}</span>
-                {% endif %}
-                <button class="px-modal__close"
-                        onclick="closeModal('{{ id }}')"
-                        aria-label="Close">&#x2715;</button>
-            </header>
-
-            <div class="px-modal__body" id="{{ id }}-body">{{ body }}</div>
-
-            {% if footer %}
-            <footer class="px-modal__footer">{{ footer }}</footer>
-            {% endif %}
-        </div>
-    </dialog>
-    ```
-
-### JavaScript
 
 Globals from **`modal.js`** (injected with the component):
 
@@ -140,28 +80,9 @@ Globals from **`modal.js`** (injected with the component):
 | `openModal(id)` | `document.getElementById(id).showModal()` if present. |
 | `closeModal(id)` | Adds `px-modal--closing`, on `animationend` removes it and calls `dialog.close()`. |
 
-**Document listener:** `click` on `event.target.tagName === 'DIALOG'` runs `closeModal(event.target.id)` (backdrop click). Any native `<dialog>` root clicked directly is affected—use unique ids and avoid multiple stacked modals unless you adjust this.
+Backdrop click closes the dialog (see [intro note](#built-in-ui-components)).
 
-### Style
-
-**Classes:** `px-modal`; closing state `px-modal--closing`; `px-modal__box`, `__header`, `__title`, `__close`, `__body`, `__footer`. Close control hover uses `var(--surface)`, `var(--text)`, `var(--radius-sm)`, `var(--transition)` from your theme.
-
-| Token | Default |
-| --- | --- |
-| `--px-modal-width` | `52rem` |
-| `--px-modal-min-height` | `28rem` |
-| `--px-modal-bg` | `var(--surface)` |
-| `--px-modal-border` | `var(--border)` |
-| `--px-modal-radius` | `var(--radius-lg)` |
-| `--px-modal-shadow` | `var(--shadow-md)` |
-| `--px-modal-header-bg` | `var(--surface-alt)` |
-| `--px-modal-header-sep` | `var(--border)` |
-| `--px-modal-footer-bg` | `var(--surface-alt)` |
-| `--px-modal-footer-sep` | `var(--border)` |
-| `--px-modal-title-color` | `var(--text)` |
-| `--px-modal-close-color` | `var(--text-muted)` |
-| `--px-modal-backdrop` | `rgb(0 0 0 / 0.6)` |
-| `--px-modal-padding` | `1.5rem` |
+**Classes:** `px-modal`; closing state `px-modal--closing`; `px-modal__box`, `__header`, `__title`, `__close`, `__body`, `__footer`. Theming: see [appendix](#modal-1).
 
 ---
 
@@ -169,34 +90,11 @@ Globals from **`modal.js`** (injected with the component):
 
 Fixed-position toast. **Assets:** `notification.css`, `notification.js`.
 
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Root id for `showNotification` / `hideNotification`. |
 | `content` | `str \| BaseComponent` | `""` | Message body. |
 | `corner` | literal | `"top-right"` | `top-right`, `top-left`, `bottom-right`, `bottom-left`. |
 | `timeout` | `int` | `5000` | Auto-dismiss ms; `0` disables. Rendered as `data-timeout`. |
-
-
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```html
-    <div class="px-notification px-notification--{{ corner }}"
-         id="{{ id }}"
-         data-timeout="{{ timeout }}"
-         role="status"
-         aria-live="polite">
-        <div class="px-notification__content">{{ content }}</div>
-        <button class="px-notification__close"
-                onclick="hideNotification('{{ id }}')"
-                aria-label="Dismiss">&#x2715;</button>
-    </div>
-    ```
-
-### JavaScript
 
 Globals from **`notification.js`**:
 
@@ -205,21 +103,7 @@ Globals from **`notification.js`**:
 | `showNotification(id)` | Clears `px-notification--hiding`, adds `px-notification--visible`. Reads `data-timeout`; if numeric `> 0`, schedules `hideNotification(id)`. |
 | `hideNotification(id)` | If visible, adds `px-notification--hiding`; on `animationend` removes `visible` / `hiding`. |
 
-### Style
-
-**Classes:** `px-notification`; placement `px-notification--top-right`, `--top-left`, `--bottom-right`, `--bottom-left`; JS state `px-notification--visible`, `px-notification--hiding`; `px-notification__content`, `px-notification__close`. Content uses `var(--font-size-sm)`, `var(--text)`; close hover uses `var(--surface)`, `var(--text)`, `var(--radius-sm)`, `var(--transition)`.
-
-| Token | Default |
-| --- | --- |
-| `--px-notification-width` | `22rem` |
-| `--px-notification-gap` | `1.25rem` (viewport inset; used in slide animations) |
-| `--px-notification-bg` | `var(--surface-alt)` |
-| `--px-notification-border` | `var(--border)` |
-| `--px-notification-radius` | `var(--radius-md)` |
-| `--px-notification-shadow` | `var(--shadow-md)` |
-| `--px-notification-padding` | `1rem 1rem 1rem 1.25rem` |
-| `--px-notification-close-color` | `var(--text-muted)` |
-| `--px-notification-z` | `500` |
+**Classes:** `px-notification`; placement `px-notification--top-right`, `--top-left`, `--bottom-right`, `--bottom-left`; JS state `px-notification--visible`, `px-notification--hiding`; `px-notification__content`, `px-notification__close`. Theming: see [appendix](#notification-1).
 
 ---
 
@@ -227,33 +111,14 @@ Globals from **`notification.js`**:
 
 Hover trigger + floating card. **Assets:** `popover.css`, `popover.js` (IIFE, no globals).
 
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Id on `px-popover-trigger`. |
 | `content` | `str \| BaseComponent` | `""` | Trigger label (`px-popover-trigger__body`). |
 | `card_content` | `str \| BaseComponent` | `""` | Panel body (`px-popover-card`). |
 | `position` | literal | `"anchor"` | `anchor` (below trigger) or `follow` (pointer). → `data-popover-position`. |
 | `backdrop` | `bool` | `False` | When `True`, emits `data-popover-backdrop` on the trigger (dim layer + lifted z-index). |
 
-**Runtime behavior:** Mouse over the trigger opens the card; leaving the trigger (and its descendants) starts a short delayed hide. With **`data-popover-backdrop`** on the trigger (set `backdrop=True` on `Popover`, or add the attribute in custom markup), the script shows a full-screen dim layer, lifts the trigger z-index, and injects `#px-popover-backdrop` if needed.
-
-
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```html
-    <span class="px-popover-trigger" id="{{ id }}" data-popover-position="{{ position }}"{% if backdrop %} data-popover-backdrop{% endif %}>
-        <span class="px-popover-trigger__body">{{ content }}</span>
-        <div class="px-popover-card" role="tooltip" aria-hidden="true">
-            {{ card_content }}
-        </div>
-    </span>
-    ```
-
-### JavaScript
+**Runtime behavior:** Mouse over the trigger opens the card; leaving the trigger (and its descendants) starts a short delayed hide. With **`data-popover-backdrop`** on the trigger (set `backdrop=True`, or add the attribute in custom markup), the script shows a full-screen dim layer, lifts the trigger z-index, and injects `#px-popover-backdrop` if needed.
 
 No exported functions. Behavior is driven by:
 
@@ -264,21 +129,7 @@ No exported functions. Behavior is driven by:
 | `data-popover-backdrop` | If present (any value), backdrop + trigger lift. |
 | `#px-popover-backdrop` | Shared element; class `px-popover-backdrop`, state `px-popover-backdrop--visible`. |
 
-### Style
-
-**Classes:** `px-popover-trigger`, `px-popover-trigger__body`, `px-popover-card`, `px-popover-card--visible`, `px-popover-backdrop`, `px-popover-backdrop--visible`.
-
-| Token | Default |
-| --- | --- |
-| `--px-popover-max-width` | `28ch` |
-| `--px-popover-bg` | `var(--surface-alt)` |
-| `--px-popover-border` | `var(--border)` |
-| `--px-popover-radius` | `var(--radius-md)` |
-| `--px-popover-shadow` | `var(--shadow-md)` |
-| `--px-popover-padding` | `var(--space-3, 0.75rem) var(--space-4, 1rem)` |
-| `--px-popover-z` | `300` |
-
-Backdrop fill is fixed **`rgba(0, 0, 0, 0.35)`** in CSS (not a token). JS sets `z-index: calc(var(--px-popover-z) + 1)` on the trigger when the backdrop is active.
+**Classes:** `px-popover-trigger`, `px-popover-trigger__body`, `px-popover-card`, `px-popover-card--visible`, `px-popover-backdrop`, `px-popover-backdrop--visible`. Backdrop fill is fixed **`rgba(0, 0, 0, 0.35)`** in CSS (not a token); JS sets `z-index: calc(var(--px-popover-z) + 1)` on the trigger when the backdrop is active. Theming: see [appendix](#popover-1).
 
 ---
 
@@ -286,26 +137,9 @@ Backdrop fill is fixed **`rgba(0, 0, 0, 0.35)`** in CSS (not a token). JS sets `
 
 In-place loading veil over a positioned ancestor. **Assets:** `loading-overlay.css`, `loading-overlay.js`.
 
-### Python
-
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| `id` | `str` | (required) | Overlay root id for show/hide helpers. |
+This component declares no extra fields beyond the inherited `id`.
 
 **Layout:** Overlay is `position: absolute; inset: 0`. Parent must be **`position: relative`** (or any non-`static` value) so coverage is correct.
-
-
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```html
-    <div class="px-loading-overlay" id="{{ id }}" role="status" aria-label="Loading" aria-live="polite">
-        <div class="px-loading-overlay__spinner"></div>
-    </div>
-    ```
-
-### JavaScript
 
 Globals from **`loading-overlay.js`**:
 
@@ -314,19 +148,7 @@ Globals from **`loading-overlay.js`**:
 | `showLoadingOverlay(id)` | Removes `px-loading-overlay--hiding`, adds `px-loading-overlay--visible`. |
 | `hideLoadingOverlay(id)` | Adds `px-loading-overlay--hiding`; on `animationend` clears visible/hiding classes. |
 
-### Style
-
-**Classes:** `px-loading-overlay`; state `px-loading-overlay--visible`, `px-loading-overlay--hiding`; `px-loading-overlay__spinner`. Spinner ring uses **`var(--radius-full)`** from your theme.
-
-| Token | Default |
-| --- | --- |
-| `--px-loading-overlay-bg` | `rgb(0 0 0 / 0.55)` |
-| `--px-loading-overlay-backdrop` | `blur(2px)` |
-| `--px-loading-overlay-z` | `100` |
-| `--px-loading-overlay-spinner-size` | `2.5rem` |
-| `--px-loading-overlay-spinner-width` | `3px` |
-| `--px-loading-overlay-spinner-color` | `var(--brand)` |
-| `--px-loading-overlay-spinner-track` | `rgb(255 255 255 / 0.1)` |
+**Classes:** `px-loading-overlay`; state `px-loading-overlay--visible`, `px-loading-overlay--hiding`; `px-loading-overlay__spinner`. Spinner ring uses **`var(--radius-full)`** from your theme. Theming: see [appendix](#loadingoverlay-1).
 
 ---
 
@@ -334,32 +156,13 @@ Globals from **`loading-overlay.js`**:
 
 Compact focus/hover hint. **Assets:** `tooltip.css`, `tooltip.js` (IIFE).
 
-
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Root `px-tooltip` id; tip element id is `{{ id }}-tip`. |
 | `trigger` | `str \| BaseComponent` | `""` | Focusable trigger (`px-tooltip__trigger`, `tabindex="0"`). |
 | `tip` | `str \| BaseComponent` | `""` | `role="tooltip"` body. |
 | `placement` | literal | `"top"` | `top`, `bottom`, `start`, `end` → `data-px-tooltip-placement`. |
 
-**Tag gotcha:** If you use `Renderer.render()` with PascalCase tags, avoid both child text and a `content` attribute on components that map children to `content`—use body text as the child or attributes only, not both.
-
-### Style tokens
-
-| Token | Default |
-| --- | --- |
-| `--px-tooltip-gap` | `6px` |
-| `--px-tooltip-bg` | `var(--surface-alt)` |
-| `--px-tooltip-border` | `var(--border)` |
-| `--px-tooltip-radius` | `var(--radius-sm)` |
-| `--px-tooltip-shadow` | `var(--shadow-md)` |
-| `--px-tooltip-padding` | `0.35rem 0.5rem` |
-| `--px-tooltip-max-width` | `20ch` |
-| `--px-tooltip-fg` | `var(--text)` |
-| `--px-tooltip-font-size` | `var(--font-size-xs)` |
-| `--px-tooltip-z` | `400` |
+Maps children to `tip`; see the [children-vs-`content` note](#built-in-ui-components). Theming: see [appendix](#tooltip-1).
 
 ---
 
@@ -367,36 +170,18 @@ Compact focus/hover hint. **Assets:** `tooltip.css`, `tooltip.js` (IIFE).
 
 Inline status banner. **Assets:** `alert.css`, `alert.js`.
 
-
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Root id for `dismissPxAlert(id)`. |
 | `variant` | literal | `"info"` | `info`, `success`, `warning`, `error` → `px-alert--{variant}`. |
 | `title` | `str` | `""` | Optional heading. |
 | `body` | `str \| BaseComponent` | `""` | Main copy. |
 | `dismissible` | `bool` | `False` | When true, renders dismiss control calling `dismissPxAlert`. |
 
-### JavaScript
-
 | Function | Description |
 | --- | --- |
 | `dismissPxAlert(id)` | Adds `px-alert--dismissed` (hides via `display: none`). |
 
-### Style tokens
-
-| Token | Default |
-| --- | --- |
-| `--px-alert-radius` | `var(--radius-md)` |
-| `--px-alert-padding` | `0.875rem 1rem` |
-| `--px-alert-border` | `var(--border)` |
-| `--px-alert-shadow` | `var(--shadow-md)` |
-| `--px-alert-title-size` | `var(--font-size-sm)` |
-| `--px-alert-body-size` | `var(--font-size-sm)` |
-| `--px-alert-dismiss-color` | `var(--text-muted)` |
-
-Variants use `color-mix` with `--brand`, `--success`, `--warning`, or `--error` / `--error-bg` / `--error-border` where applicable.
+Variants use `color-mix` with `--brand`, `--success`, `--warning`, or `--error` / `--error-bg` / `--error-border` where applicable. Theming: see [appendix](#alert-1).
 
 ---
 
@@ -404,36 +189,19 @@ Variants use `color-mix` with `--brand`, `--success`, `--warning`, or `--error` 
 
 Button + anchored panel. **Assets:** `dropdown.css`, `dropdown.js`.
 
-
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Wrapper id; trigger id `{{ id }}-trigger`, menu `{{ id }}-menu`. |
 | `trigger` | `str \| BaseComponent` | `""` | Button label. |
 | `menu` | `str \| BaseComponent` | `""` | Panel HTML (e.g. links or custom markup). |
 
-### JavaScript
+Trigger id is `{{ id }}-trigger`, menu is `{{ id }}-menu`.
 
 | Function | Description |
 | --- | --- |
 | `togglePxDropdown(id)` | Toggles `hidden` on the menu and `aria-expanded` on the trigger. |
 | `closePxDropdown(id)` | Closes the menu. |
 
-**Listeners:** `document` `click` closes any open menu whose root does not contain the event target. `keydown` `Escape` closes all open menus.
-
-### Style tokens
-
-| Token | Default |
-| --- | --- |
-| `--px-dropdown-menu-bg` | `var(--surface-alt)` |
-| `--px-dropdown-menu-border` | `var(--border)` |
-| `--px-dropdown-menu-radius` | `var(--radius-md)` |
-| `--px-dropdown-menu-shadow` | `var(--shadow-md)` |
-| `--px-dropdown-menu-padding` | `0.35rem 0` |
-| `--px-dropdown-menu-min-w` | `10rem` |
-| `--px-dropdown-menu-max-h` | `min(70dvh, 24rem)` |
-| `--px-dropdown-z` | `350` |
+**Listeners:** `document` `click` closes any open menu whose root does not contain the event target. `keydown` `Escape` closes all open menus. Theming: see [appendix](#dropdown-1).
 
 ---
 
@@ -441,42 +209,19 @@ Button + anchored panel. **Assets:** `dropdown.css`, `dropdown.js`.
 
 `<dialog>` sheet from an edge. **Assets:** `drawer.css`, `drawer.js`.
 
-
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Dialog id for `openPxDrawer` / `closePxDrawer`. |
 | `side` | literal | `"right"` | `left`, `right`, or `bottom` → `px-drawer--{side}`. |
 | `title` | `str \| BaseComponent` | `""` | Header title. |
 | `body` | `str \| BaseComponent` | `""` | Scrollable body. |
 | `footer` | `str \| BaseComponent` | `""` | Optional footer strip. |
-
-### JavaScript
 
 | Function | Description |
 | --- | --- |
 | `openPxDrawer(id)` | `showModal()` on the dialog. |
 | `closePxDrawer(id)` | Adds `px-drawer--closing`; on `animationend`, removes it and `dialog.close()`. |
 
-**Listener:** `click` on `DIALOG.px-drawer` (backdrop hit) calls `closePxDrawer`—same pattern as modal; keep ids unique.
-
-### Style tokens
-
-| Token | Default |
-| --- | --- |
-| `--px-drawer-width` | `min(24rem, 100vw)` |
-| `--px-drawer-height-bottom` | `min(50dvh, 28rem)` |
-| `--px-drawer-bg` | `var(--surface)` |
-| `--px-drawer-border` | `var(--border)` |
-| `--px-drawer-shadow` | `var(--shadow-md)` |
-| `--px-drawer-backdrop` | `rgb(0 0 0 / 0.45)` |
-| `--px-drawer-header-bg` | `var(--surface-alt)` |
-| `--px-drawer-header-sep` | `var(--border)` |
-| `--px-drawer-footer-bg` | `var(--surface-alt)` |
-| `--px-drawer-footer-sep` | `var(--border)` |
-| `--px-drawer-padding` | `1rem` |
-| `--px-drawer-z` | `250` |
+Backdrop click closes the dialog (see [intro note](#built-in-ui-components)). Theming: see [appendix](#drawer-1).
 
 ---
 
@@ -484,25 +229,13 @@ Button + anchored panel. **Assets:** `dropdown.css`, `dropdown.js`.
 
 Determinate or indeterminate meter. **Assets:** `progress.css` only.
 
-
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Wrapper id. |
 | `value` | `float \| None` | `None` | Omit or `None` for indeterminate `<progress>`. |
 | `max` | `float` | `100` | Passed to `<progress max="…">`. |
 | `label` | `str` | `""` | Optional `px-progress__label`; wires `aria-labelledby` when set. |
 
-### Style tokens
-
-| Token | Default |
-| --- | --- |
-| `--px-progress-height` | `0.5rem` |
-| `--px-progress-radius` | `var(--radius-full)` |
-| `--px-progress-track` | `var(--surface-alt)` |
-| `--px-progress-fill` | `var(--brand)` |
-| `--px-progress-indeterminate-speed` | `1.2s` |
+Theming: see [appendix](#progress-1).
 
 ---
 
@@ -510,28 +243,13 @@ Determinate or indeterminate meter. **Assets:** `progress.css` only.
 
 Placeholder shimmer blocks. **Assets:** `skeleton.css` only.
 
-
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Root id. |
 | `variant` | literal | `"text"` | `text` (stacked lines), `circle`, or `rect`. |
 | `lines` | `int` | `3` | For `text`, count of `px-skeleton__line` rows. |
 | `class_name` | `str` | `""` | Extra classes on the root. |
 
-### Style tokens
-
-| Token | Default |
-| --- | --- |
-| `--px-skeleton-bg` | `var(--surface-alt)` |
-| `--px-skeleton-shine` | `color-mix(in srgb, var(--text) 8%, var(--surface-alt))` |
-| `--px-skeleton-line-height` | `0.65rem` |
-| `--px-skeleton-line-gap` | `0.5rem` |
-| `--px-skeleton-circle-size` | `2.5rem` |
-| `--px-skeleton-rect-height` | `6rem` |
-| `--px-skeleton-rect-radius` | `var(--radius-md)` |
-| `--px-skeleton-duration` | `1.2s` |
+Theming: see [appendix](#skeleton-1).
 
 ---
 
@@ -539,27 +257,13 @@ Placeholder shimmer blocks. **Assets:** `skeleton.css` only.
 
 Centered empty view. **Assets:** `empty-state.css` only (template file **`empty-state.html`** next to `empty_state.py`).
 
-
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Root id. |
 | `title` | `str \| BaseComponent` | `""` | Heading. |
 | `description` | `str \| BaseComponent` | `""` | Supporting text. |
 | `action` | `str \| BaseComponent` | `""` | Optional slot (e.g. button markup). |
 
-### Style tokens
-
-| Token | Default |
-| --- | --- |
-| `--px-empty-state-padding` | `2rem 1.5rem` |
-| `--px-empty-state-max-width` | `28rem` |
-| `--px-empty-state-title-size` | `var(--font-size-md)` |
-| `--px-empty-state-desc-size` | `var(--font-size-sm)` |
-| `--px-empty-state-title-color` | `var(--text)` |
-| `--px-empty-state-desc-color` | `var(--text-muted)` |
-| `--px-empty-state-gap` | `0.5rem` |
+Theming: see [appendix](#emptystate-1).
 
 ---
 
@@ -567,55 +271,13 @@ Centered empty view. **Assets:** `empty-state.css` only (template file **`empty-
 
 Separator line. **Assets:** `divider.css` only.
 
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Root id. |
 | `orientation` | literal | `"horizontal"` | `horizontal` (default `hr`) or `vertical` (bar). |
 | `label` | `str` | `""` | If set with horizontal orientation, flex row with label between lines. |
 | `class_name` | `str` | `""` | Extra classes on the root. |
 
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```jinja
-    {% if orientation == 'vertical' %}
-    <div id="{{ id }}"
-         class="px-divider px-divider--vertical{% if class_name %} {{ class_name }}{% endif %}"
-         role="separator"
-         aria-orientation="vertical"
-         {% if label %}aria-label="{{ label }}"{% endif %}></div>
-    {% elif label %}
-    <div id="{{ id }}" class="px-divider px-divider--labeled{% if class_name %} {{ class_name }}{% endif %}" role="presentation">
-      <span class="px-divider__line" aria-hidden="true"></span>
-      <span class="px-divider__label">{{ label }}</span>
-      <span class="px-divider__line" aria-hidden="true"></span>
-    </div>
-    {% else %}
-    <hr id="{{ id }}"
-        class="px-divider px-divider--horizontal{% if class_name %} {{ class_name }}{% endif %}"
-        role="separator"
-        aria-orientation="horizontal" />
-    {% endif %}
-    ```
-
-### JavaScript
-
-No bundled script.
-
-### Style
-
-**Classes:** `px-divider--horizontal`, `px-divider--vertical`, `px-divider--labeled`, `px-divider__line`, `px-divider__label`.
-
-| Token | Default |
-| --- | --- |
-| `--px-divider-color` | `var(--border)` |
-| `--px-divider-thickness` | `1px` |
-| `--px-divider-gap` | `0.75rem` |
-| `--px-divider-label-color` | `var(--text-muted)` |
-| `--px-divider-label-size` | `var(--font-size-sm)` |
+**Classes:** `px-divider--horizontal`, `px-divider--vertical`, `px-divider--labeled`, `px-divider__line`, `px-divider__label`. Theming: see [appendix](#divider-1).
 
 ---
 
@@ -623,44 +285,12 @@ No bundled script.
 
 Inline loading indicator. **Assets:** `spinner.css` only.
 
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Root id. |
 | `size` | literal | `"md"` | `sm`, `md`, or `lg`. |
 | `label` | `str` | `"Loading"` | Visually hidden; exposed to assistive tech. |
 
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```jinja
-    <span id="{{ id }}"
-          class="px-spinner px-spinner--{{ size }}"
-          role="status"
-          aria-live="polite"
-          aria-busy="true">
-      <span class="px-spinner__ring" aria-hidden="true"></span>
-      <span class="px-spinner__label">{{ label }}</span>
-    </span>
-    ```
-
-### JavaScript
-
-No bundled script.
-
-### Style
-
-**Classes:** `px-spinner`, `px-spinner--sm|md|lg`, `px-spinner__ring`, `px-spinner__label` (screen-reader-only).
-
-| Token | Default |
-| --- | --- |
-| `--px-spinner-sm` | `1.25rem` |
-| `--px-spinner-md` | `2rem` |
-| `--px-spinner-lg` | `2.75rem` |
-| `--px-spinner-track` | `color-mix(in srgb, var(--text-muted) 35%, transparent)` |
-| `--px-spinner-accent` | `var(--brand)` |
+**Classes:** `px-spinner`, `px-spinner--sm|md|lg`, `px-spinner__ring`, `px-spinner__label` (screen-reader-only). Theming: see [appendix](#spinner-1).
 
 ---
 
@@ -668,48 +298,15 @@ No bundled script.
 
 Image or initials in a circle. **Assets:** `avatar.css` only (template **`avatar.html`**).
 
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Root id. |
 | `src` | `str` | `""` | Image URL; when empty, initials fallback is shown. |
 | `alt` | `str` | `""` | `img` alt text; also used as `title` on initials. |
 | `initials` | `str` | `""` | Up to two characters (trimmed/capped in validation). |
 | `size` | literal | `"md"` | `sm`, `md`, or `lg`. |
 | `class_name` | `str` | `""` | Extra classes on the root. |
 
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```jinja
-    <div id="{{ id }}"
-         class="px-avatar px-avatar--{{ size }}{% if class_name %} {{ class_name }}{% endif %}">
-      {% if src %}
-      <img class="px-avatar__img" src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" />
-      {% else %}
-      <span class="px-avatar__initials" {% if alt %}title="{{ alt }}"{% endif %}>{{ initials or "?" }}</span>
-      {% endif %}
-    </div>
-    ```
-
-### JavaScript
-
-No bundled script.
-
-### Style
-
-**Classes:** `px-avatar`, `px-avatar--sm|md|lg`, `px-avatar__img`, `px-avatar__initials`.
-
-| Token | Default |
-| --- | --- |
-| `--px-avatar-sm` | `2rem` |
-| `--px-avatar-md` | `2.5rem` |
-| `--px-avatar-lg` | `3.25rem` |
-| `--px-avatar-bg` | `var(--surface-alt)` |
-| `--px-avatar-fg` | `var(--text-muted)` |
-| `--px-avatar-border` | `var(--border)` |
+**Classes:** `px-avatar`, `px-avatar--sm|md|lg`, `px-avatar__img`, `px-avatar__initials`. Theming: see [appendix](#avatar-1).
 
 ---
 
@@ -717,53 +314,14 @@ No bundled script.
 
 Grouped content with optional header and footer. **Assets:** `card.css` only.
 
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Root id. |
 | `title` | `str \| BaseComponent` | `""` | Default header title (ignored if `header` is set). |
 | `header` | `str \| BaseComponent` | `""` | Custom header slot; replaces `title` block when set. |
 | `body` | `str \| BaseComponent` | `""` | Main content. |
 | `footer` | `str \| BaseComponent` | `""` | Optional footer. |
 
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```jinja
-    <article id="{{ id }}" class="px-card">
-      {% if header or title %}
-      <header class="px-card__header">
-        {% if header %}
-        {{ header }}
-        {% else %}
-        <h3 class="px-card__title">{{ title }}</h3>
-        {% endif %}
-      </header>
-      {% endif %}
-      <div class="px-card__body">{{ body }}</div>
-      {% if footer %}
-      <footer class="px-card__footer">{{ footer }}</footer>
-      {% endif %}
-    </article>
-    ```
-
-### JavaScript
-
-No bundled script.
-
-### Style
-
-**Classes:** `px-card`, `px-card__header`, `px-card__title`, `px-card__body`, `px-card__footer`.
-
-| Token | Default |
-| --- | --- |
-| `--px-card-bg` | `var(--surface-alt)` |
-| `--px-card-border` | `var(--border)` |
-| `--px-card-radius` | `var(--radius-md)` |
-| `--px-card-title-color` | `var(--text)` |
-| `--px-card-padding` | `var(--space-4, 1rem)` |
+**Classes:** `px-card`, `px-card__header`, `px-card__title`, `px-card__body`, `px-card__footer`. Theming: see [appendix](#card-1).
 
 ---
 
@@ -771,107 +329,29 @@ No bundled script.
 
 Ordered trail of links. **Assets:** `breadcrumb.css` only.
 
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Root `nav` id. |
 | `items` | `list[tuple[str, str \| None]]` | `[]` | `(label, href)` left to right; `href` `None` marks the current page. |
 
 `items` may also be passed as a **JSON array** string (e.g. from PascalCase tags): `[["Home","/"],["Here",null]]`.
 
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```jinja
-    <nav id="{{ id }}" class="px-breadcrumb" aria-label="Breadcrumb">
-      <ol class="px-breadcrumb__list">
-        {% for label, href in items %}
-        <li class="px-breadcrumb__item">
-          {% if href %}
-          <a class="px-breadcrumb__link" href="{{ href }}">{{ label }}</a>
-          {% else %}
-          <span class="px-breadcrumb__current" aria-current="page">{{ label }}</span>
-          {% endif %}
-        </li>
-        {% endfor %}
-      </ol>
-    </nav>
-    ```
-
-### JavaScript
-
-No bundled script.
-
-### Style
-
-**Classes:** `px-breadcrumb`, `px-breadcrumb__list`, `px-breadcrumb__item`, `px-breadcrumb__link`, `px-breadcrumb__current`. Separators via `::after` on items except the last.
-
-| Token | Default |
-| --- | --- |
-| `--px-breadcrumb-sep` | `"/"` |
-| `--px-breadcrumb-link-color` | `var(--brand)` |
-| `--px-breadcrumb-current-color` | `var(--text)` |
+**Classes:** `px-breadcrumb`, `px-breadcrumb__list`, `px-breadcrumb__item`, `px-breadcrumb__link`, `px-breadcrumb__current`. Separators via `::after` on items except the last. Theming: see [appendix](#breadcrumb-1).
 
 ---
 
 ## TabGroup
 
-Tab buttons and panels. **Assets:** `tab-group.css`, **`tab-group.js`** (kebab-case filenames so the renderer’s JS/CSS collector finds them; see `LoadingOverlay` → `loading-overlay.*`).
-
-### Python
+Tab buttons and panels. **Assets:** `tab-group.css`, **`tab-group.js`** (kebab-case filenames so the renderer's JS/CSS collector finds them; see `LoadingOverlay` → `loading-overlay.*`).
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Root id; tab and panel ids are derived from it. |
 | `tabs` | `dict[str, str \| BaseComponent]` | `{}` | **Insertion order** is tab order; keys are labels, values are panel bodies. |
 
 `tabs` may also be a **JSON object** string from markup tags (values are HTML strings).
 
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```jinja
-    <div id="{{ id }}" class="px-tab-group">
-      <div class="px-tab-group__list" role="tablist" aria-label="Tabs">
-        {% for label, panel in tabs.items() %}
-        <button type="button"
-                class="px-tab-group__tab"
-                role="tab"
-                id="{{ id }}-tab-{{ loop.index0 }}"
-                aria-controls="{{ id }}-panel-{{ loop.index0 }}"
-                aria-selected="{% if loop.first %}true{% else %}false{% endif %}"
-                tabindex="{% if loop.first %}0{% else %}-1{% endif %}">{{ label }}</button>
-        {% endfor %}
-      </div>
-      {% for label, panel in tabs.items() %}
-      <div class="px-tab-group__panel"
-           role="tabpanel"
-           id="{{ id }}-panel-{{ loop.index0 }}"
-           aria-labelledby="{{ id }}-tab-{{ loop.index0 }}"
-           {% if not loop.first %}hidden{% endif %}>{{ panel }}</div>
-      {% endfor %}
-    </div>
-    ```
-
-### JavaScript
-
 **`tab-group.js`:** `click` delegation on `.px-tab-group__tab` updates `aria-selected`, `tabindex`, and `hidden` on sibling panels within the same `.px-tab-group`.
 
-### Style
-
-**Classes:** `px-tab-group`, `px-tab-group__list`, `px-tab-group__tab`, `px-tab-group__panel`.
-
-| Token | Default |
-| --- | --- |
-| `--px-tab-group-border` | `var(--border)` |
-| `--px-tab-group-bg` | `var(--surface-alt)` |
-| `--px-tab-group-tab-active-fg` | `var(--text)` |
-| `--px-tab-group-tab-active-bg` | `color-mix(in srgb, var(--surface) 55%, var(--surface-alt))` |
-| `--px-tab-group-tab-active-border` | `var(--brand)` |
-| `--px-tab-group-panel-bg` | `var(--surface)` |
+**Classes:** `px-tab-group`, `px-tab-group__list`, `px-tab-group__tab`, `px-tab-group__panel`. Theming: see [appendix](#tabgroup-1).
 
 ---
 
@@ -879,36 +359,13 @@ Tab buttons and panels. **Assets:** `tab-group.css`, **`tab-group.js`** (kebab-c
 
 Host for **distributed** tab-like switching: all bodies render here; controls are separate [`PanelTrigger`](#paneltrigger) components. **Unstyled** aside from `hidden` panels. **Assets:** `panel.css`, **`panel.js`**.
 
-### Python
-
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Root id; must match `PanelTrigger.panel_id`. Slot element ids are `{{ id }}-panel-{{ key }}`. |
 | `panels` | `dict[str, str \| BaseComponent]` | `{}` | **Insertion order** sets the initially visible slot (first is shown). Keys must match `[a-zA-Z0-9_-]+`. |
 
-`panels` may be a **JSON object** string from PascalCase tags. Keys are used in HTML `id` attributes and `data-px-panel-key`.
-
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```jinja
-    <div id="{{ id }}" class="px-panel">
-      {% for panel_key, panel_body in panels.items() %}
-      <div class="px-panel__panel"
-           role="tabpanel"
-           id="{{ id }}-panel-{{ panel_key }}"
-           data-px-panel-key="{{ panel_key }}"
-           {% if not loop.first %}hidden{% endif %}>{{ panel_body }}</div>
-      {% endfor %}
-    </div>
-    ```
-
-### JavaScript
+`panels` may be a **JSON object** string from PascalCase tags. Keys are used in HTML `id` attributes and `data-px-panel-key`. Slot element ids are `{{ id }}-panel-{{ key }}`. The `id` must match `PanelTrigger.panel_id`.
 
 **`panel.js`:** `click` on `.px-panel-trigger` shows the matching `.px-panel__panel` inside the host `getElementById(panel_id)`, hides others, syncs `aria-selected` / `tabIndex` on **all** triggers for that host. **`pxPanelInit`** runs on `DOMContentLoaded`, `htmx:afterSwap`, and `htmx:afterSettle` so swapped fragments pick up correct ARIA after partial updates.
-
-### Style
 
 **Classes:** `px-panel`, `px-panel__panel`. No theme tokens; minimal rules for `[hidden]` panels.
 
@@ -916,37 +373,15 @@ Host for **distributed** tab-like switching: all bodies render here; controls ar
 
 ## PanelTrigger
 
-Invisible wrapper that wires clicks to a [`Panel`](#panel) slot (place it anywhere; put your own links, buttons, or styled markup in `content`, same pattern as [`Popover`](#popover) / [`Notification`](#notification)). **Assets:** `panel-trigger.css`. Render a [`Panel`](#panel) on the same page so **`panel.js`** is included (`PanelTrigger` does not load `panel.js` by asset name).
-
-### Python
+Invisible wrapper that wires clicks to a [`Panel`](#panel) slot (place it anywhere; put your own links, buttons, or styled markup in `content`, same pattern as [`Popover`](#popover) / [`Notification`](#notification)). **Assets:** `panel-trigger.css`. See the [`panel.js` loading note](#built-in-ui-components)—render a `Panel` on the same page so the script is included.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | `str` | (required) | Wrapper element id. |
 | `panel_id` | `str` | (required) | Must equal the target `Panel.id`. |
 | `panel` | `str` | (required) | Key matching a key in `Panel.panels`; `[a-zA-Z0-9_-]+`. |
 | `content` | `str \| BaseComponent` | `""` | Inner HTML / nested components (your visible control). |
 
-### HTML
-
-??? abstract "HTML (Jinja template)"
-
-    ```jinja
-    <div id="{{ id }}"
-         class="px-panel-trigger"
-         role="tab"
-         data-px-panel-id="{{ panel_id }}"
-         data-px-panel-key="{{ panel }}"
-         aria-controls="{{ panel_id }}-panel-{{ panel }}"
-         aria-selected="false"
-         tabindex="-1">{{ content }}</div>
-    ```
-
-### JavaScript
-
-**`panel.js`** is loaded when a [`Panel`](#panel) is rendered (same directory). `PanelTrigger` does not match `panel-trigger.js`, so include a `Panel` on the page or add the script yourself.
-
-### Style
+Maps children to `content`; see the [children-vs-`content` note](#built-in-ui-components).
 
 **`panel-trigger.css`:** `.px-panel-trigger { display: contents; }` so the wrapper does not create a layout box. Override in your app (e.g. `display: block`) if you need a real box.
 
@@ -987,3 +422,245 @@ open_chat = PanelTrigger(
     id="open-chat", panel_id="app-panels", panel="chat", content="Chat"
 )
 ```
+
+---
+
+## Theming tokens
+
+Per-component `--px-*` custom properties and their default mappings. Override any token in your own CSS. Components not listed here (Panel, PanelTrigger, Tooltip's IIFE behavior, etc.) expose no tokens or are noted inline above.
+
+### Badge
+
+| Token | Default (maps to) |
+| --- | --- |
+| `--px-badge-font-size` | `var(--font-size-xs)` |
+| `--px-badge-radius-sm` | `var(--radius-sm)` |
+| `--px-badge-radius-md` | `var(--radius-md)` |
+| `--px-badge-radius-full` | `var(--radius-full)` |
+| `--px-badge-brand-bg` | `var(--brand-subtle)` |
+| `--px-badge-brand-fg` | `var(--brand-muted)` |
+| `--px-badge-brand-accent` | `var(--brand)` |
+| `--px-badge-error-bg` | `var(--error-bg)` |
+| `--px-badge-error-fg` | `var(--error)` |
+| `--px-badge-error-border` | `var(--error-border)` |
+| `--px-badge-neutral-bg` | `var(--surface-alt)` |
+| `--px-badge-neutral-fg` | `var(--text)` |
+| `--px-badge-neutral-border` | `var(--border)` |
+| `--px-badge-muted-bg` | `var(--surface)` |
+| `--px-badge-muted-fg` | `var(--text-muted)` |
+| `--px-badge-muted-border` | `var(--border)` |
+
+### Modal
+
+| Token | Default |
+| --- | --- |
+| `--px-modal-width` | `52rem` |
+| `--px-modal-min-height` | `28rem` |
+| `--px-modal-bg` | `var(--surface)` |
+| `--px-modal-border` | `var(--border)` |
+| `--px-modal-radius` | `var(--radius-lg)` |
+| `--px-modal-shadow` | `var(--shadow-md)` |
+| `--px-modal-header-bg` | `var(--surface-alt)` |
+| `--px-modal-header-sep` | `var(--border)` |
+| `--px-modal-footer-bg` | `var(--surface-alt)` |
+| `--px-modal-footer-sep` | `var(--border)` |
+| `--px-modal-title-color` | `var(--text)` |
+| `--px-modal-close-color` | `var(--text-muted)` |
+| `--px-modal-backdrop` | `rgb(0 0 0 / 0.6)` |
+| `--px-modal-padding` | `1.5rem` |
+
+Close control hover uses `var(--surface)`, `var(--text)`, `var(--radius-sm)`, `var(--transition)` from your theme.
+
+### Notification
+
+| Token | Default |
+| --- | --- |
+| `--px-notification-width` | `22rem` |
+| `--px-notification-gap` | `1.25rem` (viewport inset; used in slide animations) |
+| `--px-notification-bg` | `var(--surface-alt)` |
+| `--px-notification-border` | `var(--border)` |
+| `--px-notification-radius` | `var(--radius-md)` |
+| `--px-notification-shadow` | `var(--shadow-md)` |
+| `--px-notification-padding` | `1rem 1rem 1rem 1.25rem` |
+| `--px-notification-close-color` | `var(--text-muted)` |
+| `--px-notification-z` | `500` |
+
+Content uses `var(--font-size-sm)`, `var(--text)`; close hover uses `var(--surface)`, `var(--text)`, `var(--radius-sm)`, `var(--transition)`.
+
+### Popover
+
+| Token | Default |
+| --- | --- |
+| `--px-popover-max-width` | `28ch` |
+| `--px-popover-bg` | `var(--surface-alt)` |
+| `--px-popover-border` | `var(--border)` |
+| `--px-popover-radius` | `var(--radius-md)` |
+| `--px-popover-shadow` | `var(--shadow-md)` |
+| `--px-popover-padding` | `var(--space-3, 0.75rem) var(--space-4, 1rem)` |
+| `--px-popover-z` | `300` |
+
+### LoadingOverlay
+
+| Token | Default |
+| --- | --- |
+| `--px-loading-overlay-bg` | `rgb(0 0 0 / 0.55)` |
+| `--px-loading-overlay-backdrop` | `blur(2px)` |
+| `--px-loading-overlay-z` | `100` |
+| `--px-loading-overlay-spinner-size` | `2.5rem` |
+| `--px-loading-overlay-spinner-width` | `3px` |
+| `--px-loading-overlay-spinner-color` | `var(--brand)` |
+| `--px-loading-overlay-spinner-track` | `rgb(255 255 255 / 0.1)` |
+
+### Tooltip
+
+| Token | Default |
+| --- | --- |
+| `--px-tooltip-gap` | `6px` |
+| `--px-tooltip-bg` | `var(--surface-alt)` |
+| `--px-tooltip-border` | `var(--border)` |
+| `--px-tooltip-radius` | `var(--radius-sm)` |
+| `--px-tooltip-shadow` | `var(--shadow-md)` |
+| `--px-tooltip-padding` | `0.35rem 0.5rem` |
+| `--px-tooltip-max-width` | `20ch` |
+| `--px-tooltip-fg` | `var(--text)` |
+| `--px-tooltip-font-size` | `var(--font-size-xs)` |
+| `--px-tooltip-z` | `400` |
+
+### Alert
+
+| Token | Default |
+| --- | --- |
+| `--px-alert-radius` | `var(--radius-md)` |
+| `--px-alert-padding` | `0.875rem 1rem` |
+| `--px-alert-border` | `var(--border)` |
+| `--px-alert-shadow` | `var(--shadow-md)` |
+| `--px-alert-title-size` | `var(--font-size-sm)` |
+| `--px-alert-body-size` | `var(--font-size-sm)` |
+| `--px-alert-dismiss-color` | `var(--text-muted)` |
+
+### Dropdown
+
+| Token | Default |
+| --- | --- |
+| `--px-dropdown-menu-bg` | `var(--surface-alt)` |
+| `--px-dropdown-menu-border` | `var(--border)` |
+| `--px-dropdown-menu-radius` | `var(--radius-md)` |
+| `--px-dropdown-menu-shadow` | `var(--shadow-md)` |
+| `--px-dropdown-menu-padding` | `0.35rem 0` |
+| `--px-dropdown-menu-min-w` | `10rem` |
+| `--px-dropdown-menu-max-h` | `min(70dvh, 24rem)` |
+| `--px-dropdown-z` | `350` |
+
+### Drawer
+
+| Token | Default |
+| --- | --- |
+| `--px-drawer-width` | `min(24rem, 100vw)` |
+| `--px-drawer-height-bottom` | `min(50dvh, 28rem)` |
+| `--px-drawer-bg` | `var(--surface)` |
+| `--px-drawer-border` | `var(--border)` |
+| `--px-drawer-shadow` | `var(--shadow-md)` |
+| `--px-drawer-backdrop` | `rgb(0 0 0 / 0.45)` |
+| `--px-drawer-header-bg` | `var(--surface-alt)` |
+| `--px-drawer-header-sep` | `var(--border)` |
+| `--px-drawer-footer-bg` | `var(--surface-alt)` |
+| `--px-drawer-footer-sep` | `var(--border)` |
+| `--px-drawer-padding` | `1rem` |
+| `--px-drawer-z` | `250` |
+
+### Progress
+
+| Token | Default |
+| --- | --- |
+| `--px-progress-height` | `0.5rem` |
+| `--px-progress-radius` | `var(--radius-full)` |
+| `--px-progress-track` | `var(--surface-alt)` |
+| `--px-progress-fill` | `var(--brand)` |
+| `--px-progress-indeterminate-speed` | `1.2s` |
+
+### Skeleton
+
+| Token | Default |
+| --- | --- |
+| `--px-skeleton-bg` | `var(--surface-alt)` |
+| `--px-skeleton-shine` | `color-mix(in srgb, var(--text) 8%, var(--surface-alt))` |
+| `--px-skeleton-line-height` | `0.65rem` |
+| `--px-skeleton-line-gap` | `0.5rem` |
+| `--px-skeleton-circle-size` | `2.5rem` |
+| `--px-skeleton-rect-height` | `6rem` |
+| `--px-skeleton-rect-radius` | `var(--radius-md)` |
+| `--px-skeleton-duration` | `1.2s` |
+
+### EmptyState
+
+| Token | Default |
+| --- | --- |
+| `--px-empty-state-padding` | `2rem 1.5rem` |
+| `--px-empty-state-max-width` | `28rem` |
+| `--px-empty-state-title-size` | `var(--font-size-md)` |
+| `--px-empty-state-desc-size` | `var(--font-size-sm)` |
+| `--px-empty-state-title-color` | `var(--text)` |
+| `--px-empty-state-desc-color` | `var(--text-muted)` |
+| `--px-empty-state-gap` | `0.5rem` |
+
+### Divider
+
+| Token | Default |
+| --- | --- |
+| `--px-divider-color` | `var(--border)` |
+| `--px-divider-thickness` | `1px` |
+| `--px-divider-gap` | `0.75rem` |
+| `--px-divider-label-color` | `var(--text-muted)` |
+| `--px-divider-label-size` | `var(--font-size-sm)` |
+
+### Spinner
+
+| Token | Default |
+| --- | --- |
+| `--px-spinner-sm` | `1.25rem` |
+| `--px-spinner-md` | `2rem` |
+| `--px-spinner-lg` | `2.75rem` |
+| `--px-spinner-track` | `color-mix(in srgb, var(--text-muted) 35%, transparent)` |
+| `--px-spinner-accent` | `var(--brand)` |
+
+### Avatar
+
+| Token | Default |
+| --- | --- |
+| `--px-avatar-sm` | `2rem` |
+| `--px-avatar-md` | `2.5rem` |
+| `--px-avatar-lg` | `3.25rem` |
+| `--px-avatar-bg` | `var(--surface-alt)` |
+| `--px-avatar-fg` | `var(--text-muted)` |
+| `--px-avatar-border` | `var(--border)` |
+
+### Card
+
+| Token | Default |
+| --- | --- |
+| `--px-card-bg` | `var(--surface-alt)` |
+| `--px-card-border` | `var(--border)` |
+| `--px-card-radius` | `var(--radius-md)` |
+| `--px-card-title-color` | `var(--text)` |
+| `--px-card-padding` | `var(--space-4, 1rem)` |
+
+### Breadcrumb
+
+| Token | Default |
+| --- | --- |
+| `--px-breadcrumb-sep` | `"/"` |
+| `--px-breadcrumb-link-color` | `var(--brand)` |
+| `--px-breadcrumb-current-color` | `var(--text)` |
+
+### TabGroup
+
+| Token | Default |
+| --- | --- |
+| `--px-tab-group-border` | `var(--border)` |
+| `--px-tab-group-bg` | `var(--surface-alt)` |
+| `--px-tab-group-tab-active-fg` | `var(--text)` |
+| `--px-tab-group-tab-active-bg` | `color-mix(in srgb, var(--surface) 55%, var(--surface-alt))` |
+| `--px-tab-group-tab-active-border` | `var(--brand)` |
+| `--px-tab-group-panel-bg` | `var(--surface)` |
+</content>
+</invoke>

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -18,9 +18,11 @@ class Card(BaseComponent):
     subtitle: str = ""   # Optional with default
 ```
 
+`BaseComponent` also provides `js` and `css` fields (lists of extra asset paths) — see [Asset Collection](assets.md).
+
 ### 2. HTML Template
 
-PyJinHX uses **Jinja2** templates for it's components:
+PyJinHX uses **Jinja2** templates for its components:
 
 ```html
 <!-- card.html -->
@@ -61,8 +63,8 @@ button = Button(text="Submit")  # Error: id is required
     This way, when you instantiate `MyComponent()` without providing an `id`, a unique value will be generated.
 
 
-!!! tip "Auto-generated IDs"
-    When using `Renderer` with `auto_id=True`, IDs are generated automatically for template-side rendering.
+!!! tip "Auto-generated IDs apply to PascalCase tags only"
+    `auto_id` does **not** affect plain Python instances — `BaseComponent(...)` always requires a truthy `id`. The `Renderer`'s `auto_id=True` only generates an `id` when a PascalCase `<Tag/>` is expanded in a template without one (see [PascalCase Tags](tags.md)). Separately, `ReactiveComponent` (not `BaseComponent`) defaults its `id` to the kebab-cased class name (e.g. `TodoCounter` → `"todo-counter"`).
 
 
 ## Template Discovery
@@ -80,17 +82,7 @@ Templates are automatically discovered based on the class name:
 
 ## Extra Fields
 
-Normally, if you pass extra fields to a class that inherits from Pydantic's `BaseModel`, it will raise an error:
-
-```python
-from pydantic import BaseModel
-class Example(BaseModel):
-    foo: int
-
-Example(foo=1, bar=2)  # Raises ValidationError: extra fields not permitted
-```
-
-With `BaseComponent`, **extra fields are accepted and available in the template context**. This allows you to pass dictionaries or data objects with additional fields without raising validation errors.
+A plain Pydantic `BaseModel` rejects unknown fields with a `ValidationError`. With `BaseComponent`, **extra fields are accepted and available in the template context**. This allows you to pass dictionaries or data objects with additional fields without raising validation errors.
 
 ```python
 from pyjinhx import BaseComponent

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -21,12 +21,10 @@ Project root is detected by looking for common markers:
 
 - `pyproject.toml`
 - `main.py`
-- `README.md`
 - `.git`
 - `.gitignore`
 - `package.json`
 - `uv.lock`
-- `.venv`
 
 ### Setting a Custom Path
 
@@ -87,6 +85,28 @@ For web apps, use a single call:
 from pyjinhx import setup
 
 setup(app, load_context_factory=lambda req: AppLoadContext(db=get_db(req)))
+```
+
+`PyJinhxSettings` has three fields:
+
+- `cache_scope` — load cache scope (default `CacheScope.REQUEST`)
+- `invalidation_backend` — cross-process invalidation backend (default `None`)
+- `reactive_dev` — enable reactive dev guardrails (default `False`)
+
+Pass a settings object via `settings=`, or override individual fields with explicit `setup()` keyword arguments. Explicit `setup()` kwargs take precedence over values from `settings=`.
+
+### Environment variables
+
+`PyJinhxSettings.from_env()` builds settings from the environment:
+
+- `PJX_LOAD_CACHE_SCOPE` — cache scope name (default `request`)
+- `PJX_REACTIVE_DEV` — enables reactive dev mode when set to `1`, `true`, or `yes`
+- `REDIS_URL` — wires a `RedisInvalidationBackend`, but only when the cache scope is `process`
+
+```python
+from pyjinhx import PyJinhxSettings, setup
+
+setup(app, settings=PyJinhxSettings.from_env())
 ```
 
 See [Configuration API](../api/config.md) for `PyJinhxSettings`, lifespan chaining, and cache defaults.

--- a/docs/guide/nesting.md
+++ b/docs/guide/nesting.md
@@ -2,6 +2,12 @@
 
 PyJinHx makes it easy to compose components together. You can nest single components, lists of components, or dictionaries of components.
 
+!!! note "Two nesting styles, two `id` rules"
+    There are two ways to nest:
+
+    - **Python field values** (this page) — you build child instances yourself, so each child needs an **explicit `id`** (a plain `BaseComponent` always requires one).
+    - **PascalCase `<Tag/>` in templates** (see [PascalCase Tags](tags.md)) — the renderer instantiates children for you and can **auto-generate the `id`** when `auto_id=True` (the default).
+
 ## Direct Nesting
 
 Pass a component as a field value:
@@ -108,6 +114,11 @@ group = ButtonGroup(
 Combine different types in lists and dicts:
 
 ```python
+class Widget(BaseComponent):
+    id: str
+    content: str
+
+
 class Container(BaseComponent):
     id: str
     items: list[Button | Card | Widget]
@@ -151,20 +162,9 @@ dashboard = Dashboard(
 
 ## Deep Nesting
 
-Components can be nested to any depth:
+Components can be nested to any depth. Reusing the `Button` and `Card` classes from above:
 
 ```python
-class Button(BaseComponent):
-    id: str
-    text: str
-
-
-class Card(BaseComponent):
-    id: str
-    title: str
-    action: Button
-
-
 class Page(BaseComponent):
     id: str
     title: str

--- a/docs/guide/registry.md
+++ b/docs/guide/registry.md
@@ -69,12 +69,7 @@ On entry, `request_scope()` also clears pending mutations, initializes the reque
 
 `load_context` and `client_backend` are **optional** — bare `Registry.request_scope()` is enough for instance isolation.
 
-For application-wide coverage, use middleware in your app (pyjinhx does not ship middleware). See the [canonical FastAPI snippet](../integrations/fastapi.md#middleware-recommended).
-
-Prefer `setup(app, ...)` — it registers middleware that calls
-`Registry.request_scope(client_backend=FastAPIClientBackend(request))` automatically.
-
-For manual wiring:
+For application-wide coverage, pyjinhx ships no middleware of its own. Prefer `setup(app, ...)`, which registers middleware that calls `Registry.request_scope(client_backend=FastAPIClientBackend(request))` for you (see the [canonical FastAPI snippet](../integrations/fastapi.md#middleware-recommended)). To wire it by hand instead, open the scope yourself:
 
 ```python
 from pyjinhx import FastAPIClientBackend, Registry, setup
@@ -159,7 +154,7 @@ The class registry enables the `Renderer` to instantiate components from PascalC
 
 ### Template context precedence
 
-During render, registered instances are injected into the Jinja context by `id` so templates can reference them by registry key. **Component field values from `model_dump()` take precedence** when a field name collides with an instance `id` (registry injection uses `setdefault`). Avoid naming a reactive field the same as its default `id` (e.g. a `Total` component with a `total` field defaults `id` to `"total"`).
+During render, registered instances are injected into the Jinja context by `id` so templates can reference them by registry key. **Component field values from `model_dump()` take precedence** when a field name collides with an instance `id` (registry injection uses `setdefault`). Watch for this with `ReactiveComponent`, whose `id` defaults to the kebab-cased class name: a `Total` reactive component with a `total` field defaults its `id` to `"total"`, so the field would shadow the instance. (A plain `BaseComponent` has no such default — it always requires an explicit `id`.)
 
 ```python
 # Class registry (automatic when you define a class)

--- a/docs/guide/tags.md
+++ b/docs/guide/tags.md
@@ -13,6 +13,9 @@ html = renderer.render('<UserCard name="Ada"/>')
 
 You can also use PascalCase tags **inside component templates** to compose components declaratively.
 
+!!! warning "Recognized tag names are strict PascalCase"
+    A tag is treated as a component only if its name matches `^[A-Z](?:[a-z]+(?:[A-Z][a-z]+)*)?$` — a capital letter followed by alternating lowercase/Capitalized words. This **rejects acronyms and trailing digits**: `UI`, `APIKey`, `HTMLBlock`, `Button2`, and `H2` are NOT recognized and pass through as raw HTML. Name components like `Api`, `ApiKey`, or `HtmlBlock` instead.
+
 ## Attributes
 
 Tag attributes become template context variables:
@@ -39,6 +42,8 @@ html = renderer.render("""
     </Card>
 """)
 ```
+
+`content` is **always** passed to a tag-instantiated component, defaulting to `""` when the tag has no inner content. (A `BaseComponent` accepts it as an extra field; declare `content: str` on your class if you want validation.)
 
 ## Template Auto-Discovery
 
@@ -102,6 +107,8 @@ If no class is registered, PyJinHx falls back to a generic `BaseComponent` and r
 ```python
 html = renderer.render('<Alert kind="warning">Be careful</Alert>')
 ```
+
+The generic-fallback instance is **removed from the registry** after rendering, so it cannot be cross-referenced by other templates (unlike a registered-class instance).
 
 ## Auto-Generated IDs
 

--- a/docs/guide/usage-tiers.md
+++ b/docs/guide/usage-tiers.md
@@ -58,7 +58,11 @@ def toggle(todo_id: int):
     return TodoItemRow.render(todo_id)  # OOB for dependents
 ```
 
-Requires `Registry.request_scope()` on every request when using auto-dirtied from `@mutates`.
+Every `ReactiveComponent` must declare `reacts_to` (the state keys it derives from) — it is enforced at class-definition time alongside `load()`.
+
+OOB swaps require an **active `ClientBackend`** so the renderer can read the client's mounted-region manifest. Wire one via `setup(app)` or `Registry.request_scope(client_backend=...)`. A bare `Registry.request_scope()` has no backend, so `render()` falls through to a plain single-region render with no OOB swaps.
+
+"Auto-dirtied" means a `@mutates`-decorated store method records the dirtied state keys it touched; the next reactive `render()` consumes them to decide which mounted regions to reload and swap.
 
 **Docs:** [Reactivity](../reactivity.md), [HTMX integration](../integrations/htmx.md)
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -148,9 +148,10 @@ class Counter(ReactiveComponent):
   pass an explicit `id` for instance-keyed regions (e.g. `id=f"row-{todo_id}"`).
 - `state_hash()` gates swaps: a region is re-sent only if its fresh hash differs from
   the one the client reported.
-- Roots are auto-stamped with `data-pjx-id` / `data-pjx-type` / `data-pjx-hash` (+
-  `data-pjx-load` when keyed via `PjxLoad`). A reactive component **must render a single
-  root element**.
+- Roots are auto-stamped with `data-pjx-id` / `data-pjx-type` / `data-pjx-hash` /
+  `data-pjx-reacts` (the space-joined `reacts_to` keys, which `pjx.js` reads to scope
+  loading indicators) — plus `data-pjx-load` when keyed via `PjxLoad`. A reactive component
+  **must render a single root element**.
 
 ### Mutation routes return `render()` — nothing else
 
@@ -174,8 +175,12 @@ def toggle():
 - **Class form (route entry)** — `Cls.render(*args, **kwargs)` for keyed types,
   `Cls.render()` for singletons: auto-`load()`s the primary, renders it as the HTMX
   main-target response, then appends OOB swaps for every *other* mounted reactive region
-  whose `reacts_to` intersects pending `@mutates` keys. The trigger region (`X-PJX-Trigger`)
-  and primary region are excluded from OOB.
+  whose `reacts_to` intersects pending `@mutates` keys. **Only the primary is excluded**
+  from OOB (HTMX already swaps it as the main response); the trigger region is **not**
+  excluded — a clicked region that depends on the dirtied keys updates itself OOB like any
+  other dependent (e.g. a "Clear completed (N)" button refreshing its own count).
+  `X-PJX-Trigger` is **client-only** (used by `pjx.js` for loading indicators); the server
+  OOB walk reads the mounted manifest, never the trigger header.
 - **Instance form** — `instance.render()`: plain render of an already-built instance
   (no re-`load()`).
 
@@ -221,9 +226,16 @@ def toggle_row(todo_id: int):
 
 - Root full-page renders auto-inject `pjx.js` unless the request already carries
   `X-PJX-Mounted`. For a raw Jinja shell, use `{{ client_script() }}` in `<head>`.
+- **Loading indicators (v0.7.1):** put `data-pjx-loading="skeleton"` (or `"spinner"`) on any
+  element inside a reactive root template. While an in-flight request dirties keys the region
+  `reacts_to`, `pjx.js` flags those elements (matched via the enclosing reactive root) until
+  the swap lands. A trigger may add `data-pjx-loading-extra="<css-selector>"` to also flag
+  regions a bulk action will touch (e.g. rows a clear-completed removes). Style via `--pjx-*`
+  CSS vars (`--pjx-skeleton-color`, `--pjx-spinner-color`, …).
 - Every `load()` is memoized in `LoadCache` (one entry per `(type, key)`). Default scope is
-  `PROCESS`. Use `LoadCache.set_scope(CacheScope.REQUEST)` per worker without Redis, or
-  `InvalidationBackend` for multi-worker `PROCESS` scope.
+  `CacheScope.REQUEST` (per-request, no cross-worker concern). Use
+  `LoadCache.set_scope(CacheScope.PROCESS)` (or `setup(cache_scope=...)`) for process-wide
+  caching, plus an `InvalidationBackend` (e.g. Redis) to fan out evictions across workers.
 
 Full guide: [docs/reactivity.md](../reactivity.md).
 
@@ -235,151 +247,36 @@ Optional package: `import pyjinhx.builtins` then `from pyjinhx.builtins import A
 
 **Host theme (set on `:root` or a wrapper):** Builtin CSS reads shared tokens. Define at least: `--surface`, `--surface-alt`, `--text`, `--text-muted`, `--border`, `--brand`, `--brand-subtle`, `--brand-muted`, `--error`, `--success`, `--warning`, `--font-size-xs`, `--font-size-sm`, `--font-size-md`, `--radius-sm`, `--radius-md`, `--radius-lg`, `--radius-full`, `--shadow-md`, `--transition`, `--space-3`, `--space-4`. Optional but used for error surfaces: `--error-bg`, `--error-border` (badge/alert error variants fall back with `color-mix` if these are missing).
 
-**Per-component tokens:** Each builtin stylesheet declares `--px-<widget>-*` on `:root`. Override them to tune one component without editing package files (examples: `--px-modal-width`, `--px-dropdown-z`, `--px-drawer-width`).
+**Per-component tokens:** Each builtin stylesheet declares `--px-<widget>-*` custom properties on `:root` — override them to tune one component without editing package files (e.g. `--px-modal-width`, `--px-dropdown-z`, `--px-drawer-width`).
 
-**Class naming:** BEM-style `px-<widget>`, `px-<widget>__element`, `px-<widget>--modifier`. **`class_name` field** (appended on the root node): `Avatar`, `Badge`, `Divider`, `Skeleton`.
+**Class naming:** BEM-style `px-<widget>`, `px-<widget>__element`, `px-<widget>--modifier`. A **`class_name` field** (appended on the root node) exists on `Avatar`, `Badge`, `Divider`, `Skeleton`.
 
-**PascalCase tag quirks:** `TabGroup.tabs`, `Panel.panels`, `Breadcrumb.items` accept a **JSON string** attribute when rendered from tag strings (same idea as dict/list in Python). `Panel` / `PanelTrigger` **panel keys** must match `[a-zA-Z0-9_-]+` (stable `id`s).
+**PascalCase tag quirks:** `TabGroup.tabs`, `Panel.panels`, `Breadcrumb.items` accept a **JSON string** attribute when rendered from tag strings (same idea as dict/list in Python). `Panel` / `PanelTrigger` **panel keys** must match `[a-zA-Z0-9_-]+` (stable `id`s). Components with bundled JS expose global helpers (e.g. `openModal(id)` / `closeModal(id)`, `openPxDrawer(id)`, `togglePxDropdown(id)`, `showNotification(id)`); others (`Popover`, `Panel`, `TabGroup`, `Tooltip`) use delegated events.
 
-### Alert
+| Component | Purpose |
+|-----------|---------|
+| `Alert` | Inline dismissible message (info / success / warning / error) |
+| `Avatar` | User image or initials, sized sm / md / lg |
+| `Badge` | Small colored label / status pill |
+| `Breadcrumb` | Navigation trail of `(label, href)` pairs |
+| `Card` | Container with optional header / body / footer slots |
+| `Divider` | Horizontal or vertical separator, optional label |
+| `Drawer` | Slide-in `<dialog>` panel (left / right / bottom) |
+| `Dropdown` | Toggleable trigger + menu |
+| `EmptyState` | Placeholder for empty content with optional action |
+| `LoadingOverlay` | Full-area spinner overlay |
+| `Modal` | Centered `<dialog>` with backdrop |
+| `Notification` | Corner-anchored auto-hiding toast |
+| `Popover` | Hover/focus floating card (follow or anchor) |
+| `Progress` | Determinate or indeterminate progress bar |
+| `Panel` | Keyed content panels (paired with `PanelTrigger`) |
+| `PanelTrigger` | Trigger that activates a `Panel` panel by key |
+| `Skeleton` | Loading placeholder (text / circle / rect) |
+| `Spinner` | Standalone loading spinner, sized sm / md / lg |
+| `TabGroup` | Tabbed panels keyed by label |
+| `Tooltip` | Hover/focus tip (top / bottom / start / end) |
 
-- **Props:** `variant` info | success | warning | error; `title`, `body`, `dismissible`.
-- **Classes:** `px-alert`, `px-alert__inner`, `px-alert__text`, `px-alert__title`, `px-alert__body`, `px-alert__dismiss`, `px-alert--info|success|warning|error`, `px-alert--dismissed`.
-- **Tokens:** `--px-alert-radius`, `--px-alert-padding`, `--px-alert-border`, `--px-alert-shadow`, `--px-alert-title-size`, `--px-alert-body-size`, `--px-alert-dismiss-color` (variants also use `--brand`, `--success`, `--warning`, `--error`, and optionally `--error-bg` / `--error-border` for error).
-- **JS:** `dismissPxAlert(id)`.
-
-### Avatar
-
-- **Props:** `src`, `alt`, `initials` (max 2 chars), `size` sm | md | lg, `class_name`.
-- **Classes:** `px-avatar`, `px-avatar--sm|md|lg`, `px-avatar__img`, `px-avatar__initials`.
-- **Tokens:** `--px-avatar-sm`, `--px-avatar-md`, `--px-avatar-lg`, `--px-avatar-bg`, `--px-avatar-fg`, `--px-avatar-border`, `--px-avatar-font-size-sm|md|lg`.
-
-### Badge
-
-- **Props:** `label`, `color` brand | error | neutral | muted, `shape` square | sm | md | full, `class_name`.
-- **Classes:** `px-badge`, `px-badge--brand|error|neutral|muted`, `px-badge--square|sm|md|full`.
-- **Tokens:** `--px-badge-font-size`, `--px-badge-radius-sm|md|full`, `--px-badge-brand-bg|fg|accent`, `--px-badge-error-bg|fg|border`, `--px-badge-neutral-bg|fg|border`, `--px-badge-muted-bg|fg|border`.
-
-### Breadcrumb
-
-- **Props:** `items` as `(label, href)` pairs (dict / JSON string in tags).
-- **Classes:** `px-breadcrumb` (on `<nav>`), `px-breadcrumb__list`, `px-breadcrumb__item`, `px-breadcrumb__link`, `px-breadcrumb__current`.
-- **Tokens:** `--px-breadcrumb-gap`, `--px-breadcrumb-sep` (e.g. `"/"`), `--px-breadcrumb-sep-color`, `--px-breadcrumb-link-color`, `--px-breadcrumb-current-color`, `--px-breadcrumb-font-size`.
-
-### Card
-
-- **Props:** `title`, `header`, `body`, `footer` (strings or nested components).
-- **Classes:** `px-card`, `px-card__header`, `px-card__title`, `px-card__body`, `px-card__footer`.
-- **Tokens:** `--px-card-bg`, `--px-card-border`, `--px-card-radius`, `--px-card-shadow`, `--px-card-title-color`, `--px-card-padding`, `--px-card-header-sep`, `--px-card-footer-sep`, `--px-card-footer-bg`.
-
-### Divider
-
-- **Props:** `orientation` horizontal | vertical, `label`, `class_name`.
-- **Classes:** `px-divider--horizontal`, `px-divider--vertical`, `px-divider--labeled`, `px-divider__line`, `px-divider__label`.
-- **Tokens:** `--px-divider-color`, `--px-divider-thickness`, `--px-divider-gap`, `--px-divider-label-color`, `--px-divider-label-size`.
-
-### Drawer
-
-- **Props:** `side` left | right | bottom; `title`, `body`, `footer`.
-- **Classes:** `<dialog class="px-drawer px-drawer--left|right|bottom">`, `px-drawer__box`, `px-drawer__header`, `px-drawer__title`, `px-drawer__close`, `px-drawer__body`, `px-drawer__footer`, `px-drawer--closing` (animation). Slide distance: `--px-drawer-slide-from` is set on left/right variants in CSS.
-- **Tokens:** `--px-drawer-width`, `--px-drawer-height-bottom`, `--px-drawer-bg`, `--px-drawer-border`, `--px-drawer-shadow`, `--px-drawer-backdrop`, `--px-drawer-header-bg`, `--px-drawer-header-sep`, `--px-drawer-footer-bg`, `--px-drawer-footer-sep`, `--px-drawer-padding`, `--px-drawer-z`.
-- **JS:** `openPxDrawer(id)`, `closePxDrawer(id)`; clicking the dialog backdrop closes.
-
-### Dropdown
-
-- **Props:** `trigger`, `menu` (strings or nested components).
-- **Classes:** `px-dropdown`, `px-dropdown__trigger`, `px-dropdown__menu`, `px-dropdown__menu--open` (toggle with `[hidden]`).
-- **Tokens:** `--px-dropdown-menu-bg`, `--px-dropdown-menu-border`, `--px-dropdown-menu-radius`, `--px-dropdown-menu-shadow`, `--px-dropdown-menu-padding`, `--px-dropdown-menu-min-w`, `--px-dropdown-menu-max-h`, `--px-dropdown-z`.
-- **JS:** `togglePxDropdown(id)`, `closePxDropdown(id)`; outside click and Escape close.
-
-### EmptyState
-
-- **Props:** `title`, `description`, `action`.
-- **Classes:** `px-empty-state`, `px-empty-state__title`, `px-empty-state__desc`, `px-empty-state__action`.
-- **Tokens:** `--px-empty-state-padding`, `--px-empty-state-max-width`, `--px-empty-state-title-size|color`, `--px-empty-state-desc-size|color`, `--px-empty-state-gap`.
-
-### LoadingOverlay
-
-- **Classes:** `px-loading-overlay`, `px-loading-overlay--visible`, `px-loading-overlay--hiding`, `px-loading-overlay__spinner`.
-- **Tokens:** `--px-loading-overlay-bg`, `--px-loading-overlay-backdrop`, `--px-loading-overlay-z`, `--px-loading-overlay-spinner-size`, `--px-loading-overlay-spinner-width`, `--px-loading-overlay-spinner-color`, `--px-loading-overlay-spinner-track`.
-- **JS:** `showLoadingOverlay(id)`, `hideLoadingOverlay(id)`.
-
-### Modal
-
-- **Props:** `title`, `header` (replaces title when set), `body`, `footer`.
-- **Classes:** `<dialog class="px-modal">`, `px-modal--closing`, `px-modal__box`, `px-modal__header`, `px-modal__title`, `px-modal__close`, `px-modal__body`, `px-modal__footer`; `::backdrop` uses `--px-modal-backdrop`.
-- **Tokens:** `--px-modal-width`, `--px-modal-min-height`, `--px-modal-bg`, `--px-modal-border`, `--px-modal-radius`, `--px-modal-shadow`, `--px-modal-header-bg`, `--px-modal-header-sep`, `--px-modal-footer-bg`, `--px-modal-footer-sep`, `--px-modal-title-color`, `--px-modal-close-color`, `--px-modal-backdrop`, `--px-modal-padding`.
-- **JS:** `openModal(id)`, `closeModal(id)`; clicking the bare `<dialog>` backdrop closes.
-
-### Notification
-
-- **Props:** `content`, `corner` top-right | top-left | bottom-right | bottom-left, `timeout` (ms, `0` = no auto-hide).
-- **Classes:** `px-notification`, `px-notification--top-right|top-left|bottom-right|bottom-left`, `px-notification--visible`, `px-notification--hiding`, `px-notification__content`, `px-notification__close`.
-- **Tokens:** `--px-notification-width`, `--px-notification-gap`, `--px-notification-bg`, `--px-notification-border`, `--px-notification-radius`, `--px-notification-shadow`, `--px-notification-padding`, `--px-notification-close-color`, `--px-notification-z`.
-- **JS:** `showNotification(id)`, `hideNotification(id)`; reads `data-timeout`.
-
-### Popover
-
-- **Props:** `content`, `card_content`, `position` follow | anchor.
-- **Classes:** `px-popover-trigger` (optional `data-popover-backdrop`), `px-popover-card`, `px-popover-card--visible`, `#px-popover-backdrop` / `px-popover-backdrop`, `px-popover-backdrop--visible`.
-- **Tokens:** `--px-popover-max-width`, `--px-popover-bg`, `--px-popover-border`, `--px-popover-radius`, `--px-popover-shadow`, `--px-popover-padding`, `--px-popover-z`.
-- **JS:** Delegated hover / focus / mousemove; single shared backdrop element.
-
-### Progress
-
-- **Props:** `value` (omit or `None` for indeterminate bar), `max`, `label`.
-- **Classes:** `px-progress`, `px-progress__label`, `px-progress__bar` (`<progress>`; `indeterminate` styling when no value).
-- **Tokens:** `--px-progress-height`, `--px-progress-radius`, `--px-progress-track`, `--px-progress-fill`, `--px-progress-indeterminate-speed`.
-
-### Panel
-
-- **Props:** `panels` map panel-key → content (dict or JSON string in tags).
-- **Classes:** `px-panel`, `px-panel__panel` (`[hidden]` toggles visibility). Almost no layout tokens in package CSS—style the host layout around it.
-- **JS:** With `PanelTrigger`: delegated `click` on `.px-panel-trigger`; `pxPanelInit()` on `DOMContentLoaded`, `htmx:afterSwap`, `htmx:afterSettle`; helpers `pxPanelShowPanel(hostRoot, panelKey)`, `pxPanelSyncTriggers(hostId, activeKey)`.
-
-### PanelTrigger
-
-- **Props:** `panel_id`, `panel` (key matching the parent `Panel.panels`), `content` (your visible markup inside the wrapper).
-- **Classes:** `px-panel-trigger` (`display: contents`; delegated `click` in `panel.js` from `Panel`).
-
-### Skeleton
-
-- **Props:** `variant` text | circle | rect, `lines` (for text), `class_name`.
-- **Classes:** `px-skeleton`, `px-skeleton--text|circle|rect`, `px-skeleton__line`, `px-skeleton__circle`, `px-skeleton__rect`.
-- **Tokens:** `--px-skeleton-bg`, `--px-skeleton-shine`, `--px-skeleton-line-height`, `--px-skeleton-line-gap`, `--px-skeleton-circle-size`, `--px-skeleton-rect-height`, `--px-skeleton-rect-radius`, `--px-skeleton-duration`.
-
-### Spinner
-
-- **Props:** `size` sm | md | lg, `label`.
-- **Classes:** `px-spinner`, `px-spinner--sm|md|lg`, `px-spinner__ring`, `px-spinner__label`.
-- **Tokens:** `--px-spinner-sm|md|lg`, `--px-spinner-track`, `--px-spinner-accent`.
-
-### TabGroup
-
-- **Props:** `tabs` map label → panel content (dict or JSON string in tags).
-- **Classes:** `px-tab-group`, `px-tab-group__list`, `px-tab-group__tab`, `px-tab-group__panel` (`[hidden]` on inactive panels; `aria-selected` on tabs).
-- **Tokens:** `--px-tab-group-border`, `--px-tab-group-bg`, `--px-tab-group-tab-fg`, `--px-tab-group-tab-active-fg`, `--px-tab-group-tab-active-bg`, `--px-tab-group-tab-active-border`, `--px-tab-group-panel-bg`, `--px-tab-group-radius`, `--px-tab-group-padding`.
-- **JS:** Delegated `click` on `.px-tab-group__tab` only.
-
-### Tooltip
-
-- **Props:** `trigger`, `tip`, `placement` top | bottom | start | end.
-- **Classes:** `px-tooltip` with `data-px-tooltip-placement`, `px-tooltip__trigger`, `px-tooltip__tip`, `px-tooltip__tip--visible`.
-- **Tokens:** `--px-tooltip-gap`, `--px-tooltip-bg`, `--px-tooltip-border`, `--px-tooltip-radius`, `--px-tooltip-shadow`, `--px-tooltip-padding`, `--px-tooltip-max-width`, `--px-tooltip-fg`, `--px-tooltip-font-size`, `--px-tooltip-z`.
-- **JS:** Delegated focus / blur / mouse enter / leave; placement reads `--px-tooltip-gap` and `data-px-tooltip-placement`.
-
-| Class | Bundled JS (globals unless noted) |
-|-------|-----------------------------------|
-| `Alert` | `dismissPxAlert(id)` |
-| `Drawer` | `openPxDrawer(id)`, `closePxDrawer(id)` |
-| `Dropdown` | `togglePxDropdown(id)`, `closePxDropdown(id)` |
-| `LoadingOverlay` | `showLoadingOverlay(id)`, `hideLoadingOverlay(id)` |
-| `Modal` | `openModal(id)`, `closeModal(id)` |
-| `Notification` | `showNotification(id)`, `hideNotification(id)` |
-| `Popover` | Delegated events + `#px-popover-backdrop` |
-| `Panel` | `pxPanelInit()`, `pxPanelShowPanel`, `pxPanelSyncTriggers` (+ trigger clicks) |
-| `TabGroup` | Delegated tab clicks |
-| `Tooltip` | Delegated focus/hover + placement |
+Full reference (props, classes, `--px-*` tokens, JS helpers per component): [../guide/builtins.md](../guide/builtins.md).
 
 ## Registry
 

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -106,7 +106,7 @@ def index():
 {% endblock %}
 ```
 
-## Request-Scoped Registry
+## Request-Scoped Registry { #middleware-recommended }
 
 In web apps, component instances from one request can leak into the next. The recommended setup is a single call:
 

--- a/docs/integrations/htmx.md
+++ b/docs/integrations/htmx.md
@@ -13,7 +13,7 @@ pip install pyjinhx
 Include HTMX in your HTML:
 
 ```html
-<script src="https://unpkg.com/htmx.org@1.9.10"></script>
+<script src="https://unpkg.com/htmx.org@2.0.3"></script>
 ```
 
 ## Project Structure
@@ -66,7 +66,7 @@ class Button(BaseComponent):
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script src="https://unpkg.com/htmx.org@2.0.3"></script>
 </head>
 <body>
     <Button id="click-me" text="Click Me" endpoint="/clicked"></Button>
@@ -143,9 +143,11 @@ document.body.addEventListener('htmx:afterSwap', (event) => {
 
 ## HTMX Patterns with PyJinHx
 
-### Use `hx-swap="outerHTML"` for Component Updates
+### Target a component by id and swap `outerHTML`
 
-When returning a full component, use `outerHTML` to replace the entire element:
+When a route returns a full component, pass its `id` in the request (so the
+server can target the right element) and use `hx-swap="outerHTML"` to replace
+the whole element with the response:
 
 ```html
 <!-- components/ui/item.html -->
@@ -153,29 +155,13 @@ When returning a full component, use `outerHTML` to replace the entire element:
     <h3>{{ title }}</h3>
     <button
         hx-post="/items/{{ id }}/update"
+        hx-vals='{"item_id": "{{ id }}"}'
         hx-target="#{{ id }}"
         hx-swap="outerHTML"
     >
         Update
     </button>
 </div>
-```
-
-### Pass Component ID in Requests
-
-Include the component ID so you can target the right element:
-
-```html
-<!-- components/ui/form.html -->
-<form
-    id="{{ id }}"
-    hx-post="/submit"
-    hx-vals='{"form_id": "{{ id }}"}'
-    hx-target="#{{ id }}"
-    hx-swap="outerHTML"
->
-    <!-- form fields -->
-</form>
 ```
 
 ### Conditional HTMX Attributes
@@ -202,21 +188,29 @@ Use Jinja conditionals to control HTMX behavior:
 
 Bundled **`panel.js`** re-runs its init on `htmx:afterSwap` and `htmx:afterSettle`, so triggers and panels stay in sync after partial HTML updates.
 
-### Loading States
+### Loading states
 
-Show loading indicators during HTMX requests:
+For ad-hoc cases you can use htmx's own [`hx-indicator`](https://htmx.org/attributes/hx-indicator/)
+with a `.htmx-indicator` element. For reactive components, PyJinHx ships built-in
+indicators instead: add `data-pjx-loading="skeleton"` or `data-pjx-loading="spinner"`
+to the element(s) that should show an in-flight effect — no extra markup or CSS
+needed. A trigger can also name extra regions to light with
+`data-pjx-loading-extra="<css-selector>"`, and every effect is themable through
+`--pjx-*` CSS custom properties. See [Loading indicators](../reactivity.md#loading-indicators-in-flight).
 
-```html
-<!-- components/ui/button.html -->
-<button
-    id="{{ id }}"
-    hx-post="{{ endpoint }}"
-    hx-indicator="#spinner"
->
-    <span class="button-text">{{ text }}</span>
-    <span id="spinner" class="htmx-indicator">Loading...</span>
-</button>
-```
+## How PyJinHx talks to htmx
+
+`pjx.js` (auto-included with reactive components) hooks a few htmx events. You
+don't call these yourself, but it helps to know what's on the wire:
+
+- On **`htmx:configRequest`** it stamps three request headers the server reads to
+  decide what to re-render: `X-PJX-Mounted` (the manifest of mounted components),
+  `X-PJX-Assets` (already-loaded script/stylesheet URLs, so they aren't re-sent),
+  and `X-PJX-Trigger` (the component that triggered the request).
+- The loading-indicator lifecycle is driven from htmx events: it lights indicators
+  on **`htmx:beforeRequest`**, re-applies them across swaps on **`htmx:afterSettle`**,
+  and clears them on **`htmx:afterOnLoad`** (plus the error/abort events
+  `htmx:responseError`, `htmx:timeout`, `htmx:sendError`, and `htmx:abort`).
 
 ## Tips
 
@@ -234,39 +228,21 @@ document.body.addEventListener('htmx:afterSwap', (event) => {
 });
 ```
 
-### Server-Sent Events
+### Server-Sent Events and WebSockets
 
-HTMX supports Server-Sent Events (SSE) for real-time updates:
-
-```html
-<!-- components/ui/feed.html -->
-<div
-    id="{{ id }}"
-    hx-sse="connect:/events"
-    hx-swap="beforeend"
->
-    <!-- Feed items will be appended here -->
-</div>
-```
-
-### WebSockets
-
-HTMX also supports WebSockets:
-
-```html
-<!-- components/ui/chat.html -->
-<div
-    id="{{ id }}"
-    hx-ws="connect:/ws"
-    hx-swap="beforeend"
->
-    <!-- Messages will be appended here -->
-</div>
-```
+These aren't PyJinHx-specific. In htmx 2 the old `hx-sse` / `hx-ws` core
+attributes are gone — SSE and WebSockets are now opt-in extensions
+(`hx-ext="sse"` with `sse-connect`, `hx-ext="ws"` with `ws-connect`). See htmx's
+[SSE](https://htmx.org/extensions/sse/) and [WebSocket](https://htmx.org/extensions/ws/)
+extension docs, and render the streamed fragments with PyJinHx components as usual.
 
 ## Dependency-aware updates (reactive OOB)
 
-The patterns above use manual `hx-target` / `hx-swap` for each interaction. For apps where **one mutation updates multiple regions** (counter, list, totals) without wiring every swap by hand, use PyJinHx reactivity:
+The patterns above use manual `hx-target` / `hx-swap` for each interaction. With
+PyJinHx reactivity, a mutation route simply returns `Cls.render()` and every
+dependent region rides along as an `hx-swap-oob` fragment — no per-swap wiring.
+This is the path to reach for when **one mutation updates multiple regions**
+(counter, list, totals):
 
 - Declare `reacts_to` + `load()` on `ReactiveComponent` subclasses
 - Return `Cls.render()` from mutation routes — dependent regions ride along as `hx-swap-oob` fragments

--- a/docs/integrations/webawesome.md
+++ b/docs/integrations/webawesome.md
@@ -1,6 +1,17 @@
 # WebAwesome
 
-PyJinHx integrates seamlessly with [WebAwesome](https://webawesome.com/) - a comprehensive web components library that provides 50+ customizable UI components built on web standards.
+[WebAwesome](https://webawesome.com/) is a web-components library (50+ custom elements
+built on web standards). It pairs well with PyJinHx, but there is no special integration:
+**WebAwesome tags are just markup PyJinHx renders.** PyJinHx has no awareness of WebAwesome
+— no asset auto-collection (the WA CDN/bundle `<script>` is the page author's
+responsibility), and no reactive coupling. Loading the WA runtime, theming, and upgrading
+the custom elements all happen client-side, exactly as in any HTML page.
+
+!!! warning "Custom-element boolean/enum attributes need a Jinja guard"
+    Custom elements treat an attribute as "on" by its **presence**, so `open="False"` or
+    `open=""` still opens a dialog. Render boolean attrs with
+    `{% if flag %}attr{% endif %}` (emit the attribute only when true), not
+    `attr="{{ flag }}"`. The same applies to enum attrs you might leave blank.
 
 ## Setup
 
@@ -149,164 +160,49 @@ task_card = TaskCard(
 form = AddTaskForm(id="add-task-form").render()
 ```
 
-## WebAwesome Components in Templates
+## How templates map to WebAwesome
 
-### Using Icons
+There is nothing WebAwesome-specific in PyJinHx — you write the custom elements directly
+in a component's `.html`, and three plain-HTML conventions carry everything you need:
 
-WebAwesome icons can be used with the `wa-icon` component:
+- **Tags** — use the element name as-is (`<wa-button>`, `<wa-card>`, `<wa-icon>`). PyJinHx
+  only expands *PascalCase* tags into its own components; lowercase custom-element tags pass
+  through untouched.
+- **Attributes** — interpolate string/enum attrs with `{{ }}` (`variant="{{ variant }}"`),
+  but emit **boolean** attrs with a guard (`{% if disabled %}disabled{% endif %}`) so a
+  falsy value omits the attribute instead of setting it to `"False"`.
+- **Slots** — place children into named slots with the standard `slot="..."` attribute
+  (`<wa-icon slot="start" …>`); default-slot content just goes between the tags.
 
-```html
-<!-- components/ui/button.html -->
-<wa-button variant="brand">
-    <wa-icon slot="start" name="check"></wa-icon>
-    Submit
-</wa-button>
+For the full element catalogue (variants, sizes, every attribute and slot), see the
+[WebAwesome docs](https://webawesome.com/) — they are the source of truth; PyJinHx
+neither adds nor constrains anything.
+
+### One representative example
+
+A dialog driven by a Python component shows all three conventions at once — interpolated
+attrs, a guarded boolean (`open`), and `slot="header"` / `slot="footer"`:
+
+```python
+# components/ui/dialog.py
+class Dialog(BaseComponent):
+    id: str
+    title: str
+    content: str
+    open: bool = False
 ```
-
-### Card Variants
-
-WebAwesome cards support different appearances:
-
-```html
-<!-- components/ui/card.html -->
-<wa-card appearance="outlined">
-    <div slot="header">Outlined Card</div>
-    <p>Content here</p>
-</wa-card>
-
-<wa-card appearance="filled">
-    <div slot="header">Filled Card</div>
-    <p>Content here</p>
-</wa-card>
-
-<wa-card appearance="elevated">
-    <div slot="header">Elevated Card</div>
-    <p>Content here</p>
-</wa-card>
-```
-
-### Input Components
-
-WebAwesome provides styled input components:
-
-```html
-<!-- components/ui/form.html -->
-<wa-input
-    name="email"
-    label="Email Address"
-    type="email"
-    required
-    placeholder="Enter your email"
-></wa-input>
-
-<wa-textarea
-    name="message"
-    label="Message"
-    rows="4"
-    placeholder="Enter your message"
-></wa-textarea>
-```
-
-### Button Variants
-
-WebAwesome buttons support multiple variants:
-
-```html
-<!-- components/ui/button.html -->
-<wa-button variant="brand">Brand</wa-button>
-<wa-button variant="success">Success</wa-button>
-<wa-button variant="danger">Danger</wa-button>
-<wa-button variant="neutral">Neutral</wa-button>
-<wa-button variant="warning">Warning</wa-button>
-```
-
-### Conditional Rendering
-
-Use Jinja conditionals to control WebAwesome component attributes:
-
-```html
-<!-- components/ui/alert.html -->
-<wa-alert
-    variant="{% if level == 'error' %}danger{% elif level == 'warning' %}warning{% else %}info{% endif %}"
-    open
->
-    {{ message }}
-</wa-alert>
-```
-
-## Tips
-
-### Component Slots
-
-WebAwesome components use slots for flexible content placement:
-
-```html
-<!-- components/ui/button.html -->
-<wa-button>
-    <wa-icon slot="start" name="save"></wa-icon>
-    Save
-    <wa-icon slot="end" name="arrow-right"></wa-icon>
-</wa-button>
-```
-
-### Styling
-
-WebAwesome components can be styled with CSS custom properties:
-
-```html
-<!-- components/ui/card.html -->
-<wa-card
-    style="--wa-card-padding: 2rem; --wa-card-border-radius: 12px;"
->
-    <div slot="header">Custom Styled Card</div>
-    <p>Content</p>
-</wa-card>
-```
-
-### Component Composition
-
-Combine multiple WebAwesome components in your PyJinHx templates:
 
 ```html
 <!-- components/ui/dialog.html -->
-<wa-dialog id="{{ id }}" open="{{ open }}">
-    <div slot="header">
-        <h2>{{ title }}</h2>
-    </div>
+<wa-dialog id="{{ id }}" {% if open %}open{% endif %}>
+    <div slot="header"><h2>{{ title }}</h2></div>
     <p>{{ content }}</p>
     <div slot="footer">
-        <wa-button variant="neutral" onclick="this.closest('wa-dialog').close()">
-            Cancel
-        </wa-button>
+        <wa-button variant="neutral" onclick="this.closest('wa-dialog').close()">Cancel</wa-button>
         <wa-button variant="brand" onclick="this.closest('wa-dialog').close()">
+            <wa-icon slot="start" name="check"></wa-icon>
             Confirm
         </wa-button>
     </div>
 </wa-dialog>
-```
-
-### Dynamic Attributes
-
-Pass WebAwesome component attributes from your Python component:
-
-```python
-# components/ui/button.py
-class Button(BaseComponent):
-    id: str
-    text: str
-    variant: str = "brand"
-    size: str = "medium"
-    disabled: bool = False
-```
-
-```html
-<!-- components/ui/button.html -->
-<wa-button
-    id="{{ id }}"
-    variant="{{ variant }}"
-    size="{{ size }}"
-    {% if disabled %}disabled{% endif %}
->
-    {{ text }}
-</wa-button>
 ```

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -130,6 +130,10 @@ singletons), renders it as the main-target response, then appends OOB swaps for 
 the region that *initiated* the request still updates out-of-band if it depends on the
 dirtied keys — e.g. a "Clear completed (N)" button updates its own count.
 
+`X-PJX-Trigger` is **client-only**: `pjx.js` reads it to drive loading indicators (which
+region the user clicked). The server reactive walk (`render` / `oob_swaps`) never reads it —
+it excludes only the primary id and gates everything else on `reacts_to` and hashes.
+
 A **plain, non-reactive** primary has no `load()` to call, so you build it and render
 the instance: `MyFragment(id=..., ...).render()`.
 
@@ -461,105 +465,21 @@ Want a different effect entirely? Use your own value (e.g. `data-pjx-loading="pu
 style `.pjx-loading--pulse` yourself — `pjx.js` applies `.pjx-loading--<value>` regardless of
 the name.
 
-## Boundaries
-
-- **Hash gating is a skip-hint, not correctness authority**: a matching client hash
-  earns permission to skip; missing/unknown/mismatched always swaps. It saves
-  bandwidth and DOM churn; database work is saved separately by the `load()` cache.
-  Default `state_hash()` uses canonical sorted JSON with `id` excluded; set
-  `state_hash_exclude` or override `state_hash()` for custom fields.
-- **Type-singleton and instance-keyed**: zero-arg `load(cls)` is a type-singleton;
-  `load(cls, resource)` is instance-keyed with a `PjxLoad` field. See *Instance-keyed
-  regions (rows)* above.
-- **Reactivity is opt-in via `ReactiveComponent`**, which requires both `load()` and
-  `reacts_to`. Reactive class `render()` auto-`load()`s the primary and OOB dependents.
-- **`load()` cache scope**: default `REQUEST`. Use `PROCESS` for cross-request caching
-  per worker; multi-worker `PROCESS` needs an `InvalidationBackend`. Eviction is
-  state-key driven (`@mutates` or `LoadCache.invalidate`).
-
 ## How it works (under the hood)
 
-### The ownership split
+**The ownership split.** Neither pyjinhx nor htmx owned the **state→view dependency
+graph** before; now it is explicit. The **server** owns the graph and the data and
+decides what changed; the **client** owns what is currently mounted and rides that up on
+every request as `X-PJX-Mounted`. There is no per-session server state — reactive roots
+are stamped with `data-pjx-*` at render time, and `pjx.js` reads the already-stamped DOM
+on `htmx:configRequest` (it never watches for changes; a DOM mutation is the *effect* of
+a swap, not its cause).
 
-Neither pyjinhx nor htmx owned the **state→view dependency graph** before. The split
-is now explicit: the **server** owns the dependency graph and the data and decides what
-changed; the **client** owns what is currently mounted and rides that up on every
-request as a manifest. There is no per-session server state.
-
-```mermaid
-flowchart LR
-    subgraph Client["Client — browser + htmx"]
-      DOM["Mounted DOM<br/>reactive roots carry<br/>data-pjx-id / -type / -hash"]
-      RT["pjx.js runtime"]
-    end
-    subgraph Server["Server — pyjinhx"]
-      G["reacts_to graph<br/>declared on components"]
-      W["oob_swaps walk"]
-      L["load() + result cache"]
-    end
-    DB[("Database")]
-
-    RT -->|"reads DOM, builds<br/>X-PJX-Mounted header"| DOM
-    DOM -->|"manifest on every request"| W
-    W --> G
-    W --> L --> DB
-    W -->|"hx-swap-oob fragments"| DOM
-```
-
-### Initial render → the manifest
-
-On a full-page render, reactive roots are stamped with `data-pjx-*` and the client
-runtime is injected when `X-PJX-Mounted` is absent (or via `client_script()` in
-a raw Jinja shell). The runtime reads the already-stamped DOM at request time — it
-never watches for changes, because DOM mutation is the *effect* of a swap, not its cause.
-
-```mermaid
-flowchart TD
-    A["full-page render"] --> B["reactive roots stamped<br/>data-pjx-* via splice stamper"]
-    A --> C["client runtime injected<br/>unless X-PJX-Mounted present"]
-    B --> D["DOM holds id + type + hash<br/>per mounted region"]
-    C --> E["on htmx:configRequest,<br/>pjx.js scans [data-pjx-id]"]
-    D --> E
-    E --> F["sets X-PJX-Mounted header<br/>= list of id, type, hash"]
-```
-
-### A mutation request, end to end
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant B as Browser (htmx + pjx.js)
-    participant R as Route handler
-    participant RD as render(dirtied, mounted)
-    participant C as load() cache
-    participant DB as Database
-
-    B->>R: POST /todos/1/toggle  (X-PJX-Mounted header)
-    R->>DB: db.toggle(1)
-    R->>RD: Counter.render()  # dirtied from @mutates; mounted from ClientBackend
-    RD->>C: invalidate(dirtied)
-    Note over C: evict cached load() results<br/>whose reacts_to hits a dirtied key
-    RD->>RD: load() + render primary → response
-    RD->>RD: oob_swaps walk (exclude_ids = self.id)
-    loop each mounted region depending on a dirtied key
-        RD->>C: cls.load()
-        alt cache miss
-            C->>DB: query
-            DB-->>C: data
-        else cache hit
-            C-->>RD: model_copy() — no DB
-        end
-        RD->>RD: render + compute fresh hash
-    end
-    RD-->>R: primary + OOB fragments
-    R-->>B: one HTML response
-    B->>B: htmx swaps main target + each hx-swap-oob region
-```
-
-### Inside `oob_swaps`: the decision pipeline
-
-Every mounted region runs this gauntlet. Ordering matters: **hash-gate before
-nesting-dedup**, so an unchanged parent never suppresses a changed child.
+A mutation route returns `Cls.render()`. That invalidates the `load()` cache for the
+dirtied keys, renders the primary as the main response, then runs the `oob_swaps` walk
+(with `exclude_ids = {primary.id}`) over the mounted manifest. Every region runs this
+gauntlet — and ordering matters: **hash-gate before nesting-dedup**, so an unchanged
+parent never suppresses a changed child.
 
 ```mermaid
 flowchart TD
@@ -585,24 +505,8 @@ The four parent/child cases (regions nested in the rendered HTML):
 | unchanged | unchanged | swap nothing |
 
 Governing invariant throughout: **when in doubt, swap** — missing, unknown, or
-mismatched hashes always send.
-
-### The `load()` cache
-
-`load()` is auto-wrapped at class-definition time so it is cache-aware everywhere it is
-called. Reads short-circuit the database; writes evict by dependency through a reverse
-index. A `threading.Lock` guards the compound consult-then-mutate operations, while the
-real `load()` (the database hit) runs outside the lock.
-
-```mermaid
-flowchart TD
-    CALL["Cls.load()"] --> HIT{"in cache?"}
-    HIT -->|hit| COPY["return model_copy()<br/>no DB; copy keeps cache pristine"]
-    HIT -->|miss| RUN["run real load() → DB"]
-    RUN --> STORE["cache cls = result<br/>index under each reacts_to key"]
-    STORE --> COPY
-
-    INV["invalidate(dirtied)<br/>auto in reactive flow, or public"] --> REV["consult reverse index<br/>key → classes"]
-    REV --> EVICT["evict every class whose<br/>reacts_to intersects dirtied"]
-    EVICT -.->|"next load() misses"| CALL
-```
+mismatched hashes always send. Hash gating is a *skip-hint*, not correctness authority:
+it saves bandwidth and DOM churn, while database work is saved separately by the
+`load()` cache (each cached `load()` returns a `model_copy()`, so the DB is hit only on
+a miss; writes evict by dependency through a reverse index, guarded by a lock around the
+consult-then-mutate while the real `load()` runs outside it).

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -20,8 +20,10 @@ Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line
 | Symbol | Description | Documentation |
 |--------|-------------|---------------|
 | `client_script()` | Emit the pyjinhx client runtime as a `<script>` tag | [Reactive API](../api/reactive-api.md#client_script) |
+| `MountedManifest` | Parser for the `X-PJX-Mounted` mounted-region manifest | [Reactive API](../api/reactive-api.md#mountedmanifest) |
 | `MountedManifest.is_present()` | Return whether `X-PJX-Mounted` is present on the request | [Reactive API](../api/reactive-api.md#mountedmanifest) |
 | `MountedManifest.parse()` | Parse the `X-PJX-Mounted` manifest | [Reactive API](../api/reactive-api.md#mountedmanifest) |
+| `LoadedAssets` | Parser for the `X-PJX-Assets` already-loaded asset list | [Reactive API](../api/reactive-api.md#loadedassets) |
 | `LoadedAssets.parse()` | Parse the `X-PJX-Assets` header for asset dedup | [Reactive API](../api/reactive-api.md#loadedassets) |
 | `ClientBackend` | ABC for per-request HTTP header access | [Client Backend](../api/client-backend.md#clientbackend) |
 | `FastAPIClientBackend` | Default backend for FastAPI/Starlette requests | [Client Backend](../api/client-backend.md) |
@@ -32,9 +34,10 @@ Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line
 | `oob_swaps()` | Compute HTMX out-of-band swap fragments for dirtied keys | [Reactive API](../api/reactive-api.md#oob_swaps) |
 | `PJX_MOUNTED_HEADER` | HTTP header name for the client mounted-region manifest | [Reactive API](../api/reactive-api.md#pjx-headers) |
 | `PJX_ASSETS_HEADER` | HTTP header name for asset URLs already loaded in the browser | [Reactive API](../api/reactive-api.md#pjx-headers) |
+| `PJX_TRIGGER_HEADER` | HTTP header name for the swap-origin region id (client-set) | [Reactive API](../api/reactive-api.md#pjx-headers) |
 | `StateKey` | Base `StrEnum` for app-level reactive key constants | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#statekey) |
 | `PjxLoad` | Marker for `Annotated[..., PjxLoad()]` fields stamped as `data-pjx-load` | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#pjxload) |
-| `MutationTracker` | Request-scoped dirtied-key accumulation | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#mutationtracker) |
+| `MutationTracker` | Request-scoped dirtied-key accumulation | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md) |
 | `mutates()` | Decorator: invalidate cache and accumulate dirtied keys after mutation | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#mutates) |
 | `TriggerManifest` | Parse `X-PJX-Trigger` (swap-origin region id) | [Reactive API](../api/reactive-api.md) |
 | `LoadContext` | Opaque base dataclass for request-scoped `load()` data | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#loadcontext) |
@@ -51,8 +54,8 @@ Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line
 |--------|-------------|---------------|
 | `setup()` | Single-call process + optional FastAPI wiring | [Configuration](../api/config.md#setup) |
 | `PyJinhxSettings` | Cache scope, invalidation backend, reactive dev flags | [Configuration](../api/config.md#pyjinhxsettings) |
-| `configure_pyjinhx()` | Process-wide startup | [Configuration](../api/config.md#configure_pyjinhx--shutdown_pyjinhx) |
-| `shutdown_pyjinhx()` | Process-wide shutdown | [Configuration](../api/config.md#configure_pyjinhx--shutdown_pyjinhx) |
+| `configure_pyjinhx()` | Process-wide startup | [Configuration](../api/config.md#configure_pyjinhx-shutdown_pyjinhx) |
+| `shutdown_pyjinhx()` | Process-wide shutdown | [Configuration](../api/config.md#configure_pyjinhx-shutdown_pyjinhx) |
 | `pyjinhx_lifespan()` | Sync context manager for tests/scripts | [Configuration](../api/config.md#pyjinhx_lifespan) |
 
 ## Load cache & invalidation
@@ -80,7 +83,7 @@ Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line
 | `asset_manifest()` | Build an `AssetManifest` from a `RenderSession` | [Assets API](../api/assets-api.md#asset_manifest) |
 | `default_asset_url()` | Map an absolute asset path to a default public URL | [Assets API](../api/assets-api.md#default_asset_url) |
 | `hashed_filename()` | Content-hash a filename for cache-busting | [Assets API](../api/assets-api.md#hashed_filename) |
-| `Finder.layout_asset_tags()` | Emit `<link>` / `<script>` tags for all discovered component assets | [Assets API](../api/assets-api.md#layout_asset_tags) |
+| `Finder.layout_asset_tags()` | Emit `<link>` / `<script>` tags for all discovered component assets | [Finder](../api/finder.md#layout_asset_tags) |
 | `make_default_asset_url_resolver()` | Build a resolver using `default_asset_url()` | [Assets API](../api/assets-api.md#make_default_asset_url_resolver) |
 | `resolver_with_hash()` | Build a resolver that embeds content hashes in URLs | [Assets API](../api/assets-api.md#resolver_with_hash) |
 | `runtime_asset_path()` | Absolute path to the bundled `pjx.js` file | [Assets API](../api/assets-api.md#runtime_asset_path) |

--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -14,6 +14,9 @@ from pyjinhx.dev import disable_reactive_dev, enable_reactive_dev
 logger = logging.getLogger("pyjinhx")
 
 
+_UNSET: Any = object()  # sentinel: distinguishes "argument omitted" from None / a real value
+
+
 @dataclass(frozen=True)
 class PyJinhxSettings:
     cache_scope: CacheScope = CacheScope.REQUEST
@@ -42,17 +45,23 @@ class PyJinhxSettings:
         )
 
     def merge(self, **overrides: Any) -> PyJinhxSettings:
+        # only fields explicitly provided (not the _UNSET sentinel) override self, so an
+        # explicit `settings=` is never clobbered by setup()'s default keyword arguments
         valid = {field.name for field in fields(self)}
-        filtered = {key: value for key, value in overrides.items() if key in valid}
+        filtered = {
+            key: value
+            for key, value in overrides.items()
+            if key in valid and value is not _UNSET
+        }
         return replace(self, **filtered)
 
 
 def _merge_settings(
     settings: PyJinhxSettings | None,
     *,
-    cache_scope: CacheScope,
-    invalidation_backend: InvalidationBackend | None,
-    reactive_dev: bool,
+    cache_scope: Any,
+    invalidation_backend: Any,
+    reactive_dev: Any,
     extra: dict[str, Any],
 ) -> PyJinhxSettings:
     return (settings or PyJinhxSettings()).merge(
@@ -71,9 +80,9 @@ def configure_pyjinhx(
     if kwargs or settings is None:
         resolved = _merge_settings(
             settings,
-            cache_scope=kwargs.pop("cache_scope", CacheScope.REQUEST),
-            invalidation_backend=kwargs.pop("invalidation_backend", None),
-            reactive_dev=kwargs.pop("reactive_dev", False),
+            cache_scope=kwargs.pop("cache_scope", _UNSET),
+            invalidation_backend=kwargs.pop("invalidation_backend", _UNSET),
+            reactive_dev=kwargs.pop("reactive_dev", _UNSET),
             extra=kwargs,
         )
     else:
@@ -133,9 +142,9 @@ def setup(
     app: object | None = None,
     *,
     settings: PyJinhxSettings | None = None,
-    cache_scope: CacheScope = CacheScope.REQUEST,
-    invalidation_backend: InvalidationBackend | None = None,
-    reactive_dev: bool = False,
+    cache_scope: CacheScope = _UNSET,
+    invalidation_backend: InvalidationBackend | None = _UNSET,
+    reactive_dev: bool = _UNSET,
     load_context_factory: Callable[[Any], object | None] | None = None,
     **kwargs: Any,
 ) -> PyJinhxSettings:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "jinja2>=3.1.6",
     "markupsafe>=3.0.3",
     "pydantic>=2.12.5",
-    "pytest>=9.0.1",
 ]
 
 [project.urls]
@@ -40,6 +39,7 @@ redis = ["redis>=5.0.0", "fakeredis>=2.26.0"]
 
 [dependency-groups]
 dev = [
+    "pytest>=9.0.1",
     "mkdocs-material>=9.7.1",
     "mkdocstrings[python]>=1.0.1",
     "fastapi>=0.115.0",

--- a/tests/57_config_test.py
+++ b/tests/57_config_test.py
@@ -72,3 +72,27 @@ def test_configure_warns_when_backend_set_with_request_scope(caplog):
     )
     assert LoadCache.scope() == CacheScope.REQUEST
     assert any("invalidation_backend" in record.message for record in caplog.records)
+
+
+def test_settings_object_not_clobbered_by_default_kwargs():
+    # regression: default kwargs must not overwrite an explicit settings=
+    # (cache_scope previously reverted to REQUEST, nulling PROCESS config).
+    resolved = configure_pyjinhx(PyJinhxSettings(cache_scope=CacheScope.PROCESS))
+    assert resolved.cache_scope == CacheScope.PROCESS
+    assert LoadCache.scope() == CacheScope.PROCESS
+
+
+def test_settings_process_keeps_invalidation_backend():
+    backend = _StubBackend()
+    resolved = configure_pyjinhx(
+        PyJinhxSettings(cache_scope=CacheScope.PROCESS, invalidation_backend=backend)
+    )
+    assert resolved.cache_scope == CacheScope.PROCESS
+    assert resolved.invalidation_backend is backend
+
+
+def test_explicit_kwarg_still_overrides_settings():
+    resolved = configure_pyjinhx(
+        PyJinhxSettings(cache_scope=CacheScope.PROCESS), cache_scope=CacheScope.NONE
+    )
+    assert resolved.cache_scope == CacheScope.NONE

--- a/uv.lock
+++ b/uv.lock
@@ -572,13 +572,12 @@ wheels = [
 
 [[package]]
 name = "pyjinhx"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
     { name = "markupsafe" },
     { name = "pydantic" },
-    { name = "pytest" },
 ]
 
 [package.optional-dependencies]
@@ -594,6 +593,7 @@ dev = [
     { name = "httpx" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pytest" },
     { name = "python-multipart" },
     { name = "redis" },
     { name = "uvicorn" },
@@ -605,7 +605,6 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "markupsafe", specifier = ">=3.0.3" },
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pytest", specifier = ">=9.0.1" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
 ]
 provides-extras = ["redis"]
@@ -617,6 +616,7 @@ dev = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mkdocs-material", specifier = ">=9.7.1" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.1" },
+    { name = "pytest", specifier = ">=9.0.1" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "uvicorn", specifier = ">=0.32.0" },


### PR DESCRIPTION
Actions the full documentation audit as a reviewable series of **9 commits** — 2 code bugs + ~28 doc fixes across 23 files. Net **−525 lines** (mostly compression). `mkdocs --strict` builds with every anchor resolving; 312 tests pass; ruff clean.

## 🐞 Code bugs (the audit surfaced)
- **`fix(config)`** — `setup(settings=PyJinhxSettings(cache_scope=PROCESS, invalidation_backend=…))` silently reverted to `REQUEST` and dropped the backend: `setup()`/`configure_pyjinhx()` forwarded their *default* kwargs into `merge()`, clobbering `settings=`. Fixed with an `_UNSET` sentinel so only explicitly-passed kwargs override. The documented multi-worker path now works (+3 regression tests).
- **`build`** — `pytest` was under `[project] dependencies` (pulled into production installs); moved to the dev dependency-group.

## ✅ Mistakes fixed
Copy-paste-breaking: `BaseComponent.render()` (zero-arg, not `*, dirtied, mounted, client`); README `Renderer.render(...)` → instance method; `default_asset_url` (no `kind`); `layout_asset_tags` (it's `Finder.layout_asset_tags()`, not an import); `detect_root_directory` (a `utils` free function). Accuracy: `reacts_to: set[str]`; `render()` doesn't read `X-PJX-Trigger`; claude-code trigger-is-NOT-excluded + `REQUEST` default; htmx 2.0.3 + extension syntax; 6 project-root markers; `auto_id`/id-default rules; README example names; `wa-dialog` boolean attr; public-api missing rows; several broken doc anchors.

## ➕ Missing info added
The v0.7.1 **loading indicators** (`data-pjx-loading` skeleton/spinner + `--pjx-*` theming tokens) are now documented on README, build-an-app, htmx, and claude-code (previously only in reactivity.md). Also: config env vars (`PJX_*`/`REDIS_URL`, `from_env()`); the PascalCase tag limitation (acronyms/digits rejected); the two nesting styles' differing `id` rules; the `[redis]` extra; the `ClientBackend` requirement for reactive OOB; `Registry.get_class()/has_class()`.

## ✂️ Compression
`builtins.md` 989→666 (inlined templates removed, `--pjx-*` tokens consolidated into one appendix, boilerplate deduped — all 20 components + props tables preserved); `claude-code.md` −103; `reactivity.md` −96 (four redundant mermaids → one + table); `webawesome.md` −114; plus README/guide dedup.

## Verification
`uv run pytest` → 312 passed · `uv run ruff check .` → clean · `uv run mkdocs build --strict` → builds (no broken anchors) · `node --check pjx.js` → valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)