### PR TITLE
Reference-count LoadingOverlay show/hide

### DIFF
--- a/docs/guide/builtins.md
+++ b/docs/guide/builtins.md
@@ -141,12 +141,13 @@ This component declares no extra fields beyond the inherited `id`.
 
 **Layout:** Overlay is `position: absolute; inset: 0`. Parent must be **`position: relative`** (or any non-`static` value) so coverage is correct.
 
-Globals from **`loading-overlay.js`**:
+Globals from **`loading-overlay.js`**. Show/hide are **reference-counted per `id`**, so overlapping async operations are safe: the overlay stays visible until every `show` is matched by a `hide`.
 
 | Function | Description |
 | --- | --- |
-| `showLoadingOverlay(id)` | Removes `px-loading-overlay--hiding`, adds `px-loading-overlay--visible`. |
-| `hideLoadingOverlay(id)` | Adds `px-loading-overlay--hiding`; on `animationend` clears visible/hiding classes. |
+| `showLoadingOverlay(id)` | Increments the count; on 0 → 1 removes `px-loading-overlay--hiding` and adds `px-loading-overlay--visible`. |
+| `hideLoadingOverlay(id)` | Decrements the count (floor 0); on 1 → 0 adds `px-loading-overlay--hiding`, then `animationend` clears both state classes. |
+| `resetLoadingOverlay(id)` | Zeroes the count and clears both state classes immediately (no animation) — escape hatch for stranded counts, e.g. a missed `hide` on an error path or htmx history back-navigation. |
 
 **Classes:** `px-loading-overlay`; state `px-loading-overlay--visible`, `px-loading-overlay--hiding`; `px-loading-overlay__spinner`. Spinner ring uses **`var(--radius-full)`** from your theme. Theming: see [appendix](#loadingoverlay-1).
 

--- a/pyjinhx/builtins/ui/loading_overlay/loading-overlay.js
+++ b/pyjinhx/builtins/ui/loading_overlay/loading-overlay.js
@@ -1,15 +1,43 @@
-function showLoadingOverlay(id) {
-    const overlay = document.getElementById(id);
-    if (!overlay) return;
-    overlay.classList.remove('px-loading-overlay--hiding');
-    overlay.classList.add('px-loading-overlay--visible');
-}
+(function () {
+    if (window.showLoadingOverlay) return;
 
-function hideLoadingOverlay(id) {
-    const overlay = document.getElementById(id);
-    if (!overlay) return;
-    overlay.classList.add('px-loading-overlay--hiding');
-    overlay.addEventListener('animationend', () => {
+    const counts = new Map();
+
+    // Only strip classes while a hide is genuinely in progress; a stale
+    // animationend (e.g. the fade-in after a cancelled hide) must be a no-op.
+    function finishHide(e) {
+        if (!e.target.classList.contains('px-loading-overlay--hiding')) return;
+        e.target.classList.remove('px-loading-overlay--visible', 'px-loading-overlay--hiding');
+    }
+
+    window.showLoadingOverlay = function (id) {
+        const overlay = document.getElementById(id);
+        if (!overlay) return;
+        const count = counts.get(id) || 0;
+        counts.set(id, count + 1);
+        if (count > 0) return;
+        overlay.classList.remove('px-loading-overlay--hiding');
+        overlay.classList.add('px-loading-overlay--visible');
+    };
+
+    window.hideLoadingOverlay = function (id) {
+        const overlay = document.getElementById(id);
+        if (!overlay) return;
+        const count = counts.get(id) || 0;
+        if (count === 0) return;
+        if (count > 1) {
+            counts.set(id, count - 1);
+            return;
+        }
+        counts.delete(id);
+        overlay.classList.add('px-loading-overlay--hiding');
+        overlay.addEventListener('animationend', finishHide);
+    };
+
+    window.resetLoadingOverlay = function (id) {
+        counts.delete(id);
+        const overlay = document.getElementById(id);
+        if (!overlay) return;
         overlay.classList.remove('px-loading-overlay--visible', 'px-loading-overlay--hiding');
-    }, { once: true });
-}
+    };
+}());


### PR DESCRIPTION
## Summary
- `showLoadingOverlay`/`hideLoadingOverlay` now reference-count per id via a `Map`: show adds the visible class only on 0 → 1 (cancelling any in-progress hide), hide decrements with a floor of 0 and starts the hide animation only on 1 → 0, so overlapping async operations no longer dismiss the overlay early. Entries are deleted at 0 so the map doesn't grow.
- New `resetLoadingOverlay(id)` escape hatch: zeroes the count and force-clears both state classes with no animation, for stranded counts (missed `hide` on an error path, htmx history back-navigation).
- Wrapped in an IIFE that bails if already installed and assigns the three functions onto `window`, so re-executing the inlined script after an htmx fragment re-ships it is a no-op and the live count map survives. Public call signatures are unchanged.
- Fixed the stale `animationend` hazard: the old `{ once: true }` listener stayed armed when a show cancelled the hide mid-animation (`animationcancel` fires, `animationend` never does) and would strip `--visible` when the next fade-in's `animationend` arrived. The handler is now a single named listener (browser dedupes repeat adds) that only strips classes while `px-loading-overlay--hiding` is genuinely present.
- Documented the ref-counted semantics and `resetLoadingOverlay` in the builtins guide.

## Test plan
- `uv run pytest tests/ -q` — 328 passed.
- `uv run ruff check .` — all checks passed.
- `uv run mkdocs build --strict` — exit 0.
- `node --check pyjinhx/builtins/ui/loading_overlay/loading-overlay.js` — clean.
- Exercised the state machine in plain node with a throwaway classList/listener stub mirroring browser semantics (listener dedupe by function reference, `animationend` dispatch with `e.target`, cancelled animations firing no `animationend`): overlapping show/show/hide/hide, hide at 0, show-mid-hide followed by the restarted fade-in's `animationend` (must not strip `--visible` — verified against `loading-overlay.css`, where the visible state animates too), bubbled child `animationend`, reset from a deep count, script re-execution preserving the count, and missing elements. 17/17 scenarios passed; the stub was not committed.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)