### PR TITLE
refactor(api)!: small, curated public surface (45 → 11 symbols)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.2
+current_version = 0.7.3
 commit = True
 tag = True
 message = Bump version: {current_version} → {new_version}

--- a/.cursor/skills/code-audit-sweep/CONVENTIONS.md
+++ b/.cursor/skills/code-audit-sweep/CONVENTIONS.md
@@ -43,7 +43,7 @@ Cite these in findings when relevant:
 
 1. **One implementation layer** — no internal module function that only delegates to a classmethod (or the reverse).
 2. **ABC + hub in core/reactive; impl in integrations** — e.g. `ClientBackend` in `pyjinhx/reactive/backend.py`, `FastAPIClientBackend` in `pyjinhx/integrations/fastapi.py`; `InvalidationBackend` + `InvalidationHub` vs `RedisInvalidationBackend` in `pyjinhx/integrations/redis.py`.
-3. **Stateful subsystems → class + classmethods + ContextVar** — `LoadCache`, `MutationTracker`, `InvalidationHub`, `ClientBackend`, `LoadContext`.
+3. **Stateful subsystems → class + classmethods + ContextVar** — `LoadCache`, `MutationTracker`, `InvalidationHub`, `ClientBackend`, `PjxContext`.
 4. **Pure transforms stay functions** — `pyjinhx/reactive/keys.py` coercion; `pjx_load.py` field discovery.
 5. **Ergonomic decorators stay module-level** — `@mutates` calls `MutationTracker.record`.
 6. **Package `__init__.py` re-exports OK; internal wrappers not OK.**

--- a/.cursor/skills/code-audit-sweep/VALIDATION.md
+++ b/.cursor/skills/code-audit-sweep/VALIDATION.md
@@ -8,7 +8,7 @@ Orchestrator dry-run after reactive refactor. Used to calibrate severity and con
 |----|----|----|
 | 0  | 0  | 0–1 |
 
-**Summary:** Post-refactor reactive package passes all lenses. No layer violations, no thin wrappers, ContextVars owned by hub classes (`LoadCache`, `MutationTracker`, `ClientBackend`) or `LoadContext` static API. Largest file `load_cache.py` (243 LOC) is cohesive single-class; below hard split threshold.
+**Summary:** Post-refactor reactive package passes all lenses. No layer violations, no thin wrappers, ContextVars owned by hub classes (`LoadCache`, `MutationTracker`, `ClientBackend`) or `PjxContext` static API. Largest file `load_cache.py` (243 LOC) is cohesive single-class; below hard split threshold.
 
 Optional P3 (not reported): `load_cache.py` slightly above 250 LOC soft ceiling — defer split until second concern appears.
 
@@ -31,7 +31,7 @@ Optional P3 (not reported): `load_cache.py` slightly above 250 LOC soft ceiling 
 ### P3 — `registry.py` module-level `_registry_context`
 
 - **Lens:** state-shape-audit
-- **Issue:** ContextVar at module level vs `ClassVar` on `Registry` (matches `LoadContext` pattern).
+- **Issue:** ContextVar at module level vs `ClassVar` on `Registry` (matches `PjxContext` pattern).
 - **Fix shape:** Optional consolidation onto `Registry` when editing; not inconsistent enough to prioritize.
 
 ## Cross-cutting (docs, not code scope)
@@ -41,6 +41,6 @@ Optional P3 (not reported): `load_cache.py` slightly above 250 LOC soft ceiling 
 ## Rubric tuning applied
 
 - Cohesive single-class files 240–260 LOC → no finding unless mixed concerns.
-- Module-level ContextVar + class static methods (`LoadContext`, `Registry`) → OK, not P2.
+- Module-level ContextVar + class static methods (`PjxContext`, `Registry`) → OK, not P2.
 - Expected baseline in orchestrator SKILL.md matches reactive dry-run.
 - **dead-code-audit** runs last in full sweep; complements `public-api-audit` with code-path and orphan-test analysis.

--- a/.cursor/skills/dead-code-audit/SKILL.md
+++ b/.cursor/skills/dead-code-audit/SKILL.md
@@ -44,8 +44,8 @@ Re-grep after each breaking reactive/API change. Absence in `pyjinhx/` but prese
 mutation_scope
 coerce_dirty_args
 interpolate_reactive_keys
-StateKey.instance_key
-StateKey.dirty_keys
+MutationKey.instance_key
+MutationKey.dirty_keys
 dirty_keys
 resolve_mounted
 resolve_effective_dirtied

--- a/.cursor/skills/dead-code-audit/SKILL.md
+++ b/.cursor/skills/dead-code-audit/SKILL.md
@@ -124,7 +124,7 @@ uv run ruff check .
 
 - [ ] No removed symbols in `pyjinhx/` (except CHANGELOG/historical notes if any)
 - [ ] No removed symbols in `tests/` imports or assertions
-- [ ] `docs/` and `examples/` use current API (`PjxLoad`, `Cls.render(*args)`, `@mutates` state keys only)
+- [ ] `docs/` and `examples/` use current API (`PjxKey`, `Cls.render(*args)`, `@mutates` state keys only)
 - [ ] No orphan compat branches (manifest `key` alias, stem invalidation index, etc.) without tests or callers
 - [ ] No tests asserting deleted behavior unless explicitly marked legacy
 - [ ] Audit skills grep current symbols (`warn_reactive_render_without_client`, not `..._mounted`)

--- a/.cursor/skills/domain-entity-audit/SKILL.md
+++ b/.cursor/skills/domain-entity-audit/SKILL.md
@@ -30,7 +30,7 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 | Cross-worker fan-out | `InvalidationBackend` + `InvalidationHub` | Redis in `reactive/` |
 | Client manifest | `MountedManifest` | loose dict parsing only |
 | Trigger region | `TriggerManifest` | ad-hoc trigger header parsing |
-| Load round-trip marker | `PjxLoad` | magic `{{ key }}` template injection |
+| Load round-trip marker | `PjxKey` | magic `{{ key }}` template injection |
 | Loaded asset URLs | `LoadedAssets` | `parse_loaded_assets()` |
 | OOB swap walk | functions in `oob.py` | `OobSwaps` class (algorithm, not entity) |
 | Dev guardrails | module functions + `_DevConfig` | public class |

--- a/.cursor/skills/domain-entity-audit/SKILL.md
+++ b/.cursor/skills/domain-entity-audit/SKILL.md
@@ -23,7 +23,7 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 | Concept | Representation | Not |
 |---------|----------------|-----|
 | Reactive UI unit | `ReactiveComponent` | functions in `component.py` only |
-| Load DI | `LoadContext` | `get_load_context()` wrapper |
+| Load DI | `PjxContext` | `get_load_context()` wrapper |
 | HTTP header source | `ClientBackend` ABC | FastAPI type in `reactive/` |
 | Load memoization | `LoadCache` | procedural `cache.py` |
 | Dirtied keys | `MutationTracker` | scattered ContextVar helpers |

--- a/.cursor/skills/public-api-audit/SKILL.md
+++ b/.cursor/skills/public-api-audit/SKILL.md
@@ -34,7 +34,7 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 
 - [ ] `import pyjinhx; set(pyjinhx.__all__) == set(dir intended)`
 - [ ] No removed symbols in docs (`mutation_scope`, `dirty_keys`, `get_load_context`, `fastapi_client_backend`, top-level `invalidate`, etc.)
-- [ ] New exports documented (`PjxLoad`, `TriggerManifest`, `PJX_TRIGGER_HEADER`)
+- [ ] New exports documented (`PjxKey`, `TriggerManifest`, `PJX_TRIGGER_HEADER`)
 - [ ] `tests/36_public_api_test.py` imports match `__all__`
 - [ ] Examples use canonical names (`LoadContext.current`, not `get_load_context`)
 - [ ] Breaking renames noted in README if user-facing

--- a/.cursor/skills/public-api-audit/SKILL.md
+++ b/.cursor/skills/public-api-audit/SKILL.md
@@ -36,7 +36,7 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 - [ ] No removed symbols in docs (`mutation_scope`, `dirty_keys`, `get_load_context`, `fastapi_client_backend`, top-level `invalidate`, etc.)
 - [ ] New exports documented (`PjxKey`, `TriggerManifest`, `PJX_TRIGGER_HEADER`)
 - [ ] `tests/36_public_api_test.py` imports match `__all__`
-- [ ] Examples use canonical names (`LoadContext.current`, not `get_load_context`)
+- [ ] Examples use canonical names (`PjxContext.current`, not `get_load_context`)
 - [ ] Breaking renames noted in README if user-facing
 
 ## Mechanical checks

--- a/.cursor/skills/state-shape-audit/SKILL.md
+++ b/.cursor/skills/state-shape-audit/SKILL.md
@@ -22,7 +22,7 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 | Situation | Shape | pyjinhx example |
 |-----------|-------|-----------------|
 | ContextVar + locks + process/request state | Class with `@classmethod` | `LoadCache`, `MutationTracker`, `InvalidationHub`, `ClientBackend` |
-| Request-scoped opaque DI bag | Static methods on frozen dataclass base | `LoadContext` |
+| Request-scoped opaque DI bag | Static methods on frozen dataclass base | `PjxContext` |
 | Pure input → output | Module functions | `coerce_reactive_key`, `pjx_load_field_names`, `PjxKey` validation |
 | Decorator ergonomics | Module decorator → class method | `@mutates` → `MutationTracker.record` |
 | Plugin extension point | ABC, no hub state | `InvalidationBackend` |
@@ -47,7 +47,7 @@ For each module-global cluster, ask: should this be methods on one class?
 ## OK patterns (do not flag)
 
 - `_dev_config` module global with functions as canonical dev API
-- Module-level ContextVar with static methods on owning type (`LoadContext.current` / `Registry.request_scope` pattern)
+- Module-level ContextVar with static methods on owning type (`PjxContext.current` / `Registry.request_scope` pattern)
 - Lazy import inside method to avoid cycles
 - `CacheScope` enum at module level next to `LoadCache` class
 

--- a/.cursor/skills/state-shape-audit/SKILL.md
+++ b/.cursor/skills/state-shape-audit/SKILL.md
@@ -23,7 +23,7 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 |-----------|-------|-----------------|
 | ContextVar + locks + process/request state | Class with `@classmethod` | `LoadCache`, `MutationTracker`, `InvalidationHub`, `ClientBackend` |
 | Request-scoped opaque DI bag | Static methods on frozen dataclass base | `LoadContext` |
-| Pure input → output | Module functions | `coerce_reactive_key`, `pjx_load_field_names`, `PjxLoad` validation |
+| Pure input → output | Module functions | `coerce_reactive_key`, `pjx_load_field_names`, `PjxKey` validation |
 | Decorator ergonomics | Module decorator → class method | `@mutates` → `MutationTracker.record` |
 | Plugin extension point | ABC, no hub state | `InvalidationBackend` |
 | Runtime coordinator | Hub class | `InvalidationHub` |

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ def toggle():
 
 Call `setup(app, ...)` once: it installs the lifespan and registry middleware that handle cache scope, optional invalidation, `LoadContext`, and the `ClientBackend` that resolves the `X-PJX-*` headers — so mutation routes call `Cls.render(*args)` with no framework kwargs. The client runtime (`pjx.js`) is injected on root full-page renders unless `X-PJX-Mounted` is already present.
 
-**Reactive ergonomics:** `StateKey` enums for typed keys; `@mutates` on store methods to accumulate pending dirtied keys for the next reactive `render()`; one `PjxLoad`-annotated field per keyed component for the `data-pjx-load` round-trip; `LoadContext` to inject request-scoped dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
+**Reactive ergonomics:** `StateKey` enums for typed keys; `@mutates` on store methods to accumulate pending dirtied keys for the next reactive `render()`; one `PjxKey`-annotated field per keyed component for the `data-pjx-load` round-trip; `LoadContext` to inject request-scoped dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
 
 **Loading indicators:** a reactive region can show an in-flight indicator while it reloads — add `data-pjx-loading="skeleton"` (or `"spinner"`) to a template element, and `pjx.js` lights it automatically off the region's `reacts_to`. Themeable via `--pjx-*` CSS variables. See the [reactivity guide](docs/reactivity.md#loading-indicators-in-flight).
 
@@ -216,7 +216,7 @@ A toggle route returns the row as the primary swap; the counter updates out-of-b
 # components.py
 from typing import Annotated, ClassVar
 
-from pyjinhx import BaseComponent, PjxLoad, ReactiveComponent, StateKey
+from pyjinhx import BaseComponent, PjxKey, ReactiveComponent, StateKey
 
 
 class Keys(StateKey):
@@ -224,7 +224,7 @@ class Keys(StateKey):
 
 
 class ItemRow(ReactiveComponent):
-    todo_id: Annotated[int, PjxLoad()]
+    todo_id: Annotated[int, PjxKey()]
     title: str = ""
     done: bool = False
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}

--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ Declare what state each component depends on. After a mutation, return `Cls.rend
 ```python
 from typing import ClassVar
 
-from pyjinhx import ReactiveComponent, StateKey
+from pyjinhx import ReactiveComponent, MutationKey
 
 
-class Keys(StateKey):
+class Keys(MutationKey):
     TODOS = "todos"
 
 
@@ -162,7 +162,7 @@ def toggle():
 
 Call `setup(app, ...)` once: it installs the lifespan and registry middleware that handle cache scope, optional invalidation, `PjxContext`, and the `ClientBackend` that resolves the `X-PJX-*` headers — so mutation routes call `Cls.render(*args)` with no framework kwargs. The client runtime (`pjx.js`) is injected on root full-page renders unless `X-PJX-Mounted` is already present.
 
-**Reactive ergonomics:** `StateKey` enums for typed keys; `@mutates` on store methods to accumulate pending dirtied keys for the next reactive `render()`; one `PjxKey`-annotated field per keyed component for the `data-pjx-load` round-trip; `PjxContext` to inject request-scoped dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
+**Reactive ergonomics:** `MutationKey` enums for typed keys; `@mutates` on store methods to accumulate pending dirtied keys for the next reactive `render()`; one `PjxKey`-annotated field per keyed component for the `data-pjx-load` round-trip; `PjxContext` to inject request-scoped dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
 
 **Loading indicators:** a reactive region can show an in-flight indicator while it reloads — add `data-pjx-loading="skeleton"` (or `"spinner"`) to a template element, and `pjx.js` lights it automatically off the region's `reacts_to`. Themeable via `--pjx-*` CSS variables. See the [reactivity guide](docs/reactivity.md#loading-indicators-in-flight).
 
@@ -216,10 +216,10 @@ A toggle route returns the row as the primary swap; the counter updates out-of-b
 # components.py
 from typing import Annotated, ClassVar
 
-from pyjinhx import BaseComponent, PjxKey, ReactiveComponent, StateKey
+from pyjinhx import BaseComponent, PjxKey, ReactiveComponent, MutationKey
 
 
-class Keys(StateKey):
+class Keys(MutationKey):
     TODOS = "todos"
 
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Import from the top level only — `from pyjinhx import BaseComponent, ReactiveC
 |--------|------|
 | Render engine (tiers 1–2) | `base`, `renderer`, `assets`, `tags`, `finder`, `registry` |
 | Reactivity (tier 3+) | `reactive`, `client`, `cache`, `mutations`, `keys`, `context`, `dev` |
-| Setup | `config` — `setup()`, `PyJinhxSettings`, lifespan helpers |
+| Setup | `config` — `setup()`, `PjxSettings`, lifespan helpers |
 | `pyjinhx/integrations/` | FastAPI wiring, Redis invalidation backend |
 | `pyjinhx/builtins/` | Optional UI kit |
 | `pyjinhx/runtime/` | Client runtime (`pjx.js`) |

--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ def toggle():
     return Counter.render()
 ```
 
-Call `setup(app, ...)` once: it installs the lifespan and registry middleware that handle cache scope, optional invalidation, `LoadContext`, and the `ClientBackend` that resolves the `X-PJX-*` headers — so mutation routes call `Cls.render(*args)` with no framework kwargs. The client runtime (`pjx.js`) is injected on root full-page renders unless `X-PJX-Mounted` is already present.
+Call `setup(app, ...)` once: it installs the lifespan and registry middleware that handle cache scope, optional invalidation, `PjxContext`, and the `ClientBackend` that resolves the `X-PJX-*` headers — so mutation routes call `Cls.render(*args)` with no framework kwargs. The client runtime (`pjx.js`) is injected on root full-page renders unless `X-PJX-Mounted` is already present.
 
-**Reactive ergonomics:** `StateKey` enums for typed keys; `@mutates` on store methods to accumulate pending dirtied keys for the next reactive `render()`; one `PjxKey`-annotated field per keyed component for the `data-pjx-load` round-trip; `LoadContext` to inject request-scoped dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
+**Reactive ergonomics:** `StateKey` enums for typed keys; `@mutates` on store methods to accumulate pending dirtied keys for the next reactive `render()`; one `PjxKey`-annotated field per keyed component for the `data-pjx-load` round-trip; `PjxContext` to inject request-scoped dependencies into `load()`; `enable_reactive_dev()` and `dependency_graph()` for guardrails and debugging.
 
 **Loading indicators:** a reactive region can show an in-flight indicator while it reloads — add `data-pjx-loading="skeleton"` (or `"spinner"`) to a template element, and `pjx.js` lights it automatically off the region's `reacts_to`. Themeable via `--pjx-*` CSS variables. See the [reactivity guide](docs/reactivity.md#loading-indicators-in-flight).
 

--- a/docs/api/assets-api.md
+++ b/docs/api/assets-api.md
@@ -33,7 +33,7 @@ Return the absolute filesystem path to the bundled `pjx.js` client runtime. Moun
 
 ```python
 from fastapi.staticfiles import StaticFiles
-from pyjinhx import runtime_asset_path
+from pyjinhx.assets import runtime_asset_path
 import os
 
 app.mount(
@@ -60,7 +60,8 @@ def make_default_asset_url_resolver(root: str) -> AssetUrlResolver
 Build a callable resolver using `default_asset_url()`. Pass to `Renderer.set_asset_url_resolver()` or `asset_manifest()`.
 
 ```python
-from pyjinhx import Renderer, make_default_asset_url_resolver
+from pyjinhx import Renderer
+from pyjinhx.assets import make_default_asset_url_resolver
 
 Renderer.set_asset_url_resolver(make_default_asset_url_resolver("./components"))
 ```
@@ -82,7 +83,8 @@ def resolver_with_hash(base_url: str, root: str) -> AssetUrlResolver
 Build an asset URL resolver that embeds a content hash in each filename. The runtime file is placed under `{base_url}/pyjinhx/{hashed}`.
 
 ```python
-from pyjinhx import Renderer, resolver_with_hash
+from pyjinhx import Renderer
+from pyjinhx.assets import resolver_with_hash
 
 Renderer.set_asset_url_resolver(resolver_with_hash("/static/components", root="./components"))
 ```
@@ -104,7 +106,8 @@ def layout_asset_tags(self, *, resolver: AssetUrlResolver) -> Markup
 Instance method on [`Finder`](finder.md). Emit `<link>` and `<script src>` tags for every component asset discovered under the finder's root. Use in layout shells to preload all component assets instead of per-page discovery.
 
 ```python
-from pyjinhx import Finder, make_default_asset_url_resolver
+from pyjinhx.assets import make_default_asset_url_resolver
+from pyjinhx.finder import Finder
 
 finder = Finder(root="./components")
 resolver = make_default_asset_url_resolver("./components")

--- a/docs/api/cache-invalidation.md
+++ b/docs/api/cache-invalidation.md
@@ -50,7 +50,7 @@ setup(app, cache_scope=CacheScope.PROCESS)   # cross-request per worker; pair wi
 
 Or set explicitly: `LoadCache.set_scope(CacheScope.REQUEST)`.
 
-Environment variable `PJX_LOAD_CACHE_SCOPE` is read by `PyJinhxSettings.from_env()` (default `request`).
+Environment variable `PJX_LOAD_CACHE_SCOPE` is read by `PjxSettings.from_env()` (default `request`).
 
 **Propagation:** when `CacheScope.PROCESS` is active, an `InvalidationBackend` is configured, and `propagate=True` (default), dirtied keys are published to other workers after local eviction. Remote handlers call `LoadCache.invalidate(..., propagate=False)` to avoid publish loops.
 
@@ -88,12 +88,12 @@ Runtime coordinator for cross-process invalidation. Passing a new backend stops 
 **Typical FastAPI setup:**
 
 ```python
-from pyjinhx import setup, PyJinhxSettings, CacheScope
+from pyjinhx import setup, PjxSettings, CacheScope
 from pyjinhx.integrations.redis import RedisInvalidationBackend
 
 setup(
     app,
-    settings=PyJinhxSettings(
+    settings=PjxSettings(
         cache_scope=CacheScope.PROCESS,
         invalidation_backend=RedisInvalidationBackend("redis://localhost:6379/0"),
     ),

--- a/docs/api/cache-invalidation.md
+++ b/docs/api/cache-invalidation.md
@@ -4,55 +4,37 @@ Public API for the reactive `load()` cache and cross-process invalidation fan-ou
 
 See [Reactivity](../reactivity.md) and [FastAPI integration](../integrations/fastapi.md) for usage patterns.
 
-## CacheScope
+## Cache scope
 
-```python
-class CacheScope(str, Enum):
-    REQUEST = "request"
-    PROCESS = "process"
-    NONE = "none"
-```
+You don't choose where cached `load()` results are stored — it is **derived** from whether an `invalidation_backend` is configured:
 
-Controls where cached `load()` results are stored.
+| Backend | Behavior |
+|---------|----------|
+| none (default) | Per-request: isolated per `Registry.request_scope()`, cleared when the scope exits — the only multi-worker-safe default |
+| configured (e.g. Redis) | Per worker process: results survive across HTTP requests, with the backend keeping every worker's cache consistent on mutation |
 
-| Scope | Behavior |
-|-------|----------|
-| `REQUEST` (default) | Isolated per `Registry.request_scope()`; cleared when the scope exits |
-| `PROCESS` | Shared per worker process; survives across HTTP requests |
-| `NONE` | No caching; every `load()` runs fresh |
-
-`Registry.request_scope()` always creates a request-scoped cache store. With `PROCESS` scope, reads fall through to the process store; with `REQUEST` scope, only the request store is used.
+`Registry.request_scope()` always creates a request-scoped cache store, so the within-request dedup that the reactive OOB walk relies on always happens. With a backend configured, reads also fall through to the process store; otherwise only the request store is used.
 
 ## LoadCache
 
 ```python
 class LoadCache:
     @classmethod
