### PR TITLE
feat: SQLite invalidation backend for single-host multi-worker setups

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.3
+current_version = 0.7.4
 commit = True
 tag = True
 message = Bump version: {current_version} → {new_version}

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -66,6 +66,7 @@ def from_env(cls) -> PjxSettings
 | Variable | Default | Effect |
 |----------|---------|--------|
 | `REDIS_URL` | unset | Auto-wire `RedisInvalidationBackend` (derives cross-request caching) |
+| `PJX_INVALIDATION_DB` | unset | Auto-wire `SqliteInvalidationBackend` from a SQLite file path (single-host; ignored if `REDIS_URL` is also set) |
 | `PJX_REACTIVE_DEV` | off | Enable dev guardrails when `1`/`true`/`yes` |
 
 ## configure_pyjinhx / shutdown_pyjinhx

--- a/docs/api/integrations-sqlite.md
+++ b/docs/api/integrations-sqlite.md
@@ -1,0 +1,69 @@
+# SQLite invalidation integration
+
+Reference `InvalidationBackend` for single-host multi-worker setups. Fans out `load()`-cache invalidation across worker processes using a shared SQLite file — no external service required. Configuring it also derives cross-request (per-worker) caching of `load()` results.
+
+Not exported from top-level `pyjinhx` — import from the integrations submodule:
+
+```python
+from pyjinhx.integrations.sqlite import SqliteInvalidationBackend
+```
+
+No optional dependencies needed — `sqlite3` is part of the Python standard library.
+
+## SqliteInvalidationBackend
+
+```python
+class SqliteInvalidationBackend(InvalidationBackend):
+    def __init__(
+        self,
+        db_path: str,
+        *,
+        channel: str = "pyjinhx:invalidate",
+        poll_interval: float = 0.5,
+        retention: float = 5.0,
+    ) -> None: ...
+```
+
+Writes dirtied keys to a shared SQLite event log so every worker on the same host evicts its local `load()` cache. Uses WAL mode and a background polling thread; no broker or network hop required.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `db_path` | *(required)* | Filesystem path to the SQLite database file. Must be a real file path — see caveats. |
+| `channel` | `"pyjinhx:invalidate"` | Namespaces apps that share one database file. |
+| `poll_interval` | `0.5` | Seconds between poll cycles. Invalidation latency is approximately this value. |
+| `retention` | `5.0` | Seconds of event history kept before pruning. Workers stalled longer than this may miss invalidations. |
+
+## With setup
+
+```python
+from pyjinhx import PjxSettings, setup
+from pyjinhx.integrations.sqlite import SqliteInvalidationBackend
+
+setup(
+    app,
+    settings=PjxSettings(
+        invalidation_backend=SqliteInvalidationBackend("/var/lib/myapp/pjx.db"),
+    ),
+    load_context_factory=...,
+)
+```
+
+Or via environment (`PjxSettings.from_env()`):
+
+```bash
+export PJX_INVALIDATION_DB=/var/lib/myapp/pjx.db
+```
+
+If both `REDIS_URL` and `PJX_INVALIDATION_DB` are set, Redis wins.
+
+## Caveats
+
+**Single-host only.** SQLite file locking is unreliable over network filesystems (NFS, CIFS, etc.). Use the Redis backend for multi-host deployments.
+
+**`:memory:` is unsupported.** Each process receives a private in-memory database, so there is no cross-process fan-out. Always pass a real file path.
+
+**WAL sidecar files.** SQLite WAL mode leaves `-wal` and `-shm` files next to the database. This is expected and normal.
+
+**Bounded staleness on long stalls.** A worker paused longer than `retention` seconds may miss pruned invalidation events, resulting in a bounded period of stale cached data. This is an accepted trade-off of the polling design.
+
+See [Configuration](config.md) and [Cache & Invalidation](cache-invalidation.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Client Backend: api/client-backend.md
       - Cache & Invalidation: api/cache-invalidation.md
       - Redis integration: api/integrations-redis.md
+      - SQLite integration: api/integrations-sqlite.md
       - Mutations, Keys & PjxContext: api/mutations-keys-context.md
       - Parser & Tag: api/parser.md
       - Assets API: api/assets-api.md

--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -26,10 +26,15 @@ class PjxSettings:
         }
         invalidation_backend: InvalidationBackend | None = None
         redis_url = os.environ.get("REDIS_URL")
+        sqlite_db = os.environ.get("PJX_INVALIDATION_DB")
         if redis_url:
             from pyjinhx.integrations.redis import RedisInvalidationBackend
 
             invalidation_backend = RedisInvalidationBackend(redis_url)
