### PR TITLE
Builtins v2 core: auto-id, tag coercion, autodiscovery warnings, golden harness

### DIFF
--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 from typing import Any, Optional
 
@@ -10,6 +11,13 @@ from .assets import RenderSession
 
 logger = logging.getLogger("pyjinhx")
 logger.setLevel(logging.WARNING)
+
+_auto_id_counter = itertools.count(1)
+
+
+def _auto_id() -> str:
+    """Generate a process-unique component id (``px-<n>``)."""
+    return f"px-{next(_auto_id_counter)}"
 
 
 class NestedComponentWrapper(BaseModel):
@@ -43,7 +51,10 @@ class BaseComponent(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    id: str = Field(..., description="The unique ID for this component.")
+    id: str = Field(
+        default_factory=_auto_id,
+        description="The unique ID for this component. Auto-generated when omitted.",
+    )
     js: list[str] = Field(
         default_factory=list,
         description="List of paths to extra JavaScript files to include.",
@@ -56,7 +67,7 @@ class BaseComponent(BaseModel):
     @field_validator("id", mode="before")
     def validate_id(cls, v: object) -> str:
         if not v:
-            raise ValueError("ID is required")
+            return _auto_id()
         return str(v)
 
     def __init_subclass__(cls, **kwargs: Any) -> None:

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -7,7 +7,6 @@ import logging
 import os
 import re
 import sys
-import uuid
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from typing import TYPE_CHECKING, Any, ClassVar

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -246,7 +246,9 @@ def render_tag_node(
             raise ValueError(
                 f'Missing required "id" for <{node.name}> and auto_id=False'
             )
-        component_id = f"{node.name.lower()}-{uuid.uuid4().hex}"
+        from .base import _auto_id
+
+        component_id = _auto_id()
 
     attrs_without_id = {k: v for k, v in node.attrs.items() if k != "id"}
 
@@ -269,7 +271,9 @@ def render_tag_node(
         updates: dict[str, Any] = dict(attrs_without_id)
         if rendered_children:
             updates["content"] = rendered_children
-        existing_instance = existing_instance.model_copy(update=updates)
+        existing_instance = type(existing_instance).model_validate(
+            {**existing_instance.model_dump(), **updates}
+        )
         Registry.get_instances()[registry_key] = existing_instance
 
         return str(

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -145,7 +145,12 @@ class ComponentAutodiscover:
             )
             spec.loader.exec_module(module)
         except Exception:
-            logger.debug("Failed to autodiscover module at %s", filepath, exc_info=True)
+            logger.warning(
+                "Autodiscovery import failed for %s; the tag will fall back to "
+                "BaseComponent and class defaults will not apply.",
+                filepath,
+                exc_info=True,
+            )
 
     @classmethod
     def try_for_tag(cls, tag_name: str, template_path: str | None) -> None:
@@ -175,6 +180,8 @@ if TYPE_CHECKING:
     from .assets import RenderSession
     from .renderer import Renderer
 
+
+_warned_unregistered_tags: set[str] = set()
 
 # Kept in sync with pyjinhx.builtins.__all__ by a test. Listed here instead of
 # imported so the error path doesn't register every builtin as a side effect.
@@ -300,6 +307,17 @@ def render_tag_node(
         if template_path is None:
             raise _missing_template_error(node.name)
         from .base import BaseComponent
+
+        component_dir = os.path.dirname(template_path)
+        snake_name = pascal_case_to_snake_case(node.name)
+        sibling_py = os.path.join(component_dir, f"{snake_name}.py")
+        if os.path.exists(sibling_py) and node.name not in _warned_unregistered_tags:
+            _warned_unregistered_tags.add(node.name)
+            logger.warning(
+                "Template found for <%s> but class %s is not registered — "
+                "defaults won't apply. Import the module defining %s at app startup.",
+                node.name, node.name, node.name,
+            )
 
         component = BaseComponent(
             id=component_id,

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -122,8 +122,9 @@ class ComponentAutodiscover:
 
     @classmethod
     def clear(cls) -> None:
-        """Drop the deduplication set. Mainly for tests."""
+        """Drop the deduplication sets. Mainly for tests."""
         cls._imported_files.clear()
+        _warned_unregistered_tags.clear()
 
     @classmethod
     def import_from_file(cls, filepath: str) -> None:
@@ -277,10 +278,13 @@ def render_tag_node(
         updates: dict[str, Any] = dict(attrs_without_id)
         if rendered_children:
             updates["content"] = rendered_children
-        existing_instance = type(existing_instance).model_validate(
-            {**existing_instance.model_dump(), **updates}
-        )
-        Registry.get_instances()[registry_key] = existing_instance
+        if updates:
+            updated_instance = existing_instance.model_copy()
+            validator = type(existing_instance).__pydantic_validator__
+            for field_name, field_value in updates.items():
+                validator.validate_assignment(updated_instance, field_name, field_value)
+            existing_instance = updated_instance
+            Registry.get_instances()[registry_key] = existing_instance
 
         return str(
             existing_instance._render(

--- a/tests/14_id_validation_test.py
+++ b/tests/14_id_validation_test.py
@@ -1,13 +1,13 @@
-import pytest
+import re
 
 from tests.ui.unified_component import UnifiedComponent
 
 
-def test_invalid_empty_id():
-    with pytest.raises(ValueError, match="ID is required"):
-        UnifiedComponent(id="", text="Test")
+def test_empty_id_autogenerates():
+    comp = UnifiedComponent(id="", text="Test")
+    assert re.fullmatch(r"px-\d+", comp.id)
 
 
-def test_invalid_none_id():
-    with pytest.raises(ValueError, match="ID is required"):
-        UnifiedComponent(id=None, text="Test")
+def test_none_id_autogenerates():
+    comp = UnifiedComponent(id=None, text="Test")
+    assert re.fullmatch(r"px-\d+", comp.id)

--- a/tests/20_html_tag_renderer_test.py
+++ b/tests/20_html_tag_renderer_test.py
@@ -23,7 +23,7 @@ def test_custom_html():
             auto_id=True,
         ).render(index_html)
 
-        expected_pattern = r"^<div id=container-[a-f0-9]{32}>\n  <span id=message-[a-f0-9]{32}>Hello Paulo!</span>\n</div>$"
+        expected_pattern = r"^<div id=px-\d+>\n  <span id=px-\d+>Hello Paulo!</span>\n</div>$"
         assert re.match(expected_pattern, rendered), (
             f"Output does not match expected pattern. Got: {rendered!r}"
         )
@@ -47,7 +47,7 @@ def test_deep_nesting():
         ).render(index_html)
 
         assert re.match(
-            r"^<section id=outer-[a-f0-9]{32} class=wrapper>\n  <div id=middle-[a-f0-9]{32}>\n  <p id=inner-[a-f0-9]{32}>Deep nesting works!</p>\n</div>\n</section>$",
+            r"^<section id=px-\d+ class=wrapper>\n  <div id=px-\d+>\n  <p id=px-\d+>Deep nesting works!</p>\n</div>\n</section>$",
             rendered,
         ), f"Output does not match expected pattern. Got: {rendered!r}"
 
@@ -68,7 +68,7 @@ def test_multiple_children():
         ).render(index_html)
 
         assert re.match(
-            r"^<ul id=list-[a-f0-9]{32}>\n  <li id=item-[a-f0-9]{32}>First</li><li id=item-[a-f0-9]{32}>Second</li><li id=item-[a-f0-9]{32}>Third</li>\n</ul>$",
+            r"^<ul id=px-\d+>\n  <li id=px-\d+>First</li><li id=px-\d+>Second</li><li id=px-\d+>Third</li>\n</ul>$",
             rendered,
         ), f"Output does not match expected pattern. Got: {rendered!r}"
 
@@ -89,7 +89,7 @@ def test_mixed_content_and_components():
         ).render(index_html)
 
         assert re.match(
-            r"^<div id=frame-[a-f0-9]{32} class=card>\n  Before <button id=actionbutton-[a-f0-9]{32}>Click Me</button> After\n</div>$",
+            r"^<div id=px-\d+ class=card>\n  Before <button id=px-\d+>Click Me</button> After\n</div>$",
             rendered,
         ), f"Output does not match expected pattern. Got: {rendered!r}"
 
@@ -129,7 +129,7 @@ def test_complex_attributes():
         ).render(index_html)
 
         assert re.match(
-            r"^<input id=input-[a-f0-9]{32} type=text name=username placeholder=Enter username required=true/>$",
+            r"^<input id=px-\d+ type=text name=username placeholder=Enter username required=true/>$",
             rendered,
         ), f"Output does not match expected pattern. Got: {rendered!r}"
 
@@ -146,7 +146,7 @@ def test_empty_component():
         ).render(index_html)
 
         assert re.match(
-            r"^<div id=spacer-[a-f0-9]{32} class=spacer></div>$", rendered
+            r"^<div id=px-\d+ class=spacer></div>$", rendered
         ), f"Output does not match expected pattern. Got: {rendered!r}"
 
 
@@ -203,7 +203,7 @@ def test_renderer_uses_registered_class():
         ).render(index_html)
 
         assert re.match(
-            r'^<button id="button-[a-f0-9]{32}" class="btn btn-primary">Click me</button>$',
+            r'^<button id="px-\d+" class="btn btn-primary">Click me</button>$',
             rendered,
         ), f"Output does not match expected pattern. Got: {rendered!r}"
 
@@ -221,7 +221,7 @@ def test_renderer_fallback_to_generic_when_class_not_found():
         ).render(index_html)
 
         assert re.match(
-            r'^<div id="custom-[a-f0-9]{32}" class="test">Some content</div>$', rendered
+            r'^<div id="px-\d+" class="test">Some content</div>$', rendered
         ), f"Output does not match expected pattern. Got: {rendered!r}"
 
 
@@ -254,7 +254,7 @@ def test_renderer_with_registered_class_and_nested_components():
         ).render(index_html)
 
         assert re.match(
-            r'^<div id="albumcard-[a-f0-9]{32}" class="card">\n  <h2>My Card</h2>\n  <button id="albumbutton-[a-f0-9]{32}">Action</button>\n</div>$',
+            r'^<div id="px-\d+" class="card">\n  <h2>My Card</h2>\n  <button id="px-\d+">Action</button>\n</div>$',
             rendered,
         ), f"Output does not match expected pattern. Got: {rendered!r}"
 