-    def scope(cls) -> CacheScope: ...
-    @classmethod
-    def set_scope(cls, scope: CacheScope) -> None: ...
-    @classmethod
     def invalidate(cls, dirtied: Iterable[object], *, propagate: bool = True) -> None: ...
     @classmethod
     def clear(cls) -> None: ...
 ```
 
-Memoizes reactive `load()` results keyed by `(class, load_arg)`.
-
-Prefer [`setup()`](config.md) at app startup:
+Memoizes reactive `load()` results keyed by `(class, load_arg)`. The scope is set for you from the configured backend (see above) — use [`setup()`](config.md) at app startup:
 
 ```python
-from pyjinhx import CacheScope, setup
+from pyjinhx import setup
 
-setup(app, cache_scope=CacheScope.REQUEST)   # default — multi-worker safe
-setup(app, cache_scope=CacheScope.PROCESS)   # cross-request per worker; pair with invalidation
+setup(app)                      # default — per-request, multi-worker safe
+setup(app, invalidation_backend=...)  # cross-request per worker; fans out evictions
 ```
 
-Or set explicitly: `LoadCache.set_scope(CacheScope.REQUEST)`.
-
-Environment variable `PJX_LOAD_CACHE_SCOPE` is read by `PjxSettings.from_env()` (default `request`).
-
-**Propagation:** when `CacheScope.PROCESS` is active, an `InvalidationBackend` is configured, and `propagate=True` (default), dirtied keys are published to other workers after local eviction. Remote handlers call `LoadCache.invalidate(..., propagate=False)` to avoid publish loops.
+**Propagation:** when an `InvalidationBackend` is configured (cross-request caching active) and `propagate=True` (default), dirtied keys are published to other workers after local eviction. Remote handlers call `LoadCache.invalidate(..., propagate=False)` to avoid publish loops.
 
 Called automatically by `@mutates` after mutations complete.
 
@@ -88,13 +70,12 @@ Runtime coordinator for cross-process invalidation. Passing a new backend stops 
 **Typical FastAPI setup:**
 
 ```python
-from pyjinhx import setup, PjxSettings, CacheScope
+from pyjinhx import setup, PjxSettings
 from pyjinhx.integrations.redis import RedisInvalidationBackend
 
 setup(
     app,
     settings=PjxSettings(
-        cache_scope=CacheScope.PROCESS,
         invalidation_backend=RedisInvalidationBackend("redis://localhost:6379/0"),
     ),
 )

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -8,13 +8,13 @@ Process-wide setup and optional FastAPI/Starlette wiring via a single entry poin
 def setup(
     app: object | None = None,
     *,
-    settings: PyJinhxSettings | None = None,
+    settings: PjxSettings | None = None,
     cache_scope: CacheScope = CacheScope.REQUEST,
     invalidation_backend: InvalidationBackend | None = None,
     reactive_dev: bool = False,
     load_context_factory: Callable[[Any], object | None] | None = None,
     **kwargs: Any,
-) -> PyJinhxSettings
+) -> PjxSettings
 ```
 
 **Single call** for typical web apps:
@@ -46,11 +46,11 @@ When `app` is provided, pyjinhx wraps `app.router.lifespan_context`:
 
 Does **not** compose deprecated `@app.on_event("startup")` handlers — use the lifespan API.
 
-## PyJinhxSettings
+## PjxSettings
 
 ```python
 @dataclass(frozen=True)
-class PyJinhxSettings:
+class PjxSettings:
     cache_scope: CacheScope = CacheScope.REQUEST
     invalidation_backend: InvalidationBackend | None = None
     reactive_dev: bool = False
