### PR TITLE
Builtins v2: contract sweep over the 9 static builtins

### DIFF
--- a/docs/guide/builtin-conventions.md
+++ b/docs/guide/builtin-conventions.md
@@ -1,0 +1,70 @@
+# Builtin conventions
+
+Every pyjinhx builtin follows the same contract, so knowing one means knowing all of them.
+
+## The contract
+
+1. **`id` is optional.** Omit it and pyjinhx generates `px-<n>`. Pass one when you need a stable
+   hook (CSS, htmx targets) — and always for reactive components, whose OOB targeting requires
+   stable identity across renders.
+2. **`class_name`** appends your classes to the root element: `Badge(label="New", class_name="pill")`.
+3. **`extra_attrs`** renders extra attributes (escaped) on the root element — the carrier for
+   `hx-*`, `data-*`, `aria-*`, or Alpine directives:
+   `Card(body=..., extra_attrs={"hx-get": "/refresh", "hx-trigger": "every 30s"})`.
+4. **All copy is props.** Every user-visible string, aria-labels included, has an English default
+   you can replace: `Modal(title="Excluir?", close_label="Fechar")`.
+5. **JS is headless.** Builtin JavaScript toggles classes and attributes only — never inline
+   styles — and communicates through `px:*` DOM events and `data-px-*` attributes. Programmatic
+   APIs live under the single `window.px` namespace.
+6. **The DOM contract is API.** Each builtin's documentation ends with a "DOM contract" block —
+   stable classes, `data-px-*` attributes, events, state attributes. We version those like code.
+
+## Events and hooks
+
+Interactive builtins fire a two-tier event vocabulary on their root element (all bubble):
+
+- `px:<component>:before-<verb>` — **cancelable**. `event.preventDefault()` aborts the action.
+  `detail = {reason, trigger}` with `reason ∈ {"escape","backdrop","api","trigger"}`.
+- `px:<component>:<verb>` — fired after the DOM change. Not cancelable.
+
+Shared vocabulary: `px:before-reveal` / `px:reveal` fire on any `[data-px-region]` (Panel panels,
+TabGroup bodies) when it is shown — `LazyPanel(when="reveal")` builds on it; `px:toast` is the
+input event ToastHost listens for (htmx fires it from `HX-Trigger` response headers).
+
+```js
+document.getElementById("confirm-del").addEventListener("px:modal:before-close", (e) => {
+    if (hasUnsavedChanges()) e.preventDefault();
+});
+```
+
+## Declarative attributes
+
+| attribute | effect |
+|---|---|
+| `data-px-open="<id>"` | click opens that Modal / Drawer |
+| `data-px-close` | click closes the nearest enclosing dismissible |
+| `data-px-toggle="<id>"` | click toggles that Popover / Dropdown menu |
+| `data-px-confirm-danger` | `hx-confirm` on this element gets a danger-styled OK button |
+| `data-px-confirm-ok`, `data-px-confirm-cancel` | per-trigger confirm-dialog label overrides |
+| `data-px-loader` | requests from this subtree show the PageLoader |
+| `data-px-region` | marks a show/hide region (emits `px:reveal`) |
+
+## The `window.px` namespace
+
+`px.modal` · `px.drawer` · `px.popover` · `px.notification` · `px.overlay` (region loading) ·
+`px.loader` (page loading) · `px.confirm` · `px.prompt` · `px.toast`. Open/close/show/hide
+functions return `false` when a `before-*` hook canceled the action.
+
+## Theming
+
+Builtins read `--px-*` tokens that default to your app-level semantic tokens. Re-skin globally in
+one block:
+
+```css
+:root {
+  --px-modal-bg: var(--surface);
+  --px-card-radius: var(--radius-lg);
+}
+```
+
+or per-context: `.settings-pane { --px-card-bg: var(--surface-alt); }`.

--- a/docs/guide/builtin-conventions.md
+++ b/docs/guide/builtin-conventions.md
@@ -2,20 +2,20 @@
 
 Every pyjinhx builtin follows the same contract, so knowing one means knowing all of them.
 
+> **Status:** the `px.*` namespace, event vocabulary, and declarative attributes described here land progressively across the 0.8.0 PR stack — this page is the contract the release converges on.
+
 ## The contract
 
 1. **`id` is optional.** Omit it and pyjinhx generates `px-<n>`. Pass one when you need a stable
    hook (CSS, htmx targets) — and always for reactive components, whose OOB targeting requires
    stable identity across renders.
 2. **`class_name`** appends your classes to the root element: `Badge(label="New", class_name="pill")`.
-3. **`extra_attrs`** renders extra attributes (validated — values may not contain `"`, `<`, or `>`) on the root element — the carrier for
+3. **`extra_attrs`** renders extra attributes (validated — values may not contain `"`) on the root element — the carrier for
    `hx-*`, `data-*`, `aria-*`, or Alpine directives:
    `Card(body=..., extra_attrs={"hx-get": "/refresh", "hx-trigger": "every 30s"})`.
 4. **All copy is props.** Every user-visible string, aria-labels included, has an English default
    you can replace: `Modal(title="Excluir?", close_label="Fechar")`.
-5. **JS is headless.** Builtin JavaScript toggles classes and attributes only — never inline
-   styles — and communicates through `px:*` DOM events and `data-px-*` attributes. Programmatic
-   APIs live under the single `window.px` namespace.
+5. **JS is headless.** Builtin JavaScript never writes inline styles for state — visibility and variants are classes/attributes; computed positioning coordinates (tooltip/popover placement) are the one sanctioned inline-style use. Communication is through `px:*` DOM events and `data-px-*` attributes; programmatic APIs live under the single `window.px` namespace.
 6. **The DOM contract is API.** Each builtin's documentation ends with a "DOM contract" block —
    stable classes, `data-px-*` attributes, events, state attributes. We version those like code.
 