@@ -281,7 +281,7 @@ def test_renderer_with_registered_class_validation():
         ).render(index_html)
 
         assert re.match(
-            r'^<input id="input-[a-f0-9]{32}" type="text" name="username" placeholder="Enter username"/>$',
+            r'^<input id="px-\d+" type="text" name="username" placeholder="Enter username"/>$',
             rendered,
         ), f"Output does not match expected pattern. Got: {rendered!r}"
 
@@ -306,6 +306,6 @@ def test_renderer_mixed_registered_and_generic():
         ).render(index_html)
 
         assert re.match(
-            r'^<header id="header-[a-f0-9]{32}"><h1>My Site</h1></header><footer id="footer-[a-f0-9]{32}">Copyright 2024</footer>$',
+            r'^<header id="px-\d+"><h1>My Site</h1></header><footer id="px-\d+">Copyright 2024</footer>$',
             rendered,
         ), f"Output does not match expected pattern. Got: {rendered!r}"

--- a/tests/66_auto_id_test.py
+++ b/tests/66_auto_id_test.py
@@ -1,0 +1,33 @@
+import re
+
+from pyjinhx import BaseComponent
+from pyjinhx.builtins import Badge
+
+
+def test_constructor_without_id_autogenerates():
+    badge = Badge(label="hi")
+    assert re.fullmatch(r"px-\d+", badge.id)
+
+
+def test_constructor_with_empty_id_autogenerates():
+    badge = Badge(id="", label="hi")
+    assert re.fullmatch(r"px-\d+", badge.id)
+
+
+def test_explicit_id_is_kept():
+    badge = Badge(id="my-badge", label="hi")
+    assert badge.id == "my-badge"
+
+
+def test_auto_ids_are_unique():
+    a = Badge(label="a")
+    b = Badge(label="b")
+    assert a.id != b.id
+
+
+def test_subclass_inherits_auto_id():
+    class AutoIdProbe(BaseComponent):
+        pass
+
+    probe = AutoIdProbe()
+    assert re.fullmatch(r"px-\d+", probe.id)

