### PR TITLE
Add builtin-import hint to tag errors and fix generic-fallback docs

### DIFF
--- a/docs/guide/builtins.md
+++ b/docs/guide/builtins.md
@@ -31,7 +31,7 @@ from pyjinhx.builtins import (
 
 **Conventions:** Markup classes use the **`px-`** prefix; overrides use **`--px-`** custom properties. Builtin CSS also references **theme variables** (`--surface`, `--border`, `--text`, `--radius-md`, `--shadow-md`, `--transition`, `--brand`, …)—define those in your global CSS or map them to your design system.
 
-**Template discovery:** Builtins ship inside `site-packages`. If your Jinja loader only covers your app tree, the renderer **falls back** to adjacent package templates for `pyjinhx.builtins` classes. Each component's Jinja template lives next to its Python source in `pyjinhx/builtins/ui/<component>/` (e.g. `pyjinhx/builtins/ui/modal/modal.html`).
+**Template discovery:** Builtins ship inside `site-packages`, not under your app's Jinja loader root, so PascalCase tags do **not** auto-discover them — `<Tooltip/>` raises a `FileNotFoundError` unless the class was imported once at startup (`import pyjinhx.builtins` or any of the imports above), which registers it. For registered builtin classes, the renderer **falls back** to adjacent package templates: each component's Jinja template lives next to its Python source in `pyjinhx/builtins/ui/<component>/` (e.g. `pyjinhx/builtins/ui/modal/modal.html`).
 
 **Inherited fields:** Every component inherits **`id`** (required), **`js`** / **`css`** (extra asset paths), **`render()`**, and **`__html__()`** from [`BaseComponent`](../api/base-component.md). Because `id` is universal it is omitted from the per-component props tables below. `extra="allow"` lets you pass additional kwargs into the Jinja context.
 

--- a/docs/guide/tags.md
+++ b/docs/guide/tags.md
@@ -105,8 +105,11 @@ html = renderer.render('<Button text="Save"/>')  # Validated using Button
 If no class is registered, PyJinHx falls back to a generic `BaseComponent` and renders using the auto-discovered template. All tag attributes become template context variables. No Pydantic validation is applied.
 
 ```python
-html = renderer.render('<Alert kind="warning">Be careful</Alert>')
+html = renderer.render('<Hint kind="warning">Be careful</Hint>')
 ```
+
+!!! note "Builtins are not auto-discovered"
+    The fallback only searches under your Jinja loader root, so it does **not** cover [built-in components](builtins.md) — their templates ship inside the pyjinhx package. Using `<Tooltip/>` (or any builtin) as a tag requires importing it once at startup (`from pyjinhx.builtins import Tooltip` or `import pyjinhx.builtins`), which registers the class. Otherwise rendering raises a `FileNotFoundError` telling you which import to add.
 
 The generic-fallback instance is **removed from the registry** after rendering, so it cannot be cross-referenced by other templates (unlike a registered-class instance).
 

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -176,6 +176,47 @@ if TYPE_CHECKING:
     from .renderer import Renderer
 
 
+# Kept in sync with pyjinhx.builtins.__all__ by a test. Listed here instead of
+# imported so the error path doesn't register every builtin as a side effect.
+_BUILTIN_TAG_NAMES = frozenset(
+    {
+        "Alert",
+        "Avatar",
+        "Badge",
+        "Breadcrumb",
+        "Card",
+        "Divider",
+        "Dropdown",
+        "Drawer",
+        "EmptyState",
+        "LoadingOverlay",
+        "Modal",
+        "Notification",
+        "Popover",
+        "Progress",
+        "Panel",
+        "PanelTrigger",
+        "Skeleton",
+        "Spinner",
+        "TabGroup",
+        "Tooltip",
+    }
+)
+
+
+def _missing_template_error(tag_name: str) -> FileNotFoundError:
+    if tag_name in _BUILTIN_TAG_NAMES:
+        return FileNotFoundError(
+            f"<{tag_name}> is a pyjinhx builtin but its class isn't registered. "
+            f"Add `from pyjinhx.builtins import {tag_name}` "
+            f"(or `import pyjinhx.builtins`) once at app startup so the tag resolves."
+        )
+    return FileNotFoundError(
+        f"No template found for <{tag_name}>. "
+        f"Expected {tag_name.lower()}.html or {tag_name.lower()}.jinja"
+    )
+
+
 def render_tag_node(
     renderer: Renderer,
     node: Tag | str,
@@ -252,10 +293,7 @@ def render_tag_node(
         )
     else:
         if template_path is None:
-            raise FileNotFoundError(
-                f"No template found for <{node.name}>. "
-                f"Expected {node.name.lower()}.html or {node.name.lower()}.jinja"
-            )
+            raise _missing_template_error(node.name)
         from .base import BaseComponent
 
         component = BaseComponent(

--- a/tests/15_template_and_engine_errors_test.py
+++ b/tests/15_template_and_engine_errors_test.py
@@ -4,6 +4,7 @@ from jinja2.exceptions import TemplateNotFound
 
 from pyjinhx import BaseComponent
 from pyjinhx.renderer import Renderer
+from pyjinhx.tags import _BUILTIN_TAG_NAMES, _missing_template_error
 
 
 def test_missing_template_file():
@@ -33,3 +34,24 @@ def test_non_filesystem_loader_error():
         component.render()
 
     Renderer.set_default_environment(original_environment)
+
+
+def test_missing_template_error_hints_at_builtin_import():
+    error = _missing_template_error("Tooltip")
+
+    assert isinstance(error, FileNotFoundError)
+    assert "from pyjinhx.builtins import Tooltip" in str(error)
+
+
+def test_missing_template_error_keeps_legacy_message():
+    error = _missing_template_error("UserCard")
+
+    assert str(error) == (
+        "No template found for <UserCard>. Expected usercard.html or usercard.jinja"
+    )
+
+
+def test_builtin_tag_names_match_builtins_all():
+    import pyjinhx.builtins
+
+    assert _BUILTIN_TAG_NAMES == frozenset(pyjinhx.builtins.__all__)


### PR DESCRIPTION
## Summary
- `<Tooltip/>` (or any of the twenty `pyjinhx.builtins` names) used as a tag without importing the builtin now raises a `FileNotFoundError` that points at the missing `from pyjinhx.builtins import Tooltip` import instead of suggesting a `tooltip.html` template. Non-builtin tags keep the exact existing message and the exception type is unchanged.
- The builtin names live in a module-level `_BUILTIN_TAG_NAMES` frozenset in `tags.py` (kept in sync with `pyjinhx.builtins.__all__` by a test) so the error path never imports `pyjinhx.builtins` — importing it would register every builtin as a side effect and make the failing tag mysteriously succeed on the next render.
- The "Generic fallback" example in `docs/guide/tags.md` used `<Alert>` — a builtin name that hits exactly this trap — so it now uses a non-builtin tag, plus a note that builtins are not auto-discovered and must be imported once at startup.
- The "Template discovery" paragraph in `docs/guide/builtins.md` now states the contract explicitly: builtin templates ship inside the package, tags only resolve once the class is imported/registered, and the in-package template fallback applies to registered builtin classes.

Closes #8
Closes #9

## Test plan
- `uv run pytest tests/ -q` — 331 passed (3 new: builtin hint, legacy message unchanged, frozenset/`__all__` sync)
- `uv run ruff check .` — all checks passed
- `uv run mkdocs build --strict` — exit 0, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)