+        elif sqlite_db:
+            from pyjinhx.integrations.sqlite import SqliteInvalidationBackend
+
+            invalidation_backend = SqliteInvalidationBackend(sqlite_db)
         return cls(
             invalidation_backend=invalidation_backend,
             reactive_dev=reactive_dev,

--- a/pyjinhx/integrations/sqlite.py
+++ b/pyjinhx/integrations/sqlite.py
@@ -105,7 +105,11 @@ class SqliteInvalidationBackend(InvalidationBackend):
         self._thread.start()
         # Wait for the poll thread to seed its cursor before returning, so
         # callers can safely call publish() immediately after start().
-        self._ready_event.wait(timeout=5.0)
+        if not self._ready_event.wait(timeout=5.0):
+            logger.warning(
+                "SQLite invalidation poll thread did not become ready within 5 s; "
+                "the listener may be silently dead."
+            )
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -115,17 +119,29 @@ class SqliteInvalidationBackend(InvalidationBackend):
         self._handler = None
 
     def _poll_loop(self) -> None:
-        # Retry _connect until we get a clean connection or stop is requested.
-        # PRAGMA journal_mode=WAL requires an exclusive lock that busy_timeout
-        # does not cover; a brief retry loop bridges that gap.
+        # Retry transient lock errors (e.g. WAL setup races) until we get a
+        # clean connection or stop is requested.  Note: start() and publish()
+        # both call _connect() synchronously in the caller's thread, so a
+        # genuinely bad db_path (e.g. missing directory) is already surfaced
+        # loudly before the poll thread ever runs.  A persistent failure here
+        # (e.g. concurrent exclusive lock that never releases) will keep
+        # retrying until stop() is called, then log an error (see below).
         conn: sqlite3.Connection | None = None
+        _any_connect_failure = False
         while conn is None and not self._stop_event.is_set():
             try:
                 conn = _connect(self._db_path)
             except sqlite3.OperationalError:
+                _any_connect_failure = True
                 logger.debug("SQLite connect retry (database locked)", exc_info=True)
                 self._stop_event.wait(0.05)
         if conn is None:
+            if _any_connect_failure:
+                logger.error(
+                    "SQLite invalidation listener could not establish a connection "
+                    "to %r and will not receive any invalidations.",
+                    self._db_path,
+                )
             self._ready_event.set()
             return
         with closing(conn):

--- a/pyjinhx/integrations/sqlite.py
+++ b/pyjinhx/integrations/sqlite.py
@@ -1,0 +1,160 @@
+"""
+SQLite invalidation backend for single-host multi-worker CacheScope.PROCESS setups.
+
+Uses a shared SQLite file as a durable event log for cross-process load-cache
+invalidation fan-out. Zero external infrastructure (``sqlite3`` is stdlib). The
+trade-offs vs Redis: single-host only (SQLite locking is unreliable over network
+filesystems) and polling-based delivery.
+
+``:memory:`` is unsupported here — each process gets a private in-memory database,
+so there is no cross-process fan-out. Use a real file path. WAL mode leaves
+``-wal``/``-shm`` sidecar files next to the database; this is expected.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from contextlib import closing
+
+from pyjinhx.cache import InvalidationBackend
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CHANNEL = "pyjinhx:invalidate"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS pjx_invalidation (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    instance_id TEXT    NOT NULL,
+    channel     TEXT    NOT NULL,
+    keys_json   TEXT    NOT NULL,
+    created_at  REAL    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS ix_pjx_invalidation_created_at
+    ON pjx_invalidation (created_at);
+"""
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    """Open a connection with WAL + busy_timeout and ensure the schema exists."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.executescript(_SCHEMA)
+    return conn
+
+
+class SqliteInvalidationBackend(InvalidationBackend):
+    """SQLite event-log fan-out for ``invalidate()`` across single-host workers."""
+
+    def __init__(
+        self,
+        db_path: str,
+        *,
+        channel: str = DEFAULT_CHANNEL,
+        poll_interval: float = 0.5,
+        retention: float = 5.0,
+    ) -> None:
+        self._db_path = db_path
+        self._channel = channel
+        self._poll_interval = poll_interval
+        self._retention = retention
+        self._instance_id = uuid.uuid4().hex
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._ready_event = threading.Event()
+        self._handler: Callable[[frozenset[str]], None] | None = None
+
+    def publish(self, keys: frozenset[str]) -> None:
+        if not keys:
+            return
+        now = time.time()
+        payload = json.dumps(sorted(keys))
+        with closing(_connect(self._db_path)) as conn, conn:
+            conn.execute(
+                "INSERT INTO pjx_invalidation "
+                "(instance_id, channel, keys_json, created_at) VALUES (?, ?, ?, ?)",
+                (self._instance_id, self._channel, payload, now),
+            )
+            conn.execute(
+                "DELETE FROM pjx_invalidation WHERE created_at < ?",
+                (now - self._retention,),
+            )
+
+    def start(self, handler: Callable[[frozenset[str]], None]) -> None:
+        if self._thread is not None:
+            return
+        # Pre-initialise the schema from the calling thread so the poll
+        # thread's _connect() doesn't race with publish() on a brand-new file.
+        with closing(_connect(self._db_path)):
+            pass
+        self._handler = handler
+        self._stop_event.clear()
+        self._ready_event.clear()
+        self._thread = threading.Thread(
+            target=self._poll_loop,
+            name="pyjinhx-sqlite-invalidation",
+            daemon=True,
+        )
+        self._thread.start()
+        # Wait for the poll thread to seed its cursor before returning, so
+        # callers can safely call publish() immediately after start().
+        self._ready_event.wait(timeout=5.0)
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+        self._handler = None
+
+    def _poll_loop(self) -> None:
+        # Retry _connect until we get a clean connection or stop is requested.
+        # PRAGMA journal_mode=WAL requires an exclusive lock that busy_timeout
+        # does not cover; a brief retry loop bridges that gap.
+        conn: sqlite3.Connection | None = None
+        while conn is None and not self._stop_event.is_set():
+            try:
+                conn = _connect(self._db_path)
+            except sqlite3.OperationalError:
+                logger.debug("SQLite connect retry (database locked)", exc_info=True)
+                self._stop_event.wait(0.05)
+        if conn is None:
+            self._ready_event.set()
+            return
+        with closing(conn):
+            # seed cursor to the current tail so history is not replayed
+            cursor = conn.execute(
+                "SELECT COALESCE(MAX(id), 0) FROM pjx_invalidation"
+            ).fetchone()[0]
+            self._ready_event.set()
+            while not self._stop_event.wait(self._poll_interval):
+                try:
+                    rows = conn.execute(
+                        "SELECT id, keys_json FROM pjx_invalidation "
+                        "WHERE id > ? AND channel = ? AND instance_id != ? "
+                        "ORDER BY id",
+                        (cursor, self._channel, self._instance_id),
+                    ).fetchall()
+                    for row_id, keys_json in rows:
+                        cursor = row_id
+                        if self._handler is None:
+                            continue
+                        try:
+                            parsed = json.loads(keys_json)
+                        except json.JSONDecodeError:
+                            logger.warning(
+                                "Ignoring invalid invalidation payload: %r", keys_json
+                            )
+                            continue
+                        if not isinstance(parsed, list):
+                            continue
+                        self._handler(frozenset(str(key) for key in parsed))
+                except Exception:
+                    logger.exception("Error in SQLite invalidation poll loop")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyjinhx"
-version = "0.7.3"
+version = "0.7.4"
 description = "UI components for Python using Pydantic and Jinja2 templates"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/57_config_test.py
+++ b/tests/57_config_test.py
@@ -90,3 +90,26 @@ def test_explicit_kwarg_still_overrides_settings():
     )
     assert resolved.invalidation_backend is None
     assert LoadCache.scope() == CacheScope.REQUEST
+
+
+def test_from_env_with_sqlite_db(tmp_path):
+    from pyjinhx.integrations.sqlite import SqliteInvalidationBackend
+
+    db = str(tmp_path / "inval.db")
+    with patch.dict(os.environ, {"PJX_INVALIDATION_DB": db}, clear=True):
+        settings = PjxSettings.from_env()
+    assert isinstance(settings.invalidation_backend, SqliteInvalidationBackend)
+    configure_pyjinhx(settings)
+    assert LoadCache.scope() == CacheScope.PROCESS
+    shutdown_pyjinhx()
+
+
+def test_from_env_redis_wins_over_sqlite(tmp_path):
+    from pyjinhx.integrations.redis import RedisInvalidationBackend
+
+    db = str(tmp_path / "inval.db")
+    with patch.dict(
+        os.environ, {"REDIS_URL": "memory://", "PJX_INVALIDATION_DB": db}, clear=True
+    ):
+        settings = PjxSettings.from_env()
+    assert isinstance(settings.invalidation_backend, RedisInvalidationBackend)

--- a/tests/63_sqlite_invalidation_test.py
+++ b/tests/63_sqlite_invalidation_test.py
@@ -1,0 +1,164 @@
+import json
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from pyjinhx.integrations.sqlite import DEFAULT_CHANNEL, SqliteInvalidationBackend
+
+
+def test_publish_inserts_one_row(tmp_path):
+    db = str(tmp_path / "inval.db")
+    backend = SqliteInvalidationBackend(db)
+    backend.publish(frozenset({"widgets", "gadgets"}))
+    conn = sqlite3.connect(db)
+    rows = conn.execute("SELECT channel, keys_json FROM pjx_invalidation").fetchall()
+    conn.close()
+    assert len(rows) == 1
+    assert rows[0][0] == DEFAULT_CHANNEL
+    assert json.loads(rows[0][1]) == ["gadgets", "widgets"]
+
+
+def test_publish_empty_keys_is_noop(tmp_path):
+    db = tmp_path / "inval.db"
+    SqliteInvalidationBackend(str(db)).publish(frozenset())
+    assert not db.exists()
+
+
+def test_fanout_delivers_keys_to_other_instance(tmp_path):
+    db = str(tmp_path / "inval.db")
+    got: list[frozenset[str]] = []
+    received = threading.Event()
+
+    def handler(keys):
+        got.append(keys)
+        received.set()
+
+    publisher = SqliteInvalidationBackend(db, poll_interval=0.05)
+    listener = SqliteInvalidationBackend(db, poll_interval=0.05)
+    listener.start(handler)
+    try:
+        publisher.publish(frozenset({"widgets"}))
+        assert received.wait(timeout=3.0)
+        assert got == [frozenset({"widgets"})]
+    finally:
+        listener.stop()
+
+
+def test_publisher_does_not_receive_its_own_events(tmp_path):
+    db = str(tmp_path / "inval.db")
+    got: list[frozenset[str]] = []
+    backend = SqliteInvalidationBackend(db, poll_interval=0.05)
+    backend.start(got.append)
+    try:
+        backend.publish(frozenset({"widgets"}))
+        time.sleep(0.3)
+        assert got == []
+    finally:
+        backend.stop()
+
+
+def test_different_channels_are_isolated(tmp_path):
+    db = str(tmp_path / "inval.db")
+    got: list[frozenset[str]] = []
+    listener = SqliteInvalidationBackend(db, channel="app-a", poll_interval=0.05)
+    publisher = SqliteInvalidationBackend(db, channel="app-b", poll_interval=0.05)
+    listener.start(got.append)
+    try:
+        publisher.publish(frozenset({"widgets"}))
+        time.sleep(0.3)
+        assert got == []
+    finally:
+        listener.stop()
+
+
+def test_history_before_start_is_not_replayed(tmp_path):
+    db = str(tmp_path / "inval.db")
+    publisher = SqliteInvalidationBackend(db, poll_interval=0.05)
+    publisher.publish(frozenset({"old"}))
+    got: list[frozenset[str]] = []
+    received = threading.Event()
+
+    def handler(keys):
+        got.append(keys)
+        received.set()
+
+    listener = SqliteInvalidationBackend(db, poll_interval=0.05)
+    listener.start(handler)
+    try:
+        publisher.publish(frozenset({"new"}))
+        assert received.wait(timeout=3.0)
+        assert got == [frozenset({"new"})]
+    finally:
+        listener.stop()
+
+
+def test_publish_prunes_rows_older_than_retention(tmp_path):
+    db = str(tmp_path / "inval.db")
+    backend = SqliteInvalidationBackend(db, retention=60.0)
+    backend.publish(frozenset({"fresh"}))
+    conn = sqlite3.connect(db)
+    with conn:
+        conn.execute(
+            "INSERT INTO pjx_invalidation "
+            "(instance_id, channel, keys_json, created_at) VALUES (?, ?, ?, ?)",
+            ("other", DEFAULT_CHANNEL, '["stale"]', 0.0),
+        )
+    conn.close()
+    backend.publish(frozenset({"trigger"}))
+    conn = sqlite3.connect(db)
+    payloads = [r[0] for r in conn.execute(
+        "SELECT keys_json FROM pjx_invalidation ORDER BY id"
+    ).fetchall()]
+    conn.close()
+    assert '["stale"]' not in payloads
+    assert '["fresh"]' in payloads
+    assert '["trigger"]' in payloads
+
+
+def test_start_twice_is_a_noop(tmp_path):
+    db = str(tmp_path / "inval.db")
+    backend = SqliteInvalidationBackend(db, poll_interval=0.05)
+    backend.start(lambda keys: None)
+    first_thread = backend._thread
+    backend.start(lambda keys: None)
+    try:
+        assert backend._thread is first_thread
+    finally:
+        backend.stop()
+
+
+def test_stop_is_idempotent(tmp_path):
+    db = str(tmp_path / "inval.db")
+    backend = SqliteInvalidationBackend(db, poll_interval=0.05)
+    backend.start(lambda keys: None)
+    backend.stop()
+    backend.stop()
+    assert backend._thread is None
+
+
+from pyjinhx.cache import CacheScope, InvalidationHub, LoadCache
+from tests.ui.reactive.cached_widget import CachedWidget, load_calls
+
+
+def test_sqlite_invalidate_evicts_process_cache(tmp_path):
+    db = str(tmp_path / "inval.db")
+    LoadCache.clear()
+    load_calls["count"] = 0
+    original_scope = LoadCache.scope()
+    try:
+        LoadCache.set_scope(CacheScope.PROCESS)
+        backend = SqliteInvalidationBackend(db, poll_interval=0.05)
+        InvalidationHub.set_backend(backend)
+        InvalidationHub.start_listener()
+        CachedWidget.load()
+        assert load_calls["count"] == 1
+        LoadCache.invalidate({"widgets"})
+        load_calls["count"] = 0
+        CachedWidget.load()
+        assert load_calls["count"] == 1
+    finally:
+        InvalidationHub.stop_listener()
+        InvalidationHub.reset()
+        LoadCache.set_scope(original_scope)

--- a/tests/63_sqlite_invalidation_test.py
+++ b/tests/63_sqlite_invalidation_test.py
@@ -3,9 +3,9 @@ import sqlite3
 import threading
 import time
 
-import pytest
-
+from pyjinhx.cache import CacheScope, InvalidationHub, LoadCache
 from pyjinhx.integrations.sqlite import DEFAULT_CHANNEL, SqliteInvalidationBackend
+from tests.ui.reactive.cached_widget import CachedWidget, load_calls
 
 
 def test_publish_inserts_one_row(tmp_path):
@@ -136,10 +136,6 @@ def test_stop_is_idempotent(tmp_path):
     backend.stop()
     backend.stop()
     assert backend._thread is None
-
-
-from pyjinhx.cache import CacheScope, InvalidationHub, LoadCache
-from tests.ui.reactive.cached_widget import CachedWidget, load_calls
 
 
 def test_sqlite_invalidate_evicts_process_cache(tmp_path):


### PR DESCRIPTION
## Summary

Adds `SqliteInvalidationBackend` — a second concrete `InvalidationBackend` alongside `RedisInvalidationBackend` — that fans out `load()`-cache invalidation across **worker processes on a single host** using a shared SQLite file, with **zero external infrastructure** (`sqlite3` is stdlib).

- **`pyjinhx/integrations/sqlite.py`** — `publish()` appends an event row to a shared SQLite file and prunes past the retention window; a daemon thread polls for new rows and invokes the handler. Mirrors the Redis sibling's lifecycle/logging. Properties: per-worker cursor seeding (no history replay), self-event skip via `instance_id` (removes the double-eviction the Redis backend has), `channel` isolation, WAL + `busy_timeout`, a `start()` readiness handshake so a `publish()` immediately after `start()` is never missed, and surfaced logging when a listener can't connect.
- **`pyjinhx/config.py`** — `from_env` auto-wires the backend from `PJX_INVALIDATION_DB`. If both `REDIS_URL` and `PJX_INVALIDATION_DB` are set, **Redis wins** (multi-host superset). Scope still derives from backend presence — no new scope knob.
- **Docs** — new `docs/api/integrations-sqlite.md` (+ nav), and `PJX_INVALIDATION_DB` added to the `from_env` env-var table in `config.md`.

**Scope boundary:** single-host only (SQLite locking is unreliable over network filesystems — use Redis for multi-host); `:memory:` is unsupported (private per-process DB → no fan-out). Both documented. The curated public API is unchanged — the backend is reachable only via `pyjinhx.integrations.sqlite`.

## Test Plan

- [x] `tests/63_sqlite_invalidation_test.py` (10 tests): publish writes row / empty no-op, cross-instance fan-out, self-skip, channel isolation, no history replay, retention pruning, start/stop idempotency, `InvalidationHub` integration under `CacheScope.PROCESS`.
- [x] `tests/57_config_test.py`: `PJX_INVALIDATION_DB` auto-wiring + Redis-precedence.
- [x] Full suite green (328 passed); no flakiness across repeated threaded-test runs.
- [x] `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)