--- a/tests/67_tag_coercion_test.py
+++ b/tests/67_tag_coercion_test.py
@@ -1,0 +1,49 @@
+import re
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+from pydantic import ValidationError
+
+from pyjinhx import BaseComponent, Renderer
+
+
+class CoercionProbe(BaseComponent):
+    count: int = 0
+    enabled: bool = False
+
+
+PROBE_TEMPLATE = '<span id="{{ id }}">{{ count }}|{{ enabled }}</span>'
+
+
+def test_tag_attrs_coerce_to_int_and_bool(tmp_path):
+    (tmp_path / "coercion_probe.html").write_text(PROBE_TEMPLATE)
+    env = Environment(loader=FileSystemLoader(str(tmp_path)))
+    renderer = Renderer(env)
+    html = renderer.render('<CoercionProbe id="p1" count="32" enabled="true"/>')
+    assert ">32|True<" in html
+
+
+def test_tag_without_id_uses_px_format(tmp_path):
+    (tmp_path / "coercion_probe.html").write_text(PROBE_TEMPLATE)
+    env = Environment(loader=FileSystemLoader(str(tmp_path)))
+    renderer = Renderer(env)
+    html = renderer.render('<CoercionProbe count="1"/>')
+    assert re.search(r'id="px-\d+"', html)
+
+
+def test_instance_reuse_update_is_validated(tmp_path):
+    (tmp_path / "coercion_probe.html").write_text(PROBE_TEMPLATE)
+    env = Environment(loader=FileSystemLoader(str(tmp_path)))
+    renderer = Renderer(env)
+    CoercionProbe(id="reuse-1", count=1)
+    html = renderer.render('<CoercionProbe id="reuse-1" count="7"/>')
+    assert ">7|" in html
+
+
+def test_instance_reuse_invalid_update_raises(tmp_path):
+    (tmp_path / "coercion_probe.html").write_text(PROBE_TEMPLATE)
+    env = Environment(loader=FileSystemLoader(str(tmp_path)))
+    renderer = Renderer(env)
+    CoercionProbe(id="reuse-2", count=1)
+    with pytest.raises(ValidationError):
+        renderer.render('<CoercionProbe id="reuse-2" count="not-a-number"/>')