--- a/docs/guide/builtin-conventions.md
+++ b/docs/guide/builtin-conventions.md
@@ -8,7 +8,7 @@ Every pyjinhx builtin follows the same contract, so knowing one means knowing al
    hook (CSS, htmx targets) — and always for reactive components, whose OOB targeting requires
    stable identity across renders.
 2. **`class_name`** appends your classes to the root element: `Badge(label="New", class_name="pill")`.
-3. **`extra_attrs`** renders extra attributes (escaped) on the root element — the carrier for
+3. **`extra_attrs`** renders extra attributes (validated — values may not contain `"`, `<`, or `>`) on the root element — the carrier for
    `hx-*`, `data-*`, `aria-*`, or Alpine directives:
    `Card(body=..., extra_attrs={"hx-get": "/refresh", "hx-trigger": "every 30s"})`.
 4. **All copy is props.** Every user-visible string, aria-labels included, has an English default

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - Nesting: guide/nesting.md
       - Asset Collection: guide/assets.md
       - Built-in UI components: guide/builtins.md
+      - Builtin conventions: guide/builtin-conventions.md
       - Configuration: guide/configuration.md
       - Reactivity: reactivity.md
   - Integrations:

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -1,10 +1,10 @@
 import itertools
 import logging
 import re
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
 
 from markupsafe import Markup
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator
 
 from .registry import Registry
 from .renderer import Renderer
@@ -15,7 +15,7 @@ logger.setLevel(logging.WARNING)
 
 _auto_id_counter = itertools.count(1)
 
-_ATTR_NAME_RE = re.compile(r"^[A-Za-z@:][A-Za-z0-9_.:@-]*$")
+_ATTR_NAME_RE = re.compile(r"[A-Za-z@:][A-Za-z0-9_.:@-]*")
 
 
 def _auto_id() -> str:
@@ -23,20 +23,28 @@ def _auto_id() -> str:
     return f"px-{next(_auto_id_counter)}"
 
 
-def validate_extra_attrs(value: dict[str, str]) -> dict[str, str]:
-    """Reject attribute names/values that could break out of an HTML attribute.
+def validate_attr_value(value: str) -> str:
+    """Reject values that could break out of a double-quoted HTML attribute.
 
     The renderer unescapes final markup by design, so attribute safety is
