### PR TITLE
Builtins v2: reveal events, declarative Notification, LazyPanel presets, loading family

### DIFF
--- a/docs/guide/builtin-conventions.md
+++ b/docs/guide/builtin-conventions.md
@@ -48,6 +48,7 @@ document.getElementById("confirm-del").addEventListener("px:modal:before-close",
 | `data-px-confirm-ok`, `data-px-confirm-cancel` | per-trigger confirm-dialog label overrides |
 | `data-px-loader` | requests from this subtree show the PageLoader |
 | `data-px-region` | marks a show/hide region (emits `px:reveal`) |
+| `data-px-autoshow` | Notification auto-shows when this attribute is present on mount |
 
 ## The `window.px` namespace
 

--- a/pyjinhx/builtins/ui/alert/alert.html
+++ b/pyjinhx/builtins/ui/alert/alert.html
@@ -1,4 +1,4 @@
-<div class="px-alert px-alert--{{ variant }}" id="{{ id }}" role="status">
+<div class="px-alert px-alert--{{ variant }}{% if class_name %} {{ class_name }}{% endif %}" id="{{ id }}" role="status"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
     <div class="px-alert__inner">
         <div class="px-alert__text">
             {% if title %}
@@ -7,7 +7,7 @@
             <div class="px-alert__body">{{ body }}</div>
         </div>
         {% if dismissible %}
-        <button type="button" class="px-alert__dismiss" onclick="dismissPxAlert('{{ id }}')" aria-label="Dismiss">&#x2715;</button>
+        <button type="button" class="px-alert__dismiss" data-px-close aria-label="{{ dismiss_label }}">&#x2715;</button>
         {% endif %}
     </div>
 </div>

--- a/pyjinhx/builtins/ui/alert/alert.js
+++ b/pyjinhx/builtins/ui/alert/alert.js
@@ -1,5 +1,24 @@
-function dismissPxAlert(id) {
-    const el = document.getElementById(id);
-    if (!el) return;
-    el.classList.add('px-alert--dismissed');
-}
+(function () {
+    window.px = window.px || {};
+    if (px._alertWired) return;
+    px._alertWired = true;
+
+    const DISMISSIBLE = '.px-notification, .px-alert, dialog.px-modal, dialog.px-drawer, [data-px-popover-panel]';
+
+    function fire(el, name, detail, cancelable) {
+        return el.dispatchEvent(new CustomEvent(name, {
+            bubbles: true, cancelable: Boolean(cancelable), detail: detail || {},
+        }));
+    }
+
+    document.addEventListener('click', (e) => {
+        const closer = e.target.closest('[data-px-close]');
+        if (!closer) return;
+        const dismissible = closer.closest(DISMISSIBLE);
+        if (!dismissible || !dismissible.classList.contains('px-alert')) return;
+        const detail = { reason: 'trigger', trigger: closer };
+        if (!fire(dismissible, 'px:alert:before-dismiss', detail, true)) return;
+        dismissible.classList.add('px-alert--dismissed');
+        fire(dismissible, 'px:alert:dismiss', detail);
+    });
+}());

--- a/pyjinhx/builtins/ui/alert/alert.py
+++ b/pyjinhx/builtins/ui/alert/alert.py
@@ -1,6 +1,9 @@
 from typing import Literal
 
+from pydantic import Field
+
 from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class Alert(BaseComponent):
@@ -8,3 +11,6 @@ class Alert(BaseComponent):
     title: str = ""
     body: str | BaseComponent = ""
     dismissible: bool = False
+    dismiss_label: str = "Dismiss"
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/drawer/drawer.js
+++ b/pyjinhx/builtins/ui/drawer/drawer.js
@@ -2,6 +2,8 @@
     window.px = window.px || {};
     if (px.drawer) return;
 
+    const DISMISSIBLE = '.px-notification, .px-alert, dialog.px-modal, dialog.px-drawer, [data-px-popover-panel]';
+
     function fire(el, name, detail, cancelable) {
         return el.dispatchEvent(new CustomEvent(name, {
             bubbles: true, cancelable: Boolean(cancelable), detail: detail || {},
@@ -57,11 +59,11 @@
         }
         const closer = e.target.closest('[data-px-close]');
         if (closer) {
-            const dialog = closer.closest('dialog.px-drawer');
-            if (dialog) {
-                close(dialog.id, 'trigger', closer);
-                return;
+            const dismissible = closer.closest(DISMISSIBLE);
+            if (dismissible && dismissible.matches('dialog.px-drawer')) {
+                close(dismissible.id, 'trigger', closer);
             }
+            return;
         }
         if (e.target.tagName === 'DIALOG' && e.target.classList.contains('px-drawer')) {
             close(e.target.id, 'backdrop', null);

--- a/pyjinhx/builtins/ui/lazy_panel/lazy-panel.html
+++ b/pyjinhx/builtins/ui/lazy_panel/lazy-panel.html
@@ -1,5 +1,5 @@
 <div id="{{ id }}"
-     class="px-lazy-panel"
+     class="px-lazy-panel{% if class_name %} {{ class_name }}{% endif %}"
      hx-get="{{ url }}"
-     hx-trigger="{{ trigger }}"
-     hx-swap="{{ swap }}">{{ content }}</div>
+     hx-trigger="{% if trigger %}{{ trigger }}{% elif when == 'reveal' %}px:reveal from:closest [data-px-region] once{% elif when == 'load' %}load{% else %}revealed{% endif %}"
+     hx-swap="{{ swap }}"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>{{ content }}</div>

--- a/pyjinhx/builtins/ui/lazy_panel/lazy_panel.py
+++ b/pyjinhx/builtins/ui/lazy_panel/lazy_panel.py
@@ -1,8 +1,16 @@
+from typing import Literal
+
+from pydantic import Field
+
 from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class LazyPanel(BaseComponent):
     url: str
-    trigger: str = "revealed"
+    when: Literal["viewport", "reveal", "load"] = "viewport"
+    trigger: str = ""
     swap: str = "outerHTML"
     content: str | BaseComponent = ""
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/loading_overlay/loading-overlay.css
+++ b/pyjinhx/builtins/ui/loading_overlay/loading-overlay.css
@@ -28,6 +28,11 @@
   animation: loading-overlay-in 150ms ease forwards;
 }
 
+.px-loading-overlay.htmx-request {
+  display: flex;
+  animation: loading-overlay-in 150ms ease forwards;
+}
+
 .px-loading-overlay--hiding {
   display: flex;
   animation: loading-overlay-out 150ms ease forwards;

--- a/pyjinhx/builtins/ui/loading_overlay/loading-overlay.html
+++ b/pyjinhx/builtins/ui/loading_overlay/loading-overlay.html
@@ -1,3 +1,3 @@
-<div class="px-loading-overlay" id="{{ id }}" role="status" aria-label="Loading" aria-live="polite">
+<div class="px-loading-overlay{% if class_name %} {{ class_name }}{% endif %}" id="{{ id }}" role="status" aria-label="{{ aria_label }}" aria-live="polite"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
     <div class="px-loading-overlay__spinner"></div>
 </div>

--- a/pyjinhx/builtins/ui/loading_overlay/loading-overlay.js
+++ b/pyjinhx/builtins/ui/loading_overlay/loading-overlay.js
@@ -1,16 +1,24 @@
 (function () {
-    if (window.showLoadingOverlay) return;
+    window.px = window.px || {};
+    if (px.overlay) return;
 
     const counts = new Map();
+
+    function fire(el, name, detail) {
+        el.dispatchEvent(new CustomEvent(name, {
+            bubbles: true, cancelable: false, detail: detail || {},
+        }));
+    }
 
     // Only strip classes while a hide is genuinely in progress; a stale
     // animationend (e.g. the fade-in after a cancelled hide) must be a no-op.
     function finishHide(e) {
         if (!e.target.classList.contains('px-loading-overlay--hiding')) return;
         e.target.classList.remove('px-loading-overlay--visible', 'px-loading-overlay--hiding');
+        fire(e.target, 'px:overlay:hide', {});
     }
 
-    window.showLoadingOverlay = function (id) {
+    function show(id) {
         const overlay = document.getElementById(id);
         if (!overlay) return;
         const count = counts.get(id) || 0;
@@ -18,9 +26,10 @@
         if (count > 0) return;
         overlay.classList.remove('px-loading-overlay--hiding');
         overlay.classList.add('px-loading-overlay--visible');
-    };
+        fire(overlay, 'px:overlay:show', {});
+    }
 
-    window.hideLoadingOverlay = function (id) {
+    function hide(id) {
         const overlay = document.getElementById(id);
         if (!overlay) return;
         const count = counts.get(id) || 0;
@@ -32,12 +41,14 @@
         counts.delete(id);
         overlay.classList.add('px-loading-overlay--hiding');
         overlay.addEventListener('animationend', finishHide);
-    };
+    }
 
-    window.resetLoadingOverlay = function (id) {
+    function reset(id) {
         counts.delete(id);
         const overlay = document.getElementById(id);
         if (!overlay) return;
         overlay.classList.remove('px-loading-overlay--visible', 'px-loading-overlay--hiding');
-    };
+    }
+
+    px.overlay = { show: show, hide: hide, reset: reset };
 }());

--- a/pyjinhx/builtins/ui/loading_overlay/loading_overlay.py
+++ b/pyjinhx/builtins/ui/loading_overlay/loading_overlay.py
@@ -1,5 +1,10 @@
+from pydantic import Field
+
 from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class LoadingOverlay(BaseComponent):
-    pass
+    aria_label: str = "Loading"
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/modal/modal.js
+++ b/pyjinhx/builtins/ui/modal/modal.js
@@ -2,6 +2,8 @@
     window.px = window.px || {};
     if (px.modal) return;
 
+    const DISMISSIBLE = '.px-notification, .px-alert, dialog.px-modal, dialog.px-drawer, [data-px-popover-panel]';
+
     function fire(el, name, detail, cancelable) {
         return el.dispatchEvent(new CustomEvent(name, {
             bubbles: true, cancelable: Boolean(cancelable), detail: detail || {},
@@ -57,11 +59,11 @@
         }
         const closer = e.target.closest('[data-px-close]');
         if (closer) {
-            const dialog = closer.closest('dialog.px-modal');
-            if (dialog) {
-                close(dialog.id, 'trigger', closer);
-                return;
+            const dismissible = closer.closest(DISMISSIBLE);
+            if (dismissible && dismissible.matches('dialog.px-modal')) {
+                close(dismissible.id, 'trigger', closer);
             }
+            return;
         }
         if (e.target.tagName === 'DIALOG' && e.target.classList.contains('px-modal')) {
             close(e.target.id, 'backdrop', null);

--- a/pyjinhx/builtins/ui/notification/notification.html
+++ b/pyjinhx/builtins/ui/notification/notification.html
@@ -1,10 +1,11 @@
-<div class="px-notification px-notification--{{ corner }}"
+<div class="px-notification px-notification--{{ corner }}{% if class_name %} {{ class_name }}{% endif %}"
      id="{{ id }}"
      data-timeout="{{ timeout }}"
+     {% if autoshow %}data-px-autoshow{% endif %}
      role="status"
-     aria-live="polite">
+     aria-live="polite"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
     <div class="px-notification__content">{{ content }}</div>
-    <button class="px-notification__close"
-            onclick="hideNotification('{{ id }}')"
-            aria-label="Dismiss">&#x2715;</button>
+    <button type="button" class="px-notification__close"
+            data-px-close
+            aria-label="{{ dismiss_label }}">&#x2715;</button>
 </div>

--- a/pyjinhx/builtins/ui/notification/notification.js
+++ b/pyjinhx/builtins/ui/notification/notification.js
@@ -30,7 +30,12 @@
 
     function hide(id, reason, trigger) {
         const el = document.getElementById(id);
-        if (!el || !el.classList.contains('px-notification--visible')) return false;
+        if (!el) {
+            clearTimeout(timers.get(id));
+            timers.delete(id);
+            return false;
+        }
+        if (!el.classList.contains('px-notification--visible')) return false;
         if (el.classList.contains('px-notification--hiding')) return false;
         const detail = { reason: reason || 'api', trigger: trigger || null };
         if (!fire(el, 'px:notification:before-hide', detail, true)) return false;

--- a/pyjinhx/builtins/ui/notification/notification.js
+++ b/pyjinhx/builtins/ui/notification/notification.js
@@ -1,23 +1,89 @@
-const _notificationTimers = {};
+(function () {
+    window.px = window.px || {};
+    if (px.notification) return;
 
-function showNotification(id) {
-    const el = document.getElementById(id);
-    if (!el) return;
-    el.classList.remove('px-notification--hiding');
-    el.classList.add('px-notification--visible');
+    const DISMISSIBLE = '.px-notification, .px-alert, dialog.px-modal, dialog.px-drawer, [data-px-popover-panel]';
+    const timers = new Map();
 
-    clearTimeout(_notificationTimers[id]);
-    const timeout = parseInt(el.dataset.timeout, 10);
-    if (timeout > 0) {
-        _notificationTimers[id] = setTimeout(() => hideNotification(id), timeout);
+    function fire(el, name, detail, cancelable) {
+        return el.dispatchEvent(new CustomEvent(name, {
+            bubbles: true, cancelable: Boolean(cancelable), detail: detail || {},
+        }));
     }
-}
 
-function hideNotification(id) {
-    const el = document.getElementById(id);
-    if (!el || !el.classList.contains('px-notification--visible')) return;
-    el.classList.add('px-notification--hiding');
-    el.addEventListener('animationend', () => {
-        el.classList.remove('px-notification--visible', 'px-notification--hiding');
-    }, { once: true });
-}
+    function show(id, reason) {
+        const el = document.getElementById(id);
+        if (!el || el.classList.contains('px-notification--visible')) return false;
+        const detail = { reason: reason || 'api', trigger: null };
+        if (!fire(el, 'px:notification:before-show', detail, true)) return false;
+        el.classList.remove('px-notification--hiding');
+        el.classList.add('px-notification--visible');
+        fire(el, 'px:notification:show', detail);
+
+        clearTimeout(timers.get(id));
+        const timeout = parseInt(el.dataset.timeout, 10);
+        if (timeout > 0) {
+            timers.set(id, setTimeout(() => hide(id, 'api'), timeout));
+        }
+        return true;
+    }
+
+    function hide(id, reason, trigger) {
+        const el = document.getElementById(id);
+        if (!el || !el.classList.contains('px-notification--visible')) return false;
+        if (el.classList.contains('px-notification--hiding')) return false;
+        const detail = { reason: reason || 'api', trigger: trigger || null };
+        if (!fire(el, 'px:notification:before-hide', detail, true)) return false;
+        clearTimeout(timers.get(id));
+        timers.delete(id);
+        el.classList.add('px-notification--hiding');
+
+        let fallbackTimer = null;
+        function finalize() {
+            el.removeEventListener('animationend', onAnimationEnd);
+            clearTimeout(fallbackTimer);
+            if (!el.classList.contains('px-notification--hiding')) return;
+            el.classList.remove('px-notification--visible', 'px-notification--hiding');
+            fire(el, 'px:notification:hide', detail);
+        }
+        function onAnimationEnd(e) {
+            if (e.target !== el) return;
+            finalize();
+        }
+        el.addEventListener('animationend', onAnimationEnd);
+        fallbackTimer = setTimeout(finalize, 250);
+        return true;
+    }
+
+    document.addEventListener('click', (e) => {
+        const closer = e.target.closest('[data-px-close]');
+        if (!closer) return;
+        const dismissible = closer.closest(DISMISSIBLE);
+        if (dismissible && dismissible.classList.contains('px-notification')) {
+            hide(dismissible.id, 'trigger', closer);
+        }
+    });
+
+    function showMounted(rootNode) {
+        if (rootNode.matches && rootNode.matches('.px-notification[data-px-autoshow]')) {
+            show(rootNode.id, 'api');
+        }
+        if (!rootNode.querySelectorAll) return;
+        rootNode.querySelectorAll('.px-notification[data-px-autoshow]').forEach((n) => {
+            show(n.id, 'api');
+        });
+    }
+    const observer = new MutationObserver((mutations) => {
+        mutations.forEach((m) => m.addedNodes.forEach((node) => {
+            if (node.nodeType === 1) showMounted(node);
+        }));
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => showMounted(document));
+    } else {
+        showMounted(document);
+    }
+
+    px.notification = { show: show, hide: hide };
+}());

--- a/pyjinhx/builtins/ui/notification/notification.py
+++ b/pyjinhx/builtins/ui/notification/notification.py
@@ -1,6 +1,9 @@
 from typing import Literal
 
+from pydantic import Field
+
 from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class Notification(BaseComponent):
@@ -9,3 +12,7 @@ class Notification(BaseComponent):
         "top-right"
     )
     timeout: int = 5000
+    autoshow: bool = True
+    dismiss_label: str = "Dismiss"
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/panel/panel.html
+++ b/pyjinhx/builtins/ui/panel/panel.html
@@ -1,9 +1,10 @@
-<div id="{{ id }}" class="px-panel">
+<div id="{{ id }}" class="px-panel{% if class_name %} {{ class_name }}{% endif %}"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
   {% for panel_key, panel_body in panels.items() %}
   <div class="px-panel__panel"
        role="tabpanel"
        id="{{ id }}-panel-{{ panel_key }}"
        data-px-panel-key="{{ panel_key }}"
+       data-px-region
        {% if not loop.first %}hidden{% endif %}>{{ panel_body }}</div>
   {% endfor %}
 </div>

--- a/pyjinhx/builtins/ui/panel/panel.js
+++ b/pyjinhx/builtins/ui/panel/panel.js
@@ -1,76 +1,93 @@
-function pxPanelSyncTriggers(hostId, activeKey) {
-    document.querySelectorAll(`.px-panel-trigger[data-px-panel-id="${hostId}"]`).forEach((triggerEl) => {
-        const isActive = triggerEl.getAttribute('data-px-panel-key') === activeKey;
-        triggerEl.setAttribute('aria-selected', isActive ? 'true' : 'false');
-        triggerEl.tabIndex = isActive ? 0 : -1;
-    });
-}
+(function () {
+    window.px = window.px || {};
+    if (px._panelWired) return;
+    px._panelWired = true;
 
-function pxPanelShowPanel(hostRoot, panelKey) {
-    const hostId = hostRoot.id;
-    if (!hostId) return;
-    hostRoot.querySelectorAll('.px-panel__panel').forEach((panelEl) => {
-        const key = panelEl.getAttribute('data-px-panel-key');
-        if (key === panelKey) {
-            panelEl.removeAttribute('hidden');
-        } else {
-            panelEl.hidden = true;
-        }
-    });
-    pxPanelSyncTriggers(hostId, panelKey);
-}
+    function fire(el, name, detail, cancelable) {
+        return el.dispatchEvent(new CustomEvent(name, {
+            bubbles: true, cancelable: Boolean(cancelable), detail: detail || {},
+        }));
+    }
 
-function pxPanelInit() {
-    document.querySelectorAll('.px-panel').forEach((root) => {
-        const hostId = root.id;
+    function pxPanelSyncTriggers(hostId, activeKey) {
+        document.querySelectorAll(`.px-panel-trigger[data-px-panel-id="${hostId}"]`).forEach((triggerEl) => {
+            const isActive = triggerEl.getAttribute('data-px-panel-key') === activeKey;
+            triggerEl.setAttribute('aria-selected', isActive ? 'true' : 'false');
+            triggerEl.tabIndex = isActive ? 0 : -1;
+        });
+    }
+
+    function pxPanelShowPanel(hostRoot, panelKey) {
+        const hostId = hostRoot.id;
         if (!hostId) return;
-        let activeKey = null;
-        root.querySelectorAll('.px-panel__panel').forEach((panelEl) => {
-            if (!panelEl.hidden) {
-                activeKey = panelEl.getAttribute('data-px-panel-key');
+        const target = hostRoot.querySelector(
+            '.px-panel__panel[data-px-panel-key="' + panelKey + '"]'
+        );
+        if (!target) return;
+        if (target.hidden) {
+            if (!fire(target, 'px:before-reveal', { reason: 'trigger', trigger: null }, true)) return;
+        }
+        hostRoot.querySelectorAll('.px-panel__panel').forEach((panelEl) => {
+            panelEl.hidden = panelEl !== target;
+        });
+        pxPanelSyncTriggers(hostId, panelKey);
+        fire(target, 'px:reveal', { reason: 'trigger', trigger: null });
+    }
+
+    function pxPanelInit() {
+        document.querySelectorAll('.px-panel').forEach((root) => {
+            const hostId = root.id;
+            if (!hostId) return;
+            let activeKey = null;
+            root.querySelectorAll('.px-panel__panel').forEach((panelEl) => {
+                if (!panelEl.hidden) {
+                    activeKey = panelEl.getAttribute('data-px-panel-key');
+                }
+            });
+            if (activeKey === null) {
+                const first = root.querySelector('.px-panel__panel');
+                if (first) {
+                    activeKey = first.getAttribute('data-px-panel-key');
+                    first.removeAttribute('hidden');
+                    root.querySelectorAll('.px-panel__panel').forEach((panelEl) => {
+                        if (panelEl !== first) panelEl.hidden = true;
+                    });
+                }
+            }
+            if (activeKey !== null) {
+                pxPanelSyncTriggers(hostId, activeKey);
+                const visible = root.querySelector('.px-panel__panel:not([hidden])');
+                if (visible) fire(visible, 'px:reveal', { reason: 'api', trigger: null });
             }
         });
-        if (activeKey === null) {
-            const first = root.querySelector('.px-panel__panel');
-            if (first) {
-                activeKey = first.getAttribute('data-px-panel-key');
-                first.removeAttribute('hidden');
-                root.querySelectorAll('.px-panel__panel').forEach((panelEl) => {
-                    if (panelEl !== first) panelEl.hidden = true;
-                });
-            }
-        }
-        if (activeKey !== null) {
-            pxPanelSyncTriggers(hostId, activeKey);
-        }
-    });
-}
-
-document.addEventListener('click', (e) => {
-    const trigger = e.target.closest('.px-panel-trigger');
-    if (!trigger) return;
-    const hostId = trigger.getAttribute('data-px-panel-id');
-    const panelKey = trigger.getAttribute('data-px-panel-key');
-    if (!hostId || !panelKey) return;
-    const hostRoot = document.getElementById(hostId);
-    if (!hostRoot || !hostRoot.classList.contains('px-panel')) return;
-    e.preventDefault();
-    const targetPanel = hostRoot.querySelector(
-        '.px-panel__panel[data-px-panel-key="' + panelKey + '"]'
-    );
-    if (!targetPanel) {
-        console.warn('px-panel: no panel for key', panelKey, 'in', hostId);
-        return;
     }
-    pxPanelShowPanel(hostRoot, panelKey);
-});
 
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', pxPanelInit);
-} else {
-    pxPanelInit();
-}
-if (document.body) {
-    document.body.addEventListener('htmx:afterSwap', pxPanelInit);
-    document.body.addEventListener('htmx:afterSettle', pxPanelInit);
-}
+    document.addEventListener('click', (e) => {
+        const trigger = e.target.closest('.px-panel-trigger');
+        if (!trigger) return;
+        const hostId = trigger.getAttribute('data-px-panel-id');
+        const panelKey = trigger.getAttribute('data-px-panel-key');
+        if (!hostId || !panelKey) return;
+        const hostRoot = document.getElementById(hostId);
+        if (!hostRoot || !hostRoot.classList.contains('px-panel')) return;
+        e.preventDefault();
+        const targetPanel = hostRoot.querySelector(
+            '.px-panel__panel[data-px-panel-key="' + panelKey + '"]'
+        );
+        if (!targetPanel) {
+            console.warn('px-panel: no panel for key', panelKey, 'in', hostId);
+            return;
+        }
+        pxPanelShowPanel(hostRoot, panelKey);
+    });
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', pxPanelInit);
+    } else {
+        pxPanelInit();
+    }
+    if (document.body) {
+        document.body.addEventListener('htmx:afterSwap', pxPanelInit);
+        document.body.addEventListener('htmx:afterSettle', pxPanelInit);
+    }
+}());

--- a/pyjinhx/builtins/ui/panel/panel.js
+++ b/pyjinhx/builtins/ui/panel/panel.js
@@ -17,21 +17,26 @@
         });
     }
 
-    function pxPanelShowPanel(hostRoot, panelKey) {
+    function pxPanelShowPanel(hostRoot, panelKey, trigger) {
         const hostId = hostRoot.id;
         if (!hostId) return;
         const target = hostRoot.querySelector(
             '.px-panel__panel[data-px-panel-key="' + panelKey + '"]'
         );
         if (!target) return;
-        if (target.hidden) {
-            if (!fire(target, 'px:before-reveal', { reason: 'trigger', trigger: null }, true)) return;
-        }
+        if (!target.hidden) return; // already active: nothing to announce
+        const detail = { reason: 'trigger', trigger: trigger || null };
+        if (!fire(target, 'px:before-reveal', detail, true)) return;
         hostRoot.querySelectorAll('.px-panel__panel').forEach((panelEl) => {
-            panelEl.hidden = panelEl !== target;
+            if (panelEl !== target) {
+                panelEl.hidden = true;
+                panelEl.removeAttribute('data-px-revealed');
+            }
         });
+        target.hidden = false;
+        target.setAttribute('data-px-revealed', '');
         pxPanelSyncTriggers(hostId, panelKey);
-        fire(target, 'px:reveal', { reason: 'trigger', trigger: null });
+        fire(target, 'px:reveal', detail);
     }
 
     function pxPanelInit() {
@@ -57,7 +62,10 @@
             if (activeKey !== null) {
                 pxPanelSyncTriggers(hostId, activeKey);
                 const visible = root.querySelector('.px-panel__panel:not([hidden])');
-                if (visible) fire(visible, 'px:reveal', { reason: 'api', trigger: null });
+                if (visible && !visible.hasAttribute('data-px-revealed')) {
+                    visible.setAttribute('data-px-revealed', '');
+                    fire(visible, 'px:reveal', { reason: 'api', trigger: null });
+                }
             }
         });
     }
@@ -78,7 +86,7 @@
             console.warn('px-panel: no panel for key', panelKey, 'in', hostId);
             return;
         }
-        pxPanelShowPanel(hostRoot, panelKey);
+        pxPanelShowPanel(hostRoot, panelKey, trigger);
     });
 
     if (document.readyState === 'loading') {

--- a/pyjinhx/builtins/ui/panel/panel.py
+++ b/pyjinhx/builtins/ui/panel/panel.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any
 from pydantic import BeforeValidator, Field, field_validator
 
 from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 def _coerce_panels(value: Any) -> dict[str, str | BaseComponent]:
@@ -23,6 +24,8 @@ class Panel(BaseComponent):
     panels: Annotated[
         dict[str, str | BaseComponent], BeforeValidator(_coerce_panels)
     ] = Field(default_factory=dict)
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)
 
     @field_validator("panels", mode="after")
     @classmethod

--- a/pyjinhx/builtins/ui/panel/panel_trigger.html
+++ b/pyjinhx/builtins/ui/panel/panel_trigger.html
@@ -1,8 +1,8 @@
 <div id="{{ id }}"
-     class="px-panel-trigger"
+     class="px-panel-trigger{% if class_name %} {{ class_name }}{% endif %}"
      role="tab"
      data-px-panel-id="{{ panel_id }}"
      data-px-panel-key="{{ panel }}"
      aria-controls="{{ panel_id }}-panel-{{ panel }}"
      aria-selected="false"
-     tabindex="-1">{{ content }}</div>
+     tabindex="-1"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>{{ content }}</div>

--- a/pyjinhx/builtins/ui/panel/panel_trigger.py
+++ b/pyjinhx/builtins/ui/panel/panel_trigger.py
@@ -1,8 +1,9 @@
 import re
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 
 from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 _PANEL_KEY_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
@@ -11,6 +12,8 @@ class PanelTrigger(BaseComponent):
     panel_id: str
     panel: str
     content: str | BaseComponent = ""
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)
 
     @field_validator("panel", mode="after")
     @classmethod

--- a/pyjinhx/builtins/ui/popover/popover.js
+++ b/pyjinhx/builtins/ui/popover/popover.js
@@ -2,6 +2,8 @@
     window.px = window.px || {};
     if (px.popover) return;
 
+    const DISMISSIBLE = '.px-notification, .px-alert, dialog.px-modal, dialog.px-drawer, [data-px-popover-panel]';
+
     function fire(el, name, detail, cancelable) {
         return el.dispatchEvent(new CustomEvent(name, {
             bubbles: true, cancelable: Boolean(cancelable), detail: detail || {},
@@ -64,11 +66,14 @@
     document.addEventListener('click', (e) => {
         const closer = e.target.closest('[data-px-close]');
         if (closer) {
-            const panel = closer.closest('[data-px-popover-panel]');
-            if (panel) {
-                close(panel, 'trigger', closer);
+            const dismissible = closer.closest(DISMISSIBLE);
+            if (dismissible && dismissible.hasAttribute && dismissible.hasAttribute('data-px-popover-panel')) {
+                close(dismissible, 'trigger', closer);
                 return;
             }
+            // Nearest dismissible is another kind (modal, drawer, alert, notification) —
+            // fall through to the outside-close loop WITHOUT toggling; no open popover
+            // panel would have the click inside its root anyway.
         }
         const toggleEl = e.target.closest('[data-px-toggle]');
         const targetPanel = toggleEl ? panelForToggle(toggleEl) : null;

--- a/pyjinhx/builtins/ui/spinner/spinner.html
+++ b/pyjinhx/builtins/ui/spinner/spinner.html
@@ -1,8 +1,8 @@
 <span id="{{ id }}"
-      class="px-spinner px-spinner--{{ size }}"
+      class="px-spinner px-spinner--{{ size }}{% if class_name %} {{ class_name }}{% endif %}"
       role="status"
       aria-live="polite"
-      aria-busy="true">
+      aria-busy="true"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
   <span class="px-spinner__ring" aria-hidden="true"></span>
   <span class="px-spinner__label">{{ label }}</span>
 </span>

--- a/pyjinhx/builtins/ui/spinner/spinner.py
+++ b/pyjinhx/builtins/ui/spinner/spinner.py
@@ -1,8 +1,13 @@
 from typing import Literal
 
+from pydantic import Field
+
 from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class Spinner(BaseComponent):
     size: Literal["sm", "md", "lg"] = "md"
     label: str = "Loading"
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/tab_group/tab-group.js
+++ b/pyjinhx/builtins/ui/tab_group/tab-group.js
@@ -1,22 +1,32 @@
-document.addEventListener('click', (e) => {
-    const tab = e.target.closest('.px-tab-group__tab');
-    if (!tab) return;
-    const root = tab.closest('.px-tab-group');
-    if (!root || !root.id) return;
-    e.preventDefault();
-    const tabs = [...root.querySelectorAll('.px-tab-group__tab')];
-    const panels = [...root.querySelectorAll('.px-tab-group__panel')];
-    const index = tabs.indexOf(tab);
-    if (index < 0) return;
-    tabs.forEach((t, i) => {
-        t.setAttribute('aria-selected', i === index ? 'true' : 'false');
-        t.tabIndex = i === index ? 0 : -1;
-    });
-    panels.forEach((p, i) => {
-        if (i === index) {
-            p.removeAttribute('hidden');
-        } else {
-            p.hidden = true;
+(function () {
+    window.px = window.px || {};
+    if (px._tabGroupWired) return;
+    px._tabGroupWired = true;
+
+    function fire(el, name, detail, cancelable) {
+        return el.dispatchEvent(new CustomEvent(name, {
+            bubbles: true, cancelable: Boolean(cancelable), detail: detail || {},
+        }));
+    }
+
+    document.addEventListener('click', (e) => {
+        const tab = e.target.closest('.px-tab-group__tab');
+        if (!tab) return;
+        const root = tab.closest('.px-tab-group');
+        if (!root || !root.id) return;
+        e.preventDefault();
+        const tabs = [...root.querySelectorAll('.px-tab-group__tab')];
+        const panels = [...root.querySelectorAll('.px-tab-group__panel')];
+        const index = tabs.indexOf(tab);
+        if (index < 0 || !panels[index]) return;
+        if (panels[index].hidden) {
+            if (!fire(panels[index], 'px:before-reveal', { reason: 'trigger', trigger: tab }, true)) return;
         }
+        tabs.forEach((t, i) => {
+            t.setAttribute('aria-selected', i === index ? 'true' : 'false');
+            t.tabIndex = i === index ? 0 : -1;
+        });
+        panels.forEach((p, i) => { p.hidden = i !== index; });
+        fire(panels[index], 'px:reveal', { reason: 'trigger', trigger: tab });
     });
-});
+}());

--- a/pyjinhx/builtins/ui/tab_group/tab-group.js
+++ b/pyjinhx/builtins/ui/tab_group/tab-group.js
@@ -19,14 +19,39 @@
         const panels = [...root.querySelectorAll('.px-tab-group__panel')];
         const index = tabs.indexOf(tab);
         if (index < 0 || !panels[index]) return;
-        if (panels[index].hidden) {
-            if (!fire(panels[index], 'px:before-reveal', { reason: 'trigger', trigger: tab }, true)) return;
-        }
+        if (!panels[index].hidden) return; // already active: nothing to announce
+        const detail = { reason: 'trigger', trigger: tab };
+        if (!fire(panels[index], 'px:before-reveal', detail, true)) return;
         tabs.forEach((t, i) => {
             t.setAttribute('aria-selected', i === index ? 'true' : 'false');
             t.tabIndex = i === index ? 0 : -1;
         });
-        panels.forEach((p, i) => { p.hidden = i !== index; });
-        fire(panels[index], 'px:reveal', { reason: 'trigger', trigger: tab });
+        panels.forEach((p, i) => {
+            p.hidden = i !== index;
+            if (i !== index) p.removeAttribute('data-px-revealed');
+        });
+        panels[index].setAttribute('data-px-revealed', '');
+        fire(panels[index], 'px:reveal', detail);
     });
+
+    // Announce the initially visible panel of each tab group exactly once,
+    // so LazyPanel(when="reveal") works in default tabs (parity with panel.js).
+    function pxTabGroupInit() {
+        document.querySelectorAll('.px-tab-group').forEach((root) => {
+            const visible = root.querySelector('.px-tab-group__panel:not([hidden])');
+            if (visible && !visible.hasAttribute('data-px-revealed')) {
+                visible.setAttribute('data-px-revealed', '');
+                fire(visible, 'px:reveal', { reason: 'api', trigger: null });
+            }
+        });
+    }
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', pxTabGroupInit);
+    } else {
+        pxTabGroupInit();
+    }
+    if (document.body) {
+        document.body.addEventListener('htmx:afterSwap', pxTabGroupInit);
+        document.body.addEventListener('htmx:afterSettle', pxTabGroupInit);
+    }
 }());

--- a/pyjinhx/builtins/ui/tab_group/tab_group.html
+++ b/pyjinhx/builtins/ui/tab_group/tab_group.html
@@ -1,5 +1,5 @@
-<div id="{{ id }}" class="px-tab-group">
-  <div class="px-tab-group__list" role="tablist" aria-label="Tabs">
+<div id="{{ id }}" class="px-tab-group{% if class_name %} {{ class_name }}{% endif %}"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
+  <div class="px-tab-group__list" role="tablist" aria-label="{{ tabs_label }}">
     {% for label, panel in tabs.items() %}
     <button type="button"
             class="px-tab-group__tab"
@@ -13,6 +13,7 @@
   {% for label, panel in tabs.items() %}
   <div class="px-tab-group__panel"
        role="tabpanel"
+       data-px-region
        id="{{ id }}-panel-{{ loop.index0 }}"
        aria-labelledby="{{ id }}-tab-{{ loop.index0 }}"
        {% if not loop.first %}hidden{% endif %}>{{ panel }}</div>

--- a/pyjinhx/builtins/ui/tab_group/tab_group.py
+++ b/pyjinhx/builtins/ui/tab_group/tab_group.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 from pydantic import BeforeValidator, Field
 
 from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 def _coerce_tabs(value: Any) -> dict[str, str | BaseComponent]:
@@ -19,3 +20,6 @@ class TabGroup(BaseComponent):
     tabs: Annotated[dict[str, str | BaseComponent], BeforeValidator(_coerce_tabs)] = (
         Field(default_factory=dict)
     )
+    tabs_label: str = "Tabs"
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/tests/71_builtin_conventions_test.py
+++ b/tests/71_builtin_conventions_test.py
@@ -12,6 +12,8 @@ SWEPT: list[type] = [
     b.Avatar, b.Badge, b.Breadcrumb, b.Card, b.Divider, b.EmptyState,
     b.Modal, b.Drawer, b.Progress, b.Skeleton, b.Tooltip,
     b.Popover, b.PopoverTrigger, b.PopoverPanel, b.Dropdown,
+    b.Notification, b.Alert, b.Panel, b.PanelTrigger, b.TabGroup,
+    b.LazyPanel, b.LoadingOverlay, b.Spinner,
 ]
 
 UI_ROOT = os.path.join(os.path.dirname(b.__file__), "ui")

--- a/tests/76_notification_redesign_test.py
+++ b/tests/76_notification_redesign_test.py
@@ -1,0 +1,22 @@
+import re
+
+from pyjinhx.builtins import Notification
+
+
+def _root(html: str) -> str:
+    match = re.search(r"<div[^>]*px-notification[^>]*>", html)
+    assert match, html
+    return match.group(0)
+
+
+def test_notification_autoshow_default_and_props():
+    html = str(Notification(id="n1", content="Saved", dismiss_label="Fechar").render())
+    assert "data-px-autoshow" in _root(html)
+    assert 'aria-label="Fechar"' in html
+    assert "data-px-close" in html
+    assert "onclick" not in html
+
+
+def test_notification_autoshow_off():
+    html = str(Notification(id="n2", content="x", autoshow=False).render())
+    assert "data-px-autoshow" not in _root(html)

--- a/tests/77_alert_dismiss_test.py
+++ b/tests/77_alert_dismiss_test.py
@@ -1,0 +1,11 @@
+from pyjinhx.builtins import Alert
+
+
+def test_alert_dismiss_props_and_wiring():
+    html = str(Alert(id="a", body="x", dismissible=True, dismiss_label="Fechar",
+                     class_name="mine", extra_attrs={"data-k": "v"}).render())
+    assert 'aria-label="Fechar"' in html
+    assert "data-px-close" in html
+    assert "onclick" not in html
+    assert 'data-k="v"' in html
+    assert "px-alert--info mine" in html

--- a/tests/78_region_reveal_test.py
+++ b/tests/78_region_reveal_test.py
@@ -1,0 +1,24 @@
+from pyjinhx.builtins import Panel, PanelTrigger, TabGroup
+
+
+def test_panel_panels_are_regions():
+    html = str(Panel(id="h", panels={"a": "<p>A</p>", "b": "<p>B</p>"}).render())
+    assert html.count("data-px-region") >= 2
+
+
+def test_panel_contract_fields():
+    html = str(Panel(id="h", panels={"a": "x"}, class_name="mine",
+                     extra_attrs={"data-k": "v"}).render())
+    assert 'class="px-panel mine"' in html and 'data-k="v"' in html
+
+
+def test_panel_trigger_contract_fields():
+    html = str(PanelTrigger(id="t", panel_id="h", panel="a", content="A",
+                            class_name="mine", extra_attrs={"data-k": "v"}).render())
+    assert "px-panel-trigger mine" in html and 'data-k="v"' in html
+
+
+def test_tab_group_regions_and_label():
+    html = str(TabGroup(id="tg", tabs={"One": "1", "Two": "2"}, tabs_label="Abas").render())
+    assert html.count("data-px-region") >= 2
+    assert 'aria-label="Abas"' in html

--- a/tests/79_loading_family_test.py
+++ b/tests/79_loading_family_test.py
@@ -1,0 +1,31 @@
+from pyjinhx.builtins import LazyPanel, LoadingOverlay, Spinner
+
+
+def test_lazy_panel_when_viewport_default():
+    html = str(LazyPanel(id="lp", url="/x").render())
+    assert 'hx-trigger="revealed"' in html
+
+
+def test_lazy_panel_when_reveal():
+    html = str(LazyPanel(id="lp", url="/x", when="reveal").render())
+    assert 'hx-trigger="px:reveal from:closest [data-px-region] once"' in html
+
+
+def test_lazy_panel_when_load():
+    html = str(LazyPanel(id="lp", url="/x", when="load").render())
+    assert 'hx-trigger="load"' in html
+
+
+def test_lazy_panel_raw_trigger_wins():
+    html = str(LazyPanel(id="lp", url="/x", when="reveal", trigger="click once").render())
+    assert 'hx-trigger="click once"' in html
+
+
+def test_loading_overlay_props():
+    html = str(LoadingOverlay(id="lo", aria_label="Carregando", class_name="mine").render())
+    assert 'aria-label="Carregando"' in html and "px-loading-overlay mine" in html
+
+
+def test_spinner_contract():
+    html = str(Spinner(id="s", class_name="htmx-indicator", extra_attrs={"data-k": "v"}).render())
+    assert "htmx-indicator" in html and 'data-k="v"' in html

--- a/tests/golden/alert_dismissible.html
+++ b/tests/golden/alert_dismissible.html
@@ -7,7 +7,7 @@
             <div class="px-alert__body">x</div>
         </div>
         
-        <button type="button" class="px-alert__dismiss" onclick="dismissPxAlert('g')" aria-label="Dismiss">✕</button>
+        <button type="button" class="px-alert__dismiss" data-px-close aria-label="Dismiss">✕</button>
         
     </div>
 </div>

--- a/tests/golden/notification.html
+++ b/tests/golden/notification.html
@@ -1,10 +1,11 @@
 <div class="px-notification px-notification--bottom-right"
      id="g"
      data-timeout="0"
+     data-px-autoshow
      role="status"
      aria-live="polite">
     <div class="px-notification__content">Hi</div>
-    <button class="px-notification__close"
-            onclick="hideNotification('g')"
+    <button type="button" class="px-notification__close"
+            data-px-close
             aria-label="Dismiss">✕</button>
 </div>

--- a/tests/golden/panel.html
+++ b/tests/golden/panel.html
@@ -4,12 +4,14 @@
        role="tabpanel"
        id="g-panel-a"
        data-px-panel-key="a"
+       data-px-region
        ><p>A</p></div>
   
   <div class="px-panel__panel"
        role="tabpanel"
        id="g-panel-b"
        data-px-panel-key="b"
+       data-px-region
        hidden><p>B</p></div>
   
 </div>

--- a/tests/golden/tab_group.html
+++ b/tests/golden/tab_group.html
@@ -21,12 +21,14 @@
   
   <div class="px-tab-group__panel"
        role="tabpanel"
+       data-px-region
        id="g-panel-0"
        aria-labelledby="g-tab-0"
        ><p>1</p></div>
   
   <div class="px-tab-group__panel"
        role="tabpanel"
+       data-px-region
        id="g-panel-1"
        aria-labelledby="g-tab-1"
        hidden><p>2</p></div>

--- a/tests/integration/app.py
+++ b/tests/integration/app.py
@@ -53,7 +53,7 @@ _SHOWCASE_TEMPLATE = """
 <h2>Notification</h2>
 <section class="demo-stack">
 {{ notification }}
-<button type="button" class="demo-btn" onclick="showNotification('g-toast')">Show notification</button>
+<button type="button" class="demo-btn" onclick="px.notification.show('g-toast')">Show notification</button>
 </section>
 
 <h2>Popover</h2>
@@ -68,8 +68,8 @@ _SHOWCASE_TEMPLATE = """
 <p style="margin:0;color:var(--text-muted);font-size:var(--font-size-sm);">Parent is position: relative</p>
 </div>
 <div class="demo-row" style="margin-top:0.75rem;">
-<button type="button" class="demo-btn" onclick="showLoadingOverlay('g-overlay')">Show overlay</button>
-<button type="button" class="demo-btn" onclick="hideLoadingOverlay('g-overlay')">Hide overlay</button>
+<button type="button" class="demo-btn" onclick="px.overlay.show('g-overlay')">Show overlay</button>
+<button type="button" class="demo-btn" onclick="px.overlay.hide('g-overlay')">Hide overlay</button>
 </div>
 </section>
 


### PR DESCRIPTION
## Summary
- **Notification auto-shows on mount** (`autoshow=True`, MutationObserver-driven): OOB-appended notifications need no `<script>showNotification(...)</script>` anymore. `px.notification.show/hide` + cancelable `px:notification:before-show/before-hide` hooks; the old top-level `const` (a re-execution SyntaxError when htmx re-shipped the script) is gone.
- **Nearest-dismissible rule everywhere**: one `data-px-close` click acts on exactly one dismissible — the nearest of notification/alert/modal/drawer/popover-panel — across all five JS files (fixes the nested-dialog cross-close deferred from PR 3).
- **Panel + TabGroup regions**: every panel/tab body carries `data-px-region` and announces `px:before-reveal` (cancelable — veto blocks the switch) / `px:reveal` strictly on hidden→visible transitions, once for the initially-visible region (`data-px-revealed` flag — no event storms on htmx re-inits, no re-fires on same-tab clicks).
- **`LazyPanel(when=...)` presets**: `viewport` (default) / `reveal` (compiles `px:reveal from:closest [data-px-region] once` — lazy-load panel/tab content on first show, no more hand-written trigger incantations) / `load`; raw `trigger` stays as the escape hatch.
- **Loading family**: LoadingOverlay → `px.overlay.{show,hide,reset}` (+ `px:overlay:show/hide` events) and works as an `hx-indicator` target via a `.htmx-request` CSS state; Spinner verified compatible with htmx's indicator mechanism (`class_name="htmx-indicator"`); Alert dismissal via `data-px-close` + `px:alert:*` hooks.
- Contract fields (class_name/extra_attrs) + copy-props (dismiss_label, tabs_label) across all eight touched builtins.

PR 5/8, stacked on #50.

## Test plan
- [x] `uv run pytest tests/ -q` — 415 passed
- [x] `uv run ruff check .` / `node --check` ×8 / mkdocs strict
- [x] Goldens: alert_dismissible, notification, panel, tab_group re-baselined (reviewed hunks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)