--- a/tests/67_tag_coercion_test.py
+++ b/tests/67_tag_coercion_test.py
@@ -47,3 +47,20 @@ def test_instance_reuse_invalid_update_raises(tmp_path):
     CoercionProbe(id="reuse-2", count=1)
     with pytest.raises(ValidationError):
         renderer.render('<CoercionProbe id="reuse-2" count="not-a-number"/>')
+
+
+def test_instance_reuse_preserves_nested_components(tmp_path):
+    from pyjinhx.builtins import Badge, Card
+
+    (tmp_path / "unused_probe.html").write_text("<i></i>")
+    original_environment = Renderer.peek_default_environment()
+    try:
+        Renderer.set_default_environment(str(tmp_path))
+        renderer = Renderer.get_default_renderer()
+        Card(id="c1", body=Badge(id="b1", label="hi"))
+        html = renderer.render('<Card id="c1" title="X"/>')
+        assert "hi" in html          # Badge subclass state survived the reuse update
+        assert "px-badge" in html    # it rendered as a Badge, not a degraded BaseComponent
+        assert ">X<" in html         # the update itself applied
+    finally:
+        Renderer.set_default_environment(original_environment)

--- a/tests/68_autodiscovery_warning_test.py
+++ b/tests/68_autodiscovery_warning_test.py
@@ -7,22 +7,30 @@ from pyjinhx.tags import ComponentAutodiscover
 def test_import_failure_warns(tmp_path, caplog):
     (tmp_path / "broken_probe.html").write_text('<i id="{{ id }}">x</i>')
     (tmp_path / "broken_probe.py").write_text("raise RuntimeError('boom')\n")
+    original_environment = Renderer.peek_default_environment()
     ComponentAutodiscover.clear()
-    renderer = Renderer.set_default_environment(str(tmp_path))
-    renderer = Renderer.get_default_renderer()
-    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
-        renderer.render('<BrokenProbe id="b1"/>')
-    assert any("broken_probe.py" in r.message or "broken_probe.py" in r.getMessage() for r in caplog.records)
+    try:
+        Renderer.set_default_environment(str(tmp_path))
+        renderer = Renderer.get_default_renderer()
+        with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+            renderer.render('<BrokenProbe id="b1"/>')
+        assert any("broken_probe.py" in r.message or "broken_probe.py" in r.getMessage() for r in caplog.records)
+    finally:
+        Renderer.set_default_environment(original_environment)
 
 
 def test_unregistered_fallback_warns_once(tmp_path, caplog):
     (tmp_path / "ghost_probe.html").write_text('<i id="{{ id }}">x</i>')
     (tmp_path / "ghost_probe.py").write_text("VALUE = 1\n")
+    original_environment = Renderer.peek_default_environment()
     ComponentAutodiscover.clear()
-    Renderer.set_default_environment(str(tmp_path))
-    renderer = Renderer.get_default_renderer()
-    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
-        renderer.render('<GhostProbe id="g1"/>')
-        renderer.render('<GhostProbe id="g2"/>')
-    hits = [r for r in caplog.records if "GhostProbe" in r.getMessage() and "not registered" in r.getMessage()]
-    assert len(hits) == 1
+    try:
+        Renderer.set_default_environment(str(tmp_path))
+        renderer = Renderer.get_default_renderer()
+        with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+            renderer.render('<GhostProbe id="g1"/>')
+            renderer.render('<GhostProbe id="g2"/>')
+        hits = [r for r in caplog.records if "GhostProbe" in r.getMessage() and "not registered" in r.getMessage()]
+        assert len(hits) == 1
+    finally:
+        Renderer.set_default_environment(original_environment)