@@ -60,7 +60,7 @@ class PyJinhxSettings:
 
 ```python
 @classmethod
-def from_env(cls) -> PyJinhxSettings
+def from_env(cls) -> PjxSettings
 ```
 
 | Variable | Default | Effect |

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -9,7 +9,6 @@ def setup(
     app: object | None = None,
     *,
     settings: PjxSettings | None = None,
-    cache_scope: CacheScope = CacheScope.REQUEST,
     invalidation_backend: InvalidationBackend | None = None,
     reactive_dev: bool = False,
     load_context_factory: Callable[[Any], object | None] | None = None,
@@ -38,7 +37,7 @@ Idempotent: a second `setup(app, ...)` on the same app is a no-op.
 
 When `app` is provided, pyjinhx wraps `app.router.lifespan_context`:
 
-1. `configure_pyjinhx(settings)` — cache scope, optional invalidation listener, reactive dev
+1. `configure_pyjinhx(settings)` — derive cache scope from the backend, optional invalidation listener, reactive dev
 2. Your existing lifespan startup (if any)
 3. Serve traffic
 4. Your existing lifespan shutdown
@@ -51,10 +50,11 @@ Does **not** compose deprecated `@app.on_event("startup")` handlers — use the 
 ```python
 @dataclass(frozen=True)
 class PjxSettings:
-    cache_scope: CacheScope = CacheScope.REQUEST
     invalidation_backend: InvalidationBackend | None = None
     reactive_dev: bool = False
 ```
+
+The load-cache scope is not a field — it is derived from `invalidation_backend`. A backend (kept consistent across workers) enables cross-request caching per worker process; without one, `load()` results are cached per request only.
 
 ### from_env
 
@@ -65,9 +65,8 @@ def from_env(cls) -> PjxSettings
 
 | Variable | Default | Effect |
 |----------|---------|--------|
-| `PJX_LOAD_CACHE_SCOPE` | `request` | `CacheScope` for `load()` cache |
+| `REDIS_URL` | unset | Auto-wire `RedisInvalidationBackend` (derives cross-request caching) |
 | `PJX_REACTIVE_DEV` | off | Enable dev guardrails when `1`/`true`/`yes` |
-| `REDIS_URL` | unset | When scope is `process`, auto-wire `RedisInvalidationBackend` |
 
 ## configure_pyjinhx / shutdown_pyjinhx
 
@@ -78,23 +77,23 @@ configure_pyjinhx(settings)   # startup
 shutdown_pyjinhx()            # shutdown
 ```
 
-Invalidation backend starts only when `cache_scope == PROCESS` and a backend is configured.
+When an `invalidation_backend` is configured, its listener starts and cross-request (process-wide) caching is enabled; otherwise caching is per-request.
 
 ## pyjinhx_lifespan
 
 Sync context manager for non-ASGI tests and scripts:
 
 ```python
-with pyjinhx_lifespan(cache_scope=CacheScope.REQUEST):
+with pyjinhx_lifespan():
     ...
 ```
 
-## Environment defaults
+## Cache defaults
 
-Default **`CacheScope.REQUEST`** — multi-worker safe without Redis. Opt into cross-request caching:
+By default (no backend), `load()` caching is **per request** — multi-worker safe without Redis. Pass an `invalidation_backend` to opt into cross-request caching per worker process:
 
 ```python
-setup(app, cache_scope=CacheScope.PROCESS, invalidation_backend=...)
+setup(app, invalidation_backend=...)
 ```
 
 See [Cache & Invalidation](cache-invalidation.md) and [Redis integration](integrations-redis.md).

--- a/docs/api/integrations-redis.md
+++ b/docs/api/integrations-redis.md
@@ -1,6 +1,6 @@
 # Redis invalidation integration
 
-Reference `InvalidationBackend` for multi-worker `CacheScope.PROCESS` setups.
+Reference `InvalidationBackend` for multi-worker setups. Configuring it also derives cross-request (per worker) caching of `load()` results.
 
 Not exported from top-level `pyjinhx` — import from the integrations submodule:
 
@@ -31,13 +31,12 @@ Publishes dirtied keys over Redis pub/sub so every worker evicts its local `load
 ## With setup
 
 ```python
-from pyjinhx import CacheScope, PjxSettings, setup
+from pyjinhx import PjxSettings, setup
 from pyjinhx.integrations.redis import RedisInvalidationBackend
 
 setup(
     app,
     settings=PjxSettings(
-        cache_scope=CacheScope.PROCESS,
         invalidation_backend=RedisInvalidationBackend("redis://localhost:6379/0"),
     ),
     load_context_factory=...,
@@ -47,7 +46,7 @@ setup(
 Or via environment (`PjxSettings.from_env()`):
 
 ```bash
-PJX_LOAD_CACHE_SCOPE=process REDIS_URL=redis://localhost:6379/0 uvicorn main:app
+REDIS_URL=redis://localhost:6379/0 uvicorn main:app
 ```
 
 See [Configuration](config.md) and [Cache & Invalidation](cache-invalidation.md).

--- a/docs/api/integrations-redis.md
+++ b/docs/api/integrations-redis.md
@@ -31,12 +31,12 @@ Publishes dirtied keys over Redis pub/sub so every worker evicts its local `load
 ## With setup
 
 ```python
-from pyjinhx import CacheScope, PyJinhxSettings, setup
+from pyjinhx import CacheScope, PjxSettings, setup
 from pyjinhx.integrations.redis import RedisInvalidationBackend
 
 setup(
     app,
-    settings=PyJinhxSettings(
+    settings=PjxSettings(
         cache_scope=CacheScope.PROCESS,
         invalidation_backend=RedisInvalidationBackend("redis://localhost:6379/0"),
     ),
@@ -44,7 +44,7 @@ setup(
 )
 ```
 
-Or via environment (`PyJinhxSettings.from_env()`):
+Or via environment (`PjxSettings.from_env()`):
 
 ```bash
 PJX_LOAD_CACHE_SCOPE=process REDIS_URL=redis://localhost:6379/0 uvicorn main:app

--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -20,21 +20,21 @@ class Keys(StateKey):
     TODOS = "todos"
 ```
 
-## PjxLoad
+## PjxKey
 
 ```python
-class PjxLoad:
+class PjxKey:
     ...
 ```
 
-Marker for `Annotated[..., PjxLoad()]`. Keyed components declare exactly one `PjxLoad` field; its value is stamped as `data-pjx-load` on render and returned in the client manifest as `load` for OOB `load()` round-trip.
+Marker for `Annotated[..., PjxKey()]`. Keyed components declare exactly one `PjxKey` field; its value is stamped as `data-pjx-load` on render and returned in the client manifest as `load` for OOB `load()` round-trip.
 
 ```python
 from typing import Annotated
-from pyjinhx import PjxLoad, ReactiveComponent
+from pyjinhx import PjxKey, ReactiveComponent
 
 class ItemRow(ReactiveComponent):
-    todo_id: Annotated[int, PjxLoad()]
+    todo_id: Annotated[int, PjxKey()]
     reacts_to: ClassVar[set[str]] = {"todos"}
 
     @classmethod

--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -4,19 +4,19 @@ Public API for reactive state keys, mutation tracking, request-scoped load conte
 
 See [Reactivity](../reactivity.md) for conceptual documentation.
 
-## StateKey
+## MutationKey
 
 ```python
-class StateKey(StrEnum):
+class MutationKey(StrEnum):
     ...
 ```
 
 Base class for app-level reactive key constants. Subclass and declare members; use the enum in `reacts_to` and `@mutates` — all normalize to their string values.
 
 ```python
-from pyjinhx import StateKey
+from pyjinhx import MutationKey
 
-class Keys(StateKey):
+class Keys(MutationKey):
     TODOS = "todos"
 ```
 
@@ -48,7 +48,7 @@ class ItemRow(ReactiveComponent):
 def mutates(*keys: ReactiveKey) -> Callable[[F], F]
 ```
 
-Decorator for store mutation methods. Each arg is a **state key** (string or `StateKey` enum). After the wrapped function returns, invalidates the load cache and accumulates pending dirtied keys for the next reactive `render()`.
+Decorator for store mutation methods. Each arg is a **state key** (string or `MutationKey` enum). After the wrapped function returns, invalidates the load cache and accumulates pending dirtied keys for the next reactive `render()`.
 
 ```python
 from pyjinhx import mutates

--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -81,7 +81,8 @@ Return or set the load context for the current scope. Reactive `load()` methods 
 Prefer `Registry.request_scope(load_context=ctx)` in web apps — it combines registry isolation, request cache, mutation tracking, and load context in one call.
 
 ```python
-from pyjinhx import LoadContext, Registry, FastAPIClientBackend
+from pyjinhx import LoadContext, Registry
+from pyjinhx.integrations.fastapi import FastAPIClientBackend
 
 @dataclass(frozen=True)
 class AppLoadContext(LoadContext):
@@ -137,7 +138,7 @@ def format_dependency_graph(*, as_mermaid: bool = False) -> str
 Format the dependency graph as a text table or Mermaid flowchart. Useful for debugging and documentation.
 
 ```python
-from pyjinhx import format_dependency_graph
+from pyjinhx.dev import format_dependency_graph
 
 print(format_dependency_graph())
 print(format_dependency_graph(as_mermaid=True))

--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -1,4 +1,4 @@
-# Mutations, Keys & LoadContext
+# Mutations, Keys & PjxContext
 
 Public API for reactive state keys, mutation tracking, request-scoped load context, and development guardrails.
 
@@ -59,33 +59,33 @@ class Store:
         ...
 ```
 
-## LoadContext
+## PjxContext
 
 ```python
 @dataclass(frozen=True)
-class LoadContext:
+class PjxContext:
     ...
 ```
 
 Opaque base for request-scoped data available inside reactive `load()`. Subclass with your own frozen dataclass fields (database session, user id, feature flags).
 
-## LoadContext.current / LoadContext.bind
+## PjxContext.current / PjxContext.bind
 
 ```python
-LoadContext.current() -> Any | None
-LoadContext.bind(ctx) -> ContextManager[None]
+PjxContext.current() -> Any | None
+PjxContext.bind(ctx) -> ContextManager[None]
 ```
 
-Return or set the load context for the current scope. Reactive `load()` methods receive a parameter annotated with `LoadContext` (or a subclass) when the context is set.
+Return or set the load context for the current scope. Reactive `load()` methods receive a parameter annotated with `PjxContext` (or a subclass) when the context is set.
 
 Prefer `Registry.request_scope(load_context=ctx)` in web apps — it combines registry isolation, request cache, mutation tracking, and load context in one call.
 
 ```python
-from pyjinhx import LoadContext, Registry
+from pyjinhx import PjxContext, Registry
 from pyjinhx.integrations.fastapi import FastAPIClientBackend
 
 @dataclass(frozen=True)
-class AppLoadContext(LoadContext):
+class AppLoadContext(PjxContext):
     db: Session
 
 with Registry.request_scope(

--- a/docs/api/parser.md
+++ b/docs/api/parser.md
@@ -16,7 +16,7 @@ HTML parser that identifies PascalCase component tags and builds a tree of `Tag`
 ### Usage
 
 ```python
-from pyjinhx import Parser
+from pyjinhx.tags import Parser, Tag
 
 parser = Parser()
 parser.feed('<Button text="OK"/><p>plain html</p>')

--- a/docs/api/reactive-api.md
+++ b/docs/api/reactive-api.md
@@ -84,7 +84,7 @@ Marker for `Annotated[..., PjxKey()]`. The field value is stamped as `data-pjx-l
 def client_script(*, mode: AssetMode | None = None, src: str | None = None) -> Markup
 ```
 
-Return the pyjinhx client runtime as a `<script>` tag. Root `BaseComponent.render()` injects the runtime automatically unless `X-PJX-Mounted` is already present on the request.
+Return the pyjinhx client runtime as a `<script>` tag (`from pyjinhx.client import client_script`). It is not part of the top-level public API — root `BaseComponent.render()` injects the runtime automatically unless `X-PJX-Mounted` is already present on the request.
 
 ## MountedManifest
 

--- a/docs/api/reactive-api.md
+++ b/docs/api/reactive-api.md
@@ -17,11 +17,11 @@ Base class for components that reload from application state via a `load()` clas
 
 - Declare `reacts_to` — **state keys** this component subscribes to (e.g. `"todos"`).
 - Implement `load()` as a `@classmethod` that returns a fresh component instance.
-- For keyed `load(cls, resource)` types, declare exactly one `Annotated[..., PjxLoad()]` field.
+- For keyed `load(cls, resource)` types, declare exactly one `Annotated[..., PjxKey()]` field.
 
 ### Keyed vs singleton
 
-A parameter after `cls` in `load()` makes the type **instance-keyed** (e.g. one row per todo). Declare `PjxLoad` on the resource field. Zero-arg `load(cls)` is a type-singleton.
+A parameter after `cls` in `load()` makes the type **instance-keyed** (e.g. one row per todo). Declare `PjxKey` on the resource field. Zero-arg `load(cls)` is a type-singleton.
 
 Singleton reactive components default `id` to the kebab-cased class name (`TodoCounter` → `"todo-counter"`).
 
@@ -69,14 +69,14 @@ Used by OOB swap gating — override for custom hashing.
 state_hash_exclude: ClassVar[frozenset[str]] = frozenset({"id"})
 ```
 
-## PjxLoad
+## PjxKey
 
 ```python
-class PjxLoad:
+class PjxKey:
     ...
 ```
 
-Marker for `Annotated[..., PjxLoad()]`. The field value is stamped as `data-pjx-load` and returned in the client manifest as `load`.
+Marker for `Annotated[..., PjxKey()]`. The field value is stamped as `data-pjx-load` and returned in the client manifest as `load`.
 
 ## client_script
 

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -169,7 +169,8 @@ On entry: clears pending mutations, initializes the request-scoped load cache, a
 **Usage:**
 
 ```python
-from pyjinhx import FastAPIClientBackend, Registry
+from pyjinhx import Registry
+from pyjinhx.integrations.fastapi import FastAPIClientBackend
 
 with Registry.request_scope(
     load_context=AppLoadContext(db=session),

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -164,7 +164,7 @@ def request_scope(cls, *, load_context: object | None = None, client_backend: ob
 
 Context manager for request-scoped component instances, load cache, mutation tracking, optional load context, and optional client backend for HTTP headers.
 
-On entry: clears pending mutations, initializes the request-scoped load cache, and optionally sets a `LoadContext` for reactive `load()` methods and a `ClientBackend` for `render()` header auto-resolution. On exit: warns about unconsumed mutations (when reactive dev is enabled), clears mutations, and resets the request cache.
+On entry: clears pending mutations, initializes the request-scoped load cache, and optionally sets a `PjxContext` for reactive `load()` methods and a `ClientBackend` for `render()` header auto-resolution. On exit: warns about unconsumed mutations (when reactive dev is enabled), clears mutations, and resets the request cache.
 
 **Usage:**
 

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -524,7 +524,7 @@ TodoApp(...).render()  # client headers from middleware ClientBackend
 ## Step 15 — Dev guardrails (optional)
 
 ```python
-from pyjinhx import enable_reactive_dev, dependency_graph, format_dependency_graph
+from pyjinhx.dev import enable_reactive_dev, dependency_graph, format_dependency_graph
 
 enable_reactive_dev()  # warnings: missing mounted, unconsumed @mutates, etc.
 print(format_dependency_graph())

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -7,7 +7,7 @@ When you're done you will have used:
 - `BaseComponent` and `ReactiveComponent`
 - Template discovery, nesting, and PascalCase tags
 - Co-located JS/CSS and asset delivery modes
-- `Registry.request_scope`, `@mutates`, and `LoadContext`
+- `Registry.request_scope`, `@mutates`, and `PjxContext`
 - Reactive `render()` with `ClientBackend` wired in middleware
 - Load-cache scopes and optional invalidation fan-out
 
@@ -433,13 +433,13 @@ mutation touches — the swap target *and* its OOB dependents.
 
 ---
 
-## Step 12 — LoadContext (avoid globals in load())
+## Step 12 — PjxContext (avoid globals in load())
 
-The context is just a **plain frozen dataclass** — `LoadContext.current()` is duck-typed, so you don't need to subclass anything:
+The context is just a **plain frozen dataclass** — `PjxContext.current()` is duck-typed, so you don't need to subclass anything:
 
 ```python
 from dataclasses import dataclass
-from pyjinhx import LoadContext
+from pyjinhx import PjxContext
 
 
 @dataclass(frozen=True)
@@ -448,7 +448,7 @@ class AppLoadContext:
 
 
 def _store():
-    ctx = LoadContext.current()
+    ctx = PjxContext.current()
     return ctx.store if isinstance(ctx, AppLoadContext) else store
 ```
 
@@ -458,7 +458,7 @@ Pass a factory to `setup()` (Step 6):
 setup(app, load_context_factory=lambda request: AppLoadContext(store=store))
 ```
 
-???+ question "Why LoadContext?"
+???+ question "Why PjxContext?"
     `load()` must rebuild components from the current world. Passing a database handle or store through a **request-scoped context** avoids hidden globals and makes tests inject a fake store. Optional `load(cls, *, ctx=...)` is supported if you prefer explicit parameters.
 
 ---
@@ -556,7 +556,7 @@ The per-step **Why?** panels above cover the *why*; this is the at-a-glance *wha
 | Tier | Pieces |
 |------|--------|
 | **Required** | `set_default_environment` · `Registry.request_scope()` middleware · root full-page render · HTMX in layout · `ReactiveComponent` (`reacts_to` + `load()`) · `@mutates(Keys.…)` on mutations · `setup()` (wires `FastAPIClientBackend`) · `PjxKey` on keyed rows |
-| **Recommended** | `LoadContext` · `data-pjx-loading` indicators · `enable_reactive_dev()` in dev |
+| **Recommended** | `PjxContext` · `data-pjx-loading` indicators · `enable_reactive_dev()` in dev |
 | **Production** | `AssetMode.REFERENCE` + URL resolver · `InvalidationBackend` for multi-worker `PROCESS` cache |
 
 ---

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -369,10 +369,10 @@ def toggle_row(todo_id: int):
 
 ```python
 from typing import Annotated
-from pyjinhx import PjxLoad
+from pyjinhx import PjxKey
 
 class TodoItemRow(ReactiveComponent):
-    todo_id: Annotated[int, PjxLoad()]
+    todo_id: Annotated[int, PjxKey()]
     title: str = ""
     done: bool = False
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}
@@ -398,8 +398,8 @@ Template (note `data-pjx-loading` — covered in Step 11):
 </li>
 ```
 
-???+ question "Why PjxLoad and load(cls, todo_id)?"
-    A parameter after `cls` makes the type **instance-keyed**. `PjxLoad` stamps `data-pjx-load` for OOB round-trip. Use the same field in templates (`{{ todo_id }}`). `reacts_to = {Keys.TODOS}` is pub-sub — all mounted rows with matching state keys may OOB-reload when todos change.
+???+ question "Why PjxKey and load(cls, todo_id)?"
+    A parameter after `cls` makes the type **instance-keyed**. `PjxKey` stamps `data-pjx-load` for OOB round-trip. Use the same field in templates (`{{ todo_id }}`). `reacts_to = {Keys.TODOS}` is pub-sub — all mounted rows with matching state keys may OOB-reload when todos change.
 
 ---
 
@@ -555,7 +555,7 @@ The per-step **Why?** panels above cover the *why*; this is the at-a-glance *wha
 
 | Tier | Pieces |
 |------|--------|
-| **Required** | `set_default_environment` · `Registry.request_scope()` middleware · root full-page render · HTMX in layout · `ReactiveComponent` (`reacts_to` + `load()`) · `@mutates(Keys.…)` on mutations · `setup()` (wires `FastAPIClientBackend`) · `PjxLoad` on keyed rows |
+| **Required** | `set_default_environment` · `Registry.request_scope()` middleware · root full-page render · HTMX in layout · `ReactiveComponent` (`reacts_to` + `load()`) · `@mutates(Keys.…)` on mutations · `setup()` (wires `FastAPIClientBackend`) · `PjxKey` on keyed rows |
 | **Recommended** | `LoadContext` · `data-pjx-loading` indicators · `enable_reactive_dev()` in dev |
 | **Production** | `AssetMode.REFERENCE` + URL resolver · `InvalidationBackend` for multi-worker `PROCESS` cache |
 

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -319,14 +319,14 @@ class TodoApp(BaseComponent):
 
 ## Step 9 — Keys, mutations, and render()
 
-Centralize reactive key strings in a `StateKey` enum so `reacts_to`, `@mutates`, and
+Centralize reactive key strings in a `MutationKey` enum so `reacts_to`, `@mutates`, and
 `dirtied` all share one vocabulary (no stray raw strings to typo). `keys.py`:
 
 ```python
-from pyjinhx import StateKey
+from pyjinhx import MutationKey
 
 
-class Keys(StateKey):
+class Keys(MutationKey):
     TODOS = "todos"
 ```
 

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -476,12 +476,12 @@ Default: **`CacheScope.REQUEST`** — `load()` results cache within each HTTP re
 Multi-worker fan-out (optional):
 
 ```python
-from pyjinhx import CacheScope, PyJinhxSettings, setup
+from pyjinhx import CacheScope, PjxSettings, setup
 from pyjinhx.integrations.redis import RedisInvalidationBackend
 
 setup(
     app,
-    settings=PyJinhxSettings(
+    settings=PjxSettings(
         cache_scope=CacheScope.PROCESS,
         invalidation_backend=RedisInvalidationBackend(os.environ["REDIS_URL"]),
     ),

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -465,24 +465,23 @@ setup(app, load_context_factory=lambda request: AppLoadContext(store=store))
 
 ## Step 13 — Load cache scope and invalidation
 
-Default: **`CacheScope.REQUEST`** — `load()` results cache within each HTTP request (multi-worker safe).
+You don't pick a cache scope — it follows the backend. By default (no `invalidation_backend`),
+`load()` results cache within each HTTP request, which is multi-worker safe.
 
-| Scope | When to use |
-|-------|-------------|
-| `REQUEST` | Default — multi-worker without Redis |
-| `PROCESS` | Single worker, or multi-worker **with** invalidation fan-out |
-| `NONE` | Debugging; always hit the store |
+| Setup | Behavior |
+|-------|----------|
+| no backend (default) | Per-request caching — multi-worker safe without Redis |
+| `invalidation_backend` set | Cross-request caching per worker, with evictions fanned out across workers |
 
-Multi-worker fan-out (optional):
+Multi-worker fan-out (also enables cross-request caching):
 
 ```python
-from pyjinhx import CacheScope, PjxSettings, setup
+from pyjinhx import PjxSettings, setup
 from pyjinhx.integrations.redis import RedisInvalidationBackend
 
 setup(
     app,
     settings=PjxSettings(
-        cache_scope=CacheScope.PROCESS,
         invalidation_backend=RedisInvalidationBackend(os.environ["REDIS_URL"]),
     ),
 )

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -18,7 +18,7 @@ uv add pyjinhx
 
 ## Optional extras
 
-The `redis` extra pulls in the dependencies for the Redis invalidation backend (used with `CacheScope.PROCESS` across multiple workers):
+The `redis` extra pulls in the dependencies for the Redis invalidation backend (used across multiple workers; configuring it also enables cross-request caching):
 
 ```bash
 pip install pyjinhx[redis]

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -115,7 +115,7 @@ widget = MyWidget(
 Inspect which assets a render used:
 
 ```python
-from pyjinhx import asset_manifest, make_default_asset_url_resolver
+from pyjinhx.assets import asset_manifest, make_default_asset_url_resolver
 
 resolver = make_default_asset_url_resolver("./components")
 manifest = asset_manifest(session, resolver=resolver)
@@ -127,7 +127,8 @@ manifest = asset_manifest(session, resolver=resolver)
 Ship every component asset from the layout shell instead of per-page discovery:
 
 ```python
-from pyjinhx import Finder, make_default_asset_url_resolver
+from pyjinhx.assets import make_default_asset_url_resolver
+from pyjinhx.finder import Finder
 
 finder = Finder(root="./components")
 resolver = make_default_asset_url_resolver("./components")
@@ -141,7 +142,7 @@ Combine with `AssetMode.REFERENCE` and reactive partial suppression so HTMX swap
 Embed content hashes in filenames:
 
 ```python
-from pyjinhx import hashed_filename, resolver_with_hash
+from pyjinhx.assets import hashed_filename, resolver_with_hash
 
 hashed_filename("components/ui/button.js")  # button.a1b2c3d4.js
 resolver = resolver_with_hash("/static/components", root="./components")
@@ -163,7 +164,7 @@ When disabled, no asset tags are emitted. Use `Finder.collect_javascript_files()
 Use `Finder` to get lists of asset files for static serving:
 
 ```python
-from pyjinhx import Finder
+from pyjinhx.finder import Finder
 
 finder = Finder(root="./components")
 
@@ -179,7 +180,9 @@ css_files = finder.collect_css_files(relative_to_root=True)
 ```python
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from pyjinhx import AssetMode, Finder, Renderer, make_default_asset_url_resolver
+from pyjinhx import AssetMode, Renderer
+from pyjinhx.assets import make_default_asset_url_resolver
+from pyjinhx.finder import Finder
 
 app = FastAPI()
 app.mount("/static/components", StaticFiles(directory="components"), name="components")

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -88,7 +88,7 @@ Partial renders ignore the asset header (no assets emitted). Dedup defaults to *
 
 In `REFERENCE` mode, root full-page renders emit `<script src="/static/pyjinhx/pjx.js">` when the request lacks `X-PJX-Mounted`. Mount the packaged file from `pyjinhx/runtime/pjx.js` or override with `Renderer.set_default_runtime_url()`.
 
-For raw Jinja shells, use `client_script(mode=AssetMode.REFERENCE)`. Pass `client_script(src=...)` to override the runtime URL (otherwise it falls back to `Renderer`'s configured URL, then `DEFAULT_RUNTIME_URL`).
+For raw Jinja shells, use `client_script(mode=AssetMode.REFERENCE)` (`from pyjinhx.client import client_script`). Pass `client_script(src=...)` to override the runtime URL (otherwise it falls back to `Renderer`'s configured URL, then `DEFAULT_RUNTIME_URL`).
 
 ### CSP
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -150,7 +150,7 @@ See [Cache & Invalidation](../api/cache-invalidation.md) and [Redis integration]
 Enable development guardrails to catch common reactive mistakes:
 
 ```python
-from pyjinhx import enable_reactive_dev, disable_reactive_dev
+from pyjinhx.dev import enable_reactive_dev, disable_reactive_dev
 
 enable_reactive_dev()           # log warnings
 enable_reactive_dev(strict=True)  # raise RuntimeError instead

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -159,4 +159,4 @@ disable_reactive_dev()
 
 Guardrails cover: mutations without a consuming `render()`, dirtied keys without `mounted`, and `depends_on()` outside the static `reacts_to` superset.
 
-Inspect the dependency graph with `dependency_graph()` or `format_dependency_graph()`. See [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#reactive-dev).
+Inspect the dependency graph with `dependency_graph()` or `format_dependency_graph()`. See [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#reactive-dev).

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -87,7 +87,7 @@ from pyjinhx import setup
 setup(app, load_context_factory=lambda req: AppLoadContext(db=get_db(req)))
 ```
 
-`PyJinhxSettings` has three fields:
+`PjxSettings` has three fields:
 
 - `cache_scope` — load cache scope (default `CacheScope.REQUEST`)
 - `invalidation_backend` — cross-process invalidation backend (default `None`)
@@ -97,19 +97,19 @@ Pass a settings object via `settings=`, or override individual fields with expli
 
 ### Environment variables
 
-`PyJinhxSettings.from_env()` builds settings from the environment:
+`PjxSettings.from_env()` builds settings from the environment:
 
 - `PJX_LOAD_CACHE_SCOPE` — cache scope name (default `request`)
 - `PJX_REACTIVE_DEV` — enables reactive dev mode when set to `1`, `true`, or `yes`
 - `REDIS_URL` — wires a `RedisInvalidationBackend`, but only when the cache scope is `process`
 
 ```python
-from pyjinhx import PyJinhxSettings, setup
+from pyjinhx import PjxSettings, setup
 
-setup(app, settings=PyJinhxSettings.from_env())
+setup(app, settings=PjxSettings.from_env())
 ```
 
-See [Configuration API](../api/config.md) for `PyJinhxSettings`, lifespan chaining, and cache defaults.
+See [Configuration API](../api/config.md) for `PjxSettings`, lifespan chaining, and cache defaults.
 
 ## Load cache scope
 
@@ -131,12 +131,12 @@ See [Cache & Invalidation](../api/cache-invalidation.md) and [Reactivity](../rea
 When using `CacheScope.PROCESS` with multiple workers, configure an `InvalidationBackend`:
 
 ```python
-from pyjinhx import CacheScope, PyJinhxSettings, setup
+from pyjinhx import CacheScope, PjxSettings, setup
 from pyjinhx.integrations.redis import RedisInvalidationBackend
 
 setup(
     app,
-    settings=PyJinhxSettings(
+    settings=PjxSettings(
         cache_scope=CacheScope.PROCESS,
         invalidation_backend=RedisInvalidationBackend("redis://..."),
     ),

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -87,11 +87,12 @@ from pyjinhx import setup
 setup(app, load_context_factory=lambda req: AppLoadContext(db=get_db(req)))
 ```
 
-`PjxSettings` has three fields:
+`PjxSettings` has two fields:
 
-- `cache_scope` — load cache scope (default `CacheScope.REQUEST`)
-- `invalidation_backend` — cross-process invalidation backend (default `None`)
+- `invalidation_backend` — cross-worker invalidation backend (default `None`)
 - `reactive_dev` — enable reactive dev guardrails (default `False`)
+
+The load-cache scope is **derived** from `invalidation_backend`: a backend (e.g. Redis) makes cross-request caching safe across workers, so `load()` results are cached per worker process; without one, they are cached per request only — the only multi-worker-safe default.
 
 Pass a settings object via `settings=`, or override individual fields with explicit `setup()` keyword arguments. Explicit `setup()` kwargs take precedence over values from `settings=`.
 
@@ -99,9 +100,8 @@ Pass a settings object via `settings=`, or override individual fields with expli
 
 `PjxSettings.from_env()` builds settings from the environment:
 
-- `PJX_LOAD_CACHE_SCOPE` — cache scope name (default `request`)
+- `REDIS_URL` — wires a `RedisInvalidationBackend` (which derives cross-request caching)
 - `PJX_REACTIVE_DEV` — enables reactive dev mode when set to `1`, `true`, or `yes`
-- `REDIS_URL` — wires a `RedisInvalidationBackend`, but only when the cache scope is `process`
 
 ```python
 from pyjinhx import PjxSettings, setup
@@ -113,31 +113,30 @@ See [Configuration API](../api/config.md) for `PjxSettings`, lifespan chaining, 
 
 ## Load cache scope
 
-Default is **`CacheScope.REQUEST`** (multi-worker safe). Opt into cross-request caching:
+You don't pick a scope — it follows the backend. By default (no `invalidation_backend`), `load()` results are cached **per request only**, the only multi-worker-safe behavior. Configure a cross-worker backend to opt into cross-request caching per worker process:
 
 ```python
-from pyjinhx import CacheScope, setup
+from pyjinhx import setup
 
-setup(app, cache_scope=CacheScope.PROCESS, invalidation_backend=...)  # see integrations.redis
-setup(app, cache_scope=CacheScope.NONE)
+setup(app)  # per-request caching (default, multi-worker safe)
+setup(app, invalidation_backend=...)  # cross-request per worker; see integrations.redis
 ```
 
-`Registry.request_scope()` initializes a request-scoped cache on entry and clears it on exit. With `PROCESS` scope, reads also use the process-wide store; with `REQUEST` scope, only the request store is used.
+`Registry.request_scope()` initializes a request-scoped cache on entry and clears it on exit. With a backend configured, reads also use the process-wide store; otherwise only the request store is used. Within-request caching always happens — it dedups the repeated `load()` calls of the reactive OOB walk.
 
 See [Cache & Invalidation](../api/cache-invalidation.md) and [Reactivity](../reactivity.md).
 
 ## Invalidation fan-out
 
-When using `CacheScope.PROCESS` with multiple workers, configure an `InvalidationBackend`:
+For multi-worker production, set a cross-worker `invalidation_backend` so `invalidate()` fans out to every process (and enables cross-request caching):
 
 ```python
-from pyjinhx import CacheScope, PjxSettings, setup
+from pyjinhx import PjxSettings, setup
 from pyjinhx.integrations.redis import RedisInvalidationBackend
 
 setup(
     app,
     settings=PjxSettings(
-        cache_scope=CacheScope.PROCESS,
         invalidation_backend=RedisInvalidationBackend("redis://..."),
     ),
 )

--- a/docs/guide/registry.md
+++ b/docs/guide/registry.md
@@ -72,7 +72,8 @@ On entry, `request_scope()` also clears pending mutations, initializes the reque
 For application-wide coverage, pyjinhx ships no middleware of its own. Prefer `setup(app, ...)`, which registers middleware that calls `Registry.request_scope(client_backend=FastAPIClientBackend(request))` for you (see the [canonical FastAPI snippet](../integrations/fastapi.md#middleware-recommended)). To wire it by hand instead, open the scope yourself:
 
 ```python
-from pyjinhx import FastAPIClientBackend, Registry, setup
+from pyjinhx import Registry, setup
+from pyjinhx.integrations.fastapi import FastAPIClientBackend
 
 setup(app)  # recommended
 # or:

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ PyJinHx layers optional features on top of a small core. You can stop at any tie
 | **1 — Components** | `BaseComponent`, templates, assets | [Quick Start](getting-started/quickstart.md) |
 | **2 — Web app** | Per-request `Registry.request_scope()` | [Registry guide](guide/registry.md) |
 | **3 — Reactive** | HTMX OOB swaps, `@mutates`, `load()` | [Reactivity](reactivity.md) |
-| **4 — Full wiring** | `LoadContext`, `ClientBackend`, cache, invalidation | [Build an App](getting-started/build-an-app.md) |
+| **4 — Full wiring** | `PjxContext`, `ClientBackend`, cache, invalidation | [Build an App](getting-started/build-an-app.md) |
 
 Details: [Usage tiers](guide/usage-tiers.md).
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -232,10 +232,10 @@ def toggle_row(todo_id: int):
   the swap lands. A trigger may add `data-pjx-loading-extra="<css-selector>"` to also flag
   regions a bulk action will touch (e.g. rows a clear-completed removes). Style via `--pjx-*`
   CSS vars (`--pjx-skeleton-color`, `--pjx-spinner-color`, …).
-- Every `load()` is memoized in `LoadCache` (one entry per `(type, key)`). Default scope is
-  `CacheScope.REQUEST` (per-request, no cross-worker concern). Use
-  `LoadCache.set_scope(CacheScope.PROCESS)` (or `setup(cache_scope=...)`) for process-wide
-  caching, plus an `InvalidationBackend` (e.g. Redis) to fan out evictions across workers.
+- Every `load()` is memoized in `LoadCache` (one entry per `(type, key)`). The scope follows
+  the backend: with no `invalidation_backend` it's per-request (no cross-worker concern); pass
+  `setup(invalidation_backend=...)` (e.g. Redis) for process-wide caching plus eviction
+  fan-out across workers.
 
 Full guide: [docs/reactivity.md](../reactivity.md).
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -129,7 +129,7 @@ definition-time error):
 
 ```python
 from typing import Annotated, ClassVar
-from pyjinhx import PjxLoad, ReactiveComponent, mutates
+from pyjinhx import PjxKey, ReactiveComponent, mutates
 
 class Counter(ReactiveComponent):
     remaining: int
@@ -150,7 +150,7 @@ class Counter(ReactiveComponent):
   the one the client reported.
 - Roots are auto-stamped with `data-pjx-id` / `data-pjx-type` / `data-pjx-hash` /
   `data-pjx-reacts` (the space-joined `reacts_to` keys, which `pjx.js` reads to scope
-  loading indicators) — plus `data-pjx-load` when keyed via `PjxLoad`. A reactive component
+  loading indicators) — plus `data-pjx-load` when keyed via `PjxKey`. A reactive component
   **must render a single root element**.
 
 ### Mutation routes return `render()` — nothing else
@@ -193,12 +193,12 @@ on every HTMX request.
 ### Instance-keyed regions (rows)
 
 A component is **instance-keyed iff `load()` takes one argument after `cls`**. Declare
-exactly one `Annotated[..., PjxLoad()]` field — its value is stamped as `data-pjx-load`
+exactly one `Annotated[..., PjxKey()]` field — its value is stamped as `data-pjx-load`
 and returned in the manifest as `load` for OOB reloads.
 
 ```python
 class TodoItemRow(ReactiveComponent):
-    todo_id: Annotated[int, PjxLoad()]
+    todo_id: Annotated[int, PjxKey()]
     title: str = ""
     reacts_to: ClassVar[set[str]] = {"todos"}
 
@@ -215,7 +215,7 @@ def toggle_row(todo_id: int):
 ```
 
 - **`render(todo_id)` → `load(todo_id)`** automatically. Set explicit `id` in `load()` for
-  stable DOM targets (e.g. `row-42`). Templates use the `PjxLoad` field:
+  stable DOM targets (e.g. `row-42`). Templates use the `PjxKey` field:
   `hx-post="/rows/{{ todo_id }}/toggle"`.
 - **`@mutates("todos")`** on store methods dirties collection-tier state; OOB pub-sub reloads
   every mounted region whose `reacts_to` intersects, with hash-gating skipping unchanged regions.
@@ -337,7 +337,7 @@ my_app/
 ```python
 from pyjinhx import (
     BaseComponent, ReactiveComponent, Renderer, Registry,
-    PjxLoad, mutates, client_script, setup,
+    PjxKey, mutates, client_script, setup,
 )
 # advanced/internal building blocks live in submodules:
 from pyjinhx.finder import Finder
@@ -351,7 +351,7 @@ from pyjinhx.builtins import Alert, Modal, Panel, PanelTrigger, TabGroup  # …
 
 - `BaseComponent` — base class for all components
 - `ReactiveComponent` — dependency-aware components (`reacts_to` + `load()`); `Cls.render(*args)` is the route entry point
-- `PjxLoad` — `Annotated[..., PjxLoad()]` marker for keyed `data-pjx-load` / manifest `load`
+- `PjxKey` — `Annotated[..., PjxKey()]` marker for keyed `data-pjx-load` / manifest `load`
 - `mutates` — decorator on store methods; state keys only (`@mutates("todos")`)
 - `setup` — wires FastAPI middleware (`Registry.request_scope`, `ClientBackend`, `LoadContext`)
 - `Renderer` — renders strings with PascalCase tags or manages environments

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -353,7 +353,7 @@ from pyjinhx.builtins import Alert, Modal, Panel, PanelTrigger, TabGroup  # …
 - `ReactiveComponent` — dependency-aware components (`reacts_to` + `load()`); `Cls.render(*args)` is the route entry point
 - `PjxKey` — `Annotated[..., PjxKey()]` marker for keyed `data-pjx-load` / manifest `load`
 - `mutates` — decorator on store methods; state keys only (`@mutates("todos")`)
-- `setup` — wires FastAPI middleware (`Registry.request_scope`, `ClientBackend`, `LoadContext`)
+- `setup` — wires FastAPI middleware (`Registry.request_scope`, `ClientBackend`, `PjxContext`)
 - `Renderer` — renders strings with PascalCase tags or manages environments
 - `Registry` — query/clear instances and classes, `request_scope()` context manager
 - `Finder` — template/asset discovery, `collect_javascript_files()`, `collect_css_files()`, `detect_root_directory()`

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -336,10 +336,15 @@ my_app/
 
 ```python
 from pyjinhx import (
-    BaseComponent, ReactiveComponent, Renderer, Registry, Finder, Parser, Tag,
-    PjxLoad, mutates, LoadCache, oob_swaps, client_script,
-    PJX_MOUNTED_HEADER, PJX_TRIGGER_HEADER, setup,
+    BaseComponent, ReactiveComponent, Renderer, Registry,
+    PjxLoad, mutates, client_script, setup,
 )
+# advanced/internal building blocks live in submodules:
+from pyjinhx.finder import Finder
+from pyjinhx.tags import Parser, Tag
+from pyjinhx.cache import LoadCache
+from pyjinhx.reactive import oob_swaps
+from pyjinhx.client import PJX_MOUNTED_HEADER, PJX_TRIGGER_HEADER
 import pyjinhx.builtins  # optional: registers all builtin classes
 from pyjinhx.builtins import Alert, Modal, Panel, PanelTrigger, TabGroup  # …
 ```

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -337,14 +337,14 @@ my_app/
 ```python
 from pyjinhx import (
     BaseComponent, ReactiveComponent, Renderer, Registry,
-    PjxKey, mutates, client_script, setup,
+    PjxKey, mutates, setup,
 )
 # advanced/internal building blocks live in submodules:
 from pyjinhx.finder import Finder
 from pyjinhx.tags import Parser, Tag
 from pyjinhx.cache import LoadCache
 from pyjinhx.reactive import oob_swaps
-from pyjinhx.client import PJX_MOUNTED_HEADER, PJX_TRIGGER_HEADER
+from pyjinhx.client import PJX_MOUNTED_HEADER, PJX_TRIGGER_HEADER, client_script
 import pyjinhx.builtins  # optional: registers all builtin classes
 from pyjinhx.builtins import Alert, Modal, Panel, PanelTrigger, TabGroup  # …
 ```

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -118,7 +118,7 @@ app = FastAPI(lifespan=my_existing_lifespan)  # optional — chained, not replac
 setup(app, load_context_factory=lambda req: AppLoadContext(db=get_db(req)))
 ```
 
-`setup(app, ...)` chains your lifespan (if any), configures cache scope and optional invalidation, and registers registry middleware with `ClientBackend` for header auto-resolution. Default load cache is **`CacheScope.REQUEST`** (multi-worker safe). See [Configuration](../api/config.md) and [Reactivity §4](../reactivity.md#4-load-results-are-cached).
+`setup(app, ...)` chains your lifespan (if any), wires optional invalidation, and registers registry middleware with `ClientBackend` for header auto-resolution. By default (no `invalidation_backend`) the load cache is per-request — multi-worker safe; pass a backend to opt into cross-request caching. See [Configuration](../api/config.md) and [Reactivity §4](../reactivity.md#4-load-results-are-cached).
 
 ### Per-Route (manual)
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -303,7 +303,7 @@ Set context per request via `setup(app, load_context_factory=...)` or
 Enable guardrails during local development:
 
 ```python
-from pyjinhx import enable_reactive_dev
+from pyjinhx.dev import enable_reactive_dev
 
 enable_reactive_dev()          # warnings
 enable_reactive_dev(strict=True)  # raise instead
@@ -318,7 +318,7 @@ Checks include:
 Inspect the dependency graph at startup:
 
 ```python
-from pyjinhx import dependency_graph, format_dependency_graph
+from pyjinhx.dev import dependency_graph, format_dependency_graph
 
 print(format_dependency_graph())
 # or format_dependency_graph(as_mermaid=True) for a flowchart
@@ -363,7 +363,7 @@ dependents. For mutations outside a render — a background job, a webhook — c
 `LoadCache.invalidate` yourself:
 
 ```python
-from pyjinhx import LoadCache
+from pyjinhx.cache import LoadCache
 
 def nightly_recalc():
     db.rebuild_todos()

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -281,16 +281,16 @@ Pass request-scoped dependencies into `load()` without global imports:
 
 ```python
 from dataclasses import dataclass
-from pyjinhx import LoadContext
+from pyjinhx import PjxContext
 
 @dataclass(frozen=True)
-class AppContext(LoadContext):
+class AppContext(PjxContext):
     db: Database
 
 class Counter(ReactiveComponent):
     @classmethod
     def load(cls, *, ctx: AppContext | None = None) -> "Counter":
-        ctx = ctx or LoadContext.current()
+        ctx = ctx or PjxContext.current()
         return cls(remaining=ctx.db.remaining())
 ```
 
@@ -355,7 +355,7 @@ Use `Registry.request_scope()` on every HTTP request (middleware) for instance r
 isolation and optional request-tier cache when scope is `REQUEST`.
 
 **Cache identity:** entries are keyed by `(component class, load key)` only. Encode
-tenant or user scope in reactive keys (e.g. `"user:7:todos"`) or ensure `LoadContext`
+tenant or user scope in reactive keys (e.g. `"user:7:todos"`) or ensure `PjxContext`
 data is stable for all requests sharing a cache entry.
 
 Reactive `render()` (and `oob_swaps`) evicts pending dirtied keys before reloading

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -337,22 +337,24 @@ Counter.load()   # cached: no DB, returns an independent copy
 
 ### Cache scope
 
-| Scope | Default | Storage | Cross-request | Multi-worker safe |
-|-------|---------|---------|---------------|-------------------|
-| `REQUEST` | yes | `ContextVar` inside `Registry.request_scope()` | no | yes |
-| `PROCESS` | opt-in | module-level dict per worker | yes | needs invalidation fan-out |
-| `NONE` | opt-in | disabled | — | yes |
+You don't choose a scope — it follows the backend. By default (no `invalidation_backend`),
+caching is per request; configuring a cross-worker backend extends it to cross-request per
+worker process.
+
+| Backend | Storage | Cross-request | Multi-worker safe |
+|---------|---------|---------------|-------------------|
+| none (default) | `ContextVar` inside `Registry.request_scope()` | no | yes |
+| configured | module-level dict per worker, fanned out on mutation | yes | yes (backend keeps workers consistent) |
 
 ```python
-from pyjinhx import CacheScope, setup
+from pyjinhx import setup
 
-setup(app)  # default CacheScope.REQUEST
-setup(app, cache_scope=CacheScope.PROCESS, invalidation_backend=...)  # cross-request per worker
-setup(app, cache_scope=CacheScope.NONE)
+setup(app)  # per-request caching (default, multi-worker safe)
+setup(app, invalidation_backend=...)  # cross-request per worker
 ```
 
 Use `Registry.request_scope()` on every HTTP request (middleware) for instance registry
-isolation and optional request-tier cache when scope is `REQUEST`.
+isolation and the request-tier cache (which dedups the OOB walk regardless of backend).
 
 **Cache identity:** entries are keyed by `(component class, load key)` only. Encode
 tenant or user scope in reactive keys (e.g. `"user:7:todos"`) or ensure `PjxContext`
@@ -373,19 +375,18 @@ def nightly_recalc():
 The cache holds one result per `(type, key)` and returns a fresh copy on every call, so
 callers can mutate what they get back without affecting the cache.
 
-### Multi-worker invalidation (`PROCESS` scope)
+### Multi-worker invalidation
 
-When using `CacheScope.PROCESS` with multiple workers, configure an
-`InvalidationBackend` so `invalidate()` fans out to every process:
+For multi-worker production, configure an `InvalidationBackend` so `invalidate()` fans out
+to every process. This is also what enables cross-request caching per worker:
 
 ```python
-from pyjinhx import CacheScope, PjxSettings, setup
+from pyjinhx import PjxSettings, setup
 from pyjinhx.integrations.redis import RedisInvalidationBackend
 
 setup(
     app,
     settings=PjxSettings(
-        cache_scope=CacheScope.PROCESS,
         invalidation_backend=RedisInvalidationBackend("redis://localhost:6379/0"),
     ),
 )

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -210,13 +210,13 @@ from the DOM without a server error.
 
 ## State keys
 
-Centralize reactive key strings in a `StateKey` enum so `reacts_to`, `dirtied`, and
+Centralize reactive key strings in a `MutationKey` enum so `reacts_to`, `dirtied`, and
 `@mutates` share one vocabulary:
 
 ```python
-from pyjinhx import StateKey
+from pyjinhx import MutationKey
 
-class Keys(StateKey):
+class Keys(MutationKey):
     TODOS = "todos"
 
 class TodoCounter(ReactiveComponent):

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -80,7 +80,7 @@ class AppShell(BaseComponent):
 For a raw Jinja layout (outside the component render path), drop in `client_script()`:
 
 ```python
-from pyjinhx import client_script
+from pyjinhx.client import client_script
 
 # in your template context
 {"pjx_runtime": client_script()}

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -379,12 +379,12 @@ When using `CacheScope.PROCESS` with multiple workers, configure an
 `InvalidationBackend` so `invalidate()` fans out to every process:
 
 ```python
-from pyjinhx import CacheScope, PyJinhxSettings, setup
+from pyjinhx import CacheScope, PjxSettings, setup
 from pyjinhx.integrations.redis import RedisInvalidationBackend
 
 setup(
     app,
-    settings=PyJinhxSettings(
+    settings=PjxSettings(
         cache_scope=CacheScope.PROCESS,
         invalidation_backend=RedisInvalidationBackend("redis://localhost:6379/0"),
     ),

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -162,14 +162,14 @@ not smeared across endpoints. Adding a progress bar that declares
 
 A reactive type can have **many mounted instances** — table rows, cards, list items.
 A component is **instance-keyed iff its `load()` takes one resource parameter after
-`cls`**; declare exactly one `PjxLoad` field on the model:
+`cls`**; declare exactly one `PjxKey` field on the model:
 
 ```python
 from typing import Annotated
-from pyjinhx import PjxLoad, ReactiveComponent
+from pyjinhx import PjxKey, ReactiveComponent
 
 class TodoItemRow(ReactiveComponent):
-    todo_id: Annotated[int, PjxLoad()]
+    todo_id: Annotated[int, PjxKey()]
     title: str = ""
     done: bool = False
     reacts_to: ClassVar[set[str]] = {"todos"}
@@ -185,7 +185,7 @@ class TodoItemRow(ReactiveComponent):
         )
 ```
 
-- **`data-pjx-load`** is stamped from the `PjxLoad` field and returned in the manifest
+- **`data-pjx-load`** is stamped from the `PjxKey` field and returned in the manifest
   so OOB reloads call `load(manifest.load)`.
 - **Templates** use the field directly: `hx-post="/rows/{{ todo_id }}/toggle"`.
 - **`reacts_to`** lists **state keys only** (e.g. `{"todos"}`). Pub-sub OOB reloads

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -23,10 +23,10 @@ These 13 symbols are the entire top-level public API; advanced/internal building
 
 | Symbol | Description | Documentation |
 |--------|-------------|---------------|
-| `mutates()` | Decorator: invalidate cache and accumulate dirtied keys after mutation | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#mutates) |
-| `StateKey` | Base `StrEnum` for app-level reactive key constants | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#statekey) |
-| `PjxKey` | Marker for `Annotated[..., PjxKey()]` fields stamped as `data-pjx-load` | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#pjxload) |
-| `LoadContext` | Opaque base dataclass for request-scoped `load()` data | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#loadcontext) |
+| `mutates()` | Decorator: invalidate cache and accumulate dirtied keys after mutation | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#mutates) |
+| `StateKey` | Base `StrEnum` for app-level reactive key constants | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#statekey) |
+| `PjxKey` | Marker for `Annotated[..., PjxKey()]` fields stamped as `data-pjx-load` | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#pjxload) |
+| `PjxContext` | Opaque base dataclass for request-scoped `load()` data | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#loadcontext) |
 
 ## Configuration
 

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -25,7 +25,7 @@ These 13 symbols are the entire top-level public API; advanced/internal building
 |--------|-------------|---------------|
 | `mutates()` | Decorator: invalidate cache and accumulate dirtied keys after mutation | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#mutates) |
 | `StateKey` | Base `StrEnum` for app-level reactive key constants | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#statekey) |
-| `PjxLoad` | Marker for `Annotated[..., PjxLoad()]` fields stamped as `data-pjx-load` | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#pjxload) |
+| `PjxKey` | Marker for `Annotated[..., PjxKey()]` fields stamped as `data-pjx-load` | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#pjxload) |
 | `LoadContext` | Opaque base dataclass for request-scoped `load()` data | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#loadcontext) |
 
 ## Configuration

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -24,23 +24,17 @@ These 13 symbols are the entire top-level public API; advanced/internal building
 | Symbol | Description | Documentation |
 |--------|-------------|---------------|
 | `mutates()` | Decorator: invalidate cache and accumulate dirtied keys after mutation | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#mutates) |
-| `MutationKey` | Base `StrEnum` for app-level reactive key constants | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#statekey) |
-| `PjxKey` | Marker for `Annotated[..., PjxKey()]` fields stamped as `data-pjx-load` | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#pjxload) |
-| `PjxContext` | Opaque base dataclass for request-scoped `load()` data | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#loadcontext) |
+| `MutationKey` | Base `StrEnum` for app-level reactive key constants | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#mutationkey) |
+| `PjxKey` | Marker for `Annotated[..., PjxKey()]` fields stamped as `data-pjx-load` | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#pjxkey) |
+| `PjxContext` | Opaque base dataclass for request-scoped `load()` data | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#pjxcontext) |
 
 ## Configuration
 
 | Symbol | Description | Documentation |
 |--------|-------------|---------------|
-| `PjxSettings` | Cache scope, invalidation backend, reactive dev flags | [Configuration](../api/config.md#pyjinhxsettings) |
+| `PjxSettings` | Cache scope, invalidation backend, reactive dev flags | [Configuration](../api/config.md#pjxsettings) |
 | `CacheScope` | Enum: `PROCESS`, `REQUEST`, or `NONE` | [Cache & Invalidation](../api/cache-invalidation.md#cachescope) |
 | `AssetMode` | Enum: `INLINE`, `REFERENCE`, or `NONE` | [Renderer](../api/renderer.md#assetmode) |
-
-## Runtime
-
-| Symbol | Description | Documentation |
-|--------|-------------|---------------|
-| `client_script()` | Emit the pyjinhx client runtime as a `<script>` tag | [Reactive API](../api/reactive-api.md#client_script) |
 
 ## Conceptual guides
 

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -2,6 +2,8 @@
 
 Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line description and a link to detailed documentation.
 
+These 13 symbols are the entire top-level public API; advanced/internal building blocks (e.g. `oob_swaps`, `LoadCache`, `ClientBackend`, the asset-resolver helpers, dev tooling) remain importable from their submodules — e.g. `from pyjinhx.cache import LoadCache`.
+
 ## Components & rendering
 
 | Symbol | Description | Documentation |
@@ -9,84 +11,36 @@ Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line
 | `BaseComponent` | Pydantic base class for UI components with Jinja templates | [BaseComponent](../api/base-component.md) |
 | `ReactiveComponent` | Base class for dependency-aware reactive components (`reacts_to` + `load()` + `depends_on()`) | [Reactive API](../api/reactive-api.md) |
 | `Renderer` | Renders PascalCase tag strings and manages default Jinja environment | [Renderer](../api/renderer.md) |
-| `RenderSession` | Per-render asset aggregation state (defined in `pyjinhx.assets`) | [Assets API](../api/assets-api.md) · [Renderer](../api/renderer.md#rendersession) |
-| `Parser` | Parses HTML strings into a tree of `Tag` nodes and raw HTML | [Parser & Tag](../api/parser.md) |
-| `Tag` | Parsed PascalCase component tag (name, attrs, children) | [Parser & Tag](../api/parser.md#tag) |
-| `Finder` | Discovers component templates and asset files on disk | [Finder](../api/finder.md) |
-| `Registry` | Class and request-scoped instance registry | [Registry](../api/registry.md) |
 
-## Reactivity
+## App wiring
 
 | Symbol | Description | Documentation |
 |--------|-------------|---------------|
-| `client_script()` | Emit the pyjinhx client runtime as a `<script>` tag | [Reactive API](../api/reactive-api.md#client_script) |
-| `MountedManifest` | Parser for the `X-PJX-Mounted` mounted-region manifest | [Reactive API](../api/reactive-api.md#mountedmanifest) |
-| `MountedManifest.is_present()` | Return whether `X-PJX-Mounted` is present on the request | [Reactive API](../api/reactive-api.md#mountedmanifest) |
-| `MountedManifest.parse()` | Parse the `X-PJX-Mounted` manifest | [Reactive API](../api/reactive-api.md#mountedmanifest) |
-| `LoadedAssets` | Parser for the `X-PJX-Assets` already-loaded asset list | [Reactive API](../api/reactive-api.md#loadedassets) |
-| `LoadedAssets.parse()` | Parse the `X-PJX-Assets` header for asset dedup | [Reactive API](../api/reactive-api.md#loadedassets) |
-| `ClientBackend` | ABC for per-request HTTP header access | [Client Backend](../api/client-backend.md#clientbackend) |
-| `FastAPIClientBackend` | Default backend for FastAPI/Starlette requests | [Client Backend](../api/client-backend.md) |
-| `ClientBackend.scope()` | Set the request-scoped client backend | [Client Backend](../api/client-backend.md#clientbackend) |
-| `ClientBackend.current()` | Return the active client backend (manifest, assets, trigger headers) | [Client Backend](../api/client-backend.md#clientbackend) |
-| `ClientBackend.reset()` | Clear the request-scoped backend (tests) | [Client Backend](../api/client-backend.md#clientbackend) |
-| `ClientBackend.resolve_client()` | Resolve explicit `client=` or fall back to backend | [Client Backend](../api/client-backend.md#auto-resolution-in-render) |
-| `oob_swaps()` | Compute HTMX out-of-band swap fragments for dirtied keys | [Reactive API](../api/reactive-api.md#oob_swaps) |
-| `PJX_MOUNTED_HEADER` | HTTP header name for the client mounted-region manifest | [Reactive API](../api/reactive-api.md#pjx-headers) |
-| `PJX_ASSETS_HEADER` | HTTP header name for asset URLs already loaded in the browser | [Reactive API](../api/reactive-api.md#pjx-headers) |
-| `PJX_TRIGGER_HEADER` | HTTP header name for the swap-origin region id (client-set) | [Reactive API](../api/reactive-api.md#pjx-headers) |
+| `setup()` | Single-call process + optional FastAPI wiring | [Configuration](../api/config.md#setup) |
+| `Registry` | Class and request-scoped instance registry | [Registry](../api/registry.md) |
+
+## Reactive authoring
+
+| Symbol | Description | Documentation |
+|--------|-------------|---------------|
+| `mutates()` | Decorator: invalidate cache and accumulate dirtied keys after mutation | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#mutates) |
 | `StateKey` | Base `StrEnum` for app-level reactive key constants | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#statekey) |
 | `PjxLoad` | Marker for `Annotated[..., PjxLoad()]` fields stamped as `data-pjx-load` | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#pjxload) |
-| `MutationTracker` | Request-scoped dirtied-key accumulation | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md) |
-| `mutates()` | Decorator: invalidate cache and accumulate dirtied keys after mutation | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#mutates) |
-| `TriggerManifest` | Parse `X-PJX-Trigger` (swap-origin region id) | [Reactive API](../api/reactive-api.md) |
 | `LoadContext` | Opaque base dataclass for request-scoped `load()` data | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#loadcontext) |
-| `LoadContext.current()` | Return the current load context, or `None` | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#loadcontext) |
-| `LoadContext.bind()` | Context manager to set the load context | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#loadcontext) |
-| `enable_reactive_dev()` | Enable dev guardrails (warnings or strict exceptions) | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#reactive-dev) |
-| `disable_reactive_dev()` | Disable dev guardrails | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#reactive-dev) |
-| `dependency_graph()` | Map reactive keys to dependent component class names | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#dependency_graph) |
-| `format_dependency_graph()` | Format the dependency graph as text or Mermaid | [Mutations, Keys & LoadContext](../api/mutations-keys-context.md#format_dependency_graph) |
 
 ## Configuration
 
 | Symbol | Description | Documentation |
 |--------|-------------|---------------|
-| `setup()` | Single-call process + optional FastAPI wiring | [Configuration](../api/config.md#setup) |
 | `PyJinhxSettings` | Cache scope, invalidation backend, reactive dev flags | [Configuration](../api/config.md#pyjinhxsettings) |
-| `configure_pyjinhx()` | Process-wide startup | [Configuration](../api/config.md#configure_pyjinhx-shutdown_pyjinhx) |
-| `shutdown_pyjinhx()` | Process-wide shutdown | [Configuration](../api/config.md#configure_pyjinhx-shutdown_pyjinhx) |
-| `pyjinhx_lifespan()` | Sync context manager for tests/scripts | [Configuration](../api/config.md#pyjinhx_lifespan) |
-
-## Load cache & invalidation
-
-| Symbol | Description | Documentation |
-|--------|-------------|---------------|
 | `CacheScope` | Enum: `PROCESS`, `REQUEST`, or `NONE` | [Cache & Invalidation](../api/cache-invalidation.md#cachescope) |
-| `LoadCache` | Memoization for reactive `load()` results | [Cache & Invalidation](../api/cache-invalidation.md#loadcache) |
-| `LoadCache.scope()` | Return the active load-cache scope | [Cache & Invalidation](../api/cache-invalidation.md#loadcache) |
-| `LoadCache.set_scope()` | Set the process-wide load-cache scope | [Cache & Invalidation](../api/cache-invalidation.md#loadcache) |
-| `LoadCache.invalidate()` | Evict cached `load()` results for dirtied keys | [Cache & Invalidation](../api/cache-invalidation.md#loadcache) |
-| `InvalidationBackend` | ABC for cross-process invalidation fan-out | [Cache & Invalidation](../api/cache-invalidation.md#invalidationbackend) |
-| `InvalidationHub` | Runtime coordinator for cross-process invalidation | [Cache & Invalidation](../api/cache-invalidation.md#invalidationhub) |
-| `InvalidationHub.set_backend()` | Configure the invalidation backend | [Cache & Invalidation](../api/cache-invalidation.md#invalidationhub) |
-| `InvalidationHub.start_listener()` | Start listening for remote invalidations | [Cache & Invalidation](../api/cache-invalidation.md#invalidationhub) |
-| `InvalidationHub.stop_listener()` | Stop the invalidation listener | [Cache & Invalidation](../api/cache-invalidation.md#invalidationhub) |
+| `AssetMode` | Enum: `INLINE`, `REFERENCE`, or `NONE` | [Renderer](../api/renderer.md#assetmode) |
 
-## Assets
+## Runtime
 
 | Symbol | Description | Documentation |
 |--------|-------------|---------------|
-| `AssetMode` | Enum: `INLINE`, `REFERENCE`, or `NONE` | [Renderer](../api/renderer.md#assetmode) |
-| `AssetManifest` | Resolved stylesheet and script URLs from a render session | [Assets API](../api/assets-api.md#assetmanifest) |
-| `DEFAULT_RUNTIME_URL` | Default public URL for `pjx.js` (`/static/pyjinhx/pjx.js`) | [Assets API](../api/assets-api.md#default_runtime_url) |
-| `asset_manifest()` | Build an `AssetManifest` from a `RenderSession` | [Assets API](../api/assets-api.md#asset_manifest) |
-| `default_asset_url()` | Map an absolute asset path to a default public URL | [Assets API](../api/assets-api.md#default_asset_url) |
-| `hashed_filename()` | Content-hash a filename for cache-busting | [Assets API](../api/assets-api.md#hashed_filename) |
-| `Finder.layout_asset_tags()` | Emit `<link>` / `<script>` tags for all discovered component assets | [Finder](../api/finder.md#layout_asset_tags) |
-| `make_default_asset_url_resolver()` | Build a resolver using `default_asset_url()` | [Assets API](../api/assets-api.md#make_default_asset_url_resolver) |
-| `resolver_with_hash()` | Build a resolver that embeds content hashes in URLs | [Assets API](../api/assets-api.md#resolver_with_hash) |
-| `runtime_asset_path()` | Absolute path to the bundled `pjx.js` file | [Assets API](../api/assets-api.md#runtime_asset_path) |
+| `client_script()` | Emit the pyjinhx client runtime as a `<script>` tag | [Reactive API](../api/reactive-api.md#client_script) |
 
 ## Conceptual guides
 

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -32,8 +32,7 @@ These 13 symbols are the entire top-level public API; advanced/internal building
 
 | Symbol | Description | Documentation |
 |--------|-------------|---------------|
-| `PjxSettings` | Cache scope, invalidation backend, reactive dev flags | [Configuration](../api/config.md#pjxsettings) |
-| `CacheScope` | Enum: `PROCESS`, `REQUEST`, or `NONE` | [Cache & Invalidation](../api/cache-invalidation.md#cachescope) |
+| `PjxSettings` | Invalidation backend and reactive dev flags | [Configuration](../api/config.md#pjxsettings) |
 | `AssetMode` | Enum: `INLINE`, `REFERENCE`, or `NONE` | [Renderer](../api/renderer.md#assetmode) |
 
 ## Conceptual guides

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -24,7 +24,7 @@ These 13 symbols are the entire top-level public API; advanced/internal building
 | Symbol | Description | Documentation |
 |--------|-------------|---------------|
 | `mutates()` | Decorator: invalidate cache and accumulate dirtied keys after mutation | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#mutates) |
-| `StateKey` | Base `StrEnum` for app-level reactive key constants | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#statekey) |
+| `MutationKey` | Base `StrEnum` for app-level reactive key constants | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#statekey) |
 | `PjxKey` | Marker for `Annotated[..., PjxKey()]` fields stamped as `data-pjx-load` | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#pjxload) |
 | `PjxContext` | Opaque base dataclass for request-scoped `load()` data | [Mutations, Keys & PjxContext](../api/mutations-keys-context.md#loadcontext) |
 

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -32,7 +32,7 @@ These 13 symbols are the entire top-level public API; advanced/internal building
 
 | Symbol | Description | Documentation |
 |--------|-------------|---------------|
-| `PyJinhxSettings` | Cache scope, invalidation backend, reactive dev flags | [Configuration](../api/config.md#pyjinhxsettings) |
+| `PjxSettings` | Cache scope, invalidation backend, reactive dev flags | [Configuration](../api/config.md#pyjinhxsettings) |
 | `CacheScope` | Enum: `PROCESS`, `REQUEST`, or `NONE` | [Cache & Invalidation](../api/cache-invalidation.md#cachescope) |
 | `AssetMode` | Enum: `INLINE`, `REFERENCE`, or `NONE` | [Renderer](../api/renderer.md#assetmode) |
 

--- a/examples/reactive_todo/README.md
+++ b/examples/reactive_todo/README.md
@@ -35,19 +35,15 @@ what's mounted on every HTMX request.
 ## Setup
 
 The app calls `setup(app, ...)` once — lifespan (cache + optional invalidation) and
-registry middleware are wired automatically. Default load cache is
-**`CacheScope.REQUEST`** (multi-worker safe without Redis).
+registry middleware are wired automatically. You don't choose a cache scope; it's derived
+from the backend. With no backend (the default) `load()` results are cached per request,
+which is multi-worker safe without Redis.
 
-Cross-request cache per worker (opt-in performance):
-
-```bash
-PJX_LOAD_CACHE_SCOPE=process uv run uvicorn examples.reactive_todo.app:app --reload
-```
-
-Multi-worker with Redis invalidation fan-out:
+Cross-request cache per worker with Redis invalidation fan-out (opt-in performance, and the
+multi-worker-safe way to cache across requests):
 
 ```bash
-PJX_LOAD_CACHE_SCOPE=process REDIS_URL=redis://localhost:6379/0 \
+REDIS_URL=redis://localhost:6379/0 \
   uv run uvicorn examples.reactive_todo.app:app --reload
 ```
 

--- a/examples/reactive_todo/app.py
+++ b/examples/reactive_todo/app.py
@@ -21,14 +21,14 @@ from examples.reactive_todo.components import (
     ItemRow,
     Total,
 )
-from pyjinhx import PyJinhxSettings, Renderer, setup
+from pyjinhx import PjxSettings, Renderer, setup
 
 Renderer.set_default_environment(Path(__file__).resolve().parents[2])
 
 app = FastAPI(title="pyjinhx reactive todo demo")
 setup(
     app,
-    settings=PyJinhxSettings.from_env(),
+    settings=PjxSettings.from_env(),
     load_context_factory=lambda _request: AppLoadContext(store=store),
 )
 

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Annotated, ClassVar, Optional
 
-from pyjinhx import BaseComponent, LoadContext, PjxKey, ReactiveComponent
+from pyjinhx import BaseComponent, PjxContext, PjxKey, ReactiveComponent
 
 from .keys import Keys
 
@@ -14,7 +14,7 @@ class AppLoadContext:
 
 
 def _store():
-    ctx = LoadContext.current()
+    ctx = PjxContext.current()
     if isinstance(ctx, AppLoadContext):
         return ctx.store
     from . import store

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Annotated, ClassVar, Optional
 
-from pyjinhx import BaseComponent, LoadContext, PjxLoad, ReactiveComponent
+from pyjinhx import BaseComponent, LoadContext, PjxKey, ReactiveComponent
 
 from .keys import Keys
 
@@ -23,7 +23,7 @@ def _store():
 
 
 class ItemRow(ReactiveComponent):
-    todo_id: Annotated[int, PjxLoad()]
+    todo_id: Annotated[int, PjxKey()]
     title: str = ""
     done: bool = False
     reacts_to: ClassVar[set[str]] = {Keys.TODOS}

--- a/examples/reactive_todo/keys.py
+++ b/examples/reactive_todo/keys.py
@@ -1,6 +1,6 @@
-from pyjinhx import StateKey
+from pyjinhx import MutationKey
 
 
-class Keys(StateKey):
+class Keys(MutationKey):
     TODOS = "todos"
     TODO_LIST = "todo-list"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,7 +92,7 @@ nav:
       - Client Backend: api/client-backend.md
       - Cache & Invalidation: api/cache-invalidation.md
       - Redis integration: api/integrations-redis.md
-      - Mutations, Keys & LoadContext: api/mutations-keys-context.md
+      - Mutations, Keys & PjxContext: api/mutations-keys-context.md
       - Parser & Tag: api/parser.md
       - Assets API: api/assets-api.md
       - Finder: api/finder.md

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -1,97 +1,40 @@
-from pyjinhx.assets import (
-    AssetManifest,
-    AssetMode,
-    DEFAULT_RUNTIME_URL,
-    RenderSession,
-    asset_manifest,
-    default_asset_url,
-    hashed_filename,
-    make_default_asset_url_resolver,
-    resolver_with_hash,
-    runtime_asset_path,
-)
+"""pyjinhx public API.
+
+Import what you need from the top-level package. Advanced/internal building
+blocks (cache internals, manifest parsing, asset-resolver helpers, dev tooling,
+``oob_swaps``, …) live in their submodules — e.g. ``from pyjinhx.cache import
+LoadCache`` — and are not part of this curated surface.
+"""
+
+from pyjinhx.assets import AssetMode
 from pyjinhx.base import BaseComponent
-from pyjinhx.finder import Finder
-from pyjinhx.tags import Parser
+from pyjinhx.cache import CacheScope
+from pyjinhx.client import client_script
+from pyjinhx.config import PyJinhxSettings, setup
+from pyjinhx.context import LoadContext
+from pyjinhx.keys import StateKey
+from pyjinhx.mutations import mutates
+from pyjinhx.reactive import PjxLoad, ReactiveComponent
 from pyjinhx.registry import Registry
 from pyjinhx.renderer import Renderer
-from pyjinhx.tags import Tag
-from pyjinhx.config import (
-    PyJinhxSettings,
-    configure_pyjinhx,
-    pyjinhx_lifespan,
-    setup,
-    shutdown_pyjinhx,
-)
-from pyjinhx.integrations.fastapi import FastAPIClientBackend
-from pyjinhx.client import (
-    ClientBackend,
-    LoadedAssets,
-    MountedManifest,
-    PJX_ASSETS_HEADER,
-    PJX_MOUNTED_HEADER,
-    PJX_TRIGGER_HEADER,
-    TriggerManifest,
-    client_script,
-)
-from pyjinhx.reactive import ReactiveComponent
-from pyjinhx.context import LoadContext
-from pyjinhx.dev import (
-    dependency_graph,
-    disable_reactive_dev,
-    enable_reactive_dev,
-    format_dependency_graph,
-)
-from pyjinhx.cache import CacheScope, InvalidationBackend, InvalidationHub, LoadCache
-from pyjinhx.keys import StateKey
-from pyjinhx.mutations import MutationTracker, mutates
-from pyjinhx.reactive import oob_swaps
-from pyjinhx.reactive import PjxLoad
 
 __all__ = [
-    "AssetManifest",
-    "AssetMode",
+    # Components & rendering
     "BaseComponent",
     "ReactiveComponent",
     "Renderer",
-    "RenderSession",
-    "Finder",
-    "Parser",
-    "Registry",
-    "Tag",
-    "oob_swaps",
-    "LoadCache",
-    "CacheScope",
-    "MutationTracker",
-    "InvalidationBackend",
-    "InvalidationHub",
-    "PyJinhxSettings",
-    "configure_pyjinhx",
-    "shutdown_pyjinhx",
-    "pyjinhx_lifespan",
+    # App wiring
     "setup",
-    "ClientBackend",
-    "FastAPIClientBackend",
-    "client_script",
-    "LoadedAssets",
-    "MountedManifest",
-    "TriggerManifest",
-    "PjxLoad",
-    "PJX_MOUNTED_HEADER",
-    "PJX_ASSETS_HEADER",
-    "PJX_TRIGGER_HEADER",
-    "StateKey",
+    "Registry",
+    # Reactive authoring
     "mutates",
+    "StateKey",
+    "PjxLoad",
     "LoadContext",
-    "enable_reactive_dev",
-    "disable_reactive_dev",
-    "dependency_graph",
-    "format_dependency_graph",
-    "DEFAULT_RUNTIME_URL",
-    "asset_manifest",
-    "default_asset_url",
-    "hashed_filename",
-    "make_default_asset_url_resolver",
-    "resolver_with_hash",
-    "runtime_asset_path",
+    # Configuration
+    "PyJinhxSettings",
+    "CacheScope",
+    "AssetMode",
+    # Runtime
+    "client_script",
 ]

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -11,7 +11,7 @@ from pyjinhx.base import BaseComponent
 from pyjinhx.cache import CacheScope
 from pyjinhx.client import client_script
 from pyjinhx.config import PyJinhxSettings, setup
-from pyjinhx.context import LoadContext
+from pyjinhx.context import PjxContext
 from pyjinhx.keys import StateKey
 from pyjinhx.mutations import mutates
 from pyjinhx.reactive import PjxKey, ReactiveComponent
@@ -30,7 +30,7 @@ __all__ = [
     "mutates",
     "StateKey",
     "PjxKey",
-    "LoadContext",
+    "PjxContext",
     # Configuration
     "PyJinhxSettings",
     "CacheScope",

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -8,7 +8,6 @@ LoadCache`` — and are not part of this curated surface.
 
 from pyjinhx.assets import AssetMode
 from pyjinhx.base import BaseComponent
-from pyjinhx.cache import CacheScope
 from pyjinhx.config import PjxSettings, setup
 from pyjinhx.context import PjxContext
 from pyjinhx.keys import MutationKey
@@ -32,6 +31,5 @@ __all__ = [
     "PjxContext",
     # Configuration
     "PjxSettings",
-    "CacheScope",
     "AssetMode",
 ]

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -12,7 +12,7 @@ from pyjinhx.cache import CacheScope
 from pyjinhx.client import client_script
 from pyjinhx.config import PjxSettings, setup
 from pyjinhx.context import PjxContext
-from pyjinhx.keys import StateKey
+from pyjinhx.keys import MutationKey
 from pyjinhx.mutations import mutates
 from pyjinhx.reactive import PjxKey, ReactiveComponent
 from pyjinhx.registry import Registry
@@ -28,7 +28,7 @@ __all__ = [
     "Registry",
     # Reactive authoring
     "mutates",
-    "StateKey",
+    "MutationKey",
     "PjxKey",
     "PjxContext",
     # Configuration

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -10,7 +10,7 @@ from pyjinhx.assets import AssetMode
 from pyjinhx.base import BaseComponent
 from pyjinhx.cache import CacheScope
 from pyjinhx.client import client_script
-from pyjinhx.config import PyJinhxSettings, setup
+from pyjinhx.config import PjxSettings, setup
 from pyjinhx.context import PjxContext
 from pyjinhx.keys import StateKey
 from pyjinhx.mutations import mutates
@@ -32,7 +32,7 @@ __all__ = [
     "PjxKey",
     "PjxContext",
     # Configuration
-    "PyJinhxSettings",
+    "PjxSettings",
     "CacheScope",
     "AssetMode",
     # Runtime

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -14,7 +14,7 @@ from pyjinhx.config import PyJinhxSettings, setup
 from pyjinhx.context import LoadContext
 from pyjinhx.keys import StateKey
 from pyjinhx.mutations import mutates
-from pyjinhx.reactive import PjxLoad, ReactiveComponent
+from pyjinhx.reactive import PjxKey, ReactiveComponent
 from pyjinhx.registry import Registry
 from pyjinhx.renderer import Renderer
 
@@ -29,7 +29,7 @@ __all__ = [
     # Reactive authoring
     "mutates",
     "StateKey",
-    "PjxLoad",
+    "PjxKey",
     "LoadContext",
     # Configuration
     "PyJinhxSettings",

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -9,7 +9,6 @@ LoadCache`` — and are not part of this curated surface.
 from pyjinhx.assets import AssetMode
 from pyjinhx.base import BaseComponent
 from pyjinhx.cache import CacheScope
-from pyjinhx.client import client_script
 from pyjinhx.config import PjxSettings, setup
 from pyjinhx.context import PjxContext
 from pyjinhx.keys import MutationKey
@@ -35,6 +34,4 @@ __all__ = [
     "PjxSettings",
     "CacheScope",
     "AssetMode",
-    # Runtime
-    "client_script",
 ]

--- a/pyjinhx/cache.py
+++ b/pyjinhx/cache.py
@@ -114,13 +114,13 @@ class LoadCache:
             if cached is not None:
                 return cls._with_key(cached.model_copy(), key)
 
-        from .context import LoadContext, invoke_raw_load
+        from .context import PjxContext, invoke_raw_load
 
         result = invoke_raw_load(
             raw_func,
             component_class,
             key=key,
-            ctx=LoadContext.current(),
+            ctx=PjxContext.current(),
             owner=component_class,
         )
         result = cls._with_key(result, key)

--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -18,13 +18,13 @@ _UNSET: Any = object()  # sentinel: distinguishes "argument omitted" from None /
 
 
 @dataclass(frozen=True)
-class PyJinhxSettings:
+class PjxSettings:
     cache_scope: CacheScope = CacheScope.REQUEST
     invalidation_backend: InvalidationBackend | None = None
     reactive_dev: bool = False
 
     @classmethod
-    def from_env(cls) -> PyJinhxSettings:
+    def from_env(cls) -> PjxSettings:
         scope_name = os.environ.get("PJX_LOAD_CACHE_SCOPE", "request").lower()
         cache_scope = CacheScope(scope_name)
         reactive_dev = os.environ.get("PJX_REACTIVE_DEV", "").lower() in {
@@ -44,7 +44,7 @@ class PyJinhxSettings:
             reactive_dev=reactive_dev,
         )
 
-    def merge(self, **overrides: Any) -> PyJinhxSettings:
+    def merge(self, **overrides: Any) -> PjxSettings:
         # only fields explicitly provided (not the _UNSET sentinel) override self, so an
         # explicit `settings=` is never clobbered by setup()'s default keyword arguments
         valid = {field.name for field in fields(self)}
@@ -57,14 +57,14 @@ class PyJinhxSettings:
 
 
 def _merge_settings(
-    settings: PyJinhxSettings | None,
+    settings: PjxSettings | None,
     *,
     cache_scope: Any,
     invalidation_backend: Any,
     reactive_dev: Any,
     extra: dict[str, Any],
-) -> PyJinhxSettings:
-    return (settings or PyJinhxSettings()).merge(
+) -> PjxSettings:
+    return (settings or PjxSettings()).merge(
         cache_scope=cache_scope,
         invalidation_backend=invalidation_backend,
         reactive_dev=reactive_dev,
@@ -73,10 +73,10 @@ def _merge_settings(
 
 
 def configure_pyjinhx(
-    settings: PyJinhxSettings | None = None,
+    settings: PjxSettings | None = None,
     /,
     **kwargs: Any,
-) -> PyJinhxSettings:
+) -> PjxSettings:
     if kwargs or settings is None:
         resolved = _merge_settings(
             settings,
@@ -123,7 +123,7 @@ def shutdown_pyjinhx() -> None:
 
 @contextmanager
 def pyjinhx_lifespan(
-    settings: PyJinhxSettings | None = None,
+    settings: PjxSettings | None = None,
     /,
     **kwargs: Any,
 ) -> Generator[None, None, None]:
@@ -141,13 +141,13 @@ def _is_asgi_app(app: object) -> bool:
 def setup(
     app: object | None = None,
     *,
-    settings: PyJinhxSettings | None = None,
+    settings: PjxSettings | None = None,
     cache_scope: CacheScope = _UNSET,
     invalidation_backend: InvalidationBackend | None = _UNSET,
     reactive_dev: bool = _UNSET,
     load_context_factory: Callable[[Any], object | None] | None = None,
     **kwargs: Any,
-) -> PyJinhxSettings:
+) -> PjxSettings:
     """
     Wire pyjinhx for this process (and optionally a web app).
 

--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -1,32 +1,24 @@
 from __future__ import annotations
 
-import logging
 import os
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, fields, replace
 from typing import Any
 
-from pyjinhx.cache import CacheScope, LoadCache, InvalidationBackend, InvalidationHub
+from pyjinhx.cache import CacheScope, InvalidationBackend, InvalidationHub, LoadCache
 from pyjinhx.dev import disable_reactive_dev, enable_reactive_dev
-
-
-logger = logging.getLogger("pyjinhx")
-
 
 _UNSET: Any = object()  # sentinel: distinguishes "argument omitted" from None / a real value
 
 
 @dataclass(frozen=True)
 class PjxSettings:
-    cache_scope: CacheScope = CacheScope.REQUEST
     invalidation_backend: InvalidationBackend | None = None
     reactive_dev: bool = False
 
     @classmethod
     def from_env(cls) -> PjxSettings:
-        scope_name = os.environ.get("PJX_LOAD_CACHE_SCOPE", "request").lower()
-        cache_scope = CacheScope(scope_name)
         reactive_dev = os.environ.get("PJX_REACTIVE_DEV", "").lower() in {
             "1",
             "true",
@@ -34,12 +26,11 @@ class PjxSettings:
         }
         invalidation_backend: InvalidationBackend | None = None
         redis_url = os.environ.get("REDIS_URL")
-        if cache_scope == CacheScope.PROCESS and redis_url:
+        if redis_url:
             from pyjinhx.integrations.redis import RedisInvalidationBackend
 
             invalidation_backend = RedisInvalidationBackend(redis_url)
         return cls(
-            cache_scope=cache_scope,
             invalidation_backend=invalidation_backend,
             reactive_dev=reactive_dev,
         )
@@ -59,13 +50,11 @@ class PjxSettings:
 def _merge_settings(
     settings: PjxSettings | None,
     *,
-    cache_scope: Any,
     invalidation_backend: Any,
     reactive_dev: Any,
     extra: dict[str, Any],
 ) -> PjxSettings:
     return (settings or PjxSettings()).merge(
-        cache_scope=cache_scope,
         invalidation_backend=invalidation_backend,
         reactive_dev=reactive_dev,
         **extra,
@@ -80,7 +69,6 @@ def configure_pyjinhx(
     if kwargs or settings is None:
         resolved = _merge_settings(
             settings,
-            cache_scope=kwargs.pop("cache_scope", _UNSET),
             invalidation_backend=kwargs.pop("invalidation_backend", _UNSET),
             reactive_dev=kwargs.pop("reactive_dev", _UNSET),
             extra=kwargs,
@@ -88,21 +76,14 @@ def configure_pyjinhx(
     else:
         resolved = settings
 
-    LoadCache.set_scope(resolved.cache_scope)
+    # The cache scope follows the backend: a cross-worker invalidation backend
+    # (e.g. Redis) makes cross-request PROCESS caching safe across workers; without
+    # one, the only multi-worker-safe behavior is per-request (REQUEST) caching.
+    backend = resolved.invalidation_backend
+    LoadCache.set_scope(CacheScope.PROCESS if backend is not None else CacheScope.REQUEST)
 
-    if (
-        resolved.invalidation_backend is not None
-        and resolved.cache_scope != CacheScope.PROCESS
-    ):
-        logger.warning(
-            "invalidation_backend is configured but cache_scope is %s; "
-            "cross-process invalidation requires CacheScope.PROCESS — ignoring backend",
-            resolved.cache_scope.value,
-        )
-        resolved = replace(resolved, invalidation_backend=None)
-
-    if resolved.invalidation_backend is not None and resolved.cache_scope == CacheScope.PROCESS:
-        InvalidationHub.set_backend(resolved.invalidation_backend)
+    if backend is not None:
+        InvalidationHub.set_backend(backend)
         InvalidationHub.start_listener()
     else:
         InvalidationHub.set_backend(None)
@@ -142,7 +123,6 @@ def setup(
     app: object | None = None,
     *,
     settings: PjxSettings | None = None,
-    cache_scope: CacheScope = _UNSET,
     invalidation_backend: InvalidationBackend | None = _UNSET,
     reactive_dev: bool = _UNSET,
     load_context_factory: Callable[[Any], object | None] | None = None,
@@ -154,10 +134,13 @@ def setup(
     With ``app=None``, only process-wide configuration runs (tests, scripts).
     With a FastAPI/Starlette app, lifespan is chained and registry middleware
     is registered.
+
+    The load-cache scope is derived from ``invalidation_backend``: cross-request
+    ``PROCESS`` caching when a backend is set (kept consistent across workers by
+    the backend), per-request ``REQUEST`` caching otherwise.
     """
     resolved = _merge_settings(
         settings,
-        cache_scope=cache_scope,
         invalidation_backend=invalidation_backend,
         reactive_dev=reactive_dev,
         extra=kwargs,

--- a/pyjinhx/context.py
+++ b/pyjinhx/context.py
@@ -17,7 +17,7 @@ def _hint_namespace(owner: type[Any] | None, func: Callable[..., Any]) -> dict[s
     globalns = dict(vars(module)) if module is not None else {}
     if owner is not None:
         globalns[owner.__name__] = owner
-    globalns.setdefault("LoadContext", LoadContext)
+    globalns.setdefault("PjxContext", PjxContext)
     return globalns
 
 
@@ -29,7 +29,7 @@ def _resolved_hints(func: Callable[..., Any], owner: type[Any] | None = None) ->
 
 
 def _is_load_context(annotation: Any) -> bool:
-    """True if ``annotation`` is ``LoadContext`` or a subclass, including ``X | None``."""
+    """True if ``annotation`` is ``PjxContext`` or a subclass, including ``X | None``."""
     if annotation is inspect.Parameter.empty or annotation is None:
         return False
     origin = get_origin(annotation)
@@ -41,7 +41,7 @@ def _is_load_context(annotation: Any) -> bool:
         )
     if origin is not None:
         return False
-    return isinstance(annotation, type) and issubclass(annotation, LoadContext)
+    return isinstance(annotation, type) and issubclass(annotation, PjxContext)
 
 
 def _is_load_context_param(param: inspect.Parameter, hints: dict[str, Any]) -> bool:
@@ -55,7 +55,7 @@ def resolve_load_context_param(
     owner: type[Any] | None = None,
 ) -> inspect.Parameter | None:
     """
-    Return the single ``load()`` parameter annotated with ``LoadContext`` (or a
+    Return the single ``load()`` parameter annotated with ``PjxContext`` (or a
     subclass), or ``None`` when absent.
 
     Raises ``TypeError`` when more than one parameter carries that annotation.
@@ -70,7 +70,7 @@ def resolve_load_context_param(
     if len(matches) > 1:
         names = ", ".join(param.name for param in matches)
         raise TypeError(
-            f"{func.__qualname__} declares multiple LoadContext parameters "
+            f"{func.__qualname__} declares multiple PjxContext parameters "
             f"({names}); at most one is allowed."
         )
     return matches[0] if matches else None
@@ -80,7 +80,7 @@ def resolve_instance_key_param(
     func: Callable[..., Any],
     owner: type[Any] | None = None,
 ) -> inspect.Parameter | None:
-    """Return the instance-key parameter, excluding ``cls`` and LoadContext params."""
+    """Return the instance-key parameter, excluding ``cls`` and PjxContext params."""
     signature = inspect.signature(func)
     hints = _resolved_hints(func, owner)
     for param in signature.parameters.values():
@@ -105,7 +105,7 @@ def invoke_raw_load(
     ctx: Any | None,
     owner: type[Any] | None = None,
 ) -> Any:
-    """Call a raw ``load()`` implementation, injecting bound LoadContext when declared."""
+    """Call a raw ``load()`` implementation, injecting bound PjxContext when declared."""
     signature = inspect.signature(raw_func)
     ctx_param = resolve_load_context_param(raw_func, owner)
     bind_kwargs: dict[str, Any] = {}
@@ -125,12 +125,12 @@ def invoke_raw_load(
 
 
 @dataclass(frozen=True)
-class LoadContext:
+class PjxContext:
     """
     Opaque base for request-scoped data available inside reactive ``load()``.
 
     Subclass or replace with your own frozen dataclass; set per request via
-    ``LoadContext.bind()`` or ``Registry.request_scope(load_context=...)``.
+    ``PjxContext.bind()`` or ``Registry.request_scope(load_context=...)``.
     """
 
     @staticmethod

--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from pyjinhx.registry import Registry
-from pyjinhx.config import PyJinhxSettings, configure_pyjinhx, shutdown_pyjinhx
+from pyjinhx.config import PjxSettings, configure_pyjinhx, shutdown_pyjinhx
 from pyjinhx.client import ClientBackend
 
 logger = logging.getLogger("pyjinhx")
@@ -32,7 +32,7 @@ class FastAPIClientBackend(ClientBackend):
 
 def apply_setup(
     app: object,
-    settings: PyJinhxSettings,
+    settings: PjxSettings,
     *,
     load_context_factory: Callable[[Any], object | None] | None = None,
 ) -> None:
@@ -46,7 +46,7 @@ def apply_setup(
     app.state.pyjinhx_setup = True
 
 
-def _chain_lifespan(app: object, settings: PyJinhxSettings) -> None:
+def _chain_lifespan(app: object, settings: PjxSettings) -> None:
     original = app.router.lifespan_context
 
     @asynccontextmanager

--- a/pyjinhx/keys.py
+++ b/pyjinhx/keys.py
@@ -25,7 +25,7 @@ def coerce_load_key_str(key: object) -> str | None:
     return coerce_reactive_key(key)
 
 
-class StateKey(StrEnum):
+class MutationKey(StrEnum):
     """
     Base class for app-level reactive state keys.
 

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -31,12 +31,12 @@ from .keys import ReactiveKey, coerce_load_key_str, coerce_reactive_keys
 from .mutations import MutationTracker
 
 
-class PjxLoad:
-    """Marker for ``Annotated[..., PjxLoad()]`` fields stamped as ``data-pjx-load``."""
+class PjxKey:
+    """Marker for ``Annotated[..., PjxKey()]`` fields stamped as ``data-pjx-load``."""
 
 
 def _metadata_has_pjx_load(metadata: tuple[Any, ...]) -> bool:
-    return any(isinstance(meta, PjxLoad) for meta in metadata)
+    return any(isinstance(meta, PjxKey) for meta in metadata)
 
 
 def _annotation_has_pjx_load(annotation: Any) -> bool:
@@ -59,7 +59,7 @@ def pjx_load_field_names(model_cls: type[Any]) -> list[str]:
     if names:
         return names
     # During __init_subclass__ pydantic has not yet populated model_fields, so
-    # fall back to the raw annotations to detect the PjxLoad marker at definition.
+    # fall back to the raw annotations to detect the PjxKey marker at definition.
     for name, annotation in getattr(model_cls, "__annotations__", {}).items():
         if _annotation_has_pjx_load(annotation):
             names.append(name)
@@ -72,7 +72,7 @@ def resolve_pjx_load_field(model_cls: type[Any]) -> str | None:
         return None
     if len(names) > 1:
         raise TypeError(
-            f"{model_cls.__name__} declares multiple PjxLoad fields {names!r}; "
+            f"{model_cls.__name__} declares multiple PjxKey fields {names!r}; "
             f"at most one is allowed."
         )
     return names[0]
@@ -87,11 +87,11 @@ def validate_pjx_load_subclass(
     if keyed and len(names) != 1:
         raise TypeError(
             f"{cls.__name__}.load() takes a resource argument; declare exactly "
-            f"one field as Annotated[..., PjxLoad()]."
+            f"one field as Annotated[..., PjxKey()]."
         )
     if not keyed and names:
         raise TypeError(
-            f"{cls.__name__}.load() takes no resource argument; PjxLoad fields "
+            f"{cls.__name__}.load() takes no resource argument; PjxKey fields "
             f"are not allowed ({names!r})."
         )
 

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -203,7 +203,7 @@ class ReactiveComponent(BaseComponent):
 
     @staticmethod
     def _load_param_count(func: Any, owner: type[Any] | None = None) -> int:
-        """Count ``load()`` parameters excluding ``cls``, LoadContext params, and variadics."""
+        """Count ``load()`` parameters excluding ``cls``, PjxContext params, and variadics."""
         from .context import _is_load_context_param, _resolved_hints
 
         signature = inspect.signature(func)

--- a/pyjinhx/registry.py
+++ b/pyjinhx/registry.py
@@ -144,7 +144,7 @@ class Registry:
 
         from pyjinhx.client import ClientBackend
         from pyjinhx.cache import LoadCache
-        from pyjinhx.context import LoadContext
+        from pyjinhx.context import PjxContext
         from pyjinhx.dev import warn_mutations_without_render
         from pyjinhx.mutations import MutationTracker
 
@@ -154,7 +154,7 @@ class Registry:
         try:
             with ExitStack() as stack:
                 if load_context is not None:
-                    stack.enter_context(LoadContext.bind(load_context))
+                    stack.enter_context(PjxContext.bind(load_context))
                 if client_backend is not None:
                     stack.enter_context(ClientBackend.scope(client_backend))
                 yield

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyjinhx"
-version = "0.7.2"
+version = "0.7.3"
 description = "UI components for Python using Pydantic and Jinja2 templates"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/34_layout_runtime_test.py
+++ b/tests/34_layout_runtime_test.py
@@ -2,7 +2,8 @@ import json
 
 import pytest
 
-from pyjinhx import BaseComponent, MountedManifest, PJX_MOUNTED_HEADER, Renderer
+from pyjinhx import BaseComponent, Renderer
+from pyjinhx.client import PJX_MOUNTED_HEADER, MountedManifest
 
 pytestmark = pytest.mark.pjx_runtime
 

--- a/tests/35_oob_swaps_test.py
+++ b/tests/35_oob_swaps_test.py
@@ -1,6 +1,6 @@
 from markupsafe import Markup
 
-from pyjinhx import oob_swaps
+from pyjinhx.reactive import oob_swaps
 from tests.ui.reactive import store
 from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401 (registers class)
 from tests.ui.reactive.reactive_clear_button import ReactiveClearButton  # noqa: F401

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -1,105 +1,76 @@
-from abc import ABC
-
 import pyjinhx
+from pyjinhx import (
+    AssetMode,
+    BaseComponent,
+    CacheScope,
+    LoadContext,
+    PjxLoad,
+    PyJinhxSettings,
+    ReactiveComponent,
+    Registry,
+    Renderer,
+    StateKey,
+    client_script,
+    mutates,
+    setup,
+)
+
+PUBLIC_API = {
+    "BaseComponent",
+    "ReactiveComponent",
+    "Renderer",
+    "setup",
+    "Registry",
+    "mutates",
+    "StateKey",
+    "PjxLoad",
+    "LoadContext",
+    "PyJinhxSettings",
+    "CacheScope",
+    "AssetMode",
+    "client_script",
+}
 
 
-def test_reactive_api_is_exported():
-    from pyjinhx import (
-        PJX_ASSETS_HEADER,
-        PJX_MOUNTED_HEADER,
-        PJX_TRIGGER_HEADER,
-        CacheScope,
-        ClientBackend,
-        FastAPIClientBackend,
-        InvalidationBackend,
-        InvalidationHub,
-        LoadCache,
-        LoadContext,
-        LoadedAssets,
-        MountedManifest,
-        MutationTracker,
-        PjxLoad,
-        ReactiveComponent,
-        TriggerManifest,
-        client_script,
-        dependency_graph,
-        enable_reactive_dev,
-        mutates,
-        oob_swaps,
-        StateKey,
-        PyJinhxSettings,
-        configure_pyjinhx,
-        shutdown_pyjinhx,
-        pyjinhx_lifespan,
-        setup,
-    )
+def test_public_api_is_exactly_the_curated_set():
+    assert set(pyjinhx.__all__) == PUBLIC_API
+    assert len(pyjinhx.__all__) == len(PUBLIC_API)  # no duplicates
 
-    assert PJX_MOUNTED_HEADER == "X-PJX-Mounted"
-    assert PJX_ASSETS_HEADER == "X-PJX-Assets"
-    assert PJX_TRIGGER_HEADER == "X-PJX-Trigger"
-    assert callable(oob_swaps)
-    assert callable(client_script)
-    assert callable(mutates)
-    assert callable(dependency_graph)
-    assert callable(enable_reactive_dev)
-    assert callable(LoadedAssets.parse)
-    assert callable(MountedManifest.parse)
-    assert callable(MountedManifest.is_present)
-    assert callable(TriggerManifest.parse)
-    assert callable(LoadCache.set_scope)
-    assert callable(LoadCache.scope)
-    assert callable(InvalidationHub.set_backend)
-    assert callable(InvalidationHub.start_listener)
-    assert callable(InvalidationHub.stop_listener)
-    assert callable(setup)
-    assert callable(PyJinhxSettings.from_env)
-    assert callable(configure_pyjinhx)
-    assert callable(shutdown_pyjinhx)
-    assert callable(pyjinhx_lifespan)
-    assert CacheScope.REQUEST == "request"
-    assert issubclass(ClientBackend, ABC)
-    assert issubclass(InvalidationBackend, ABC)
-    assert issubclass(FastAPIClientBackend, ClientBackend)
-    assert callable(ClientBackend.scope)
-    assert callable(ClientBackend.current)
-    assert callable(LoadContext.current)
-    assert callable(LoadContext.bind)
-    assert callable(MutationTracker.record)
-    assert issubclass(ReactiveComponent, pyjinhx.BaseComponent)
+
+def test_public_symbols_are_correct():
+    assert issubclass(ReactiveComponent, BaseComponent)
     assert issubclass(StateKey, str)
+    assert CacheScope.REQUEST == "request"
+    assert AssetMode.INLINE is not None
     assert PjxLoad.__name__ == "PjxLoad"
+    for fn in (setup, mutates, client_script, PyJinhxSettings.from_env,
+               Renderer.set_default_environment, Registry.request_scope,
+               LoadContext.current):
+        assert callable(fn)
 
 
-def test_names_in_all():
+def test_internals_are_not_in_the_public_surface():
+    # advanced/internal building blocks must NOT leak into the top-level API
     for name in (
-        "oob_swaps",
-        "ReactiveComponent",
-        "client_script",
-        "LoadedAssets",
-        "MountedManifest",
-        "TriggerManifest",
-        "PjxLoad",
-        "PJX_MOUNTED_HEADER",
-        "PJX_ASSETS_HEADER",
-        "PJX_TRIGGER_HEADER",
-        "StateKey",
-        "mutates",
-        "LoadContext",
-        "enable_reactive_dev",
-        "disable_reactive_dev",
-        "dependency_graph",
-        "format_dependency_graph",
-        "CacheScope",
-        "LoadCache",
-        "MutationTracker",
-        "InvalidationBackend",
-        "InvalidationHub",
-        "PyJinhxSettings",
-        "configure_pyjinhx",
-        "shutdown_pyjinhx",
-        "pyjinhx_lifespan",
-        "setup",
-        "ClientBackend",
-        "FastAPIClientBackend",
+        "oob_swaps", "LoadCache", "InvalidationHub", "InvalidationBackend",
+        "MutationTracker", "Finder", "Parser", "Tag", "ClientBackend",
+        "FastAPIClientBackend", "MountedManifest", "TriggerManifest", "LoadedAssets",
+        "PJX_MOUNTED_HEADER", "PJX_ASSETS_HEADER", "PJX_TRIGGER_HEADER",
+        "configure_pyjinhx", "shutdown_pyjinhx", "pyjinhx_lifespan",
+        "enable_reactive_dev", "disable_reactive_dev", "dependency_graph",
+        "format_dependency_graph", "AssetManifest", "RenderSession", "asset_manifest",
+        "default_asset_url", "hashed_filename", "make_default_asset_url_resolver",
+        "resolver_with_hash", "runtime_asset_path", "DEFAULT_RUNTIME_URL",
     ):
-        assert name in pyjinhx.__all__
+        assert name not in pyjinhx.__all__
+        assert not hasattr(pyjinhx, name)
+
+
+def test_internals_remain_importable_from_submodules():
+    # still available for advanced use — just not on the curated surface
+    from pyjinhx.cache import InvalidationHub, LoadCache  # noqa: F401
+    from pyjinhx.client import PJX_MOUNTED_HEADER, ClientBackend, MountedManifest  # noqa: F401
+    from pyjinhx.config import configure_pyjinhx, pyjinhx_lifespan, shutdown_pyjinhx  # noqa: F401
+    from pyjinhx.dev import dependency_graph, enable_reactive_dev  # noqa: F401
+    from pyjinhx.integrations.fastapi import FastAPIClientBackend  # noqa: F401
+    from pyjinhx.reactive import oob_swaps  # noqa: F401

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -5,7 +5,7 @@ from pyjinhx import (
     CacheScope,
     PjxContext,
     PjxKey,
-    PyJinhxSettings,
+    PjxSettings,
     ReactiveComponent,
     Registry,
     Renderer,
@@ -25,7 +25,7 @@ PUBLIC_API = {
     "StateKey",
     "PjxKey",
     "PjxContext",
-    "PyJinhxSettings",
+    "PjxSettings",
     "CacheScope",
     "AssetMode",
     "client_script",
@@ -43,7 +43,7 @@ def test_public_symbols_are_correct():
     assert CacheScope.REQUEST == "request"
     assert AssetMode.INLINE is not None
     assert PjxKey.__name__ == "PjxKey"
-    for fn in (setup, mutates, client_script, PyJinhxSettings.from_env,
+    for fn in (setup, mutates, client_script, PjxSettings.from_env,
                Renderer.set_default_environment, Registry.request_scope,
                PjxContext.current):
         assert callable(fn)

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -2,7 +2,6 @@ import pyjinhx
 from pyjinhx import (
     AssetMode,
     BaseComponent,
-    CacheScope,
     MutationKey,
     PjxContext,
     PjxKey,
@@ -25,7 +24,6 @@ PUBLIC_API = {
     "PjxKey",
     "PjxContext",
     "PjxSettings",
-    "CacheScope",
     "AssetMode",
 }
 
@@ -38,7 +36,6 @@ def test_public_api_is_exactly_the_curated_set():
 def test_public_symbols_are_correct():
     assert issubclass(ReactiveComponent, BaseComponent)
     assert issubclass(MutationKey, str)
-    assert CacheScope.REQUEST == "request"
     assert AssetMode.INLINE is not None
     assert PjxKey.__name__ == "PjxKey"
     for fn in (setup, mutates, PjxSettings.from_env,
@@ -50,7 +47,7 @@ def test_public_symbols_are_correct():
 def test_internals_are_not_in_the_public_surface():
     # advanced/internal building blocks must NOT leak into the top-level API
     for name in (
-        "client_script", "oob_swaps", "LoadCache", "InvalidationHub",
+        "CacheScope", "client_script", "oob_swaps", "LoadCache", "InvalidationHub",
         "InvalidationBackend", "MutationTracker", "Finder", "Parser", "Tag",
         "ClientBackend", "FastAPIClientBackend", "MountedManifest", "TriggerManifest",
         "LoadedAssets", "PJX_MOUNTED_HEADER", "PJX_ASSETS_HEADER", "PJX_TRIGGER_HEADER",
@@ -66,7 +63,7 @@ def test_internals_are_not_in_the_public_surface():
 
 def test_internals_remain_importable_from_submodules():
     # still available for advanced use — just not on the curated surface
-    from pyjinhx.cache import InvalidationHub, LoadCache  # noqa: F401
+    from pyjinhx.cache import CacheScope, InvalidationHub, LoadCache  # noqa: F401
     from pyjinhx.client import (  # noqa: F401
         PJX_MOUNTED_HEADER,
         ClientBackend,

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -3,14 +3,13 @@ from pyjinhx import (
     AssetMode,
     BaseComponent,
     CacheScope,
+    MutationKey,
     PjxContext,
     PjxKey,
     PjxSettings,
     ReactiveComponent,
     Registry,
     Renderer,
-    MutationKey,
-    client_script,
     mutates,
     setup,
 )
@@ -28,7 +27,6 @@ PUBLIC_API = {
     "PjxSettings",
     "CacheScope",
     "AssetMode",
-    "client_script",
 }
 
 
@@ -43,7 +41,7 @@ def test_public_symbols_are_correct():
     assert CacheScope.REQUEST == "request"
     assert AssetMode.INLINE is not None
     assert PjxKey.__name__ == "PjxKey"
-    for fn in (setup, mutates, client_script, PjxSettings.from_env,
+    for fn in (setup, mutates, PjxSettings.from_env,
                Renderer.set_default_environment, Registry.request_scope,
                PjxContext.current):
         assert callable(fn)
@@ -52,10 +50,10 @@ def test_public_symbols_are_correct():
 def test_internals_are_not_in_the_public_surface():
     # advanced/internal building blocks must NOT leak into the top-level API
     for name in (
-        "oob_swaps", "LoadCache", "InvalidationHub", "InvalidationBackend",
-        "MutationTracker", "Finder", "Parser", "Tag", "ClientBackend",
-        "FastAPIClientBackend", "MountedManifest", "TriggerManifest", "LoadedAssets",
-        "PJX_MOUNTED_HEADER", "PJX_ASSETS_HEADER", "PJX_TRIGGER_HEADER",
+        "client_script", "oob_swaps", "LoadCache", "InvalidationHub",
+        "InvalidationBackend", "MutationTracker", "Finder", "Parser", "Tag",
+        "ClientBackend", "FastAPIClientBackend", "MountedManifest", "TriggerManifest",
+        "LoadedAssets", "PJX_MOUNTED_HEADER", "PJX_ASSETS_HEADER", "PJX_TRIGGER_HEADER",
         "configure_pyjinhx", "shutdown_pyjinhx", "pyjinhx_lifespan",
         "enable_reactive_dev", "disable_reactive_dev", "dependency_graph",
         "format_dependency_graph", "AssetManifest", "RenderSession", "asset_manifest",
@@ -69,7 +67,12 @@ def test_internals_are_not_in_the_public_surface():
 def test_internals_remain_importable_from_submodules():
     # still available for advanced use — just not on the curated surface
     from pyjinhx.cache import InvalidationHub, LoadCache  # noqa: F401
-    from pyjinhx.client import PJX_MOUNTED_HEADER, ClientBackend, MountedManifest  # noqa: F401
+    from pyjinhx.client import (  # noqa: F401
+        PJX_MOUNTED_HEADER,
+        ClientBackend,
+        MountedManifest,
+        client_script,
+    )
     from pyjinhx.config import configure_pyjinhx, pyjinhx_lifespan, shutdown_pyjinhx  # noqa: F401
     from pyjinhx.dev import dependency_graph, enable_reactive_dev  # noqa: F401
     from pyjinhx.integrations.fastapi import FastAPIClientBackend  # noqa: F401

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -4,7 +4,7 @@ from pyjinhx import (
     BaseComponent,
     CacheScope,
     LoadContext,
-    PjxLoad,
+    PjxKey,
     PyJinhxSettings,
     ReactiveComponent,
     Registry,
@@ -23,7 +23,7 @@ PUBLIC_API = {
     "Registry",
     "mutates",
     "StateKey",
-    "PjxLoad",
+    "PjxKey",
     "LoadContext",
     "PyJinhxSettings",
     "CacheScope",
@@ -42,7 +42,7 @@ def test_public_symbols_are_correct():
     assert issubclass(StateKey, str)
     assert CacheScope.REQUEST == "request"
     assert AssetMode.INLINE is not None
-    assert PjxLoad.__name__ == "PjxLoad"
+    assert PjxKey.__name__ == "PjxKey"
     for fn in (setup, mutates, client_script, PyJinhxSettings.from_env,
                Renderer.set_default_environment, Registry.request_scope,
                LoadContext.current):

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -3,7 +3,7 @@ from pyjinhx import (
     AssetMode,
     BaseComponent,
     CacheScope,
-    LoadContext,
+    PjxContext,
     PjxKey,
     PyJinhxSettings,
     ReactiveComponent,
@@ -24,7 +24,7 @@ PUBLIC_API = {
     "mutates",
     "StateKey",
     "PjxKey",
-    "LoadContext",
+    "PjxContext",
     "PyJinhxSettings",
     "CacheScope",
     "AssetMode",
@@ -45,7 +45,7 @@ def test_public_symbols_are_correct():
     assert PjxKey.__name__ == "PjxKey"
     for fn in (setup, mutates, client_script, PyJinhxSettings.from_env,
                Renderer.set_default_environment, Registry.request_scope,
-               LoadContext.current):
+               PjxContext.current):
         assert callable(fn)
 
 

--- a/tests/36_public_api_test.py
+++ b/tests/36_public_api_test.py
@@ -9,7 +9,7 @@ from pyjinhx import (
     ReactiveComponent,
     Registry,
     Renderer,
-    StateKey,
+    MutationKey,
     client_script,
     mutates,
     setup,
@@ -22,7 +22,7 @@ PUBLIC_API = {
     "setup",
     "Registry",
     "mutates",
-    "StateKey",
+    "MutationKey",
     "PjxKey",
     "PjxContext",
     "PjxSettings",
@@ -39,7 +39,7 @@ def test_public_api_is_exactly_the_curated_set():
 
 def test_public_symbols_are_correct():
     assert issubclass(ReactiveComponent, BaseComponent)
-    assert issubclass(StateKey, str)
+    assert issubclass(MutationKey, str)
     assert CacheScope.REQUEST == "request"
     assert AssetMode.INLINE is not None
     assert PjxKey.__name__ == "PjxKey"

--- a/tests/37_hash_gating_test.py
+++ b/tests/37_hash_gating_test.py
@@ -1,6 +1,6 @@
 from markupsafe import Markup
 
-from pyjinhx import oob_swaps
+from pyjinhx.reactive import oob_swaps
 from tests.ui.reactive import store
 from tests.ui.reactive.reactive_counter import ReactiveCounter
 from tests.ui.reactive.reactive_clear_button import ReactiveClearButton  # noqa: F401

--- a/tests/38_reactive_render_test.py
+++ b/tests/38_reactive_render_test.py
@@ -2,7 +2,8 @@ import json
 
 from markupsafe import Markup
 
-from pyjinhx import PJX_MOUNTED_HEADER, oob_swaps
+from pyjinhx.client import PJX_MOUNTED_HEADER
+from pyjinhx.reactive import oob_swaps
 from tests.reactive_test_support import reactive_client, record_mutation
 from tests.ui.reactive import store
 from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401

--- a/tests/39_load_cache_test.py
+++ b/tests/39_load_cache_test.py
@@ -1,6 +1,7 @@
 from typing import ClassVar
 
-from pyjinhx import ReactiveComponent, LoadCache
+from pyjinhx import ReactiveComponent
+from pyjinhx.cache import LoadCache
 from tests.ui.reactive.cached_widget import CachedWidget, load_calls
 
 
@@ -76,6 +77,6 @@ def test_invalidate_cleans_reverse_index_across_keys():
 
 
 def test_invalidate_is_exported():
-    from pyjinhx import LoadCache as exported
+    from pyjinhx.cache import LoadCache as exported
 
     assert callable(exported)

--- a/tests/40_load_cache_integration_test.py
+++ b/tests/40_load_cache_integration_test.py
@@ -1,4 +1,4 @@
-from pyjinhx import oob_swaps
+from pyjinhx.reactive import oob_swaps
 from tests.ui.reactive import store
 from tests.ui.reactive.reactive_counter import ReactiveCounter
 from tests.ui.reactive.reactive_clear_button import ReactiveClearButton  # noqa: F401

--- a/tests/41_reactive_render_defaults_test.py
+++ b/tests/41_reactive_render_defaults_test.py
@@ -1,4 +1,4 @@
-from pyjinhx import oob_swaps  # noqa: F401
+from pyjinhx.reactive import oob_swaps  # noqa: F401
 from tests.reactive_test_support import reactive_client, record_mutation
 from tests.ui.reactive import store
 from tests.ui.reactive.reactive_counter import ReactiveCounter

--- a/tests/43_instance_key_cache_test.py
+++ b/tests/43_instance_key_cache_test.py
@@ -1,6 +1,7 @@
 from typing import Annotated, ClassVar
 
-from pyjinhx import LoadCache, PjxLoad, ReactiveComponent
+from pyjinhx import PjxLoad, ReactiveComponent
+from pyjinhx.cache import LoadCache
 
 load_calls = {"n": 0}
 

--- a/tests/43_instance_key_cache_test.py
+++ b/tests/43_instance_key_cache_test.py
@@ -1,13 +1,13 @@
 from typing import Annotated, ClassVar
 
-from pyjinhx import PjxLoad, ReactiveComponent
+from pyjinhx import PjxKey, ReactiveComponent
 from pyjinhx.cache import LoadCache
 
 load_calls = {"n": 0}
 
 
 class Row(ReactiveComponent):
-    row_key: Annotated[str, PjxLoad()]
+    row_key: Annotated[str, PjxKey()]
     title: str = ""
     reacts_to: ClassVar[set[str]] = {"row", "rows"}
 

--- a/tests/44_instance_key_render_test.py
+++ b/tests/44_instance_key_render_test.py
@@ -1,11 +1,11 @@
 from typing import Annotated, ClassVar
 
-from pyjinhx import PjxLoad, ReactiveComponent
+from pyjinhx import PjxKey, ReactiveComponent
 from pyjinhx.utils import read_client_runtime
 
 
 class KeyedCard(ReactiveComponent):
-    card_key: Annotated[str, PjxLoad()]
+    card_key: Annotated[str, PjxKey()]
     title: str = ""
     reacts_to: ClassVar[set[str]] = {"card"}
 

--- a/tests/45_instance_key_walk_test.py
+++ b/tests/45_instance_key_walk_test.py
@@ -1,4 +1,5 @@
-from pyjinhx import LoadCache, oob_swaps
+from pyjinhx.cache import LoadCache
+from pyjinhx.reactive import oob_swaps
 
 from tests.ui.reactive.user_row import UserRow  # noqa: F401
 

--- a/tests/46_reactive_render_classform_test.py
+++ b/tests/46_reactive_render_classform_test.py
@@ -9,7 +9,7 @@ active and mutations are pending.
 import pytest
 from markupsafe import Markup
 
-from pyjinhx import oob_swaps  # noqa: F401
+from pyjinhx.reactive import oob_swaps  # noqa: F401
 from tests.reactive_test_support import reactive_client, record_mutation
 from tests.ui.reactive import store
 from tests.ui.reactive.reactive_counter import ReactiveCounter

--- a/tests/47_reactive_keys_and_enum_load_test.py
+++ b/tests/47_reactive_keys_and_enum_load_test.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Annotated, ClassVar
 
-from pyjinhx import PjxLoad, ReactiveComponent
+from pyjinhx import PjxKey, ReactiveComponent
 from pyjinhx.cache import LoadCache
 from pyjinhx.reactive import oob_swaps
 from pyjinhx.keys import (
@@ -27,7 +27,7 @@ class TodoId(Enum):
 
 
 class EnumRow(ReactiveComponent):
-    row_key: Annotated[str, PjxLoad()]
+    row_key: Annotated[str, PjxKey()]
     label: str = ""
     reacts_to: ClassVar[set[str | StateKey]] = {StateKey.ROW}
 

--- a/tests/47_reactive_keys_and_enum_load_test.py
+++ b/tests/47_reactive_keys_and_enum_load_test.py
@@ -11,14 +11,14 @@ from pyjinhx.keys import (
 )
 
 
-class StateKey(str, Enum):
+class MutationKey(str, Enum):
     TODOS = "todos"
     ROW = "row"
 
 
 def test_coerce_reactive_key_unwraps_enum():
-    assert coerce_reactive_key(StateKey.TODOS) == "todos"
-    assert coerce_reactive_keys({StateKey.TODOS, "users"}) == {"todos", "users"}
+    assert coerce_reactive_key(MutationKey.TODOS) == "todos"
+    assert coerce_reactive_keys({MutationKey.TODOS, "users"}) == {"todos", "users"}
 
 
 class TodoId(Enum):
@@ -29,7 +29,7 @@ class TodoId(Enum):
 class EnumRow(ReactiveComponent):
     row_key: Annotated[str, PjxKey()]
     label: str = ""
-    reacts_to: ClassVar[set[str | StateKey]] = {StateKey.ROW}
+    reacts_to: ClassVar[set[str | MutationKey]] = {MutationKey.ROW}
 
     @classmethod
     def load(cls, key: str) -> "EnumRow":
@@ -42,7 +42,7 @@ def test_reacts_to_coerces_enums_at_class_definition():
 
 class TodoCounter(ReactiveComponent):
     remaining: int = 0
-    reacts_to: ClassVar[set[str | StateKey]] = {StateKey.TODOS}
+    reacts_to: ClassVar[set[str | MutationKey]] = {MutationKey.TODOS}
 
     @classmethod
     def load(cls) -> "TodoCounter":
@@ -64,7 +64,7 @@ def test_dirtied_enum_matches_enum_reacts_to_in_oob_swaps():
     LoadCache.clear()
     out = str(
         oob_swaps(
-            {StateKey.TODOS},
+            {MutationKey.TODOS},
             [{"id": "counter", "type": "TodoCounter", "hash": "stale"}],
         )
     )

--- a/tests/47_reactive_keys_and_enum_load_test.py
+++ b/tests/47_reactive_keys_and_enum_load_test.py
@@ -1,7 +1,9 @@
 from enum import Enum
 from typing import Annotated, ClassVar
 
-from pyjinhx import LoadCache, PjxLoad, ReactiveComponent, oob_swaps
+from pyjinhx import PjxLoad, ReactiveComponent
+from pyjinhx.cache import LoadCache
+from pyjinhx.reactive import oob_swaps
 from pyjinhx.keys import (
     coerce_load_key_str,
     coerce_reactive_key,

--- a/tests/48_reactive_keys_helpers_test.py
+++ b/tests/48_reactive_keys_helpers_test.py
@@ -1,7 +1,7 @@
-from pyjinhx.keys import StateKey, coerce_reactive_key, coerce_reactive_keys
+from pyjinhx.keys import MutationKey, coerce_reactive_key, coerce_reactive_keys
 
 
-class TodoKeys(StateKey):
+class TodoKeys(MutationKey):
     TODOS = "todos"
 
 

--- a/tests/49_mutations_test.py
+++ b/tests/49_mutations_test.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from pyjinhx import LoadCache, Registry, Renderer, mutates
+from pyjinhx import Registry, Renderer, mutates
+from pyjinhx.cache import LoadCache
 from pyjinhx.mutations import MutationTracker
 from tests.reactive_test_support import reactive_client
 from tests.ui.reactive.reactive_clear_button import ReactiveClearButton

--- a/tests/50_asset_reference_mode_test.py
+++ b/tests/50_asset_reference_mode_test.py
@@ -6,8 +6,8 @@ from pyjinhx import (
     AssetMode,
     BaseComponent,
     Renderer,
-    client_script,
 )
+from pyjinhx.client import client_script
 from pyjinhx.assets import (
     asset_manifest,
     hashed_filename,

--- a/tests/50_asset_reference_mode_test.py
+++ b/tests/50_asset_reference_mode_test.py
@@ -5,15 +5,17 @@ import pytest
 from pyjinhx import (
     AssetMode,
     BaseComponent,
-    Finder,
     Renderer,
-    asset_manifest,
     client_script,
+)
+from pyjinhx.assets import (
+    asset_manifest,
     hashed_filename,
     make_default_asset_url_resolver,
-    oob_swaps,
     resolver_with_hash,
 )
+from pyjinhx.finder import Finder
+from pyjinhx.reactive import oob_swaps
 from pyjinhx.utils import read_client_runtime
 from tests.ui.reactive.reactive_counter import ReactiveCounter
 from tests.ui.unified_component import UnifiedComponent

--- a/tests/50_load_context_test.py
+++ b/tests/50_load_context_test.py
@@ -3,7 +3,8 @@ from typing import Annotated, ClassVar
 
 import pytest
 
-from pyjinhx import LoadCache, PjxLoad, ReactiveComponent, Registry
+from pyjinhx import PjxLoad, ReactiveComponent, Registry
+from pyjinhx.cache import LoadCache
 from pyjinhx.context import (
     LoadContext,
     resolve_load_context_param,

--- a/tests/50_load_context_test.py
+++ b/tests/50_load_context_test.py
@@ -6,13 +6,13 @@ import pytest
 from pyjinhx import PjxKey, ReactiveComponent, Registry
 from pyjinhx.cache import LoadCache
 from pyjinhx.context import (
-    LoadContext,
+    PjxContext,
     resolve_load_context_param,
 )
 
 
 @dataclass(frozen=True)
-class AppLoadContext(LoadContext):
+class AppLoadContext(PjxContext):
     value: int = 0
 
 
@@ -41,26 +41,26 @@ class CtxPlain(ReactiveComponent):
 
     @classmethod
     def load(cls) -> "CtxPlain":
-        ctx = LoadContext.current()
+        ctx = PjxContext.current()
         value = ctx.value if isinstance(ctx, AppLoadContext) else -1
         return cls(id="ctx-plain", value=value)
 
 
 def test_load_context_current_outside_scope_is_none():
-    assert LoadContext.current() is None
+    assert PjxContext.current() is None
 
 
 def test_load_context_bind_sets_context():
     ctx = AppLoadContext(value=7)
-    with LoadContext.bind(ctx):
-        assert LoadContext.current() is ctx
-    assert LoadContext.current() is None
+    with PjxContext.bind(ctx):
+        assert PjxContext.current() is ctx
+    assert PjxContext.current() is None
 
 
 def test_load_receives_context_by_type_not_name():
     LoadCache.clear()
     ctx = AppLoadContext(value=42)
-    with LoadContext.bind(ctx):
+    with PjxContext.bind(ctx):
         instance = CtxSingleton.load()
     assert instance.value == 42
 
@@ -69,7 +69,7 @@ def test_keyed_load_injects_context_positionally():
     assert CtxKeyed._pjx_keyed is True
     LoadCache.clear()
     ctx = AppLoadContext(value=9)
-    with LoadContext.bind(ctx):
+    with PjxContext.bind(ctx):
         row = CtxKeyed.load("a")
     assert row.label == "a:9"
     assert row.id == "ctx-keyed-a"
@@ -78,7 +78,7 @@ def test_keyed_load_injects_context_positionally():
 def test_load_contextvar_when_no_context_param():
     LoadCache.clear()
     ctx = AppLoadContext(value=5)
-    with LoadContext.bind(ctx):
+    with PjxContext.bind(ctx):
         instance = CtxPlain.load()
     assert instance.value == 5
 
@@ -103,7 +103,7 @@ def test_resolve_load_context_param_detects_subclass_annotation():
 
 
 def test_duplicate_load_context_params_raise_at_class_definition():
-    with pytest.raises(TypeError, match="multiple LoadContext parameters"):
+    with pytest.raises(TypeError, match="multiple PjxContext parameters"):
 
         class DuplicateCtxLoad(ReactiveComponent):
             reacts_to: ClassVar[set[str]] = {"dup"}
@@ -112,6 +112,6 @@ def test_duplicate_load_context_params_raise_at_class_definition():
             def load(
                 cls,
                 first: AppLoadContext,
-                second: LoadContext,
+                second: PjxContext,
             ) -> "DuplicateCtxLoad":
                 return cls(id="dup")

--- a/tests/50_load_context_test.py
+++ b/tests/50_load_context_test.py
@@ -3,7 +3,7 @@ from typing import Annotated, ClassVar
 
 import pytest
 
-from pyjinhx import PjxLoad, ReactiveComponent, Registry
+from pyjinhx import PjxKey, ReactiveComponent, Registry
 from pyjinhx.cache import LoadCache
 from pyjinhx.context import (
     LoadContext,
@@ -26,7 +26,7 @@ class CtxSingleton(ReactiveComponent):
 
 
 class CtxKeyed(ReactiveComponent):
-    row_key: Annotated[str, PjxLoad()]
+    row_key: Annotated[str, PjxKey()]
     label: str = ""
     reacts_to: ClassVar[set[str]] = {"row"}
 

--- a/tests/51_client_asset_manifest_test.py
+++ b/tests/51_client_asset_manifest_test.py
@@ -6,10 +6,9 @@ import pytest
 from pyjinhx import (
     AssetMode,
     BaseComponent,
-    LoadedAssets,
-    PJX_ASSETS_HEADER,
     Renderer,
 )
+from pyjinhx.client import PJX_ASSETS_HEADER, LoadedAssets
 from pyjinhx.reactive import oob_swaps
 from pyjinhx.utils import read_client_runtime
 from tests.ui.reactive.reactive_counter import ReactiveCounter

--- a/tests/51_reactive_dev_test.py
+++ b/tests/51_reactive_dev_test.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 import pytest
 
 from pyjinhx import ReactiveComponent, Registry, mutates
-from pyjinhx import LoadCache
+from pyjinhx.cache import LoadCache
 from pyjinhx.dev import (
     dependency_graph,
     disable_reactive_dev,

--- a/tests/53_load_cache_scope_test.py
+++ b/tests/53_load_cache_scope_test.py
@@ -1,5 +1,5 @@
-from pyjinhx import CacheScope, Registry
-from pyjinhx.cache import LoadCache
+from pyjinhx import Registry
+from pyjinhx.cache import CacheScope, LoadCache
 from tests.ui.reactive.cached_widget import CachedWidget, load_calls
 
 

--- a/tests/53_load_cache_scope_test.py
+++ b/tests/53_load_cache_scope_test.py
@@ -1,4 +1,5 @@
-from pyjinhx import CacheScope, LoadCache, Registry
+from pyjinhx import CacheScope, Registry
+from pyjinhx.cache import LoadCache
 from tests.ui.reactive.cached_widget import CachedWidget, load_calls
 
 

--- a/tests/54_invalidation_backend_test.py
+++ b/tests/54_invalidation_backend_test.py
@@ -1,7 +1,6 @@
 from collections.abc import Callable
 
-from pyjinhx import CacheScope
-from pyjinhx.cache import InvalidationBackend, InvalidationHub, LoadCache
+from pyjinhx.cache import CacheScope, InvalidationBackend, InvalidationHub, LoadCache
 
 
 class FakeInvalidationBackend(InvalidationBackend):

--- a/tests/54_invalidation_backend_test.py
+++ b/tests/54_invalidation_backend_test.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 
-from pyjinhx import CacheScope, InvalidationBackend, InvalidationHub, LoadCache
+from pyjinhx import CacheScope
+from pyjinhx.cache import InvalidationBackend, InvalidationHub, LoadCache
 
 
 class FakeInvalidationBackend(InvalidationBackend):

--- a/tests/55_memory_redis_invalidation_test.py
+++ b/tests/55_memory_redis_invalidation_test.py
@@ -1,5 +1,4 @@
-from pyjinhx import CacheScope
-from pyjinhx.cache import InvalidationHub, LoadCache
+from pyjinhx.cache import CacheScope, InvalidationHub, LoadCache
 from pyjinhx.integrations.redis import MEMORY_REDIS_URL, RedisInvalidationBackend
 from tests.ui.reactive.cached_widget import CachedWidget, load_calls
 

--- a/tests/55_memory_redis_invalidation_test.py
+++ b/tests/55_memory_redis_invalidation_test.py
@@ -1,6 +1,6 @@
-from pyjinhx import CacheScope, LoadCache
+from pyjinhx import CacheScope
+from pyjinhx.cache import InvalidationHub, LoadCache
 from pyjinhx.integrations.redis import MEMORY_REDIS_URL, RedisInvalidationBackend
-from pyjinhx.cache import InvalidationHub
 from tests.ui.reactive.cached_widget import CachedWidget, load_calls
 
 

--- a/tests/56_client_backend_test.py
+++ b/tests/56_client_backend_test.py
@@ -1,5 +1,6 @@
-from pyjinhx import FastAPIClientBackend, Registry
+from pyjinhx import Registry
 from pyjinhx.client import ClientBackend
+from pyjinhx.integrations.fastapi import FastAPIClientBackend
 
 
 class _FakeRequest:

--- a/tests/57_config_test.py
+++ b/tests/57_config_test.py
@@ -1,13 +1,13 @@
 import os
 from unittest.mock import patch
 
-from pyjinhx import CacheScope, PyJinhxSettings
+from pyjinhx import CacheScope, PjxSettings
 from pyjinhx.cache import InvalidationBackend, LoadCache
 from pyjinhx.config import configure_pyjinhx, pyjinhx_lifespan, shutdown_pyjinhx
 
 
 def test_pyjinhx_settings_default_is_request():
-    assert PyJinhxSettings().cache_scope == CacheScope.REQUEST
+    assert PjxSettings().cache_scope == CacheScope.REQUEST
 
 
 def test_configure_pyjinhx_sets_cache_scope():
@@ -16,7 +16,7 @@ def test_configure_pyjinhx_sets_cache_scope():
 
 
 def test_configure_pyjinhx_accepts_settings_object():
-    settings = PyJinhxSettings(cache_scope=CacheScope.REQUEST)
+    settings = PjxSettings(cache_scope=CacheScope.REQUEST)
     configure_pyjinhx(settings)
     assert LoadCache.scope() == CacheScope.REQUEST
 
@@ -29,7 +29,7 @@ def test_pyjinhx_lifespan_context_manager():
 
 def test_from_env_defaults_to_request():
     with patch.dict(os.environ, {}, clear=True):
-        settings = PyJinhxSettings.from_env()
+        settings = PjxSettings.from_env()
     assert settings.cache_scope == CacheScope.REQUEST
     assert settings.invalidation_backend is None
 
@@ -40,7 +40,7 @@ def test_from_env_process_with_redis_url():
         {"PJX_LOAD_CACHE_SCOPE": "process", "REDIS_URL": "memory://"},
         clear=True,
     ):
-        settings = PyJinhxSettings.from_env()
+        settings = PjxSettings.from_env()
     assert settings.cache_scope == CacheScope.PROCESS
     assert settings.invalidation_backend is not None
 
@@ -71,7 +71,7 @@ def test_configure_warns_when_backend_set_with_request_scope(caplog):
 def test_settings_object_not_clobbered_by_default_kwargs():
     # regression: default kwargs must not overwrite an explicit settings=
     # (cache_scope previously reverted to REQUEST, nulling PROCESS config).
-    resolved = configure_pyjinhx(PyJinhxSettings(cache_scope=CacheScope.PROCESS))
+    resolved = configure_pyjinhx(PjxSettings(cache_scope=CacheScope.PROCESS))
     assert resolved.cache_scope == CacheScope.PROCESS
     assert LoadCache.scope() == CacheScope.PROCESS
 
@@ -79,7 +79,7 @@ def test_settings_object_not_clobbered_by_default_kwargs():
 def test_settings_process_keeps_invalidation_backend():
     backend = _StubBackend()
     resolved = configure_pyjinhx(
-        PyJinhxSettings(cache_scope=CacheScope.PROCESS, invalidation_backend=backend)
+        PjxSettings(cache_scope=CacheScope.PROCESS, invalidation_backend=backend)
     )
     assert resolved.cache_scope == CacheScope.PROCESS
     assert resolved.invalidation_backend is backend
@@ -87,6 +87,6 @@ def test_settings_process_keeps_invalidation_backend():
 
 def test_explicit_kwarg_still_overrides_settings():
     resolved = configure_pyjinhx(
-        PyJinhxSettings(cache_scope=CacheScope.PROCESS), cache_scope=CacheScope.NONE
+        PjxSettings(cache_scope=CacheScope.PROCESS), cache_scope=CacheScope.NONE
     )
     assert resolved.cache_scope == CacheScope.NONE

--- a/tests/57_config_test.py
+++ b/tests/57_config_test.py
@@ -1,48 +1,9 @@
 import os
 from unittest.mock import patch
 
-from pyjinhx import CacheScope, PjxSettings
-from pyjinhx.cache import InvalidationBackend, LoadCache
+from pyjinhx import PjxSettings
+from pyjinhx.cache import CacheScope, InvalidationBackend, LoadCache
 from pyjinhx.config import configure_pyjinhx, pyjinhx_lifespan, shutdown_pyjinhx
-
-
-def test_pyjinhx_settings_default_is_request():
-    assert PjxSettings().cache_scope == CacheScope.REQUEST
-
-
-def test_configure_pyjinhx_sets_cache_scope():
-    configure_pyjinhx(cache_scope=CacheScope.NONE)
-    assert LoadCache.scope() == CacheScope.NONE
-
-
-def test_configure_pyjinhx_accepts_settings_object():
-    settings = PjxSettings(cache_scope=CacheScope.REQUEST)
-    configure_pyjinhx(settings)
-    assert LoadCache.scope() == CacheScope.REQUEST
-
-
-def test_pyjinhx_lifespan_context_manager():
-    with pyjinhx_lifespan(cache_scope=CacheScope.REQUEST):
-        assert LoadCache.scope() == CacheScope.REQUEST
-    shutdown_pyjinhx()
-
-
-def test_from_env_defaults_to_request():
-    with patch.dict(os.environ, {}, clear=True):
-        settings = PjxSettings.from_env()
-    assert settings.cache_scope == CacheScope.REQUEST
-    assert settings.invalidation_backend is None
-
-
-def test_from_env_process_with_redis_url():
-    with patch.dict(
-        os.environ,
-        {"PJX_LOAD_CACHE_SCOPE": "process", "REDIS_URL": "memory://"},
-        clear=True,
-    ):
-        settings = PjxSettings.from_env()
-    assert settings.cache_scope == CacheScope.PROCESS
-    assert settings.invalidation_backend is not None
 
 
 class _StubBackend(InvalidationBackend):
@@ -56,37 +17,76 @@ class _StubBackend(InvalidationBackend):
         pass
 
 
-def test_configure_warns_when_backend_set_with_request_scope(caplog):
-    import logging
+def test_pyjinhx_settings_default_has_no_backend():
+    assert PjxSettings().invalidation_backend is None
 
-    caplog.set_level(logging.WARNING, logger="pyjinhx")
-    configure_pyjinhx(
-        cache_scope=CacheScope.REQUEST,
-        invalidation_backend=_StubBackend(),
-    )
+
+def test_configure_pyjinhx_no_backend_is_request():
+    configure_pyjinhx()
     assert LoadCache.scope() == CacheScope.REQUEST
-    assert any("invalidation_backend" in record.message for record in caplog.records)
+
+
+def test_configure_pyjinhx_with_backend_is_process():
+    configure_pyjinhx(invalidation_backend=_StubBackend())
+    assert LoadCache.scope() == CacheScope.PROCESS
+
+
+def test_configure_pyjinhx_accepts_settings_object():
+    settings = PjxSettings()
+    configure_pyjinhx(settings)
+    assert LoadCache.scope() == CacheScope.REQUEST
+
+
+def test_pyjinhx_lifespan_context_manager():
+    with pyjinhx_lifespan():
+        assert LoadCache.scope() == CacheScope.REQUEST
+    shutdown_pyjinhx()
+
+
+def test_from_env_defaults_to_request():
+    with patch.dict(os.environ, {}, clear=True):
+        settings = PjxSettings.from_env()
+    assert settings.invalidation_backend is None
+    configure_pyjinhx(settings)
+    assert LoadCache.scope() == CacheScope.REQUEST
+
+
+def test_from_env_process_with_redis_url():
+    with patch.dict(os.environ, {"REDIS_URL": "memory://"}, clear=True):
+        settings = PjxSettings.from_env()
+    assert settings.invalidation_backend is not None
+    configure_pyjinhx(settings)
+    assert LoadCache.scope() == CacheScope.PROCESS
+
+
+def test_configure_with_backend_is_process_and_keeps_backend():
+    backend = _StubBackend()
+    resolved = configure_pyjinhx(invalidation_backend=backend)
+    assert resolved.invalidation_backend is backend
+    assert LoadCache.scope() == CacheScope.PROCESS
 
 
 def test_settings_object_not_clobbered_by_default_kwargs():
     # regression: default kwargs must not overwrite an explicit settings=
-    # (cache_scope previously reverted to REQUEST, nulling PROCESS config).
-    resolved = configure_pyjinhx(PjxSettings(cache_scope=CacheScope.PROCESS))
-    assert resolved.cache_scope == CacheScope.PROCESS
+    # (an explicit backend previously reverted to None, nulling PROCESS config).
+    backend = _StubBackend()
+    resolved = configure_pyjinhx(PjxSettings(invalidation_backend=backend))
+    assert resolved.invalidation_backend is backend
     assert LoadCache.scope() == CacheScope.PROCESS
 
 
 def test_settings_process_keeps_invalidation_backend():
     backend = _StubBackend()
-    resolved = configure_pyjinhx(
-        PjxSettings(cache_scope=CacheScope.PROCESS, invalidation_backend=backend)
-    )
-    assert resolved.cache_scope == CacheScope.PROCESS
+    resolved = configure_pyjinhx(PjxSettings(invalidation_backend=backend))
     assert resolved.invalidation_backend is backend
+    assert LoadCache.scope() == CacheScope.PROCESS
 
 
 def test_explicit_kwarg_still_overrides_settings():
+    # explicit invalidation_backend=None overrides a backend on the settings object,
+    # which derives REQUEST instead of PROCESS.
     resolved = configure_pyjinhx(
-        PjxSettings(cache_scope=CacheScope.PROCESS), cache_scope=CacheScope.NONE
+        PjxSettings(invalidation_backend=_StubBackend()), invalidation_backend=None
     )
-    assert resolved.cache_scope == CacheScope.NONE
+    assert resolved.invalidation_backend is None
+    assert LoadCache.scope() == CacheScope.REQUEST

--- a/tests/57_config_test.py
+++ b/tests/57_config_test.py
@@ -1,15 +1,9 @@
 import os
 from unittest.mock import patch
 
-from pyjinhx import (
-    CacheScope,
-    InvalidationBackend,
-    LoadCache,
-    PyJinhxSettings,
-    configure_pyjinhx,
-    pyjinhx_lifespan,
-    shutdown_pyjinhx,
-)
+from pyjinhx import CacheScope, PyJinhxSettings
+from pyjinhx.cache import InvalidationBackend, LoadCache
+from pyjinhx.config import configure_pyjinhx, pyjinhx_lifespan, shutdown_pyjinhx
 
 
 def test_pyjinhx_settings_default_is_request():

--- a/tests/58_setup_fastapi_test.py
+++ b/tests/58_setup_fastapi_test.py
@@ -4,14 +4,30 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from pyjinhx import CacheScope, setup
-from pyjinhx.cache import LoadCache
+from pyjinhx import setup
+from pyjinhx.cache import CacheScope, InvalidationBackend, LoadCache
 from pyjinhx.client import ClientBackend
 
 
-def test_setup_without_app_configures_process():
-    setup(cache_scope=CacheScope.REQUEST)
+class _StubBackend(InvalidationBackend):
+    def publish(self, keys: frozenset[str]) -> None:
+        pass
+
+    def start(self, handler) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+
+def test_setup_without_app_no_backend_is_request():
+    setup()
     assert LoadCache.scope() == CacheScope.REQUEST
+
+
+def test_setup_without_app_with_backend_is_process():
+    setup(invalidation_backend=_StubBackend())
+    assert LoadCache.scope() == CacheScope.PROCESS
 
 
 def test_setup_chains_existing_lifespan():
@@ -24,7 +40,7 @@ def test_setup_chains_existing_lifespan():
         events.append("user_stop")
 
     app = FastAPI(lifespan=user_lifespan)
-    setup(app, cache_scope=CacheScope.REQUEST)
+    setup(app)
 
     with TestClient(app) as _client:
         assert events == ["user_start"]
@@ -34,7 +50,7 @@ def test_setup_chains_existing_lifespan():
 
 def test_setup_middleware_wires_client_backend():
     app = FastAPI()
-    setup(app, cache_scope=CacheScope.REQUEST)
+    setup(app)
 
     @app.get("/")
     def index():
@@ -48,8 +64,9 @@ def test_setup_middleware_wires_client_backend():
 
 def test_setup_is_idempotent():
     app = FastAPI()
-    setup(app, cache_scope=CacheScope.REQUEST)
-    setup(app, cache_scope=CacheScope.PROCESS)
+    setup(app)
+    # A second setup() (which would derive PROCESS from a backend) is a no-op.
+    setup(app, invalidation_backend=_StubBackend())
     assert app.state.pyjinhx_setup is True
 
     with TestClient(app) as client:
@@ -59,4 +76,4 @@ def test_setup_is_idempotent():
 
 def test_setup_rejects_non_asgi_app():
     with pytest.raises(TypeError, match="Starlette/FastAPI-like app"):
-        setup(object(), cache_scope=CacheScope.REQUEST)
+        setup(object())

--- a/tests/58_setup_fastapi_test.py
+++ b/tests/58_setup_fastapi_test.py
@@ -4,12 +4,9 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from pyjinhx import (
-    CacheScope,
-    ClientBackend,
-    LoadCache,
-    setup,
-)
+from pyjinhx import CacheScope, setup
+from pyjinhx.cache import LoadCache
+from pyjinhx.client import ClientBackend
 
 
 def test_setup_without_app_configures_process():

--- a/tests/59_cache_default_test.py
+++ b/tests/59_cache_default_test.py
@@ -1,5 +1,6 @@
-from pyjinhx import CacheScope, LoadCache, configure_pyjinhx, shutdown_pyjinhx
-from pyjinhx.cache import InvalidationHub
+from pyjinhx import CacheScope
+from pyjinhx.cache import InvalidationHub, LoadCache
+from pyjinhx.config import configure_pyjinhx, shutdown_pyjinhx
 
 
 def test_configure_pyjinhx_defaults_to_request_scope():

--- a/tests/59_cache_default_test.py
+++ b/tests/59_cache_default_test.py
@@ -1,5 +1,4 @@
-from pyjinhx import CacheScope
-from pyjinhx.cache import InvalidationHub, LoadCache
+from pyjinhx.cache import CacheScope, InvalidationHub, LoadCache
 from pyjinhx.config import configure_pyjinhx, shutdown_pyjinhx
 
 

--- a/tests/61_depends_on_test.py
+++ b/tests/61_depends_on_test.py
@@ -3,8 +3,10 @@ from typing import ClassVar
 
 import pytest
 
-from pyjinhx import LoadCache, ReactiveComponent, Registry, Renderer, enable_reactive_dev, oob_swaps
-from pyjinhx.dev import disable_reactive_dev
+from pyjinhx import ReactiveComponent, Registry, Renderer
+from pyjinhx.cache import LoadCache
+from pyjinhx.dev import disable_reactive_dev, enable_reactive_dev
+from pyjinhx.reactive import oob_swaps
 from tests.ui.reactive.conditional_panel import ConditionalPanel  # noqa: F401
 from tests.ui.reactive.dynamic_widget import DynamicWidget
 from tests.ui.reactive.store import state

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,9 @@ from typing import Any
 
 import pytest
 
-from pyjinhx import CacheScope, Registry
+from pyjinhx import Registry
 from pyjinhx.assets import RenderSession
-from pyjinhx.cache import InvalidationHub, LoadCache
+from pyjinhx.cache import CacheScope, InvalidationHub, LoadCache
 from pyjinhx.client import ClientBackend
 from pyjinhx.config import shutdown_pyjinhx
 from pyjinhx.mutations import MutationTracker

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,12 @@ from typing import Any
 
 import pytest
 
-from pyjinhx import CacheScope, ClientBackend, LoadCache, MutationTracker, Registry, shutdown_pyjinhx
+from pyjinhx import CacheScope, Registry
 from pyjinhx.assets import RenderSession
-from pyjinhx.cache import InvalidationHub
+from pyjinhx.cache import InvalidationHub, LoadCache
+from pyjinhx.client import ClientBackend
+from pyjinhx.config import shutdown_pyjinhx
+from pyjinhx.mutations import MutationTracker
 
 
 def _noop_inject_runtime(

--- a/tests/integration/test_instance_keyed.py
+++ b/tests/integration/test_instance_keyed.py
@@ -5,7 +5,8 @@ import pytest
 
 from examples.reactive_todo import store
 from examples.reactive_todo.components import ItemRow
-from pyjinhx import PJX_MOUNTED_HEADER, Renderer
+from pyjinhx import Renderer
+from pyjinhx.client import PJX_MOUNTED_HEADER
 
 ROOT = Path(__file__).resolve().parents[2]
 

--- a/tests/integration/test_reactive_todo.py
+++ b/tests/integration/test_reactive_todo.py
@@ -5,7 +5,8 @@ import pytest
 
 from examples.reactive_todo import store
 from examples.reactive_todo.components import Counter, Total
-from pyjinhx import PJX_MOUNTED_HEADER, Renderer
+from pyjinhx import Renderer
+from pyjinhx.client import PJX_MOUNTED_HEADER
 
 ROOT = Path(__file__).resolve().parents[2]
 

--- a/tests/reactive_test_support.py
+++ b/tests/reactive_test_support.py
@@ -6,8 +6,8 @@ import json
 from collections.abc import Iterator
 from contextlib import contextmanager
 
-from pyjinhx import FastAPIClientBackend
 from pyjinhx.client import ClientBackend
+from pyjinhx.integrations.fastapi import FastAPIClientBackend
 from pyjinhx.mutations import MutationTracker
 
 

--- a/tests/ui/reactive/user_row.py
+++ b/tests/ui/reactive/user_row.py
@@ -1,12 +1,12 @@
 from typing import Annotated, ClassVar
 
-from pyjinhx import PjxLoad, ReactiveComponent
+from pyjinhx import PjxKey, ReactiveComponent
 
 names = {"1": "Alice", "2": "Bob", "3": "Carol"}
 
 
 class UserRow(ReactiveComponent):
-    user_key: Annotated[str, PjxLoad()]
+    user_key: Annotated[str, PjxKey()]
     name: str = ""
     reacts_to: ClassVar[set[str]] = {"users"}
 

--- a/uv.lock
+++ b/uv.lock
@@ -572,7 +572,7 @@ wheels = [
 
 [[package]]
 name = "pyjinhx"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Shrinks `pyjinhx`'s top-level public API from **45 symbols to 11** — just what you need to build an app — and makes the names/config consistent. Everything removed is still importable from its submodule for advanced use. **Breaking**, released as 0.7.3 (alpha). 316 tests pass; ruff clean; `mkdocs --strict` builds.

## The new surface (11)
| Group | Symbols |
|---|---|
| Components & rendering | `BaseComponent`, `ReactiveComponent`, `Renderer` |
| App wiring | `setup`, `Registry` |
| Reactive authoring | `mutates`, `MutationKey`, `PjxKey`, `PjxContext` |
| Configuration | `PjxSettings`, `AssetMode` |

## What changed (one commit each)
1. **Shrink 45 → 13** — drop ~32 internals from the top level (`oob_swaps`, `LoadCache`, `Invalidation*`, the manifest/header classes + constants, `ClientBackend`/`FastAPIClientBackend`, asset-resolver helpers, `Finder`/`Parser`/`Tag`, dev tooling, `configure_pyjinhx`/`shutdown_pyjinhx`/`pyjinhx_lifespan`). All remain importable from submodules.
2. **Renames** for clarity + a consistent `Pjx*` prefix: `PjxLoad → PjxKey`, `LoadContext → PjxContext`, `PyJinhxSettings → PjxSettings`, `StateKey → MutationKey`.
3. **Drop `client_script`** — the client runtime auto-injects on root renders; raw-shell users import it from `pyjinhx.client`.
4. **Derive the cache scope from the backend** — `cache_scope` / `CacheScope` / `PJX_LOAD_CACHE_SCOPE` are gone. Scope now follows whether a cross-worker invalidation backend (Redis) is configured: **backend → PROCESS** (cross-request, kept consistent across workers), **none → REQUEST** (per-request, the only multi-worker-safe default). This deletes a whole class of misconfiguration (the old backend-vs-scope warn-guard) and the `setup(settings=…)` merge footgun.

## Migration
- `from pyjinhx import PjxLoad, LoadContext, PyJinhxSettings, StateKey, CacheScope, client_script` → use the new names (`PjxKey`, `PjxContext`, `PjxSettings`, `MutationKey`); import `client_script` from `pyjinhx.client`; drop `CacheScope`.
- `setup(app, cache_scope=CacheScope.PROCESS, invalidation_backend=redis)` → `setup(app, invalidation_backend=redis)` (PROCESS is derived).
- Internals (`LoadCache`, `oob_swaps`, …): `from pyjinhx.<module> import …`.

A `tests/36_public_api_test.py` guard asserts the surface is exactly these 11 and that the internals stay importable from submodules.

## Verification
`uv run pytest` → 316 passed · `uv run ruff check .` → clean · `node --check pjx.js` → valid · `uv run mkdocs build --strict` → builds (no broken anchors) · example app serves and derives REQUEST scope with no backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)