-    enforced here instead of by Jinja autoescaping.
+    enforced at construction time. Post-construction mutation bypasses this.
     """
-    for name, attr_value in value.items():
-        if not _ATTR_NAME_RE.match(name):
-            raise ValueError(f"extra_attrs name {name!r} is not a valid attribute name")
-        if any(ch in attr_value for ch in ('"', "<", ">")):
-            raise ValueError(
-                f"extra_attrs value for {name!r} must not contain '\"', '<' or '>'"
-            )
+    if '"' in value:
+        raise ValueError('attribute values must not contain \'"\'')
     return value
+
+
+def validate_extra_attrs(value: dict[str, str]) -> dict[str, str]:
+    """Reject attribute names/values that could break out of an HTML attribute."""
+    for name, attr_value in value.items():
+        if not _ATTR_NAME_RE.fullmatch(name):
+            raise ValueError(f"extra_attrs name {name!r} is not a valid attribute name")
+        validate_attr_value(attr_value)
+    return value
+
+
+AttrValue = Annotated[str, AfterValidator(validate_attr_value)]
+ExtraAttrs = Annotated[dict[str, str], AfterValidator(validate_extra_attrs)]
 
 
 class NestedComponentWrapper(BaseModel):

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+import re
 from typing import Any, Optional
 
 from markupsafe import Markup
@@ -14,10 +15,28 @@ logger.setLevel(logging.WARNING)
 
 _auto_id_counter = itertools.count(1)
 
+_ATTR_NAME_RE = re.compile(r"^[A-Za-z@:][A-Za-z0-9_.:@-]*$")
+
 
 def _auto_id() -> str:
     """Generate a process-unique component id (``px-<n>``)."""
     return f"px-{next(_auto_id_counter)}"
+
+
+def validate_extra_attrs(value: dict[str, str]) -> dict[str, str]:
+    """Reject attribute names/values that could break out of an HTML attribute.
+
+    The renderer unescapes final markup by design, so attribute safety is
+    enforced here instead of by Jinja autoescaping.
+    """
+    for name, attr_value in value.items():
+        if not _ATTR_NAME_RE.match(name):
+            raise ValueError(f"extra_attrs name {name!r} is not a valid attribute name")
+        if any(ch in attr_value for ch in ('"', "<", ">")):
+            raise ValueError(
+                f"extra_attrs value for {name!r} must not contain '\"', '<' or '>'"
+            )
+    return value
 
 
 class NestedComponentWrapper(BaseModel):

--- a/pyjinhx/builtins/ui/avatar/avatar.html
+++ b/pyjinhx/builtins/ui/avatar/avatar.html
@@ -1,5 +1,5 @@
 <div id="{{ id }}"
-     class="px-avatar px-avatar--{{ size }}{% if class_name %} {{ class_name }}{% endif %}">
+     class="px-avatar px-avatar--{{ size }}{% if class_name %} {{ class_name }}{% endif %}"{% if color %} style="background:{{ color }};"{% endif %}{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
   {% if src %}
   <img class="px-avatar__img" src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" />
   {% else %}

--- a/pyjinhx/builtins/ui/avatar/avatar.py
+++ b/pyjinhx/builtins/ui/avatar/avatar.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 
 from pyjinhx import BaseComponent
+from pyjinhx.base import validate_extra_attrs
 
 
 class Avatar(BaseComponent):
@@ -14,10 +15,10 @@ class Avatar(BaseComponent):
     color: str = ""
     extra_attrs: dict[str, str] = Field(default_factory=dict)
 
-    @field_validator("extra_attrs", mode="before")
+    @field_validator("extra_attrs")
     @classmethod
-    def _sanitize_extra_attrs(cls, v: dict) -> dict:
-        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}
+    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
+        return validate_extra_attrs(value)
 
     @field_validator("initials", mode="before")
     @classmethod

--- a/pyjinhx/builtins/ui/avatar/avatar.py
+++ b/pyjinhx/builtins/ui/avatar/avatar.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 
 from pyjinhx import BaseComponent
 
@@ -11,6 +11,13 @@ class Avatar(BaseComponent):
     initials: str = ""
     size: Literal["sm", "md", "lg"] = "md"
     class_name: str = ""
+    color: str = ""
+    extra_attrs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("extra_attrs", mode="before")
+    @classmethod
+    def _sanitize_extra_attrs(cls, v: dict) -> dict:
+        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}
 
     @field_validator("initials", mode="before")
     @classmethod

--- a/pyjinhx/builtins/ui/avatar/avatar.py
+++ b/pyjinhx/builtins/ui/avatar/avatar.py
@@ -3,7 +3,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import validate_extra_attrs
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class Avatar(BaseComponent):
@@ -11,14 +11,9 @@ class Avatar(BaseComponent):
     alt: str = ""
     initials: str = ""
     size: Literal["sm", "md", "lg"] = "md"
-    class_name: str = ""
-    color: str = ""
-    extra_attrs: dict[str, str] = Field(default_factory=dict)
-
-    @field_validator("extra_attrs")
-    @classmethod
-    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
-        return validate_extra_attrs(value)
+    class_name: AttrValue = ""
+    color: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)
 
     @field_validator("initials", mode="before")
     @classmethod

--- a/pyjinhx/builtins/ui/badge/badge.html
+++ b/pyjinhx/builtins/ui/badge/badge.html
@@ -1,1 +1,1 @@
-<span class="px-badge px-badge--{{ color }} px-badge--{{ shape }}{% if class_name %} {{ class_name }}{% endif %}">{{ label }}</span>
+<span id="{{ id }}" class="px-badge px-badge--{{ color }} px-badge--{{ shape }}{% if class_name %} {{ class_name }}{% endif %}"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>{{ label }}</span>

--- a/pyjinhx/builtins/ui/badge/badge.py
+++ b/pyjinhx/builtins/ui/badge/badge.py
@@ -1,19 +1,14 @@
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import validate_extra_attrs
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class Badge(BaseComponent):
     label: str = ""
     color: Literal["brand", "error", "neutral", "muted"] = "neutral"
     shape: Literal["square", "sm", "md", "full"] = "md"
-    class_name: str = ""
-    extra_attrs: dict[str, str] = Field(default_factory=dict)
-
-    @field_validator("extra_attrs")
-    @classmethod
-    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
-        return validate_extra_attrs(value)
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/badge/badge.py
+++ b/pyjinhx/builtins/ui/badge/badge.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 
 from pyjinhx import BaseComponent
+from pyjinhx.base import validate_extra_attrs
 
 
 class Badge(BaseComponent):
@@ -12,7 +13,7 @@ class Badge(BaseComponent):
     class_name: str = ""
     extra_attrs: dict[str, str] = Field(default_factory=dict)
 
-    @field_validator("extra_attrs", mode="before")
+    @field_validator("extra_attrs")
     @classmethod
-    def _sanitize_extra_attrs(cls, v: dict) -> dict:
-        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}
+    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
+        return validate_extra_attrs(value)

--- a/pyjinhx/builtins/ui/badge/badge.py
+++ b/pyjinhx/builtins/ui/badge/badge.py
@@ -1,5 +1,7 @@
 from typing import Literal
 
+from pydantic import Field, field_validator
+
 from pyjinhx import BaseComponent
 
 
@@ -8,3 +10,9 @@ class Badge(BaseComponent):
     color: Literal["brand", "error", "neutral", "muted"] = "neutral"
     shape: Literal["square", "sm", "md", "full"] = "md"
     class_name: str = ""
+    extra_attrs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("extra_attrs", mode="before")
+    @classmethod
+    def _sanitize_extra_attrs(cls, v: dict) -> dict:
+        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}

--- a/pyjinhx/builtins/ui/breadcrumb/breadcrumb.html
+++ b/pyjinhx/builtins/ui/breadcrumb/breadcrumb.html
@@ -1,4 +1,4 @@
-<nav id="{{ id }}" class="px-breadcrumb" aria-label="Breadcrumb">
+<nav id="{{ id }}" class="px-breadcrumb{% if class_name %} {{ class_name }}{% endif %}" aria-label="{{ aria_label }}"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
   <ol class="px-breadcrumb__list">
     {% for label, href in items %}
     <li class="px-breadcrumb__item">

--- a/pyjinhx/builtins/ui/breadcrumb/breadcrumb.py
+++ b/pyjinhx/builtins/ui/breadcrumb/breadcrumb.py
@@ -1,7 +1,7 @@
 import json
 from typing import Annotated, Any
 
-from pydantic import BeforeValidator, Field
+from pydantic import BeforeValidator, Field, field_validator
 
 from pyjinhx import BaseComponent
 
@@ -21,3 +21,11 @@ class Breadcrumb(BaseComponent):
         list[tuple[str, str | None]],
         BeforeValidator(_coerce_breadcrumb_items),
     ] = Field(default_factory=list)
+    aria_label: str = "Breadcrumb"
+    class_name: str = ""
+    extra_attrs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("extra_attrs", mode="before")
+    @classmethod
+    def _sanitize_extra_attrs(cls, v: dict) -> dict:
+        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}

--- a/pyjinhx/builtins/ui/breadcrumb/breadcrumb.py
+++ b/pyjinhx/builtins/ui/breadcrumb/breadcrumb.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 from pydantic import BeforeValidator, Field, field_validator
 
 from pyjinhx import BaseComponent
+from pyjinhx.base import validate_extra_attrs
 
 
 def _coerce_breadcrumb_items(value: Any) -> list[tuple[str, str | None]]:
@@ -25,7 +26,7 @@ class Breadcrumb(BaseComponent):
     class_name: str = ""
     extra_attrs: dict[str, str] = Field(default_factory=dict)
 
-    @field_validator("extra_attrs", mode="before")
+    @field_validator("extra_attrs")
     @classmethod
-    def _sanitize_extra_attrs(cls, v: dict) -> dict:
-        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}
+    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
+        return validate_extra_attrs(value)

--- a/pyjinhx/builtins/ui/breadcrumb/breadcrumb.py
+++ b/pyjinhx/builtins/ui/breadcrumb/breadcrumb.py
@@ -1,10 +1,10 @@
 import json
 from typing import Annotated, Any
 
-from pydantic import BeforeValidator, Field, field_validator
+from pydantic import BeforeValidator, Field
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import validate_extra_attrs
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 def _coerce_breadcrumb_items(value: Any) -> list[tuple[str, str | None]]:
@@ -23,10 +23,5 @@ class Breadcrumb(BaseComponent):
         BeforeValidator(_coerce_breadcrumb_items),
     ] = Field(default_factory=list)
     aria_label: str = "Breadcrumb"
-    class_name: str = ""
-    extra_attrs: dict[str, str] = Field(default_factory=dict)
-
-    @field_validator("extra_attrs")
-    @classmethod
-    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
-        return validate_extra_attrs(value)
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/card/card.html
+++ b/pyjinhx/builtins/ui/card/card.html
@@ -1,4 +1,4 @@
-<article id="{{ id }}" class="px-card">
+<article id="{{ id }}" class="px-card{% if class_name %} {{ class_name }}{% endif %}"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
   {% if header or title %}
   <header class="px-card__header">
     {% if header %}

--- a/pyjinhx/builtins/ui/card/card.py
+++ b/pyjinhx/builtins/ui/card/card.py
@@ -1,3 +1,5 @@
+from pydantic import Field, field_validator
+
 from pyjinhx import BaseComponent
 
 
@@ -6,3 +8,10 @@ class Card(BaseComponent):
     header: str | BaseComponent = ""
     body: str | BaseComponent = ""
     footer: str | BaseComponent = ""
+    class_name: str = ""
+    extra_attrs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("extra_attrs", mode="before")
+    @classmethod
+    def _sanitize_extra_attrs(cls, v: dict) -> dict:
+        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}

--- a/pyjinhx/builtins/ui/card/card.py
+++ b/pyjinhx/builtins/ui/card/card.py
@@ -1,7 +1,7 @@
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import validate_extra_attrs
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class Card(BaseComponent):
@@ -9,10 +9,5 @@ class Card(BaseComponent):
     header: str | BaseComponent = ""
     body: str | BaseComponent = ""
     footer: str | BaseComponent = ""
-    class_name: str = ""
-    extra_attrs: dict[str, str] = Field(default_factory=dict)
-
-    @field_validator("extra_attrs")
-    @classmethod
-    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
-        return validate_extra_attrs(value)
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/card/card.py
+++ b/pyjinhx/builtins/ui/card/card.py
@@ -1,6 +1,7 @@
 from pydantic import Field, field_validator
 
 from pyjinhx import BaseComponent
+from pyjinhx.base import validate_extra_attrs
 
 
 class Card(BaseComponent):
@@ -11,7 +12,7 @@ class Card(BaseComponent):
     class_name: str = ""
     extra_attrs: dict[str, str] = Field(default_factory=dict)
 
-    @field_validator("extra_attrs", mode="before")
+    @field_validator("extra_attrs")
     @classmethod
-    def _sanitize_extra_attrs(cls, v: dict) -> dict:
-        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}
+    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
+        return validate_extra_attrs(value)

--- a/pyjinhx/builtins/ui/divider/divider.html
+++ b/pyjinhx/builtins/ui/divider/divider.html
@@ -3,9 +3,9 @@
      class="px-divider px-divider--vertical{% if class_name %} {{ class_name }}{% endif %}"
      role="separator"
      aria-orientation="vertical"
-     {% if label %}aria-label="{{ label }}"{% endif %}></div>
+     {% if label %}aria-label="{{ label }}"{% endif %}{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}></div>
 {% elif label %}
-<div id="{{ id }}" class="px-divider px-divider--labeled{% if class_name %} {{ class_name }}{% endif %}" role="presentation">
+<div id="{{ id }}" class="px-divider px-divider--labeled{% if class_name %} {{ class_name }}{% endif %}" role="presentation"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
   <span class="px-divider__line" aria-hidden="true"></span>
   <span class="px-divider__label">{{ label }}</span>
   <span class="px-divider__line" aria-hidden="true"></span>
@@ -14,5 +14,5 @@
 <hr id="{{ id }}"
     class="px-divider px-divider--horizontal{% if class_name %} {{ class_name }}{% endif %}"
     role="separator"
-    aria-orientation="horizontal" />
+    aria-orientation="horizontal"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %} />
 {% endif %}

--- a/pyjinhx/builtins/ui/divider/divider.py
+++ b/pyjinhx/builtins/ui/divider/divider.py
@@ -1,5 +1,7 @@
 from typing import Literal
 
+from pydantic import Field, field_validator
+
 from pyjinhx import BaseComponent
 
 
@@ -7,3 +9,9 @@ class Divider(BaseComponent):
     orientation: Literal["horizontal", "vertical"] = "horizontal"
     label: str = ""
     class_name: str = ""
+    extra_attrs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("extra_attrs", mode="before")
+    @classmethod
+    def _sanitize_extra_attrs(cls, v: dict) -> dict:
+        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}

--- a/pyjinhx/builtins/ui/divider/divider.py
+++ b/pyjinhx/builtins/ui/divider/divider.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 
 from pyjinhx import BaseComponent
+from pyjinhx.base import validate_extra_attrs
 
 
 class Divider(BaseComponent):
@@ -11,7 +12,7 @@ class Divider(BaseComponent):
     class_name: str = ""
     extra_attrs: dict[str, str] = Field(default_factory=dict)
 
-    @field_validator("extra_attrs", mode="before")
+    @field_validator("extra_attrs")
     @classmethod
-    def _sanitize_extra_attrs(cls, v: dict) -> dict:
-        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}
+    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
+        return validate_extra_attrs(value)

--- a/pyjinhx/builtins/ui/divider/divider.py
+++ b/pyjinhx/builtins/ui/divider/divider.py
@@ -1,18 +1,13 @@
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import validate_extra_attrs
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class Divider(BaseComponent):
     orientation: Literal["horizontal", "vertical"] = "horizontal"
     label: str = ""
-    class_name: str = ""
-    extra_attrs: dict[str, str] = Field(default_factory=dict)
-
-    @field_validator("extra_attrs")
-    @classmethod
-    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
-        return validate_extra_attrs(value)
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/empty_state/empty-state.html
+++ b/pyjinhx/builtins/ui/empty_state/empty-state.html
@@ -1,4 +1,4 @@
-<div class="px-empty-state" id="{{ id }}">
+<div class="px-empty-state{% if class_name %} {{ class_name }}{% endif %}" id="{{ id }}"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
     {% if image %}
     <div class="px-empty-state__image">{{ image }}</div>
     {% endif %}

--- a/pyjinhx/builtins/ui/empty_state/empty_state.py
+++ b/pyjinhx/builtins/ui/empty_state/empty_state.py
@@ -1,7 +1,7 @@
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import validate_extra_attrs
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class EmptyState(BaseComponent):
@@ -10,10 +10,5 @@ class EmptyState(BaseComponent):
     description: str | BaseComponent = ""
     action: str | BaseComponent = ""
     actions: list[str | BaseComponent] = Field(default_factory=list)
-    class_name: str = ""
-    extra_attrs: dict[str, str] = Field(default_factory=dict)
-
-    @field_validator("extra_attrs")
-    @classmethod
-    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
-        return validate_extra_attrs(value)
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/empty_state/empty_state.py
+++ b/pyjinhx/builtins/ui/empty_state/empty_state.py
@@ -1,6 +1,7 @@
 from pydantic import Field, field_validator
 
 from pyjinhx import BaseComponent
+from pyjinhx.base import validate_extra_attrs
 
 
 class EmptyState(BaseComponent):
@@ -12,7 +13,7 @@ class EmptyState(BaseComponent):
     class_name: str = ""
     extra_attrs: dict[str, str] = Field(default_factory=dict)
 
-    @field_validator("extra_attrs", mode="before")
+    @field_validator("extra_attrs")
     @classmethod
-    def _sanitize_extra_attrs(cls, v: dict) -> dict:
-        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}
+    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
+        return validate_extra_attrs(value)

--- a/pyjinhx/builtins/ui/empty_state/empty_state.py
+++ b/pyjinhx/builtins/ui/empty_state/empty_state.py
@@ -1,4 +1,4 @@
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from pyjinhx import BaseComponent
 
@@ -9,3 +9,10 @@ class EmptyState(BaseComponent):
     description: str | BaseComponent = ""
     action: str | BaseComponent = ""
     actions: list[str | BaseComponent] = Field(default_factory=list)
+    class_name: str = ""
+    extra_attrs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("extra_attrs", mode="before")
+    @classmethod
+    def _sanitize_extra_attrs(cls, v: dict) -> dict:
+        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}

--- a/pyjinhx/builtins/ui/progress/progress.html
+++ b/pyjinhx/builtins/ui/progress/progress.html
@@ -1,11 +1,11 @@
-<div class="px-progress" id="{{ id }}">
+<div class="px-progress{% if class_name %} {{ class_name }}{% endif %}" id="{{ id }}"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
     {% if label %}
     <span class="px-progress__label" id="{{ id }}-label">{{ label }}</span>
     {% endif %}
     {% if value is none %}
     <progress class="px-progress__bar"
               max="{{ max }}"
-              {% if label %}aria-labelledby="{{ id }}-label"{% else %}aria-label="Loading"{% endif %}></progress>
+              {% if label %}aria-labelledby="{{ id }}-label"{% else %}aria-label="{{ loading_label }}"{% endif %}></progress>
     {% else %}
     <progress class="px-progress__bar"
               max="{{ max }}"

--- a/pyjinhx/builtins/ui/progress/progress.py
+++ b/pyjinhx/builtins/ui/progress/progress.py
@@ -1,3 +1,5 @@
+from pydantic import Field, field_validator
+
 from pyjinhx import BaseComponent
 
 
@@ -5,3 +7,11 @@ class Progress(BaseComponent):
     value: float | None = None
     max: float = 100
     label: str = ""
+    loading_label: str = "Loading"
+    class_name: str = ""
+    extra_attrs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("extra_attrs", mode="before")
+    @classmethod
+    def _sanitize_extra_attrs(cls, v: dict) -> dict:
+        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}

--- a/pyjinhx/builtins/ui/progress/progress.py
+++ b/pyjinhx/builtins/ui/progress/progress.py
@@ -1,6 +1,7 @@
 from pydantic import Field, field_validator
 
 from pyjinhx import BaseComponent
+from pyjinhx.base import validate_extra_attrs
 
 
 class Progress(BaseComponent):
@@ -11,7 +12,7 @@ class Progress(BaseComponent):
     class_name: str = ""
     extra_attrs: dict[str, str] = Field(default_factory=dict)
 
-    @field_validator("extra_attrs", mode="before")
+    @field_validator("extra_attrs")
     @classmethod
-    def _sanitize_extra_attrs(cls, v: dict) -> dict:
-        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}
+    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
+        return validate_extra_attrs(value)

--- a/pyjinhx/builtins/ui/progress/progress.py
+++ b/pyjinhx/builtins/ui/progress/progress.py
@@ -1,7 +1,7 @@
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import validate_extra_attrs
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class Progress(BaseComponent):
@@ -9,10 +9,5 @@ class Progress(BaseComponent):
     max: float = 100
     label: str = ""
     loading_label: str = "Loading"
-    class_name: str = ""
-    extra_attrs: dict[str, str] = Field(default_factory=dict)
-
-    @field_validator("extra_attrs")
-    @classmethod
-    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
-        return validate_extra_attrs(value)
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/skeleton/skeleton.html
+++ b/pyjinhx/builtins/ui/skeleton/skeleton.html
@@ -1,4 +1,4 @@
-<div class="px-skeleton px-skeleton--{{ variant }}{% if class_name %} {{ class_name }}{% endif %}" id="{{ id }}">
+<div class="px-skeleton px-skeleton--{{ variant }}{% if class_name %} {{ class_name }}{% endif %}" id="{{ id }}"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
     {% if variant == 'text' %}
     {% for _ in range(lines) %}
     <div class="px-skeleton__line"></div>

--- a/pyjinhx/builtins/ui/skeleton/skeleton.py
+++ b/pyjinhx/builtins/ui/skeleton/skeleton.py
@@ -1,5 +1,7 @@
 from typing import Literal
 
+from pydantic import Field, field_validator
+
 from pyjinhx import BaseComponent
 
 
@@ -7,3 +9,9 @@ class Skeleton(BaseComponent):
     variant: Literal["text", "circle", "rect"] = "text"
     lines: int = 3
     class_name: str = ""
+    extra_attrs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("extra_attrs", mode="before")
+    @classmethod
+    def _sanitize_extra_attrs(cls, v: dict) -> dict:
+        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}

--- a/pyjinhx/builtins/ui/skeleton/skeleton.py
+++ b/pyjinhx/builtins/ui/skeleton/skeleton.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 
 from pyjinhx import BaseComponent
+from pyjinhx.base import validate_extra_attrs
 
 
 class Skeleton(BaseComponent):
@@ -11,7 +12,7 @@ class Skeleton(BaseComponent):
     class_name: str = ""
     extra_attrs: dict[str, str] = Field(default_factory=dict)
 
-    @field_validator("extra_attrs", mode="before")
+    @field_validator("extra_attrs")
     @classmethod
-    def _sanitize_extra_attrs(cls, v: dict) -> dict:
-        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}
+    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
+        return validate_extra_attrs(value)

--- a/pyjinhx/builtins/ui/skeleton/skeleton.py
+++ b/pyjinhx/builtins/ui/skeleton/skeleton.py
@@ -1,18 +1,13 @@
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import validate_extra_attrs
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class Skeleton(BaseComponent):
     variant: Literal["text", "circle", "rect"] = "text"
     lines: int = 3
-    class_name: str = ""
-    extra_attrs: dict[str, str] = Field(default_factory=dict)
-
-    @field_validator("extra_attrs")
-    @classmethod
-    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
-        return validate_extra_attrs(value)
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/tooltip/tooltip.html
+++ b/pyjinhx/builtins/ui/tooltip/tooltip.html
@@ -1,4 +1,4 @@
-<span class="px-tooltip" id="{{ id }}" data-px-tooltip-placement="{{ placement }}">
+<span class="px-tooltip{% if class_name %} {{ class_name }}{% endif %}" id="{{ id }}" data-px-tooltip-placement="{{ placement }}"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
     <span class="px-tooltip__trigger" tabindex="0" aria-describedby="{{ id }}-tip">{{ trigger }}</span>
     <span class="px-tooltip__tip" id="{{ id }}-tip" role="tooltip" hidden>{{ tip }}</span>
 </span>

--- a/pyjinhx/builtins/ui/tooltip/tooltip.js
+++ b/pyjinhx/builtins/ui/tooltip/tooltip.js
@@ -1,4 +1,7 @@
 (function () {
+    window.px = window.px || {};
+    if (px._tooltipWired) return;
+    px._tooltipWired = true;
     let activeTip = null;
     let hideTimer = null;
 

--- a/pyjinhx/builtins/ui/tooltip/tooltip.py
+++ b/pyjinhx/builtins/ui/tooltip/tooltip.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 
 from pyjinhx import BaseComponent
+from pyjinhx.base import validate_extra_attrs
 
 
 class Tooltip(BaseComponent):
@@ -12,7 +13,7 @@ class Tooltip(BaseComponent):
     class_name: str = ""
     extra_attrs: dict[str, str] = Field(default_factory=dict)
 
-    @field_validator("extra_attrs", mode="before")
+    @field_validator("extra_attrs")
     @classmethod
-    def _sanitize_extra_attrs(cls, v: dict) -> dict:
-        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}
+    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
+        return validate_extra_attrs(value)

--- a/pyjinhx/builtins/ui/tooltip/tooltip.py
+++ b/pyjinhx/builtins/ui/tooltip/tooltip.py
@@ -1,19 +1,14 @@
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import validate_extra_attrs
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class Tooltip(BaseComponent):
     trigger: str | BaseComponent = ""
     tip: str | BaseComponent = ""
     placement: Literal["top", "bottom", "start", "end"] = "top"
-    class_name: str = ""
-    extra_attrs: dict[str, str] = Field(default_factory=dict)
-
-    @field_validator("extra_attrs")
-    @classmethod
-    def _validate_extra_attrs(cls, value: dict[str, str]) -> dict[str, str]:
-        return validate_extra_attrs(value)
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/tooltip/tooltip.py
+++ b/pyjinhx/builtins/ui/tooltip/tooltip.py
@@ -1,5 +1,7 @@
 from typing import Literal
 
+from pydantic import Field, field_validator
+
 from pyjinhx import BaseComponent
 
 
@@ -7,3 +9,10 @@ class Tooltip(BaseComponent):
     trigger: str | BaseComponent = ""
     tip: str | BaseComponent = ""
     placement: Literal["top", "bottom", "start", "end"] = "top"
+    class_name: str = ""
+    extra_attrs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("extra_attrs", mode="before")
+    @classmethod
+    def _sanitize_extra_attrs(cls, v: dict) -> dict:
+        return {k: str(val).replace("<", "").replace(">", "") for k, val in v.items()}

--- a/tests/70_static_sweep_test.py
+++ b/tests/70_static_sweep_test.py
@@ -1,0 +1,38 @@
+from pyjinhx.builtins import (
+    Avatar, Badge, Breadcrumb, Card, Divider, EmptyState, Progress, Skeleton, Tooltip,
+)
+
+SWEPT = [Avatar, Badge, Breadcrumb, Card, Divider, EmptyState, Progress, Skeleton, Tooltip]
+
+
+def test_contract_fields_present():
+    for cls in SWEPT:
+        assert "class_name" in cls.model_fields, cls.__name__
+        assert "extra_attrs" in cls.model_fields, cls.__name__
+
+
+def test_class_name_and_extra_attrs_render():
+    html = str(Badge(id="b", label="x", class_name="mine", extra_attrs={"data-k": "v"}).render())
+    assert 'class="px-badge px-badge--neutral px-badge--md mine"' in html
+    assert 'data-k="v"' in html
+    assert 'id="b"' in html  # Badge root gains an id attribute
+
+
+def test_extra_attrs_values_are_escaped():
+    html = str(Badge(id="b", label="x", extra_attrs={"data-k": '"><script>'}).render())
+    assert "<script>" not in html
+
+
+def test_avatar_color():
+    html = str(Avatar(id="a", initials="PM", color="#A0C080").render())
+    assert "background:#A0C080" in html.replace(" ", "")
+
+
+def test_breadcrumb_aria_label_prop():
+    html = str(Breadcrumb(id="bc", items=[("Home", "/")], aria_label="Caminho").render())
+    assert 'aria-label="Caminho"' in html
+
+
+def test_progress_loading_label_prop():
+    html = str(Progress(id="p", loading_label="Carregando").render())
+    assert 'aria-label="Carregando"' in html

--- a/tests/70_static_sweep_test.py
+++ b/tests/70_static_sweep_test.py
@@ -7,12 +7,6 @@ from pyjinhx.builtins import (
 SWEPT = [Avatar, Badge, Breadcrumb, Card, Divider, EmptyState, Progress, Skeleton, Tooltip]
 
 
-def test_contract_fields_present():
-    for cls in SWEPT:
-        assert "class_name" in cls.model_fields, cls.__name__
-        assert "extra_attrs" in cls.model_fields, cls.__name__
-
-
 def test_class_name_and_extra_attrs_render():
     html = str(Badge(id="b", label="x", class_name="mine", extra_attrs={"data-k": "v"}).render())
     assert 'class="px-badge px-badge--neutral px-badge--md mine"' in html
@@ -25,11 +19,21 @@ def test_extra_attrs_rejects_breakout_values():
         Badge(id="b", label="x", extra_attrs={"data-k": '"><script>'})
     with pytest.raises(ValueError):
         Badge(id="b", label="x", extra_attrs={"data-k": '" onmouseover="x'})
+    # < and > are spec-legal inside double-quoted attrs — must NOT be rejected
+    badge = Badge(id="b", label="x", extra_attrs={"x-show": "count > 3"})
+    assert 'x-show="count &gt; 3"' in str(badge.render()) or 'x-show="count > 3"' in str(badge.render())
 
 
 def test_extra_attrs_rejects_bad_names():
     with pytest.raises(ValueError):
         Badge(id="b", label="x", extra_attrs={"data k": "v"})
+
+
+def test_class_name_and_color_reject_quotes():
+    with pytest.raises(ValueError):
+        Badge(id="b", label="x", class_name='mine" onmouseover="x')
+    with pytest.raises(ValueError):
+        Avatar(id="a", initials="X", color='red" onmouseover="x')
 
 
 def test_extra_attrs_allows_htmx_and_alpine_names():
@@ -38,7 +42,12 @@ def test_extra_attrs_allows_htmx_and_alpine_names():
         "x-on:click.prevent": "go()", "hx-on::after-swap": "init()",
         "aria-label": "ok",
     }).render())
-    assert 'hx-get="/x"' in html and '@click="open = !open"' in html
+    assert 'hx-get="/x"' in html
+    assert '@click="open = !open"' in html
+    assert 'data-k="v"' in html
+    assert 'x-on:click.prevent="go()"' in html
+    assert 'hx-on::after-swap="init()"' in html
+    assert 'aria-label="ok"' in html
 
 
 def test_avatar_color():

--- a/tests/70_static_sweep_test.py
+++ b/tests/70_static_sweep_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pyjinhx.builtins import (
     Avatar, Badge, Breadcrumb, Card, Divider, EmptyState, Progress, Skeleton, Tooltip,
 )
@@ -18,9 +20,25 @@ def test_class_name_and_extra_attrs_render():
     assert 'id="b"' in html  # Badge root gains an id attribute
 
 
-def test_extra_attrs_values_are_escaped():
-    html = str(Badge(id="b", label="x", extra_attrs={"data-k": '"><script>'}).render())
-    assert "<script>" not in html
+def test_extra_attrs_rejects_breakout_values():
+    with pytest.raises(ValueError):
+        Badge(id="b", label="x", extra_attrs={"data-k": '"><script>'})
+    with pytest.raises(ValueError):
+        Badge(id="b", label="x", extra_attrs={"data-k": '" onmouseover="x'})
+
+
+def test_extra_attrs_rejects_bad_names():
+    with pytest.raises(ValueError):
+        Badge(id="b", label="x", extra_attrs={"data k": "v"})
+
+
+def test_extra_attrs_allows_htmx_and_alpine_names():
+    html = str(Badge(id="b", label="x", extra_attrs={
+        "hx-get": "/x", "data-k": "v", "@click": "open = !open",
+        "x-on:click.prevent": "go()", "hx-on::after-swap": "init()",
+        "aria-label": "ok",
+    }).render())
+    assert 'hx-get="/x"' in html and '@click="open = !open"' in html
 
 
 def test_avatar_color():

--- a/tests/71_builtin_conventions_test.py
+++ b/tests/71_builtin_conventions_test.py
@@ -1,0 +1,56 @@
+# tests/71_builtin_conventions_test.py
+"""Mechanical enforcement of docs/guide/builtin-conventions.md.
+
+SWEPT grows phase by phase; Phase 7 asserts SWEPT covers every builtin.
+"""
+import os
+import re
+
+import pyjinhx.builtins as b
+
+SWEPT: list[type] = [
+    b.Avatar, b.Badge, b.Breadcrumb, b.Card, b.Divider, b.EmptyState,
+    b.Progress, b.Skeleton, b.Tooltip,
+]
+
+UI_ROOT = os.path.join(os.path.dirname(b.__file__), "ui")
+
+
+def _component_dir(cls: type) -> str:
+    import inspect
+    return os.path.dirname(inspect.getfile(cls))
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_swept_builtins_declare_contract_fields():
+    for cls in SWEPT:
+        assert "class_name" in cls.model_fields, cls.__name__
+        assert "extra_attrs" in cls.model_fields, cls.__name__
+
+
+def test_swept_templates_have_no_literal_aria_labels():
+    for cls in SWEPT:
+        directory = _component_dir(cls)
+        for name in os.listdir(directory):
+            if not name.endswith((".html", ".jinja")):
+                continue
+            content = _read(os.path.join(directory, name))
+            for match in re.finditer(r'aria-label="([^"]*)"', content):
+                assert "{{" in match.group(1), (
+                    f"{cls.__name__}/{name}: hardcoded aria-label {match.group(1)!r}; make it a prop"
+                )
+
+
+def test_swept_js_files_are_guarded_iifes():
+    for cls in SWEPT:
+        directory = _component_dir(cls)
+        for name in os.listdir(directory):
+            if not name.endswith(".js"):
+                continue
+            content = _read(os.path.join(directory, name)).lstrip()
+            assert content.startswith("(function ()"), f"{cls.__name__}/{name}: not an IIFE"
+            assert "window.px = window.px || {}" in content, f"{cls.__name__}/{name}: missing px guard"

--- a/tests/golden/badge_default.html
+++ b/tests/golden/badge_default.html
@@ -1,1 +1,1 @@
-<span class="px-badge px-badge--neutral px-badge--md">New</span>
+<span id="g" class="px-badge px-badge--neutral px-badge--md">New</span>


### PR DESCRIPTION
## Summary
- Avatar, Badge, Breadcrumb, Card, Divider, EmptyState, Progress, Skeleton, Tooltip now follow the builtin contract: `class_name` (root class extension) + `extra_attrs` (attribute passthrough) on every root element, all copy as props (`Breadcrumb.aria_label`, `Progress.loading_label`), `Avatar.color`, Badge gains a root `id`.
- Attribute safety: `AttrValue`/`ExtraAttrs` annotated aliases in `base.py` reject quote-breakout (`"`) in values and validate attribute names (`fullmatch`); htmx/Alpine syntaxes (`@click`, `x-on:click.prevent`, `hx-on::after-swap`, `x-show="count > 3"`) all pass. Rejection, never silent mutation. (The renderer unescapes final markup by design, so construct-time validation is the effective guard.)
- `tooltip.js` gains the px-namespace re-execution guard (htmx fragment re-ships no longer double-bind).
- New `docs/guide/builtin-conventions.md` (the contract, with a status callout for sections landing later in the stack) + mechanical enforcement tests (`tests/71`).
- Goldens: only `badge_default.html` re-baselined (the added id) — everything else byte-identical, proving the sweep is additive.

PR 2/8, stacked on #47.

## Test plan
- [x] `uv run pytest tests/ -q` — 385 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run mkdocs build --strict` — OK
- [x] `node --check` tooltip.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)