--- a/tests/68_autodiscovery_warning_test.py
+++ b/tests/68_autodiscovery_warning_test.py
@@ -1,0 +1,28 @@
+import logging
+
+from pyjinhx import Renderer
+from pyjinhx.tags import ComponentAutodiscover
+
+
+def test_import_failure_warns(tmp_path, caplog):
+    (tmp_path / "broken_probe.html").write_text('<i id="{{ id }}">x</i>')
+    (tmp_path / "broken_probe.py").write_text("raise RuntimeError('boom')\n")
+    ComponentAutodiscover.clear()
+    renderer = Renderer.set_default_environment(str(tmp_path))
+    renderer = Renderer.get_default_renderer()
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        renderer.render('<BrokenProbe id="b1"/>')
+    assert any("broken_probe.py" in r.message or "broken_probe.py" in r.getMessage() for r in caplog.records)
+
+
+def test_unregistered_fallback_warns_once(tmp_path, caplog):
+    (tmp_path / "ghost_probe.html").write_text('<i id="{{ id }}">x</i>')
+    (tmp_path / "ghost_probe.py").write_text("VALUE = 1\n")
+    ComponentAutodiscover.clear()
+    Renderer.set_default_environment(str(tmp_path))
+    renderer = Renderer.get_default_renderer()
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        renderer.render('<GhostProbe id="g1"/>')
+        renderer.render('<GhostProbe id="g2"/>')
+    hits = [r for r in caplog.records if "GhostProbe" in r.getMessage() and "not registered" in r.getMessage()]
+    assert len(hits) == 1

--- a/tests/69_golden_builtins_test.py
+++ b/tests/69_golden_builtins_test.py
@@ -1,0 +1,72 @@
+"""Golden-HTML snapshots for every builtin.
+
+Regenerate intentionally with:  PJX_GOLDEN_UPDATE=1 uv run pytest tests/69_golden_builtins_test.py -q
+Auto-generated ids (px-<n>) are masked so snapshots are stable.
+"""
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from pyjinhx.assets import AssetMode
+from pyjinhx.renderer import Renderer
+
+import pyjinhx.builtins as b
+
+GOLDEN_DIR = Path(__file__).parent / "golden"
+
+CASES = [
+    ("alert_default", lambda: b.Alert(id="g", body="Saved.")),
+    ("alert_dismissible", lambda: b.Alert(id="g", title="Heads up", body="x", dismissible=True, variant="warning")),
+    ("avatar_initials", lambda: b.Avatar(id="g", initials="PM")),
+    ("avatar_image", lambda: b.Avatar(id="g", src="/u.png", alt="User", size="lg")),
+    ("badge_default", lambda: b.Badge(id="g", label="New")),
+    ("breadcrumb", lambda: b.Breadcrumb(id="g", items=[("Home", "/"), ("Here", None)])),
+    ("card_full", lambda: b.Card(id="g", title="T", body="B", footer="F")),
+    ("divider_labeled", lambda: b.Divider(id="g", label="or")),
+    ("drawer", lambda: b.Drawer(id="g", title="T", body="B", footer="F")),
+    ("dropdown", lambda: b.Dropdown(id="g", trigger="Menu", menu="<a href='/x'>X</a>")),
+    ("empty_state", lambda: b.EmptyState(id="g", title="Nothing", description="D", action="<button>A</button>")),
+    ("lazy_panel", lambda: b.LazyPanel(id="g", url="/load")),
+    ("loading_overlay", lambda: b.LoadingOverlay(id="g")),
+    ("modal", lambda: b.Modal(id="g", title="T", body="B", footer="F")),
+    ("notification", lambda: b.Notification(id="g", content="Hi", corner="bottom-right", timeout=0)),
+    ("panel", lambda: b.Panel(id="g", panels={"a": "<p>A</p>", "b": "<p>B</p>"})),
+    ("panel_trigger", lambda: b.PanelTrigger(id="g", panel_id="host", panel="a", content="Tab A")),
+    ("popover", lambda: b.Popover(id="g", content="hover me", card_content="tip")),
+    ("progress_determinate", lambda: b.Progress(id="g", value=40, label="Upload")),
+    ("progress_indeterminate", lambda: b.Progress(id="g")),
+    ("skeleton_text", lambda: b.Skeleton(id="g", lines=2)),
+    ("spinner", lambda: b.Spinner(id="g")),
+    ("tab_group", lambda: b.TabGroup(id="g", tabs={"One": "<p>1</p>", "Two": "<p>2</p>"})),
+    ("tooltip", lambda: b.Tooltip(id="g", trigger="?", tip="Help")),
+]
+
+
+def _normalize(html: str) -> str:
+    html = re.sub(r"px-\d+", "px-AUTO", html)
+    return html.strip() + "\n"
+
+
+@pytest.fixture()
+def _markup_only_renderer():
+    prev_js, prev_css = Renderer._default_js_mode, Renderer._default_css_mode
+    Renderer.set_default_js_mode(AssetMode.NONE)
+    Renderer.set_default_css_mode(AssetMode.NONE)
+    yield
+    Renderer.set_default_js_mode(prev_js)
+    Renderer.set_default_css_mode(prev_css)
+
+
+@pytest.mark.parametrize("name,factory", CASES, ids=[c[0] for c in CASES])
+def test_golden(name, factory, _markup_only_renderer):
+    rendered = _normalize(str(factory().render()))
+    path = GOLDEN_DIR / f"{name}.html"
+    if os.environ.get("PJX_GOLDEN_UPDATE") == "1":
+        GOLDEN_DIR.mkdir(exist_ok=True)
+        path.write_text(rendered)
+    assert path.exists(), f"missing snapshot {path.name}; run with PJX_GOLDEN_UPDATE=1"
+    assert rendered == path.read_text(), (
+        f"golden mismatch for {name}; if intentional, regenerate with PJX_GOLDEN_UPDATE=1 and review the diff"
+    )

