### PR TITLE
Builtins v2: Modal + Drawer go headless (px namespace, hooks, fragment lifecycle)

### DIFF
--- a/pyjinhx/builtins/ui/drawer/drawer.html
+++ b/pyjinhx/builtins/ui/drawer/drawer.html
@@ -1,11 +1,11 @@
-<dialog class="px-drawer px-drawer--{{ side }}" id="{{ id }}">
+<dialog class="px-drawer px-drawer--{{ side }}{% if class_name %} {{ class_name }}{% endif %}" id="{{ id }}"{% if open_on_mount %} data-px-open-on-mount{% endif %}{% if remove_on_close %} data-px-remove-on-close{% endif %}{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
     <div class="px-drawer__box">
         <header class="px-drawer__header">
             <span class="px-drawer__title">{{ title }}</span>
             <button type="button"
                     class="px-drawer__close"
-                    onclick="closePxDrawer('{{ id }}')"
-                    aria-label="Close">&#x2715;</button>
+                    data-px-close
+                    aria-label="{{ close_label }}">&#x2715;</button>
         </header>
         <div class="px-drawer__body">{{ body }}</div>
         {% if footer %}

--- a/pyjinhx/builtins/ui/drawer/drawer.js
+++ b/pyjinhx/builtins/ui/drawer/drawer.js
@@ -1,25 +1,88 @@
-function openPxDrawer(id) {
-    const el = document.getElementById(id);
-    if (!el) return;
-    el.showModal();
-}
+(function () {
+    window.px = window.px || {};
+    if (px.drawer) return;
 
-function closePxDrawer(id) {
-    const el = document.getElementById(id);
-    if (!el) return;
-    el.classList.add('px-drawer--closing');
-    el.addEventListener(
-        'animationend',
-        () => {
-            el.classList.remove('px-drawer--closing');
-            el.close();
-        },
-        { once: true }
-    );
-}
-
-document.addEventListener('click', (e) => {
-    if (e.target.tagName === 'DIALOG' && e.target.classList.contains('px-drawer')) {
-        closePxDrawer(e.target.id);
+    function fire(el, name, detail, cancelable) {
+        return el.dispatchEvent(new CustomEvent(name, {
+            bubbles: true, cancelable: Boolean(cancelable), detail: detail || {},
+        }));
     }
-});
+
+    function open(id, reason, trigger) {
+        const drawer = document.getElementById(id);
+        if (!drawer || drawer.open) return false;
+        const detail = { reason: reason || 'api', trigger: trigger || null };
+        if (!fire(drawer, 'px:drawer:before-open', detail, true)) return false;
+        drawer.showModal();
+        fire(drawer, 'px:drawer:open', detail);
+        return true;
+    }
+
+    function close(id, reason, trigger) {
+        const drawer = document.getElementById(id);
+        if (!drawer || !drawer.open) return false;
+        const detail = { reason: reason || 'api', trigger: trigger || null };
+        if (!fire(drawer, 'px:drawer:before-close', detail, true)) return false;
+        drawer.classList.add('px-drawer--closing');
+        drawer.addEventListener('animationend', () => {
+            drawer.classList.remove('px-drawer--closing');
+            drawer.close();
+            fire(drawer, 'px:drawer:close', detail);
+            if (drawer.hasAttribute('data-px-remove-on-close')) drawer.remove();
+        }, { once: true });
+        return true;
+    }
+
+    document.addEventListener('click', (e) => {
+        const opener = e.target.closest('[data-px-open]');
+        if (opener) {
+            const target = document.getElementById(opener.getAttribute('data-px-open'));
+            if (target && target.classList.contains('px-drawer')) {
+                open(target.id, 'trigger', opener);
+                return;
+            }
+        }
+        const closer = e.target.closest('[data-px-close]');
+        if (closer) {
+            const dialog = closer.closest('dialog.px-drawer');
+            if (dialog) {
+                close(dialog.id, 'trigger', closer);
+                return;
+            }
+        }
+        if (e.target.tagName === 'DIALOG' && e.target.classList.contains('px-drawer')) {
+            close(e.target.id, 'backdrop', null);
+        }
+    });
+
+    // Native Escape fires `cancel`; intercept (capture — it doesn't bubble)
+    // and route through close() so px:drawer:before-close can veto it.
+    document.addEventListener('cancel', (e) => {
+        const dialog = e.target;
+        if (!(dialog instanceof HTMLDialogElement)) return;
+        if (!dialog.classList.contains('px-drawer')) return;
+        e.preventDefault();
+        close(dialog.id, 'escape', null);
+    }, true);
+
+    // open_on_mount: fragment-delivered drawers (hx-swap="beforeend") open on arrival.
+    function openMounted(rootNode) {
+        if (!rootNode.querySelectorAll) return;
+        rootNode.querySelectorAll('dialog.px-drawer[data-px-open-on-mount]').forEach((d) => {
+            if (!d.open) open(d.id, 'api', null);
+        });
+    }
+    const observer = new MutationObserver((mutations) => {
+        mutations.forEach((m) => m.addedNodes.forEach((n) => {
+            if (n.nodeType === 1) openMounted(n);
+        }));
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => openMounted(document));
+    } else {
+        openMounted(document);
+    }
+
+    px.drawer = { open: open, close: close };
+}());

--- a/pyjinhx/builtins/ui/drawer/drawer.js
+++ b/pyjinhx/builtins/ui/drawer/drawer.js
@@ -21,15 +21,28 @@
     function close(id, reason, trigger) {
         const drawer = document.getElementById(id);
         if (!drawer || !drawer.open) return false;
+        if (drawer.classList.contains('px-drawer--closing')) return false;
         const detail = { reason: reason || 'api', trigger: trigger || null };
         if (!fire(drawer, 'px:drawer:before-close', detail, true)) return false;
         drawer.classList.add('px-drawer--closing');
-        drawer.addEventListener('animationend', () => {
+
+        let fallbackTimer = null;
+        function finalize() {
+            drawer.removeEventListener('animationend', onAnimationEnd);
+            clearTimeout(fallbackTimer);
+            if (!drawer.classList.contains('px-drawer--closing')) return;
             drawer.classList.remove('px-drawer--closing');
             drawer.close();
             fire(drawer, 'px:drawer:close', detail);
             if (drawer.hasAttribute('data-px-remove-on-close')) drawer.remove();
-        }, { once: true });
+        }
+        function onAnimationEnd(e) {
+            if (e.target !== drawer) return; // ignore bubbled descendant animations
+            finalize();
+        }
+        drawer.addEventListener('animationend', onAnimationEnd);
+        // Fallback for animation-less environments (prefers-reduced-motion, overrides).
+        fallbackTimer = setTimeout(finalize, 250);
         return true;
     }
 
@@ -67,6 +80,9 @@
 
     // open_on_mount: fragment-delivered drawers (hx-swap="beforeend") open on arrival.
     function openMounted(rootNode) {
+        if (rootNode.matches && rootNode.matches('dialog.px-drawer[data-px-open-on-mount]')) {
+            if (!rootNode.open) open(rootNode.id, 'api', null);
+        }
         if (!rootNode.querySelectorAll) return;
         rootNode.querySelectorAll('dialog.px-drawer[data-px-open-on-mount]').forEach((d) => {
             if (!d.open) open(d.id, 'api', null);

--- a/pyjinhx/builtins/ui/drawer/drawer.py
+++ b/pyjinhx/builtins/ui/drawer/drawer.py
@@ -1,6 +1,9 @@
 from typing import Literal
 
+from pydantic import Field
+
 from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class Drawer(BaseComponent):
@@ -8,3 +11,8 @@ class Drawer(BaseComponent):
     title: str | BaseComponent = ""
     body: str | BaseComponent = ""
     footer: str | BaseComponent = ""
+    close_label: str = "Close"
+    open_on_mount: bool = False
+    remove_on_close: bool = False
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/modal/modal.html
+++ b/pyjinhx/builtins/ui/modal/modal.html
@@ -1,4 +1,4 @@
-<dialog class="px-modal" id="{{ id }}">
+<dialog class="px-modal{% if class_name %} {{ class_name }}{% endif %}" id="{{ id }}"{% if open_on_mount %} data-px-open-on-mount{% endif %}{% if remove_on_close %} data-px-remove-on-close{% endif %}{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
     <div class="px-modal__box">
         <header class="px-modal__header">
             {% if header %}
@@ -6,9 +6,7 @@
             {% else %}
             <span class="px-modal__title">{{ title }}</span>
             {% endif %}
-            <button class="px-modal__close"
-                    onclick="closeModal('{{ id }}')"
-                    aria-label="Close">&#x2715;</button>
+            <button type="button" class="px-modal__close" data-px-close aria-label="{{ close_label }}">&#x2715;</button>
         </header>
 
         <div class="px-modal__body" id="{{ id }}-body">{{ body }}</div>

--- a/pyjinhx/builtins/ui/modal/modal.js
+++ b/pyjinhx/builtins/ui/modal/modal.js
@@ -1,23 +1,88 @@
-function openModal(id) {
-    const modal = document.getElementById(id);
-    if (!modal) return;
-    modal.showModal();
-}
+(function () {
+    window.px = window.px || {};
+    if (px.modal) return;
 
-function closeModal(id) {
-    const modal = document.getElementById(id);
-    if (!modal || !modal.open) return;
-    modal.classList.add('px-modal--closing');
-    modal.addEventListener('animationend', () => {
-        modal.classList.remove('px-modal--closing');
-        modal.close();
-    }, { once: true });
-}
-
-// Close on backdrop click (click lands on the <dialog> element itself,
-// not on any child, when the user clicks outside the modal box)
-document.addEventListener('click', (e) => {
-    if (e.target.tagName === 'DIALOG') {
-        closeModal(e.target.id);
+    function fire(el, name, detail, cancelable) {
+        return el.dispatchEvent(new CustomEvent(name, {
+            bubbles: true, cancelable: Boolean(cancelable), detail: detail || {},
+        }));
     }
-});
+
+    function open(id, reason, trigger) {
+        const modal = document.getElementById(id);
+        if (!modal || modal.open) return false;
+        const detail = { reason: reason || 'api', trigger: trigger || null };
+        if (!fire(modal, 'px:modal:before-open', detail, true)) return false;
+        modal.showModal();
+        fire(modal, 'px:modal:open', detail);
+        return true;
+    }
+
+    function close(id, reason, trigger) {
+        const modal = document.getElementById(id);
+        if (!modal || !modal.open) return false;
+        const detail = { reason: reason || 'api', trigger: trigger || null };
+        if (!fire(modal, 'px:modal:before-close', detail, true)) return false;
+        modal.classList.add('px-modal--closing');
+        modal.addEventListener('animationend', () => {
+            modal.classList.remove('px-modal--closing');
+            modal.close();
+            fire(modal, 'px:modal:close', detail);
+            if (modal.hasAttribute('data-px-remove-on-close')) modal.remove();
+        }, { once: true });
+        return true;
+    }
+
+    document.addEventListener('click', (e) => {
+        const opener = e.target.closest('[data-px-open]');
+        if (opener) {
+            const target = document.getElementById(opener.getAttribute('data-px-open'));
+            if (target && target.classList.contains('px-modal')) {
+                open(target.id, 'trigger', opener);
+                return;
+            }
+        }
+        const closer = e.target.closest('[data-px-close]');
+        if (closer) {
+            const dialog = closer.closest('dialog.px-modal');
+            if (dialog) {
+                close(dialog.id, 'trigger', closer);
+                return;
+            }
+        }
+        if (e.target.tagName === 'DIALOG' && e.target.classList.contains('px-modal')) {
+            close(e.target.id, 'backdrop', null);
+        }
+    });
+
+    // Native Escape fires `cancel`; intercept (capture — it doesn't bubble)
+    // and route through close() so px:modal:before-close can veto it.
+    document.addEventListener('cancel', (e) => {
+        const dialog = e.target;
+        if (!(dialog instanceof HTMLDialogElement)) return;
+        if (!dialog.classList.contains('px-modal')) return;
+        e.preventDefault();
+        close(dialog.id, 'escape', null);
+    }, true);
+
+    // open_on_mount: fragment-delivered modals (hx-swap="beforeend") open on arrival.
+    function openMounted(rootNode) {
+        if (!rootNode.querySelectorAll) return;
+        rootNode.querySelectorAll('dialog.px-modal[data-px-open-on-mount]').forEach((m) => {
+            if (!m.open) open(m.id, 'api', null);
+        });
+    }
+    const observer = new MutationObserver((mutations) => {
+        mutations.forEach((m) => m.addedNodes.forEach((n) => {
+            if (n.nodeType === 1) openMounted(n);
+        }));
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => openMounted(document));
+    } else {
+        openMounted(document);
+    }
+
+    px.modal = { open: open, close: close };
+}());

--- a/pyjinhx/builtins/ui/modal/modal.js
+++ b/pyjinhx/builtins/ui/modal/modal.js
@@ -21,15 +21,28 @@
     function close(id, reason, trigger) {
         const modal = document.getElementById(id);
         if (!modal || !modal.open) return false;
+        if (modal.classList.contains('px-modal--closing')) return false;
         const detail = { reason: reason || 'api', trigger: trigger || null };
         if (!fire(modal, 'px:modal:before-close', detail, true)) return false;
         modal.classList.add('px-modal--closing');
-        modal.addEventListener('animationend', () => {
+
+        let fallbackTimer = null;
+        function finalize() {
+            modal.removeEventListener('animationend', onAnimationEnd);
+            clearTimeout(fallbackTimer);
+            if (!modal.classList.contains('px-modal--closing')) return;
             modal.classList.remove('px-modal--closing');
             modal.close();
             fire(modal, 'px:modal:close', detail);
             if (modal.hasAttribute('data-px-remove-on-close')) modal.remove();
-        }, { once: true });
+        }
+        function onAnimationEnd(e) {
+            if (e.target !== modal) return; // ignore bubbled descendant animations
+            finalize();
+        }
+        modal.addEventListener('animationend', onAnimationEnd);
+        // Fallback for animation-less environments (prefers-reduced-motion, overrides).
+        fallbackTimer = setTimeout(finalize, 250);
         return true;
     }
 
@@ -67,6 +80,9 @@
 
     // open_on_mount: fragment-delivered modals (hx-swap="beforeend") open on arrival.
     function openMounted(rootNode) {
+        if (rootNode.matches && rootNode.matches('dialog.px-modal[data-px-open-on-mount]')) {
+            if (!rootNode.open) open(rootNode.id, 'api', null);
+        }
         if (!rootNode.querySelectorAll) return;
         rootNode.querySelectorAll('dialog.px-modal[data-px-open-on-mount]').forEach((m) => {
             if (!m.open) open(m.id, 'api', null);

--- a/pyjinhx/builtins/ui/modal/modal.py
+++ b/pyjinhx/builtins/ui/modal/modal.py
@@ -1,4 +1,7 @@
+from pydantic import Field
+
 from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class Modal(BaseComponent):
@@ -6,3 +9,8 @@ class Modal(BaseComponent):
     header: str | BaseComponent = ""
     body: str | BaseComponent = ""
     footer: str | BaseComponent = ""
+    close_label: str = "Close"
+    open_on_mount: bool = False
+    remove_on_close: bool = False
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/tests/71_builtin_conventions_test.py
+++ b/tests/71_builtin_conventions_test.py
@@ -10,7 +10,7 @@ import pyjinhx.builtins as b
 
 SWEPT: list[type] = [
     b.Avatar, b.Badge, b.Breadcrumb, b.Card, b.Divider, b.EmptyState,
-    b.Progress, b.Skeleton, b.Tooltip,
+    b.Modal, b.Drawer, b.Progress, b.Skeleton, b.Tooltip,
 ]
 
 UI_ROOT = os.path.join(os.path.dirname(b.__file__), "ui")

--- a/tests/72_modal_redesign_test.py
+++ b/tests/72_modal_redesign_test.py
@@ -1,0 +1,32 @@
+import re
+
+from pyjinhx.builtins import Modal
+
+
+def _dialog(html: str) -> str:
+    """Extract only the <dialog> element from a rendered component (strips inline script/style)."""
+    m = re.search(r"<dialog[\s\S]*?</dialog>", html)
+    return m.group(0) if m else html
+
+
+def test_modal_contract_and_lifecycle_attrs():
+    html = str(Modal(
+        id="m1", title="T", body="B",
+        close_label="Fechar", class_name="danger",
+        extra_attrs={"data-x": "1"},
+        open_on_mount=True, remove_on_close=True,
+    ).render())
+    assert 'class="px-modal danger"' in html
+    assert 'aria-label="Fechar"' in html
+    assert 'data-x="1"' in html
+    assert "data-px-open-on-mount" in html
+    assert "data-px-remove-on-close" in html
+    assert "data-px-close" in html
+    assert "onclick" not in html
+
+
+def test_modal_defaults_omit_lifecycle_attrs():
+    dialog = _dialog(str(Modal(id="m2", body="B").render()))
+    assert "data-px-open-on-mount" not in dialog
+    assert "data-px-remove-on-close" not in dialog
+    assert 'aria-label="Close"' in dialog

--- a/tests/73_drawer_redesign_test.py
+++ b/tests/73_drawer_redesign_test.py
@@ -1,4 +1,12 @@
+import re
+
 from pyjinhx.builtins import Drawer
+
+
+def _dialog(html: str) -> str:
+    """Extract only the <dialog> element from a rendered component (strips inline script/style)."""
+    m = re.search(r"<dialog[\s\S]*?</dialog>", html)
+    return m.group(0) if m else html
 
 
 def test_drawer_contract_and_lifecycle_attrs():
@@ -15,3 +23,10 @@ def test_drawer_contract_and_lifecycle_attrs():
     assert "data-px-remove-on-close" in html
     assert "data-px-close" in html
     assert "onclick" not in html
+
+
+def test_drawer_defaults_omit_lifecycle_attrs():
+    dialog = _dialog(str(Drawer(id="d2", body="B").render()))
+    assert "data-px-open-on-mount" not in dialog
+    assert "data-px-remove-on-close" not in dialog
+    assert 'aria-label="Close"' in dialog

--- a/tests/73_drawer_redesign_test.py
+++ b/tests/73_drawer_redesign_test.py
@@ -1,0 +1,17 @@
+from pyjinhx.builtins import Drawer
+
+
+def test_drawer_contract_and_lifecycle_attrs():
+    html = str(Drawer(
+        id="d1", title="T", body="B",
+        close_label="Fechar", class_name="wide",
+        extra_attrs={"data-x": "1"},
+        open_on_mount=True, remove_on_close=True,
+    ).render())
+    assert 'class="px-drawer px-drawer--right wide"' in html
+    assert 'aria-label="Fechar"' in html
+    assert 'data-x="1"' in html
+    assert "data-px-open-on-mount" in html
+    assert "data-px-remove-on-close" in html
+    assert "data-px-close" in html
+    assert "onclick" not in html

--- a/tests/golden/drawer.html
+++ b/tests/golden/drawer.html
@@ -4,7 +4,7 @@
             <span class="px-drawer__title">T</span>
             <button type="button"
                     class="px-drawer__close"
-                    onclick="closePxDrawer('g')"
+                    data-px-close
                     aria-label="Close">✕</button>
         </header>
         <div class="px-drawer__body">B</div>

--- a/tests/golden/modal.html
+++ b/tests/golden/modal.html
@@ -4,9 +4,7 @@
             
             <span class="px-modal__title">T</span>
             
-            <button class="px-modal__close"
-                    onclick="closeModal('g')"
-                    aria-label="Close">✕</button>
+            <button type="button" class="px-modal__close" data-px-close aria-label="Close">✕</button>
         </header>
 
         <div class="px-modal__body" id="g-body">B</div>

--- a/tests/integration/app.py
+++ b/tests/integration/app.py
@@ -45,7 +45,7 @@ _SHOWCASE_TEMPLATE = """
 <h2>Modal</h2>
 <section class="demo-stack">
 {{ modal }}
-<button type="button" class="demo-btn" onclick="openModal('g-modal')">Open modal</button>
+<button type="button" class="demo-btn" data-px-open="g-modal">Open modal</button>
 </section>
 
 <h2>Notification</h2>
@@ -89,7 +89,7 @@ _SHOWCASE_TEMPLATE = """
 <h2>Drawer</h2>
 <section class="demo-stack">
 {{ drawer }}
-<button type="button" class="demo-btn" onclick="openPxDrawer('g-drawer')">Open drawer</button>
+<button type="button" class="demo-btn" data-px-open="g-drawer">Open drawer</button>
 </section>
 
 <h2>Progress</h2>


### PR DESCRIPTION
## Summary
- `openModal()`/`closeModal()`/`openPxDrawer()`/`closePxDrawer()` globals and `onclick=` call sites are gone. New: `px.modal.open/close(id)`, `px.drawer.open/close(id)`, declarative `data-px-open="<id>"` / `data-px-close` triggers.
- Cancelable hook events on the root: `px:modal:before-open/before-close` (`preventDefault()` vetoes; `detail = {reason, trigger}`) + `px:modal:open/close` after-events — same for drawer. Escape is intercepted (capture-phase `cancel`) and routed through the veto hook.
- Fragment lifecycle for the htmx body-mounted pattern: `open_on_mount=True` (auto-opens on arrival — works when the fragment root IS the dialog) and `remove_on_close=True` (tears the element out, no fragment ghosts).
- Close lifecycle hardened: re-entry guard, descendant-animation filtering, and a 250ms fallback so dialogs close under `prefers-reduced-motion`/animation-less CSS.
- Templates: `close_label` prop (was hardcoded `aria-label="Close"`), `class_name`, `extra_attrs`. IIFE+guard JS — htmx re-ships no longer double-bind listeners.

Known deferral: a `data-px-close` inside *nested* dialogs (Drawer inside Modal) closes both — the nearest-dismissible rule lands in PR 5 of this stack, which amends these exact branches.

PR 3/8, stacked on #48.

## Test plan
- [x] `uv run pytest tests/ -q` — 389 passed
- [x] `uv run ruff check .` / `node --check` modal.js, drawer.js
- [x] Goldens: only modal.html + drawer.html re-baselined (onclick → data-px-close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)