### PR TITLE
Builtins v2: ToastHost, AvatarStack, PageLoader + loading-states guide

### DIFF
--- a/docs/guide/loading.md
+++ b/docs/guide/loading.md
@@ -23,3 +23,7 @@ Five loading niches, one decision rule: *what is missing?*
 ```
 
 `htmx-request` is htmx's own class; without htmx these indicators simply stay hidden.
+
+!!! note "Singletons"
+    `ToastHost` and `PageLoader` are mounted **once in your layout**. `PageLoader`'s
+    `active_on_load` state clears on full page loads — don't deliver one via a fragment swap.

--- a/docs/guide/loading.md
+++ b/docs/guide/loading.md
@@ -1,0 +1,25 @@
+# Loading states
+
+Five loading niches, one decision rule: *what is missing?*
+
+| What's missing | Builtin | Activation |
+|---|---|---|
+| Content not loaded yet | `Skeleton` | None — it IS the placeholder; the swap replaces it (`LazyPanel(content=Skeleton())`) |
+| Request in flight, inline | `Spinner` | `Spinner(class_name="htmx-indicator")` + `hx-indicator="#its-id"` — htmx toggles it, zero JS |
+| Request in flight, region-blocking | `LoadingOverlay` | `hx-indicator` pointing at it, **or** `px.overlay.show/hide/reset(id)` for non-htmx work (pick one mechanism per element) |
+| Request in flight, page navigation | `PageLoader` | Automatic: htmx lifecycle events for GETs targeting `nav_targets`, plus any request from inside `[data-px-loader]`; `px.loader.wrap(promise)` for manual async |
+| Determinate progress | `Progress` | `value`/`max` props |
+
+```html
+<!-- inline: search box with a spinner -->
+<input hx-get="/search" hx-trigger="keyup changed delay:300ms" hx-indicator="#search-spin">
+<Spinner id="search-spin" class_name="htmx-indicator"/>
+
+<!-- region: a card that blocks while refreshing -->
+<div hx-get="/stats" hx-trigger="every 60s" hx-indicator="#stats-overlay">
+  <LoadingOverlay id="stats-overlay"/>
+  ...
+</div>
+```
+
+`htmx-request` is htmx's own class; without htmx these indicators simply stay hidden.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Asset Collection: guide/assets.md
       - Built-in UI components: guide/builtins.md
       - Builtin conventions: guide/builtin-conventions.md
+      - Loading states: guide/loading.md
       - Configuration: guide/configuration.md
       - Reactivity: reactivity.md
   - Integrations:

--- a/pyjinhx/builtins/__init__.py
+++ b/pyjinhx/builtins/__init__.py
@@ -1,6 +1,7 @@
 from .ui import (
     Alert,
     Avatar,
+    AvatarStack,
     Badge,
     Breadcrumb,
     Card,
@@ -13,6 +14,7 @@ from .ui import (
     LoadingOverlay,
     Modal,
     Notification,
+    PageLoader,
     Popover,
     PopoverPanel,
     PopoverTrigger,
@@ -23,12 +25,14 @@ from .ui import (
     Skeleton,
     Spinner,
     TabGroup,
+    ToastHost,
     Tooltip,
 )
 
 __all__ = [
     "Alert",
     "Avatar",
+    "AvatarStack",
     "Badge",
     "Breadcrumb",
     "Card",
@@ -41,6 +45,7 @@ __all__ = [
     "LoadingOverlay",
     "Modal",
     "Notification",
+    "PageLoader",
     "Popover",
     "PopoverPanel",
     "PopoverTrigger",
@@ -51,5 +56,6 @@ __all__ = [
     "Skeleton",
     "Spinner",
     "TabGroup",
+    "ToastHost",
     "Tooltip",
 ]

--- a/pyjinhx/builtins/ui/__init__.py
+++ b/pyjinhx/builtins/ui/__init__.py
@@ -1,5 +1,6 @@
 from pyjinhx.builtins.ui.alert import Alert
 from pyjinhx.builtins.ui.avatar import Avatar
+from pyjinhx.builtins.ui.avatar_stack import AvatarStack
 from pyjinhx.builtins.ui.badge import Badge
 from pyjinhx.builtins.ui.breadcrumb import Breadcrumb
 from pyjinhx.builtins.ui.card import Card
@@ -12,6 +13,7 @@ from pyjinhx.builtins.ui.lazy_panel import LazyPanel
 from pyjinhx.builtins.ui.loading_overlay import LoadingOverlay
 from pyjinhx.builtins.ui.modal import Modal
 from pyjinhx.builtins.ui.notification import Notification
+from pyjinhx.builtins.ui.page_loader import PageLoader
 from pyjinhx.builtins.ui.popover import Popover, PopoverPanel, PopoverTrigger
 from pyjinhx.builtins.ui.progress import Progress
 from pyjinhx.builtins.ui.prompt_dialog import PromptDialog
@@ -19,11 +21,13 @@ from pyjinhx.builtins.ui.panel import Panel, PanelTrigger
 from pyjinhx.builtins.ui.skeleton import Skeleton
 from pyjinhx.builtins.ui.spinner import Spinner
 from pyjinhx.builtins.ui.tab_group import TabGroup
+from pyjinhx.builtins.ui.toast_host import ToastHost
 from pyjinhx.builtins.ui.tooltip import Tooltip
 
 __all__ = [
     "Alert",
     "Avatar",
+    "AvatarStack",
     "Badge",
     "Breadcrumb",
     "Card",
@@ -36,6 +40,7 @@ __all__ = [
     "LoadingOverlay",
     "Modal",
     "Notification",
+    "PageLoader",
     "Popover",
     "PopoverPanel",
     "PopoverTrigger",
@@ -46,5 +51,6 @@ __all__ = [
     "Skeleton",
     "Spinner",
     "TabGroup",
+    "ToastHost",
     "Tooltip",
 ]

--- a/pyjinhx/builtins/ui/avatar_stack/__init__.py
+++ b/pyjinhx/builtins/ui/avatar_stack/__init__.py
@@ -1,0 +1,3 @@
+from .avatar_stack import AvatarStack
+
+__all__ = ["AvatarStack"]

--- a/pyjinhx/builtins/ui/avatar_stack/avatar-stack.css
+++ b/pyjinhx/builtins/ui/avatar_stack/avatar-stack.css
@@ -1,0 +1,37 @@
+:root {
+  --px-avatar-stack-overlap: -0.5rem;
+  --px-avatar-stack-ring:    var(--surface);
+}
+
+.px-avatar-stack {
+  display: inline-flex;
+  align-items: center;
+}
+
+.px-avatar-stack > .px-avatar,
+.px-avatar-stack > .px-avatar-stack__more {
+  box-shadow: 0 0 0 2px var(--px-avatar-stack-ring);
+}
+
+.px-avatar-stack > * + * {
+  margin-left: var(--px-avatar-stack-overlap);
+}
+
+.px-avatar-stack__more {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  height: 2rem;
+  padding: 0 0.3rem;
+  border-radius: 50%;
+  background: var(--surface-alt);
+  color: var(--text-muted);
+  font-size: var(--font-size-sm, 0.85rem);
+  font-weight: 600;
+}
+
+.px-avatar-stack__empty {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm, 0.85rem);
+}

--- a/pyjinhx/builtins/ui/avatar_stack/avatar_stack.html
+++ b/pyjinhx/builtins/ui/avatar_stack/avatar_stack.html
@@ -1,0 +1,5 @@
+<div id="{{ id }}" class="px-avatar-stack{% if class_name %} {{ class_name }}{% endif %}"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
+  {% for avatar in avatars %}{{ avatar }}{% endfor %}
+  {% if extra_count > 0 %}<span class="px-avatar-stack__more">+{{ extra_count }}</span>{% endif %}
+  {% if not avatars and empty_label %}<span class="px-avatar-stack__empty">{{ empty_label }}</span>{% endif %}
+</div>

--- a/pyjinhx/builtins/ui/avatar_stack/avatar_stack.py
+++ b/pyjinhx/builtins/ui/avatar_stack/avatar_stack.py
@@ -1,0 +1,12 @@
+from pydantic import Field
+
+from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
+
+
+class AvatarStack(BaseComponent):
+    avatars: list[str | BaseComponent] = Field(default_factory=list)
+    extra_count: int = 0
+    empty_label: str = ""
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/page_loader/__init__.py
+++ b/pyjinhx/builtins/ui/page_loader/__init__.py
@@ -1,0 +1,3 @@
+from .page_loader import PageLoader
+
+__all__ = ["PageLoader"]

--- a/pyjinhx/builtins/ui/page_loader/page-loader.css
+++ b/pyjinhx/builtins/ui/page_loader/page-loader.css
@@ -1,0 +1,31 @@
+:root {
+  --px-page-loader-backdrop: rgb(0 0 0 / 0.15);
+  --px-page-loader-z:        9999;
+  --px-page-loader-size:     2rem;
+}
+
+.px-page-loader {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: var(--px-page-loader-z);
+  background: var(--px-page-loader-backdrop);
+  backdrop-filter: blur(2px);
+  align-items: center;
+  justify-content: center;
+}
+
+.px-page-loader--active {
+  display: flex;
+}
+
+.px-page-loader__spinner {
+  width: var(--px-page-loader-size);
+  height: var(--px-page-loader-size);
+  border: 2px solid var(--border);
+  border-top-color: var(--brand, currentColor);
+  border-radius: 50%;
+  animation: px-page-loader-spin 0.7s linear infinite;
+}
+
+@keyframes px-page-loader-spin { to { transform: rotate(360deg); } }

--- a/pyjinhx/builtins/ui/page_loader/page-loader.js
+++ b/pyjinhx/builtins/ui/page_loader/page-loader.js
@@ -1,0 +1,100 @@
+(function () {
+    window.px = window.px || {};
+    if (px.loader) return;
+
+    function fire(el, name) {
+        el.dispatchEvent(new CustomEvent(name, { bubbles: true, detail: {} }));
+    }
+
+    function loaderEl() {
+        return document.querySelector('[data-px-page-loader]');
+    }
+
+    function navTargets() {
+        const el = loaderEl();
+        if (!el || !el.dataset.navTargets) return new Set();
+        return new Set(el.dataset.navTargets.split(',').map((s) => s.trim()).filter(Boolean));
+    }
+
+    let pending = 0;
+    const tracked = new WeakSet();
+
+    function show() {
+        pending += 1;
+        const el = loaderEl();
+        if (pending === 1 && el && !el.classList.contains('px-page-loader--active')) {
+            el.classList.add('px-page-loader--active');
+            fire(el, 'px:loader:show');
+        }
+    }
+
+    function hide() {
+        setTimeout(() => {
+            pending -= 1;
+            if (pending <= 0) {
+                pending = 0;
+                const el = loaderEl();
+                if (el && el.classList.contains('px-page-loader--active')) {
+                    el.classList.remove('px-page-loader--active');
+                    fire(el, 'px:loader:hide');
+                }
+            }
+        }, 300);
+    }
+
+    function reset() {
+        pending = 0;
+        const el = loaderEl();
+        if (el) el.classList.remove('px-page-loader--active');
+    }
+
+    async function wrap(promise) {
+        show();
+        try {
+            return await promise;
+        } finally {
+            hide();
+        }
+    }
+
+    function isNavigationRequest(detail) {
+        const config = detail && detail.requestConfig;
+        const verb = ((config && config.verb) || 'get').toLowerCase();
+        if (verb !== 'get') return false;
+        const target = detail.target || (config && config.target);
+        return Boolean(target && target.id && navTargets().has(target.id));
+    }
+
+    function shouldTrack(detail) {
+        const elt = detail && detail.elt;
+        if (elt && elt.closest && elt.closest('[data-px-loader]')) return true;
+        return isNavigationRequest(detail);
+    }
+
+    document.addEventListener('htmx:beforeRequest', (e) => {
+        if (!shouldTrack(e.detail)) return;
+        tracked.add(e.detail);
+        show();
+    });
+    ['htmx:afterRequest', 'htmx:responseError', 'htmx:sendError'].forEach((name) => {
+        document.addEventListener(name, (e) => {
+            if (!tracked.has(e.detail)) return;
+            tracked.delete(e.detail);
+            hide();
+        });
+    });
+    document.addEventListener('htmx:historyRestore', reset);
+
+    // Cold load: the template ships active (active_on_load); hide when ready.
+    function coldLoadDone() {
+        const el = loaderEl();
+        if (el) el.classList.remove('px-page-loader--active');
+    }
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', coldLoadDone);
+    } else {
+        coldLoadDone();
+    }
+
+    px.loader = { show: show, hide: hide, wrap: wrap, reset: reset };
+}());

--- a/pyjinhx/builtins/ui/page_loader/page_loader.html
+++ b/pyjinhx/builtins/ui/page_loader/page_loader.html
@@ -1,0 +1,9 @@
+<div id="{{ id }}"
+     class="px-page-loader{% if active_on_load %} px-page-loader--active{% endif %}{% if class_name %} {{ class_name }}{% endif %}"
+     data-px-page-loader
+     data-nav-targets="{{ nav_targets }}"
+     role="status"
+     aria-label="{{ loading_label }}"
+     aria-live="polite"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
+    <div class="px-page-loader__spinner" aria-hidden="true"></div>
+</div>

--- a/pyjinhx/builtins/ui/page_loader/page_loader.py
+++ b/pyjinhx/builtins/ui/page_loader/page_loader.py
@@ -1,0 +1,12 @@
+from pydantic import Field
+
+from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
+
+
+class PageLoader(BaseComponent):
+    nav_targets: str = "app-content"
+    active_on_load: bool = True
+    loading_label: str = "Loading"
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/toast_host/__init__.py
+++ b/pyjinhx/builtins/ui/toast_host/__init__.py
@@ -1,0 +1,3 @@
+from .toast_host import ToastHost
+
+__all__ = ["ToastHost"]

--- a/pyjinhx/builtins/ui/toast_host/toast-host.css
+++ b/pyjinhx/builtins/ui/toast_host/toast-host.css
@@ -1,0 +1,60 @@
+:root {
+  --px-toast-bg:      var(--surface);
+  --px-toast-border:  var(--border);
+  --px-toast-radius:  var(--radius-md);
+  --px-toast-shadow:  var(--shadow-md);
+  --px-toast-gap:     0.5rem;
+  --px-toast-z:       1000;
+  --px-toast-info:    var(--brand, #5c8fa8);
+  --px-toast-success: #3e7d4f;
+  --px-toast-warning: #b07415;
+  --px-toast-error:   #b3261e;
+}
+
+.px-toast-host {
+  position: fixed;
+  z-index: var(--px-toast-z);
+  display: flex;
+  flex-direction: column;
+  gap: var(--px-toast-gap);
+  pointer-events: none;
+}
+
+.px-toast-host--top-right    { top: 1.5rem; right: 1.5rem; }
+.px-toast-host--top-left     { top: 1.5rem; left: 1.5rem; }
+.px-toast-host--bottom-right { bottom: 1.5rem; right: 1.5rem; }
+.px-toast-host--bottom-left  { bottom: 1.5rem; left: 1.5rem; }
+
+.px-toast {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 0.9rem;
+  background: var(--px-toast-bg);
+  border: 1px solid var(--px-toast-border);
+  border-left: 3px solid var(--px-toast-info);
+  border-radius: var(--px-toast-radius);
+  box-shadow: var(--px-toast-shadow);
+  color: var(--text);
+  pointer-events: auto;
+  animation: px-toast-in 150ms ease;
+}
+
+.px-toast--success { border-left-color: var(--px-toast-success); }
+.px-toast--warning { border-left-color: var(--px-toast-warning); }
+.px-toast--error   { border-left-color: var(--px-toast-error); }
+
+.px-toast--hiding { animation: px-toast-out 150ms ease forwards; }
+
+.px-toast__dismiss {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  line-height: 1;
+}
+
+@keyframes px-toast-in  { from { opacity: 0; transform: translateY(0.4rem); } to { opacity: 1; transform: none; } }
+@keyframes px-toast-out { from { opacity: 1; } to { opacity: 0; } }

--- a/pyjinhx/builtins/ui/toast_host/toast-host.js
+++ b/pyjinhx/builtins/ui/toast_host/toast-host.js
@@ -38,7 +38,7 @@
         toast.className = 'px-toast px-toast--' + level;
         const message = document.createElement('span');
         message.className = 'px-toast__message';
-        message.textContent = data.message || '';
+        message.textContent = data.message || data.value || '';
         const dismiss = document.createElement('button');
         dismiss.type = 'button';
         dismiss.className = 'px-toast__dismiss';

--- a/pyjinhx/builtins/ui/toast_host/toast-host.js
+++ b/pyjinhx/builtins/ui/toast_host/toast-host.js
@@ -1,0 +1,90 @@
+(function () {
+    window.px = window.px || {};
+    if (px.toast) return;
+
+    const wiredEvents = new Set();
+
+    function fire(el, name, detail) {
+        el.dispatchEvent(new CustomEvent(name, { bubbles: true, detail: detail || {} }));
+    }
+
+    function host() {
+        return document.querySelector('[data-px-toast-host]');
+    }
+
+    function removeToast(hostEl, toast) {
+        if (!toast.isConnected) return;
+        toast.classList.add('px-toast--hiding');
+        toast.addEventListener('animationend', () => {
+            if (!toast.isConnected) return;
+            toast.remove();
+            fire(hostEl, 'px:toasthost:hide', {});
+        }, { once: true });
+        // Fallback for animation-less environments.
+        setTimeout(() => {
+            if (toast.isConnected) {
+                toast.remove();
+                fire(hostEl, 'px:toasthost:hide', {});
+            }
+        }, 600);
+    }
+
+    function showToast(detail) {
+        const hostEl = host();
+        if (!hostEl) return;
+        const data = typeof detail === 'string' ? { message: detail } : (detail || {});
+        const level = data.level || 'info';
+        const toast = document.createElement('div');
+        toast.className = 'px-toast px-toast--' + level;
+        const message = document.createElement('span');
+        message.className = 'px-toast__message';
+        message.textContent = data.message || '';
+        const dismiss = document.createElement('button');
+        dismiss.type = 'button';
+        dismiss.className = 'px-toast__dismiss';
+        dismiss.setAttribute('aria-label', hostEl.dataset.dismissLabel || 'Dismiss');
+        dismiss.textContent = '✕';
+        dismiss.addEventListener('click', () => removeToast(hostEl, toast));
+        toast.appendChild(message);
+        toast.appendChild(dismiss);
+        hostEl.appendChild(toast);
+        fire(hostEl, 'px:toasthost:show', { level: level });
+
+        const timeout = Number(data.timeout != null ? data.timeout : hostEl.dataset.timeout) || 0;
+        if (timeout > 0) setTimeout(() => removeToast(hostEl, toast), timeout);
+    }
+
+    function wire(eventName) {
+        if (!eventName || wiredEvents.has(eventName)) return;
+        wiredEvents.add(eventName);
+        // htmx fires HX-Trigger events on the triggering element or body; they
+        // bubble to window. Listening on window catches htmx and manual fires.
+        window.addEventListener(eventName, (e) => showToast(e.detail));
+    }
+
+    function wireMounted(rootNode) {
+        if (rootNode.matches && rootNode.matches('[data-px-toast-host]')) {
+            wire(rootNode.dataset.eventName || 'px:toast');
+        }
+        if (!rootNode.querySelectorAll) return;
+        rootNode.querySelectorAll('[data-px-toast-host]').forEach((h) => {
+            wire(h.dataset.eventName || 'px:toast');
+        });
+    }
+    const observer = new MutationObserver((mutations) => {
+        mutations.forEach((m) => m.addedNodes.forEach((n) => {
+            if (n.nodeType === 1) wireMounted(n);
+        }));
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => wireMounted(document));
+    } else {
+        wireMounted(document);
+    }
+
+    px.toast = function (message, options) {
+        const opts = options || {};
+        showToast({ message: message, level: opts.level, timeout: opts.timeout });
+    };
+}());

--- a/pyjinhx/builtins/ui/toast_host/toast_host.html
+++ b/pyjinhx/builtins/ui/toast_host/toast_host.html
@@ -1,0 +1,8 @@
+<div id="{{ id }}"
+     class="px-toast-host px-toast-host--{{ position }}{% if class_name %} {{ class_name }}{% endif %}"
+     data-px-toast-host
+     data-event-name="{{ event_name }}"
+     data-timeout="{{ timeout }}"
+     data-dismiss-label="{{ dismiss_label }}"
+     aria-live="polite"
+     aria-atomic="false"{% for k, v in extra_attrs.items() %} {{ k }}="{{ v }}"{% endfor %}></div>

--- a/pyjinhx/builtins/ui/toast_host/toast_host.py
+++ b/pyjinhx/builtins/ui/toast_host/toast_host.py
@@ -1,0 +1,17 @@
+from typing import Literal
+
+from pydantic import Field
+
+from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, ExtraAttrs
+
+
+class ToastHost(BaseComponent):
+    position: Literal["top-right", "top-left", "bottom-right", "bottom-left"] = (
+        "bottom-right"
+    )
+    timeout: int = 4000
+    dismiss_label: str = "Dismiss"
+    event_name: str = "px:toast"
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -189,6 +189,7 @@ _BUILTIN_TAG_NAMES = frozenset(
     {
         "Alert",
         "Avatar",
+        "AvatarStack",
         "Badge",
         "Breadcrumb",
         "Card",
@@ -201,6 +202,7 @@ _BUILTIN_TAG_NAMES = frozenset(
         "LoadingOverlay",
         "Modal",
         "Notification",
+        "PageLoader",
         "Popover",
         "PopoverPanel",
         "PopoverTrigger",
@@ -211,6 +213,7 @@ _BUILTIN_TAG_NAMES = frozenset(
         "Skeleton",
         "Spinner",
         "TabGroup",
+        "ToastHost",
         "Tooltip",
     }
 )

--- a/tests/69_golden_builtins_test.py
+++ b/tests/69_golden_builtins_test.py
@@ -21,6 +21,7 @@ CASES = [
     ("alert_dismissible", lambda: b.Alert(id="g", title="Heads up", body="x", dismissible=True, variant="warning")),
     ("avatar_initials", lambda: b.Avatar(id="g", initials="PM")),
     ("avatar_image", lambda: b.Avatar(id="g", src="/u.png", alt="User", size="lg")),
+    ("avatar_stack", lambda: b.AvatarStack(id="g", avatars=[b.Avatar(id="g-a", initials="AB")], extra_count=2)),
     ("badge_default", lambda: b.Badge(id="g", label="New")),
     ("breadcrumb", lambda: b.Breadcrumb(id="g", items=[("Home", "/"), ("Here", None)])),
     ("card_full", lambda: b.Card(id="g", title="T", body="B", footer="F")),
@@ -33,6 +34,7 @@ CASES = [
     ("loading_overlay", lambda: b.LoadingOverlay(id="g")),
     ("modal", lambda: b.Modal(id="g", title="T", body="B", footer="F")),
     ("notification", lambda: b.Notification(id="g", content="Hi", corner="bottom-right", timeout=0)),
+    ("page_loader", lambda: b.PageLoader(id="g")),
     ("panel", lambda: b.Panel(id="g", panels={"a": "<p>A</p>", "b": "<p>B</p>"})),
     ("panel_trigger", lambda: b.PanelTrigger(id="g", panel_id="host", panel="a", content="Tab A")),
     ("popover_compound", lambda: b.Popover(id="g", content=(
@@ -45,6 +47,7 @@ CASES = [
     ("skeleton_text", lambda: b.Skeleton(id="g", lines=2)),
     ("spinner", lambda: b.Spinner(id="g")),
     ("tab_group", lambda: b.TabGroup(id="g", tabs={"One": "<p>1</p>", "Two": "<p>2</p>"})),
+    ("toast_host", lambda: b.ToastHost(id="g")),
     ("tooltip", lambda: b.Tooltip(id="g", trigger="?", tip="Help")),
 ]
 

--- a/tests/71_builtin_conventions_test.py
+++ b/tests/71_builtin_conventions_test.py
@@ -9,11 +9,11 @@ import re
 import pyjinhx.builtins as b
 
 SWEPT: list[type] = [
-    b.Avatar, b.Badge, b.Breadcrumb, b.Card, b.ConfirmDialog, b.Divider, b.EmptyState,
-    b.Modal, b.Drawer, b.Progress, b.PromptDialog, b.Skeleton, b.Tooltip,
-    b.Popover, b.PopoverTrigger, b.PopoverPanel, b.Dropdown,
-    b.Notification, b.Alert, b.Panel, b.PanelTrigger, b.TabGroup,
-    b.LazyPanel, b.LoadingOverlay, b.Spinner,
+    b.Alert, b.Avatar, b.AvatarStack, b.Badge, b.Breadcrumb, b.Card, b.ConfirmDialog,
+    b.Divider, b.Drawer, b.Dropdown, b.EmptyState, b.LazyPanel, b.LoadingOverlay,
+    b.Modal, b.Notification, b.PageLoader, b.Panel, b.PanelTrigger,
+    b.Popover, b.PopoverPanel, b.PopoverTrigger, b.Progress, b.PromptDialog,
+    b.Skeleton, b.Spinner, b.TabGroup, b.ToastHost, b.Tooltip,
 ]
 
 UI_ROOT = os.path.join(os.path.dirname(b.__file__), "ui")
@@ -57,3 +57,10 @@ def test_swept_js_files_are_guarded_iifes():
             content = _read(os.path.join(directory, name)).lstrip()
             assert content.startswith("(function ()"), f"{cls.__name__}/{name}: not an IIFE"
             assert "window.px = window.px || {}" in content, f"{cls.__name__}/{name}: missing px guard"
+
+
+def test_swept_covers_every_builtin():
+    exported = {getattr(b, name) for name in b.__all__}
+    assert set(SWEPT) == exported, sorted(
+        c.__name__ for c in exported.symmetric_difference(set(SWEPT))
+    )

--- a/tests/81_toast_host_test.py
+++ b/tests/81_toast_host_test.py
@@ -1,0 +1,18 @@
+from pyjinhx.builtins import ToastHost
+
+
+def test_toast_host_markers_and_config():
+    html = str(ToastHost(id="th", position="top-right", timeout=2500,
+                         dismiss_label="Fechar", event_name="toast").render())
+    assert "data-px-toast-host" in html
+    assert 'data-event-name="toast"' in html
+    assert 'data-timeout="2500"' in html
+    assert 'data-dismiss-label="Fechar"' in html
+    assert "px-toast-host--top-right" in html
+    assert 'aria-live="polite"' in html
+
+
+def test_toast_host_defaults():
+    html = str(ToastHost(id="th").render())
+    assert 'data-event-name="px:toast"' in html
+    assert "px-toast-host--bottom-right" in html

--- a/tests/82_avatar_stack_test.py
+++ b/tests/82_avatar_stack_test.py
@@ -1,0 +1,23 @@
+from pyjinhx.builtins import Avatar, AvatarStack
+
+
+def test_stack_renders_avatars_and_overflow():
+    html = str(AvatarStack(
+        id="st",
+        avatars=[Avatar(id="a1", initials="AB"), Avatar(id="a2", initials="CD")],
+        extra_count=3,
+    ).render())
+    assert 'id="a1"' in html and 'id="a2"' in html
+    assert ">+3<" in html
+    assert html.index('id="a1"') < html.index('id="a2"')
+
+
+def test_stack_empty_label():
+    html = str(AvatarStack(id="st", empty_label="Sem membros").render())
+    assert "Sem membros" in html
+
+
+def test_stack_no_empty_label_when_avatars_present():
+    html = str(AvatarStack(id="st", avatars=[Avatar(id="a1", initials="AB")],
+                           empty_label="Sem membros").render())
+    assert "Sem membros" not in html

--- a/tests/83_page_loader_test.py
+++ b/tests/83_page_loader_test.py
@@ -1,0 +1,22 @@
+import re
+
+from pyjinhx.builtins import PageLoader
+
+
+def _root(html: str) -> str:
+    match = re.search(r"<div[^>]*px-page-loader[^>]*>", html)
+    assert match, html
+    return match.group(0)
+
+
+def test_page_loader_config_attrs():
+    html = str(PageLoader(id="pl", nav_targets="app-content,org-pane",
+                          loading_label="Carregando").render())
+    assert 'data-nav-targets="app-content,org-pane"' in html
+    assert "px-page-loader--active" in _root(html)
+    assert 'aria-label="Carregando"' in html
+
+
+def test_page_loader_inactive_on_load():
+    html = str(PageLoader(id="pl", active_on_load=False).render())
+    assert "px-page-loader--active" not in _root(html)

--- a/tests/golden/avatar_stack.html
+++ b/tests/golden/avatar_stack.html
@@ -1,0 +1,10 @@
+<div id="g" class="px-avatar-stack">
+  <div id="g-a"
+     class="px-avatar px-avatar--md">
+  
+  <span class="px-avatar__initials" >AB</span>
+  
+</div>
+  <span class="px-avatar-stack__more">+2</span>
+  
+</div>

--- a/tests/golden/page_loader.html
+++ b/tests/golden/page_loader.html
@@ -1,0 +1,9 @@
+<div id="g"
+     class="px-page-loader px-page-loader--active"
+     data-px-page-loader
+     data-nav-targets="app-content"
+     role="status"
+     aria-label="Loading"
+     aria-live="polite">
+    <div class="px-page-loader__spinner" aria-hidden="true"></div>
+</div>

--- a/tests/golden/toast_host.html
+++ b/tests/golden/toast_host.html
@@ -1,0 +1,8 @@
+<div id="g"
+     class="px-toast-host px-toast-host--bottom-right"
+     data-px-toast-host
+     data-event-name="px:toast"
+     data-timeout="4000"
+     data-dismiss-label="Dismiss"
+     aria-live="polite"
+     aria-atomic="false"></div>


### PR DESCRIPTION
## Summary
- **ToastHost** (singleton): `aria-live` container that turns `HX-Trigger: {"px:toast": {"message": ..., "level": ...}}` response headers into styled, stacking, auto-dismissing toasts — zero call-site code on either end. Scalar payloads (`{"px:toast": "Saved!"}`) work too; `event_name` is configurable so existing apps' header names keep working; `px.toast(message, {level, timeout})` for programmatic fires. Messages render via `textContent`, never HTML.
- **AvatarStack** (CSS-only): overlapping avatar list with server-computed `+N` overflow chip and `empty_label` — the `EmptyState.actions` slot idiom (`list[str | BaseComponent]`).
- **PageLoader** (singleton): app-shell navigation loader driven entirely by htmx lifecycle events — shows for GETs targeting `nav_targets` ids or anything inside `[data-px-loader]`, ref-counted with delayed hide, back-button reset, visible during cold load until DOM ready. `px.loader.{show,hide,wrap,reset}` for manual async.
- New `docs/guide/loading.md`: the five-niche decision table (Skeleton / Spinner / LoadingOverlay / PageLoader / Progress) with the hx-indicator recipes.
- The conventions enforcement test now asserts **full coverage: all 28 exported builtins** follow the contract.

PR 7/8, stacked on #52. The library is now 28 components.

## Test plan
- [x] `uv run pytest tests/ -q` — 432 passed
- [x] `uv run ruff check .` / `node --check` ×2 / mkdocs strict
- [x] Goldens: 3 new baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)