--- a/tests/golden/alert_default.html
+++ b/tests/golden/alert_default.html
@@ -1,0 +1,9 @@
+<div class="px-alert px-alert--info" id="g" role="status">
+    <div class="px-alert__inner">
+        <div class="px-alert__text">
+            
+            <div class="px-alert__body">Saved.</div>
+        </div>
+        
+    </div>
+</div>

--- a/tests/golden/alert_dismissible.html
+++ b/tests/golden/alert_dismissible.html
@@ -1,0 +1,13 @@
+<div class="px-alert px-alert--warning" id="g" role="status">
+    <div class="px-alert__inner">
+        <div class="px-alert__text">
+            
+            <div class="px-alert__title">Heads up</div>
+            
+            <div class="px-alert__body">x</div>
+        </div>
+        
+        <button type="button" class="px-alert__dismiss" onclick="dismissPxAlert('g')" aria-label="Dismiss">✕</button>
+        
+    </div>
+</div>

--- a/tests/golden/avatar_image.html
+++ b/tests/golden/avatar_image.html
@@ -1,0 +1,6 @@
+<div id="g"
+     class="px-avatar px-avatar--lg">
+  
+  <img class="px-avatar__img" src="/u.png" alt="User" loading="lazy" decoding="async" />
+  
+</div>

--- a/tests/golden/avatar_initials.html
+++ b/tests/golden/avatar_initials.html
@@ -1,0 +1,6 @@
+<div id="g"
+     class="px-avatar px-avatar--md">
+  
+  <span class="px-avatar__initials" >PM</span>
+  
+</div>

--- a/tests/golden/badge_default.html
+++ b/tests/golden/badge_default.html
@@ -1,0 +1,1 @@
+<span class="px-badge px-badge--neutral px-badge--md">New</span>

--- a/tests/golden/breadcrumb.html
+++ b/tests/golden/breadcrumb.html
@@ -1,0 +1,17 @@
+<nav id="g" class="px-breadcrumb" aria-label="Breadcrumb">
+  <ol class="px-breadcrumb__list">
+    
+    <li class="px-breadcrumb__item">
+      
+      <a class="px-breadcrumb__link" href="/">Home</a>
+      
+    </li>
+    
+    <li class="px-breadcrumb__item">
+      
+      <span class="px-breadcrumb__current" aria-current="page">Here</span>
+      
+    </li>
+    
+  </ol>
+</nav>

--- a/tests/golden/card_full.html
+++ b/tests/golden/card_full.html
@@ -1,0 +1,13 @@
+<article id="g" class="px-card">
+  
+  <header class="px-card__header">
+    
+    <h3 class="px-card__title">T</h3>
+    
+  </header>
+  
+  <div class="px-card__body">B</div>
+  
+  <footer class="px-card__footer">F</footer>
+  
+</article>

--- a/tests/golden/divider_labeled.html
+++ b/tests/golden/divider_labeled.html
@@ -1,0 +1,5 @@
+<div id="g" class="px-divider px-divider--labeled" role="presentation">
+  <span class="px-divider__line" aria-hidden="true"></span>
+  <span class="px-divider__label">or</span>
+  <span class="px-divider__line" aria-hidden="true"></span>
+</div>

--- a/tests/golden/drawer.html
+++ b/tests/golden/drawer.html
@@ -1,0 +1,15 @@
+<dialog class="px-drawer px-drawer--right" id="g">
+    <div class="px-drawer__box">
+        <header class="px-drawer__header">
+            <span class="px-drawer__title">T</span>
+            <button type="button"
+                    class="px-drawer__close"
+                    onclick="closePxDrawer('g')"
+                    aria-label="Close">✕</button>
+        </header>
+        <div class="px-drawer__body">B</div>
+        
+        <footer class="px-drawer__footer">F</footer>
+        
+    </div>
+</dialog>

--- a/tests/golden/dropdown.html
+++ b/tests/golden/dropdown.html
@@ -1,0 +1,14 @@
+<div class="px-dropdown" id="g">
+    <button type="button"
+            class="px-dropdown__trigger"
+            id="g-trigger"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-controls="g-menu"
+            onclick="togglePxDropdown('g')">Menu</button>
+    <div class="px-dropdown__menu"
+         id="g-menu"
+         role="region"
+         aria-label="Submenu"
+         hidden><a href='/x'>X</a></div>
+</div>

--- a/tests/golden/empty_state.html
+++ b/tests/golden/empty_state.html
@@ -1,0 +1,9 @@
+<div class="px-empty-state" id="g">
+    
+    <h3 class="px-empty-state__title">Nothing</h3>
+    <p class="px-empty-state__desc">D</p>
+    
+    <div class="px-empty-state__action"><button>A</button></div>
+    
+    
+</div>

--- a/tests/golden/lazy_panel.html
+++ b/tests/golden/lazy_panel.html
@@ -1,0 +1,5 @@
+<div id="g"
+     class="px-lazy-panel"
+     hx-get="/load"
+     hx-trigger="revealed"
+     hx-swap="outerHTML"></div>

--- a/tests/golden/loading_overlay.html
+++ b/tests/golden/loading_overlay.html
@@ -1,0 +1,3 @@
+<div class="px-loading-overlay" id="g" role="status" aria-label="Loading" aria-live="polite">
+    <div class="px-loading-overlay__spinner"></div>
+</div>

--- a/tests/golden/modal.html
+++ b/tests/golden/modal.html
@@ -1,0 +1,18 @@
+<dialog class="px-modal" id="g">
+    <div class="px-modal__box">
+        <header class="px-modal__header">
+            
+            <span class="px-modal__title">T</span>
+            
+            <button class="px-modal__close"
+                    onclick="closeModal('g')"
+                    aria-label="Close">✕</button>
+        </header>
+
+        <div class="px-modal__body" id="g-body">B</div>
+
+        
+        <footer class="px-modal__footer">F</footer>
+        
+    </div>
+</dialog>

--- a/tests/golden/notification.html
+++ b/tests/golden/notification.html
@@ -1,0 +1,10 @@
+<div class="px-notification px-notification--bottom-right"
+     id="g"
+     data-timeout="0"
+     role="status"
+     aria-live="polite">
+    <div class="px-notification__content">Hi</div>
+    <button class="px-notification__close"
+            onclick="hideNotification('g')"
+            aria-label="Dismiss">✕</button>
+</div>

--- a/tests/golden/panel.html
+++ b/tests/golden/panel.html
@@ -1,0 +1,15 @@
+<div id="g" class="px-panel">
+  
+  <div class="px-panel__panel"
+       role="tabpanel"
+       id="g-panel-a"
+       data-px-panel-key="a"
+       ><p>A</p></div>
+  
+  <div class="px-panel__panel"
+       role="tabpanel"
+       id="g-panel-b"
+       data-px-panel-key="b"
+       hidden><p>B</p></div>
+  
+</div>

--- a/tests/golden/panel_trigger.html
+++ b/tests/golden/panel_trigger.html
@@ -1,0 +1,8 @@
+<div id="g"
+     class="px-panel-trigger"
+     role="tab"
+     data-px-panel-id="host"
+     data-px-panel-key="a"
+     aria-controls="host-panel-a"
+     aria-selected="false"
+     tabindex="-1">Tab A</div>

--- a/tests/golden/popover.html
+++ b/tests/golden/popover.html
@@ -1,0 +1,6 @@
+<span class="px-popover-trigger" id="g" data-popover-position="anchor" >
+    <span class="px-popover-trigger__body">hover me</span>
+    <div class="px-popover-card" role="tooltip" aria-hidden="true">
+        tip
+    </div>
+</span>

--- a/tests/golden/progress_determinate.html
+++ b/tests/golden/progress_determinate.html
@@ -1,0 +1,14 @@
+<div class="px-progress" id="g">
+    
+    <span class="px-progress__label" id="g-label">Upload</span>
+    
+    
+    <progress class="px-progress__bar"
+              max="100"
+              value="40.0"
+              aria-valuenow="40.0"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-labelledby="g-label"></progress>
+    
+</div>

--- a/tests/golden/progress_indeterminate.html
+++ b/tests/golden/progress_indeterminate.html
@@ -1,0 +1,8 @@
+<div class="px-progress" id="g">
+    
+    
+    <progress class="px-progress__bar"
+              max="100"
+              aria-label="Loading"></progress>
+    
+</div>

--- a/tests/golden/skeleton_text.html
+++ b/tests/golden/skeleton_text.html
@@ -1,0 +1,9 @@
+<div class="px-skeleton px-skeleton--text" id="g">
+    
+    
+    <div class="px-skeleton__line"></div>
+    
+    <div class="px-skeleton__line"></div>
+    
+    
+</div>

--- a/tests/golden/spinner.html
+++ b/tests/golden/spinner.html
@@ -1,0 +1,8 @@
+<span id="g"
+      class="px-spinner px-spinner--md"
+      role="status"
+      aria-live="polite"
+      aria-busy="true">
+  <span class="px-spinner__ring" aria-hidden="true"></span>
+  <span class="px-spinner__label">Loading</span>
+</span>

--- a/tests/golden/tab_group.html
+++ b/tests/golden/tab_group.html
@@ -1,0 +1,34 @@
+<div id="g" class="px-tab-group">
+  <div class="px-tab-group__list" role="tablist" aria-label="Tabs">
+    
+    <button type="button"
+            class="px-tab-group__tab"
+            role="tab"
+            id="g-tab-0"
+            aria-controls="g-panel-0"
+            aria-selected="true"
+            tabindex="0">One</button>
+    
+    <button type="button"
+            class="px-tab-group__tab"
+            role="tab"
+            id="g-tab-1"
+            aria-controls="g-panel-1"
+            aria-selected="false"
+            tabindex="-1">Two</button>
+    
+  </div>
+  
+  <div class="px-tab-group__panel"
+       role="tabpanel"
+       id="g-panel-0"
+       aria-labelledby="g-tab-0"
+       ><p>1</p></div>
+  
+  <div class="px-tab-group__panel"
+       role="tabpanel"
+       id="g-panel-1"
+       aria-labelledby="g-tab-1"
+       hidden><p>2</p></div>
+  
+</div>

--- a/tests/golden/tooltip.html
+++ b/tests/golden/tooltip.html
@@ -1,0 +1,4 @@
+<span class="px-tooltip" id="g" data-px-tooltip-placement="top">
+    <span class="px-tooltip__trigger" tabindex="0" aria-describedby="g-tip">?</span>
+    <span class="px-tooltip__tip" id="g-tip" role="tooltip" hidden>Help</span>
+</span>


### PR DESCRIPTION
## Summary
- `BaseComponent.id` is now optional — omitted/falsy ids auto-generate `px-<n>`; the tag path uses the same generator (`auto_id=False` still raises).
- Tag instance-reuse updates now validate per-field on a `model_copy()` (was: unvalidated `model_copy(update=...)`) — coercion applies, bad values raise, and nested component state/extras/private attrs are preserved (regression-tested).
- Autodiscovery import failures and unregistered-sibling-class fallbacks now log warnings instead of failing silently (nori's eager-import footgun).
- Golden-HTML snapshot harness baselines all 24 builtin renders (markup-only, auto-ids masked); later redesign PRs re-baseline intentionally with reviewable diffs.

PR 1/8 of the 0.8.0 builtins-v2 plan. The next phases stack on this branch — merging bottom-up with `--delete-branch` auto-retargets the stack.

## Test plan
- [x] `uv run pytest tests/ -q` — 374 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run mkdocs build --strict` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)