### PR TITLE
Docs audit sweep + bare gallery snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ class Button(BaseComponent):
 ```
 
 ```python
+# components/card.py
 from pyjinhx import BaseComponent, Renderer
 
 class Card(BaseComponent):
@@ -56,7 +57,7 @@ Drop a `button.css` or `card.js` next to the component and it's included once, a
 Components declare what state they depend on. Return one component from a mutation route — every other mounted region that reacts to the same keys updates via out-of-band swaps, no manual wiring:
 
 ```python
-from pyjinhx import ReactiveComponent, MutationKey, setup
+from pyjinhx import ReactiveComponent, MutationKey, mutates, setup
 
 class Keys(MutationKey):
     TODOS = "todos"
@@ -68,11 +69,15 @@ class Counter(ReactiveComponent, react={Keys.TODOS}):
     def load(cls) -> "Counter":
         return cls(remaining=db.remaining())
 
+@mutates(Keys.TODOS)
+def toggle_all():
+    db.toggle_all()
+
 setup(app)  # FastAPI: lifespan + middleware, done
 
 @app.post("/todos/toggle")
 def toggle():
-    db.toggle_all()
+    toggle_all()
     return Counter.render()  # other regions reacting to TODOS update too
 ```
 

--- a/docs/api/base-component.md
+++ b/docs/api/base-component.md
@@ -12,7 +12,7 @@ Subclasses are automatically registered and can be rendered using their correspo
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `id` | `str` | Yes | - | Unique identifier for the component instance |
+| `id` | `str` | No | auto-generated (`px-<n>`) when omitted | Unique identifier for the component instance |
 | `js` | `list[str]` | No | `[]` | Paths to additional JavaScript files to include when rendering |
 | `css` | `list[str]` | No | `[]` | Paths to additional CSS files to include when rendering |
 
@@ -28,7 +28,7 @@ def render() -> Markup
 
 Render this component to HTML using its associated Jinja template.
 
-The template is auto-discovered based on the component class name (e.g., `MyButton` looks for `my_button.html` or `my_button.jinja`). All component fields are available in the template context, and nested components are rendered recursively.
+The template is auto-discovered based on the component class name (e.g., `MyButton` looks for `my_button.html` or `my_button.jinja`). All component fields are available in the template context, and nested components are rendered recursively. Subclasses with no adjacent template inherit the nearest ancestor's template and assets through the MRO (first found per kind); a class may have at most one concrete component base — multiple concrete bases raise `TypeError` at definition time (see [Component guide](../guide/components.md)).
 
 This is a plain, zero-argument render. The dependency-aware reactive behavior (`dirtied` / `mounted` / `client`) lives on `ReactiveComponent` — see [Reactive API](reactive-api.md).
 

--- a/docs/api/client-backend.md
+++ b/docs/api/client-backend.md
@@ -34,7 +34,7 @@ Abstract base — implement for non-FastAPI frameworks if needed.
 
 ## FastAPIClientBackend
 
-Defined in `pyjinhx.integrations.fastapi` (re-exported from `pyjinhx`):
+Defined in `pyjinhx.integrations.fastapi`:
 
 ```python
 class FastAPIClientBackend(ClientBackend):

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -9,12 +9,14 @@ def setup(
     app: object | None = None,
     *,
     settings: PjxSettings | None = None,
-    invalidation_backend: InvalidationBackend | None = None,
-    reactive_dev: bool = False,
+    invalidation_backend: InvalidationBackend | None = ...,  # unset sentinel
+    reactive_dev: bool = ...,  # unset sentinel
     load_context_factory: Callable[[Any], object | None] | None = None,
     **kwargs: Any,
 ) -> PjxSettings
 ```
+
+When omitted, `invalidation_backend` and `reactive_dev` never override a value already present in `settings` — their defaults are unset sentinels, so only explicitly passed values are applied.
 
 **Single call** for typical web apps:
 
@@ -89,12 +91,3 @@ with pyjinhx_lifespan():
     ...
 ```
 
-## Cache defaults
-
-By default (no backend), `load()` caching is **per request** — multi-worker safe without Redis. Pass an `invalidation_backend` to opt into cross-request caching per worker process:
-
-```python
-setup(app, invalidation_backend=...)
-```
-
-See [Cache & Invalidation](cache-invalidation.md) and [Redis integration](integrations-redis.md).

--- a/docs/api/finder.md
+++ b/docs/api/finder.md
@@ -30,9 +30,9 @@ Find a file by name under the root directory.
 **Parameters:**
 - `filename` (str): The filename to search for.
 
-**Returns:** The full path to the first matching file.
+**Returns:** The full path to the unique matching file.
 
-**Raises:** `FileNotFoundError` if the file is not found.
+**Raises:** `FileNotFoundError` if the file is not found, or if multiple files match (ambiguous template name).
 
 ##### find_template_for_tag()
 

--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -40,7 +40,9 @@ class ItemRow(ReactiveComponent, react={Keys.TODOS}):
     todo_id: Annotated[int, PjxKey()]
 
     @classmethod
-    def load(cls, todo_id: int) -> "ItemRow":
+    def load(cls, todo_id: int | str) -> "ItemRow":
+        # The cache wrapper passes the key as a string; convert before use.
+        resolved_id = int(todo_id)
         ...
 ```
 

--- a/docs/api/reactive-api.md
+++ b/docs/api/reactive-api.md
@@ -18,6 +18,7 @@ Base class for components that reload from application state via a `load()` clas
 - Declare the `react` **class keyword** — a set of `MutationKey` members this component subscribes to: `class Counter(ReactiveComponent, react={Keys.TODOS})`.
 - Implement `load()` as a `@classmethod` that returns a fresh component instance.
 - For keyed `load(cls, resource)` types, declare exactly one `Annotated[..., PjxKey()]` field.
+- **Subclassing builtins** — a builtin can be mixed in directly: `class LiveBadge(ReactiveComponent, Badge, react={...})`. The subclass inherits the builtin's template and assets via the MRO. At most one concrete component base is allowed — `class X(Badge, Card)` raises `TypeError` at definition. See [Making builtins reactive](../reactivity.md#making-builtins-reactive).
 
 ### Keyed vs singleton
 

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -182,11 +182,4 @@ with Registry.request_scope(
 # Registry, cache, and mutations automatically restored
 ```
 
-**Features:**
-
-- Creates a fresh empty registry on entry
-- Restores previous registry state on exit (even if an exception occurs)
-- Supports nesting—each scope is independent
-- Prevents "Overwriting..." warnings when reusing component IDs across requests
-
-See the [FastAPI integration guide](../integrations/fastapi.md#middleware-recommended) for practical examples.
+Scopes support nesting — each scope is independent. See the [Component Registry guide](../guide/registry.md) for conceptual documentation and the [FastAPI integration guide](../integrations/fastapi.md#middleware-recommended) for practical examples.

--- a/docs/api/renderer.md
+++ b/docs/api/renderer.md
@@ -55,7 +55,7 @@ Return a cached default renderer instance.
 - `js_mode` (AssetMode | None): JavaScript delivery mode
 - `css_mode` (AssetMode | None): CSS delivery mode
 
-**Returns:** A Renderer instance cached by environment identity, asset modes, and resolver identity.
+**Returns:** A Renderer instance cached by environment identity, `auto_id`, asset modes, and resolver identity.
 
 ##### set_default_js_mode()
 

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -1,6 +1,6 @@
 # Gallery
 
-Every builtin, rendered by pyjinhx at docs build time. Click through to the [guide](guide/builtins.md) for props and DOM contracts.
+The builtins, rendered by pyjinhx at docs build time (LazyPanel needs a backend, so it sits this page out). Click through to the [guide](guide/builtins.md) for props and DOM contracts.
 
 ## Static
 

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -5,7 +5,7 @@ This guide walks a complete path from zero to a **reactive FastAPI + HTMX app** 
 When you're done you will have used:
 
 - `BaseComponent` and `ReactiveComponent`
-- Template discovery, nesting, and PascalCase tags
+- Template discovery and nesting via typed child fields
 - Co-located JS/CSS and asset delivery modes
 - `Registry.request_scope`, `@mutates`, and `PjxContext`
 - Reactive `render()` with `ClientBackend` wired in middleware
@@ -42,16 +42,21 @@ uv add pyjinhx fastapi uvicorn httpx python-multipart
 
 ```
 my_app/
-├── app.py                 # FastAPI routes
-├── store.py               # mutations + @mutates
-├── keys.py                # reactive key enums
+├── app.py                   # FastAPI routes
+├── store.py                 # mutations + @mutates
+├── keys.py                  # reactive key enums
 ├── components/
-│   ├── todo_app.py
-│   ├── todo_app.html
-│   ├── todo_row.py
-│   ├── todo_row.html
 │   ├── todo_counter.py
-│   └── todo_counter.html
+│   ├── todo_counter.html
+│   ├── todo-counter.js
+│   ├── todo_list.py
+│   ├── todo_list.html
+│   ├── todo_panel.py
+│   ├── todo_panel.html
+│   ├── todo_item_row.py
+│   ├── todo_item_row.html
+│   ├── todo_app.py
+│   └── todo_app.html
 └── pyproject.toml
 ```
 
@@ -89,8 +94,8 @@ Renderer.set_default_environment("./components")
 print(TodoCounter(id="counter", remaining=3).render())
 ```
 
-???+ question "Why BaseComponent and a required id?"
-    `BaseComponent` is a **Pydantic model** — fields are validated at construction time. The `id` is the stable DOM identity: HTMX targets, registry lookups, and reactive `data-pjx-id` stamping all depend on it. Without an `id`, the library cannot reliably find or swap a region later.
+???+ question "Why BaseComponent and a stable id?"
+    `BaseComponent` is a **Pydantic model** — fields are validated at construction time. The `id` is the stable DOM identity: HTMX targets, registry lookups, and reactive `data-pjx-id` stamping all depend on it. Omitted ids auto-generate a `px-<n>` value; reactive components additionally default to the kebab-cased class name. Explicit ids matter when you need a stable swap target across requests.
 
 ???+ question "Why set_default_environment?"
     The renderer needs one search root for templates (and co-located assets). You set it once at startup (module import or app factory), not per render.
@@ -138,37 +143,43 @@ print(page.render())
 
 ---
 
-## Step 3 — Compose with PascalCase tags in templates
+## Step 3 — A panel with typed child fields
 
 `components/todo_panel.py`:
 
 ```python
 from pyjinhx import BaseComponent
 
+from components.todo_counter import TodoCounter
+
 
 class TodoPanel(BaseComponent):
     id: str
-    remaining: int = 0
+    counter: TodoCounter
 ```
 
 `components/todo_panel.html`:
 
 ```html
 <div id="{{ id }}" class="panel">
-  <TodoCounter id="counter" remaining="{{ remaining }}"/>
+  {{ counter }}
 </div>
 ```
 
-???+ question "Why PascalCase tags?"
-    Tags let **templates own layout** while Python owns data. The parent template emits `<TodoCounter .../>`; PyJinHx expands it using the registered `TodoCounter` class — attrs become constructor fields. Resolution order: existing instance with same class+id → registered class → template-only fallback.
+Build it in Python; the template decides where the child renders:
 
-    See: [PascalCase tags](../guide/tags.md).
+```python
+TodoPanel(id="panel", counter=TodoCounter(id="counter", remaining=3)).render()
+```
+
+???+ question "Why typed child fields?"
+    The panel declares **which child it holds** as a typed Pydantic field; the template owns **where it goes** — `{{ counter }}` renders the nested component in place. This is the same style the runnable `examples/reactive_todo` app uses. PyJinHx also supports `<PascalCase/>` tags for template-driven composition — see [PascalCase tags](../guide/tags.md).
 
 ---
 
 ## Step 4 — Co-located assets
 
-Add `components/todo_counter.js` next to `todo_counter.py`:
+Add `components/todo-counter.js` next to `todo_counter.py` (asset filenames are the **kebab-cased** class name):
 
 ```javascript
 console.log("todo counter ready");
@@ -177,7 +188,7 @@ console.log("todo counter ready");
 On the **root** render, PyJinHx collects JS/CSS once and injects it (inline by default):
 
 ```python
-TodoPanel(id="panel", remaining=2).render()
+TodoPanel(id="panel", counter=TodoCounter(id="counter", remaining=2)).render()
 # → <style>...</style> HTML <script>...</script>
 ```
 
@@ -197,6 +208,7 @@ from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from pyjinhx import Renderer
 
+from components.todo_counter import TodoCounter
 from components.todo_panel import TodoPanel
 
 Renderer.set_default_environment("./components")
@@ -205,7 +217,7 @@ app = FastAPI()
 
 @app.get("/", response_class=HTMLResponse)
 def index():
-    return TodoPanel(id="panel", remaining=3).render()
+    return TodoPanel(id="panel", counter=TodoCounter(id="counter", remaining=3)).render()
 ```
 
 Run: `uvicorn app:app --reload`
@@ -228,7 +240,7 @@ from pyjinhx import Registry
 @app.get("/", response_class=HTMLResponse)
 def index():
     with Registry.request_scope():
-        return TodoPanel(id="panel", remaining=3).render()
+        return TodoPanel(id="panel", counter=TodoCounter(id="counter", remaining=3)).render()
 ```
 
 For a real app, use **`setup(app, ...)`** so lifespan and middleware are wired automatically:
@@ -237,7 +249,7 @@ For a real app, use **`setup(app, ...)`** so lifespan and middleware are wired a
 from pyjinhx import setup
 
 app = FastAPI()
-setup(app, load_context_factory=lambda req: AppLoadContext(db=get_db(req)))
+setup(app, load_context_factory=lambda request: AppLoadContext(store=store))  # AppLoadContext defined in Step 12
 ```
 
 See [Configuration API](../api/config.md) and [FastAPI integration](../integrations/fastapi.md).
@@ -287,8 +299,8 @@ for now just note that `Keys.TODOS` and `store` are imported from there:
 ```python
 from pyjinhx import ReactiveComponent
 
-from .keys import Keys
-from . import store
+from keys import Keys
+import store
 
 
 class TodoCounter(ReactiveComponent, react={Keys.TODOS}):
@@ -333,17 +345,30 @@ class Keys(MutationKey):
 ```python
 from pyjinhx import mutates
 
-from .keys import Keys
+from keys import Keys
+
+_todos: dict[int, dict] = {}
+_next_id = 1
+
+
+def remaining() -> int:
+    return sum(1 for t in _todos.values() if not t["done"])
+
+
+def get(todo_id: int) -> object:
+    return type("Todo", (), _todos[todo_id])()
 
 
 @mutates(Keys.TODOS)
 def add(text: str) -> None:
-    ...
+    global _next_id
+    _todos[_next_id] = {"text": text, "done": False}
+    _next_id += 1
 
 
 @mutates(Keys.TODOS)
 def toggle(todo_id: int) -> None:
-    ...
+    _todos[todo_id]["done"] = not _todos[todo_id]["done"]
 ```
 
 Route (the `TodoItemRow` it renders is the instance-keyed row **we define in Step 10**):
@@ -375,15 +400,18 @@ class TodoItemRow(ReactiveComponent, react={Keys.TODOS}):
     done: bool = False
 
     @classmethod
-    def load(cls, todo_id: int) -> "TodoItemRow":
-        todo = store.get(todo_id)
+    def load(cls, todo_id: int | str) -> "TodoItemRow":
+        resolved_id = int(todo_id)  # cache wrapper passes the key as a string
+        todo = store.get(resolved_id)
         return cls(
-            id=f"row-{todo_id}",
-            todo_id=todo_id,
+            id=f"row-{resolved_id}",
+            todo_id=resolved_id,
             title=todo.text,
             done=todo.done,
         )
 ```
+
+The `load()` key arrives as a **string** from the cache wrapper (the manifest serialises to JSON), so annotate `int | str` and convert inside `load()`.
 
 Template (note `data-pjx-loading` — covered in Step 11):
 
@@ -432,7 +460,7 @@ mutation touches — the swap target *and* its OOB dependents.
 
 ## Step 12 — PjxContext (avoid globals in load())
 
-The context is just a **plain frozen dataclass** — `PjxContext.current()` is duck-typed, so you don't need to subclass anything:
+The context is just a **plain frozen dataclass** — `PjxContext.current()` is duck-typed, so you don't need to subclass anything for this manual pattern (the annotation-injected `ctx:` parameter style does require a `PjxContext` subclass annotation):
 
 ```python
 from dataclasses import dataclass
@@ -473,6 +501,8 @@ You don't pick a cache scope — it follows the backend. By default (no `invalid
 Multi-worker fan-out (also enables cross-request caching):
 
 ```python
+import os
+
 from pyjinhx import PjxSettings, setup
 from pyjinhx.integrations.redis import RedisInvalidationBackend
 
@@ -535,11 +565,11 @@ print(format_dependency_graph())
 
 ```python
 import pyjinhx.builtins  # register templates
-from pyjinhx.builtins import Alert, Button, Card
+from pyjinhx.builtins import Alert, Card, Modal
 ```
 
 ???+ question "Why builtins?"
-    Optional ready-made components (Alert, Modal, Panel, …) with co-located CSS/JS. Use when you want a consistent kit without building every primitive. Your app components follow the same `BaseComponent` rules.
+    Optional ready-made components (Alert, Card, Modal, Panel, …) with co-located CSS/JS. Use when you want a consistent kit without building every primitive. Your app components follow the same `BaseComponent` rules.
 
     See: [Built-in UI components](../guide/builtins.md).
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -32,7 +32,7 @@ PyJinHx automatically installs these runtime dependencies:
 - **MarkupSafe** - Safe HTML string handling
 - **Pydantic** - Data validation and settings
 
-PyJinHx does **not** install a web framework. FastAPI, Starlette, and uvicorn are user-supplied — install them yourself before following the FastAPI quickstart or [Build an App](build-an-app.md):
+PyJinHx does **not** install a web framework. FastAPI, Starlette, and uvicorn are user-supplied — install them yourself before following the [FastAPI quickstart](../integrations/fastapi.md) or [Build an App](build-an-app.md):
 
 ```bash
 pip install fastapi uvicorn

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -31,7 +31,7 @@ class Button(BaseComponent):
 Every component:
 
 - Inherits from `BaseComponent`
-- Has a required `id` field (unique identifier)
+- Has an `id` field — auto-generated (`px-<n>`) if omitted; redeclare `id: str` to require one
 - Can have additional fields with optional defaults
 
 ## Step 2: Create the Template
@@ -46,7 +46,9 @@ Create `components/ui/button.html` (same directory as the class):
 
 !!! info "Template Discovery"
     PyJinHx automatically finds templates by converting the class name to snake_case.
-    `Button` → `button.html`, `ActionButton` → `action_button.html`
+    `Button` → `button.html`, `ActionButton` → `action_button.html` — kebab-case
+    (`action-button.html`) and `.jinja` candidates are also tried; see
+    [PascalCase tags](../guide/tags.md) for the full list.
 
 ## Step 3: Render the Component
 

--- a/docs/guide/builtin-conventions.md
+++ b/docs/guide/builtin-conventions.md
@@ -2,8 +2,6 @@
 
 Every pyjinhx builtin follows the same contract, so knowing one means knowing all of them.
 
-> **Status:** the `px.*` namespace, event vocabulary, and declarative attributes described here land progressively across the 0.8.0 PR stack — this page is the contract the release converges on.
-
 ## The contract
 
 1. **`id` is optional.** Omit it and pyjinhx generates `px-<n>`. Pass one when you need a stable

--- a/docs/guide/builtins.md
+++ b/docs/guide/builtins.md
@@ -46,7 +46,7 @@ from pyjinhx.builtins import (
 
 **Template discovery:** Builtins ship inside `site-packages`, not under your app's Jinja loader root, so PascalCase tags do **not** auto-discover them — `<Tooltip/>` raises a `FileNotFoundError` unless the class was imported once at startup (`import pyjinhx.builtins` or any of the imports above), which registers it. For registered builtin classes, the renderer **falls back** to adjacent package templates: each component's Jinja template lives next to its Python source in `pyjinhx/builtins/ui/<component>/` (e.g. `pyjinhx/builtins/ui/modal/modal.html`). Subclasses of builtins inherit the builtin's template and assets through the MRO, so `class TaskBadge(Badge)` renders like a Badge — see the [reactivity guide](../reactivity.md#making-builtins-reactive) for the reactive pattern.
 
-**Inherited fields:** Every component inherits **`id`** (optional — omitted/falsy ids become `px-<n>`; reactive components need stable ids, defaulted to the kebab-cased class name; pass explicit ids for instance-keyed rows), **`js`** / **`css`** (extra asset paths), **`render()`**, and **`__html__()`** from [`BaseComponent`](../api/base-component.md). `id` is omitted from per-component props tables below. Every builtin also accepts `class_name` (extra classes appended to the root) and `extra_attrs` (validated `dict[str, str]` rendered on the root element).
+**Inherited fields:** Every component inherits `id`, `js`/`css` (extra-asset fields — see [BaseComponent](../api/base-component.md)), `class_name`, `extra_attrs`, `render()`, and `__html__()` — see [builtin-conventions.md](./builtin-conventions.md) for the full contract. `id` is omitted from per-component props tables below.
 
 **Theming:** Per-component `--px-*` tokens are collected in the [Theming tokens](#theming-tokens) appendix. Each component section points there.
 
@@ -88,7 +88,7 @@ from pyjinhx.builtins import (
 | ToggleSwitch | `toggle-switch.css` | — |
 | Tooltip | `tooltip.css` | `tooltip.js` (IIFE, no API) |
 
-**Children-vs-`content` tag gotcha (children-mapping components):** Several components map children to a single attribute (e.g. Tooltip `tip`, Notification `content`, PanelTrigger `content`). If you use `Renderer.render()` with PascalCase tags, do **not** supply both child text and the corresponding attribute on the same tag—use body text as the child *or* the attribute, not both.
+**Children-vs-`content` tag gotcha (children-mapping components):** Several components map children to a single attribute (e.g. Notification `content`, PanelTrigger `content`). If you use `Renderer.render()` with PascalCase tags, do **not** supply both child text and the corresponding attribute on the same tag—use body text as the child *or* the attribute, not both.
 
 **Backdrop click (Modal and Drawer):** Both render a native `<dialog>`; a document `click` listener treats a click whose target is the `<dialog>` root itself (the backdrop) as a close. Any native `<dialog>` clicked directly is affected—use unique ids and avoid stacking multiple dialogs unless you adjust this.
 
@@ -244,9 +244,9 @@ In-place loading veil over a positioned ancestor. **Assets:** `region-loader.css
 
 **Layout:** Overlay is `position: absolute; inset: 0`. Parent must be **`position: relative`** (or any non-`static` value) so coverage is correct.
 
-Also works as an **`hx-indicator`** target: htmx adds `htmx-request` to the element, and the overlay CSS responds to `.px-region-loader.htmx-request` by activating the veil — no JS call required. For programmatic use, `show`/`hide` are **reference-counted per `id`** so overlapping async operations are safe.
+Supports both declarative (`hx-indicator`) and programmatic use (`px.loader.region.*`).
 
-**DOM contract.** Root `.px-region-loader` (state: `.px-region-loader--visible`, `.px-region-loader--hiding`; also responds to `.htmx-request` as an htmx indicator).
+**DOM contract.** Root `.px-region-loader` (state: `.px-region-loader--visible`, `.px-region-loader--hiding`; also responds to `.htmx-request` as an htmx indicator — CSS activates the veil, no JS call required).
 Events (non-cancelable): `px:region-loader:show`, `px:region-loader:hide`.
 API: `px.loader.region.show/hide/reset(id)` and `px.loader.region.wrap(id, promise)`. Ref-counted for concurrent sources: visible from the first `show(id)` to the last `hide(id)`; `show`/`hide` events fire only on real visibility transitions (a show during an in-flight hide cancels it silently); hides finalize via a fallback timer even when animations are disabled. `wrap(id, promise)` pairs show/hide around any async task. Nodes replaced by a swap while sources remain active are re-lit on htmx:afterSettle.
 
@@ -266,9 +266,9 @@ Compact focus/hover hint. **Assets:** `tooltip.css`, `tooltip.js` (IIFE — no A
 | `tip` | `str \| BaseComponent` | `""` | `role="tooltip"` body. |
 | `placement` | literal | `"top"` | `top`, `bottom`, `start`, `end` → `data-px-tooltip-placement`. |
 
-**DOM contract.** Root `.px-tooltip`. `data-px-tooltip-placement` drives JS positioning (`top`/`bottom`/`start`/`end`). Tip shows on `mouseover`/`focusin` of `.px-tooltip__trigger`; hides on `mouseout`/`focusout`; repositions on `scroll`. No JS API (`px._tooltipWired` guard only).
+**DOM contract.** Root `.px-tooltip`. `data-px-tooltip-placement` drives JS positioning (`top`/`bottom`/`start`/`end`). Tip shows on `mouseover` anywhere inside `.px-tooltip` root, or on `focusin` of `.px-tooltip__trigger`; hides on `mouseout`/`focusout`; repositions on `scroll`. No JS API (`px._tooltipWired` guard only).
 
-**Classes:** `px-tooltip`, `px-tooltip__trigger`, `px-tooltip__tip`, `px-tooltip__tip--visible`. Maps children to `tip`; see the [children-vs-`content` note](#built-in-ui-components). Theming: see [Tooltip tokens](#tooltip-tokens).
+**Classes:** `px-tooltip`, `px-tooltip__trigger`, `px-tooltip__tip`, `px-tooltip__tip--visible`. Tip text goes through the `tip` attribute — children are not mapped and are silently dropped; see the [children-vs-`content` note](#built-in-ui-components). Theming: see [Tooltip tokens](#tooltip-tokens).
 
 ---
 
@@ -353,6 +353,7 @@ Determinate or indeterminate meter. **Assets:** `progress.css` only.
 | `value` | `float \| None` | `None` | Omit or `None` for indeterminate `<progress>`. |
 | `max` | `float` | `100` | Passed to `<progress max="…">`. |
 | `label` | `str` | `""` | Optional `px-progress__label`; wires `aria-labelledby` when set. |
+| `loading_label` | `str` | `"Loading"` | `aria-label` fallback on `<progress>` when `label` is empty. |
 
 **DOM contract.** Root `.px-progress`; no JS API.
 
@@ -509,6 +510,7 @@ Ordered trail of links. **Assets:** `breadcrumb.css` only.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `items` | `list[tuple[str, str \| None]]` | `[]` | `(label, href)` left to right; `href` `None` marks the current page. |
+| `aria_label` | `str` | `"Breadcrumb"` | `aria-label` on the `<nav>` wrapper. |
 
 `items` may also be passed as a **JSON array** string (e.g. from PascalCase tags): `[["Home","/"],["Here",null]]`.
 
@@ -531,7 +533,7 @@ Tab buttons and panels. **Assets:** `tab-group.css`, `tab-group.js`.
 
 `tabs` may also be a **JSON object** string from markup tags (values are HTML strings).
 
-**DOM contract.** Root `.px-tab-group` with `data-px-region` (fires `px:reveal`/`px:before-reveal` on panel switch). Tab elements: `.px-tab-group__tab` with `data-px-panel-key`; panel elements: `.px-tab-group__panel[data-px-region]`. `px:before-reveal` (cancelable) fires before switching; `px:reveal` fires after; `data-px-revealed` is set on the visible panel. `tab-group.js` delegates `click` within `.px-tab-group__list`, updates `aria-selected`, `tabindex`, and `hidden`.
+**DOM contract.** Root `.px-tab-group` (no `data-px-region` on the root). Tab elements: `.px-tab-group__tab` (no `data-px-panel-key` — tabs match panels by insertion-order index); panel elements: `.px-tab-group__panel[data-px-region]` (each panel carries `data-px-region`). `px:before-reveal` (cancelable) fires before switching; `px:reveal` fires after; `data-px-revealed` is set on the visible panel. `tab-group.js` delegates `click` document-wide on `.px-tab-group__tab` (not scoped to `.px-tab-group__list`), updates `aria-selected`, `tabindex`, and `hidden`. On `DOMContentLoaded`, `htmx:afterSwap`, and `htmx:afterSettle`, `pxTabGroupInit` announces the initially visible panel once (`px:reveal`, reason `"api"`) so `LazyPanel(when="reveal")` works in default tabs.
 
 **Classes:** `px-tab-group`, `px-tab-group__list`, `px-tab-group__tab`, `px-tab-group__panel`. Theming: see [TabGroup tokens](#tabgroup-tokens).
 
@@ -567,7 +569,7 @@ Invisible wrapper that wires clicks to a [`Panel`](#panel) slot. **Assets:** `pa
 
 Maps children to `content`; see the [children-vs-`content` note](#built-in-ui-components).
 
-**DOM contract.** Root `.px-panel-trigger[data-px-panel-id][data-px-panel-key]`; no own JS (wired by `panel.js`). `display: contents` so no layout box.
+**DOM contract.** Root `.px-panel-trigger[data-px-panel-id][data-px-panel-key]`; no own JS (wired by `panel.js`). `display: contents` so no layout box. On every panel switch, `panel.js` syncs `aria-selected` and `tabindex` on every `.px-panel-trigger[data-px-panel-id]` matching the host Panel.
 
 **Classes:** `px-panel-trigger`. No theming tokens.
 
@@ -779,7 +781,7 @@ ChipInput(id="tags", name="tags", values=["python", "jinja2"], placeholder="Add 
 **DOM contract.** Root `div.px-chip-input[data-px-chip-input][data-name][data-remove-label]`; state: `[data-disabled]`.
 Each chip: `span.px-chip-input__chip[data-px-chip]` containing a `.px-chip-input__label`, `input[type=hidden]`, and (when enabled) `button.px-chip-input__remove[data-px-chip-remove]`.
 Text field: `input.px-chip-input__field`.
-Events (bubble from root): `px:chip-input:before-add`* (detail `{value}`), `px:chip-input:add`, `px:chip-input:before-remove`* (detail `{value}`), `px:chip-input:remove` — `*` = cancelable. Commit triggers: `Enter`, `,`, `focusout`; Backspace on empty field removes the last chip.
+Events (bubble from root): `px:chip-input:before-add`* (detail `{value}`), `px:chip-input:add`, `px:chip-input:before-remove`* (detail `{value}`), `px:chip-input:remove` — `*` = cancelable. Commit triggers: `Enter`, `,`, `focusout`, `submit` (form submit commits pending text); Backspace on empty field removes the last chip.
 
 **Classes:** `px-chip-input`, `px-chip-input__chip`, `px-chip-input__label`, `px-chip-input__remove`, `px-chip-input__field`. Theming: see [ChipInput tokens](#chipinput-tokens).
 

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -40,15 +40,15 @@ PyJinHX uses **Jinja2** templates for its components:
 
 ## The `id` Field
 
-Every component requires an `id`:
+`id` is **auto-generated** (`px-<n>`) when omitted. Pass an explicit id for stable hooks (CSS selectors, htmx targets, reactive OOB targeting):
 
 ```python
-button = Button(id="submit", text="Submit")  # OK
-button = Button(text="Submit")  # Error: id is required
+button = Button(id="submit", text="Submit")  # explicit — stable hook
+button = Button(text="Submit")               # auto-generated px-<n>
 ```
 
-!!! tip "Customizing the `id` Field"
-    You can override the `id` field in your component to automatically generate a value using Pydantic's `default_factory`. For example, to have a random UUID assigned if no `id` is passed:
+!!! tip "Using your own id scheme"
+    Override `id` with a `default_factory` to apply your own generation strategy — for example a UUID:
 
     ```python
     import uuid
@@ -60,11 +60,11 @@ button = Button(text="Submit")  # Error: id is required
         # ... other fields ...
     ```
 
-    This way, when you instantiate `MyComponent()` without providing an `id`, a unique value will be generated.
+    A subclass that redeclares `id: str` **without** a default makes it required at instantiation time.
 
 
 !!! tip "Auto-generated IDs apply to PascalCase tags only"
-    `auto_id` does **not** affect plain Python instances — `BaseComponent(...)` always requires a truthy `id`. The `Renderer`'s `auto_id=True` only generates an `id` when a PascalCase `<Tag/>` is expanded in a template without one (see [PascalCase Tags](tags.md)). Separately, `ReactiveComponent` (not `BaseComponent`) defaults its `id` to the kebab-cased class name (e.g. `TodoCounter` → `"todo-counter"`).
+    `auto_id` does **not** affect plain Python instances — omitting `id` on `BaseComponent(...)` falls back to the built-in `px-<n>` counter. The `Renderer`'s `auto_id=True` only generates an `id` when a PascalCase `<Tag/>` is expanded in a template without one (see [PascalCase Tags](tags.md)). Separately, `ReactiveComponent` (not `BaseComponent`) defaults its `id` to the kebab-cased class name (e.g. `TodoCounter` → `"todo-counter"`).
 
 
 ## Template Discovery

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -101,6 +101,7 @@ Pass a settings object via `settings=`, or override individual fields with expli
 `PjxSettings.from_env()` builds settings from the environment:
 
 - `REDIS_URL` — wires a `RedisInvalidationBackend` (which derives cross-request caching)
+- `PJX_INVALIDATION_DB` — wires a `SqliteInvalidationBackend` with the given path (used when `REDIS_URL` is not set)
 - `PJX_REACTIVE_DEV` — enables reactive dev mode when set to `1`, `true`, or `yes`
 
 ```python

--- a/docs/guide/loading.md
+++ b/docs/guide/loading.md
@@ -1,6 +1,6 @@
 # Loading states
 
-Five loading niches, one decision rule: *what is missing?*
+Six loading niches, one decision rule: *what is missing?*
 
 | What's missing | Builtin | Activation |
 |---|---|---|

--- a/docs/guide/nesting.md
+++ b/docs/guide/nesting.md
@@ -5,7 +5,7 @@ PyJinHx makes it easy to compose components together. You can nest single compon
 !!! note "Two nesting styles, two `id` rules"
     There are two ways to nest:
 
-    - **Python field values** (this page) — you build child instances yourself, so each child needs an **explicit `id`** (a plain `BaseComponent` always requires one).
+    - **Python field values** (this page) — you build child instances yourself; give each child an **explicit `id`** (auto-generated `px-<n>` ids are not stable hooks).
     - **PascalCase `<Tag/>` in templates** (see [PascalCase Tags](tags.md)) — the renderer instantiates children for you and can **auto-generate the `id`** when `auto_id=True` (the default).
 
 ## Direct Nesting

--- a/docs/guide/registry.md
+++ b/docs/guide/registry.md
@@ -65,7 +65,7 @@ def index():
     # Registry automatically cleaned up
 ```
 
-On entry, `request_scope()` also clears pending mutations, initializes the request-tier load cache, and optionally sets `load_context` and `client_backend`. On exit, it warns about unconsumed mutations (when reactive dev is enabled), clears mutations, and resets the request cache.
+On entry, `request_scope()` also clears pending mutations, initializes the request-tier load cache, and optionally sets `load_context` and `client_backend`. On exit — even when an exception occurs — it restores the previous registry state, warns about unconsumed mutations (when reactive dev is enabled), clears mutations, and resets the request cache.
 
 `load_context` and `client_backend` are **optional** — bare `Registry.request_scope()` is enough for instance isolation.
 
@@ -155,7 +155,7 @@ The class registry enables the `Renderer` to instantiate components from PascalC
 
 ### Template context precedence
 
-During render, registered instances are injected into the Jinja context by `id` so templates can reference them by registry key. **Component field values from `model_dump()` take precedence** when a field name collides with an instance `id` (registry injection uses `setdefault`). Watch for this with `ReactiveComponent`, whose `id` defaults to the kebab-cased class name: a `Total` reactive component with a `total` field defaults its `id` to `"total"`, so the field would shadow the instance. (A plain `BaseComponent` has no such default — it always requires an explicit `id`.)
+During render, registered instances are injected into the Jinja context by `id` so templates can reference them by registry key. **Component field values from `model_dump()` take precedence** when a field name collides with an instance `id` (registry injection uses `setdefault`). Watch for this with `ReactiveComponent`, whose `id` defaults to the kebab-cased class name: a `Total` reactive component with a `total` field defaults its `id` to `"total"`, so the field would shadow the instance. (A plain `BaseComponent` defaults to `px-<n>` — not the kebab-class default that reactive components get.)
 
 ```python
 # Class registry (automatic when you define a class)

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -40,6 +40,13 @@ def demo_markup(value):
     return str(value)
 
 
+def demo_source(factory):
+    """The factory's body as a bare expression: drop the def line and the return keyword."""
+    lines = textwrap.dedent(inspect.getsource(factory)).strip().splitlines()
+    body = textwrap.dedent("\n".join(lines[1:]))
+    return body.removeprefix("return ")
+
+
 def on_page_markdown(markdown, *, page, config, files):
     def replace(match):
         name = match.group(1)
@@ -47,7 +54,7 @@ def on_page_markdown(markdown, *, page, config, files):
             raise ValueError(f"unknown demo {name!r} in {page.file.src_path}")
         factory, height = DEMOS[name]
         prefix = "../" * page.url.count("/")
-        source = textwrap.dedent(inspect.getsource(factory)).strip()
+        source = demo_source(factory)
         return (
             f'<iframe src="{prefix}demos/{name.lower()}.html" height="{height}" '
             f'style="{_IFRAME_STYLE}" loading="lazy" title="{name} demo"></iframe>\n\n'

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,30 +51,6 @@ Within Tier 1, PyJinHx offers two complementary approaches:
     html = renderer.render('<Button text="Submit" variant="primary"/>')
     ```
 
-## Quick Example
-
-```python
-from pyjinhx import BaseComponent
-
-class Button(BaseComponent):
-    id: str
-    text: str
-    variant: str = "default"
-```
-
-```html
-<!-- button.html (next to button.py) -->
-<button id="{{ id }}" class="btn btn-{{ variant }}">
-    {{ text }}
-</button>
-```
-
-```python
-button = Button(id="cta", text="Click me", variant="primary")
-print(button.render())
-# <button id="cta" class="btn btn-primary">Click me</button>
-```
-
 ## Next Steps
 
 - [Installation](getting-started/installation.md) - Install PyJinHx
@@ -83,4 +59,4 @@ print(button.render())
 - [Guide](guide/components.md) - Feature reference
 - [Built-in UI components](guide/builtins.md) - Optional `pyjinhx.builtins` package
 - [Public API Index](reference/public-api.md) - Every symbol exported from `pyjinhx`
-- [Migrating from 0.4.x](migration.md) - Upgrading a render-only `0.4.x` app to the current release
+- [Migration guide](migration.md) — 0.8 → 0.9 breaking changes and upgrading from 0.4.x

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -27,7 +27,7 @@ class Card(BaseComponent):
     subtitle: str = ""   # optional
 ```
 
-The template is auto-discovered from the class name: `Card` → `card.html`/`card.jinja`; `ActionButton` → `action_button` or `action-button` (`.html` or `.jinja`).
+The template is auto-discovered from the class name: `Card` → `card.html`/`card.jinja`; `ActionButton` → `action_button` or `action-button` (`.html` or `.jinja`). Subclasses with no adjacent template inherit the nearest ancestor's template and assets through the MRO (first found per kind), so do **not** duplicate templates for every subclass; a class may have at most one concrete component base (definition-time `TypeError`).
 
 ## Rendering
 
@@ -52,7 +52,7 @@ Fields typed as components — `action: Button`, `items: list[Button]`, `widgets
 
 ## Assets (JS & CSS)
 
-**Kebab-case** `.js`/`.css` files next to the component (`TabGroup` → `tab-group.js`; a snake_case stem like `tab_group.js` is **not** collected) are auto-collected, deduplicated per render session, and injected at the root render — CSS as `<style>` before the HTML, JS as `<script>` after, one tag per component so an error in one doesn't break others.
+**Kebab-case** `.js`/`.css` files next to the component (`TabGroup` → `tab-group.js`; a snake_case stem like `tab_group.js` is **not** collected) are auto-collected, deduplicated per render session, and injected at the root render — CSS as `<style>` before the HTML, JS as `<script>` after, one tag per component so an error in one doesn't break others. Subclasses with no adjacent assets inherit the nearest ancestor's assets through the MRO (first found per kind).
 
 Add extra files via the `js=[...]` / `css=[...]` fields; missing files warn on the `pyjinhx` logger. For production use `AssetMode.REFERENCE` with `Renderer.set_asset_url_resolver()`; disable with `AssetMode.NONE`. For layout preload use `Finder(root).collect_javascript_files()` / `.collect_css_files()` or `layout_asset_tags()`.
 
@@ -127,7 +127,7 @@ Set an explicit `id` in `load()` for stable DOM targets; templates use the key f
 
 ### Client runtime & cache
 
-- Root full-page renders auto-inject `pjx.js` unless the request already carries `X-PJX-Mounted`. For a raw Jinja shell, put `{{ client_script() }}` in `<head>`.
+- Root full-page renders auto-inject `pjx.js` unless the request already carries `X-PJX-Mounted`. For a raw Jinja shell, call `client_script()` Python-side and pass it into the template context (e.g. `{"pjx_runtime": client_script()}`), then render with `{{ pjx_runtime }}` in `<head>` or `<body>`.
 - **Loading indicators:** `data-pjx-loading="skeleton"` (or `"spinner"`) on any element inside a reactive root template flags it (matched via the enclosing reactive root) while an in-flight request dirties keys the region reacts to, until the swap lands. A trigger may add `data-pjx-loading-extra="<css-selector>"` to also flag regions a bulk action will touch. Style via `--pjx-*` CSS vars (`--pjx-skeleton-color`, `--pjx-spinner-color`, …).
 - Every `load()` is memoized in `LoadCache`, one entry per `(type, key)`. Scope follows the backend: per-request with no `invalidation_backend`; pass `setup(invalidation_backend=...)` (e.g. Redis) for process-wide caching plus eviction fan-out across workers.
 
@@ -164,7 +164,8 @@ from pyjinhx import (
     setup,              # wires FastAPI middleware (request_scope, ClientBackend, PjxContext)
 )
 # advanced/internal building blocks live in submodules:
-from pyjinhx.finder import Finder        # asset/template discovery, detect_root_directory()
+from pyjinhx.finder import Finder        # asset/template discovery
+from pyjinhx.utils import detect_root_directory  # locate project root
 from pyjinhx.tags import Parser, Tag     # HTML parsing internals (rarely needed)
 from pyjinhx.cache import LoadCache      # LoadCache.invalidate — manual cache eviction
 from pyjinhx.reactive import oob_swaps   # manual OOB walk (tests/advanced)

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -118,7 +118,7 @@ app = FastAPI(lifespan=my_existing_lifespan)  # optional — chained, not replac
 setup(app, load_context_factory=lambda req: AppLoadContext(db=get_db(req)))
 ```
 
-`setup(app, ...)` chains your lifespan (if any), wires optional invalidation, and registers registry middleware with `ClientBackend` for header auto-resolution. By default (no `invalidation_backend`) the load cache is per-request — multi-worker safe; pass a backend to opt into cross-request caching. See [Configuration](../api/config.md) and [Reactivity §4](../reactivity.md#4-load-results-are-cached).
+`setup(app, ...)` chains your lifespan (if any), wires optional invalidation, and registers registry middleware with `ClientBackend` for header auto-resolution. By default (no `invalidation_backend`) the load cache is per-request — multi-worker safe; pass a backend to opt into cross-request caching. See [Configuration](../api/config.md) and [Reactivity → load() results are cached](../reactivity.md#load-results-are-cached).
 
 ### Per-Route (manual)
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -177,7 +177,7 @@ intermediate `0.5`–`0.7` reactive API, apply these renames:
 | `PyJinhxSettings` | `PjxSettings` |
 | `LoadContext` | `PjxContext` |
 | `PjxLoad` | `PjxKey` |
-| `client_script()` | removed (the client runtime is injected via `setup()` now) |
+| `client_script()` | no longer top-level — `from pyjinhx.client import client_script` |
 
 Also note the **public surface was curated from ~45 down to ~11 symbols**. Advanced/internal
 symbols are no longer top-level — import them from their submodule
@@ -277,7 +277,7 @@ class NavMembersBadge(ReactiveComponent, react={Keys.MEMBERS}):
 @app.post("/orgs/{slug}/members/{mid}/remove")
 def remove_member_route(slug: str, mid: str):
     remove_member(slug, mid)          # @mutates records Keys.MEMBERS as dirtied
-    return MembersList.render()       # framework reloads every mounted region whose
+    return MembersCounter.render()    # framework reloads every mounted region whose
                                       # react keys ∩ {MEMBERS} ≠ ∅, hashes them, and
                                       # appends an hx-swap-oob fragment for each *changed* one
 ```
@@ -316,7 +316,7 @@ StateKey         → MutationKey
 PyJinhxSettings  → PjxSettings
 LoadContext      → PjxContext
 PjxLoad          → PjxKey
-client_script()  → (removed; runtime injected by setup())
+client_script()  → no longer top-level — from pyjinhx.client import client_script
 
 # Advanced symbols are no longer top-level — import from submodules
 from pyjinhx.cache import LoadCache, CacheScope

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -24,7 +24,7 @@ the hash the client reported, and a matching hash is skipped.
 
 See the [Public API Index](reference/public-api.md) for every exported reactive symbol.
 
-## 1. Make a component reactive
+## Make a component reactive
 
 Subclass `ReactiveComponent` and declare **both** the `react` class keyword and a
 `load()` classmethod — `ReactiveComponent` enforces both (a missing `load()` can't be
@@ -57,9 +57,7 @@ class Counter(ReactiveComponent, react={Keys.TODOS}):
 - `state_hash()` — canonical SHA-256 of sorted JSON from `model_dump(mode="json")`
   with `state_hash_exclude` applied (`id` is excluded by default). Override for custom
   hashing or add fields to `state_hash_exclude` for ephemeral UI-only state.
-- `depends_on()` — optional runtime narrowing for load-cache indexing after `load()`.
-  The static `react` set must remain a **superset** of every key `depends_on()`
-  may return (dev mode enforces this). `oob_swaps` matches on the static `react` set only.
+- `depends_on()` — optional runtime narrowing for load-cache indexing; the static `react` set must remain a superset. See [Runtime dependencies](#runtime-dependencies-depends_on).
 
 Reactive components are stamped with `data-pjx-id`, `data-pjx-type` (the class
 name), and `data-pjx-hash` on their root element automatically.
@@ -95,7 +93,7 @@ Fit: display builtins (Badge, Progress, AvatarStack, EmptyState, Card).
 Stateful overlays (Modal, Drawer, Popover, Dropdown) are a poor fit — an OOB
 swap replaces the region's DOM, so an open dialog snaps shut mid-interaction.
 
-## 2. Ship the client runtime
+## Ship the client runtime
 
 On root full-page renders, `pjx.js` is injected automatically unless the request
 already carries a valid `X-PJX-Mounted` header (meaning the runtime is active in
@@ -124,13 +122,13 @@ from pyjinhx.client import client_script
 </body>
 ```
 
-The runtime attaches two client manifests to every htmx request:
+The runtime attaches these headers to htmx requests:
 
 | Header | Purpose |
 |--------|---------|
 | `X-PJX-Mounted` | Reactive regions currently in the DOM (`id`, `type`, `hash`, optional `load`) |
 | `X-PJX-Assets` | URLs of `<script src>` and `<link rel="stylesheet">` already loaded |
-| `X-PJX-Trigger` | `data-pjx-id` of the element that started the HTMX request |
+| `X-PJX-Trigger` | `data-pjx-id` of the element that started the request — sent only when a reactive root triggered it |
 
 Wire `FastAPIClientBackend` via `setup(app, ...)` — see the
 [canonical snippet](integrations/fastapi.md#middleware-recommended) and
@@ -139,7 +137,7 @@ Wire `FastAPIClientBackend` via `setup(app, ...)` — see the
 `@mutates`. Full-page routes call `.render()` plainly; boosted navigations skip
 re-injecting `pjx.js` when `X-PJX-Mounted` is present.
 
-## 3. Emit OOB swaps from your route
+## Emit OOB swaps from your route
 
 A mutation route does exactly one thing: **`return <component>.render(...)`**. You
 never call `load()` and never assemble swaps yourself. For a **reactive** primary,
@@ -174,17 +172,7 @@ the instance: `MyFragment(id=..., ...).render()`.
 
 ### Under the hood: `oob_swaps()`
 
-`render()` delegates its dependency walk to `oob_swaps(dirtied, mounted)` (passing
-`exclude_ids={primary.id}`), which returns the concatenated `hx-swap-oob` fragments.
-It's exported for tests and advanced composition, but it is **not** how you write a
-route — a route returns `render()`, not bare swaps. `oob_swaps`:
-- keeps only mounted regions whose `react` keys intersect `dirtied`,
-- calls each region's `load()` and re-renders it,
-- skips a region whose freshly computed `state_hash()` matches the hash the client
-  reported (its DOM value is already current); a missing or mismatched hash always
-  swaps — *when in doubt, swap*,
-- drops any region nested inside another swapped region (the parent already contains it),
-- returns concatenated `hx-swap-oob` fragments (empty if nothing changed).
+`render()` delegates its dependency walk to `oob_swaps(dirtied, mounted)` — hash-gate, nesting-dedup, and delete-on-LookupError in one call. It's exported for tests and advanced composition, but routes return `render()`, not bare swaps. Full walk mechanics are in [How it works (under the hood)](#how-it-works-under-the-hood) below.
 
 The dependency graph lives in exactly one place — the `react` class keyword
 declarations — not smeared across endpoints. Adding a progress bar that declares
@@ -209,15 +197,18 @@ class TodoItemRow(ReactiveComponent, react={Keys.TODOS}):
     done: bool = False
 
     @classmethod
-    def load(cls, todo_id: int) -> "TodoItemRow":
-        t = store.get(todo_id)
+    def load(cls, todo_id: int | str) -> "TodoItemRow":
+        resolved_id = int(todo_id)  # cache wrapper passes the key as a string
+        t = store.get(resolved_id)
         return cls(
-            id=f"row-{todo_id}",
-            todo_id=todo_id,
+            id=f"row-{resolved_id}",
+            todo_id=resolved_id,
             title=t.text,
             done=t.done,
         )
 ```
+
+The `load()` key arrives as a **string** from the cache wrapper (the manifest serialises to JSON), so annotate `int | str` and convert inside `load()`.
 
 - **`data-pjx-load`** is stamped from the `PjxKey` field and returned in the manifest
   so OOB reloads call `load(manifest.load)`.
@@ -285,12 +276,7 @@ class AdminPanel(ReactiveComponent, react={Keys.USER, Keys.SETTINGS}):
         return {Keys.SETTINGS}
 ```
 
-`depends_on()` affects load-cache reverse indexing; `oob_swaps` matches on the static
-`react` set only.
-
-`dependency_graph()` uses the static superset only. In dev mode,
-`enable_reactive_dev()` warns (or raises) when `depends_on()` returns keys outside
-the superset.
+`depends_on()` narrows load-cache reverse indexing; `oob_swaps` and `dependency_graph()` always use the static `react` superset, and dev mode warns (or raises) when `depends_on()` returns keys outside it.
 
 ## Mutation tracking (`@mutates`)
 
@@ -320,13 +306,16 @@ Pass request-scoped dependencies into `load()` without global imports:
 
 ```python
 from dataclasses import dataclass
-from pyjinhx import PjxContext
+from pyjinhx import MutationKey, PjxContext, ReactiveComponent
+
+class Keys(MutationKey):
+    TODOS = "todos"
 
 @dataclass(frozen=True)
 class AppContext(PjxContext):
     db: Database
 
-class Counter(ReactiveComponent):
+class Counter(ReactiveComponent, react={Keys.TODOS}):
     @classmethod
     def load(cls, *, ctx: AppContext | None = None) -> "Counter":
         ctx = ctx or PjxContext.current()
@@ -363,7 +352,7 @@ print(format_dependency_graph())
 # or format_dependency_graph(as_mermaid=True) for a flowchart
 ```
 
-## 4. `load()` results are cached
+## `load()` results are cached
 
 Every reactive component's `load()` is wrapped in a **dependency-keyed cache**.
 Repeated reads within the same request return the cached result and skip the database
@@ -395,8 +384,8 @@ setup(app, invalidation_backend=...)  # cross-request per worker
 Use `Registry.request_scope()` on every HTTP request (middleware) for instance registry
 isolation and the request-tier cache (which dedups the OOB walk regardless of backend).
 
-**Cache identity:** entries are keyed by `(component class, load key)` only. Encode
-tenant or user scope in reactive keys (e.g. `"user:7:todos"`) or ensure `PjxContext`
+**Cache identity:** entries are keyed by `(component class, load key)` only. For per-user
+isolation use a `PjxKey`-keyed instance (one entry per user id) or ensure `PjxContext`
 data is stable for all requests sharing a cache entry.
 
 Reactive `render()` (and `oob_swaps`) evicts pending dirtied keys before reloading
@@ -408,7 +397,7 @@ from pyjinhx.cache import LoadCache
 
 def nightly_recalc():
     db.rebuild_todos()
-    LoadCache.invalidate({"todos"})
+    LoadCache.invalidate({Keys.TODOS})
 ```
 
 The cache holds one result per `(type, key)` and returns a fresh copy on every call, so

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -2,7 +2,7 @@
 
 Every symbol exported from `pyjinhx` (`__all__`) is listed below with a one-line description and a link to detailed documentation.
 
-These 13 symbols are the entire top-level public API; advanced/internal building blocks (e.g. `oob_swaps`, `LoadCache`, `ClientBackend`, the asset-resolver helpers, dev tooling) remain importable from their submodules — e.g. `from pyjinhx.cache import LoadCache`.
+These 11 symbols are the entire top-level public API; advanced/internal building blocks (e.g. `oob_swaps`, `LoadCache`, `ClientBackend`, the asset-resolver helpers, dev tooling) remain importable from their submodules — e.g. `from pyjinhx.cache import LoadCache`.
 
 ## Components & rendering
 

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -12,7 +12,11 @@ from html.parser import HTMLParser
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from .registry import Registry
-from .utils import extract_tag_name_from_raw, pascal_case_to_snake_case
+from .utils import (
+    extract_tag_name_from_raw,
+    pascal_case_to_snake_case,
+    tag_name_to_template_filenames,
+)
 
 logger = logging.getLogger("pyjinhx")
 
@@ -231,9 +235,9 @@ def _missing_template_error(tag_name: str) -> FileNotFoundError:
             f"Add `from pyjinhx.builtins import {tag_name}` "
             f"(or `import pyjinhx.builtins`) once at app startup so the tag resolves."
         )
+    candidates = ", ".join(tag_name_to_template_filenames(tag_name))
     return FileNotFoundError(
-        f"No template found for <{tag_name}>. "
-        f"Expected {tag_name.lower()}.html or {tag_name.lower()}.jinja"
+        f"No template found for <{tag_name}>. Expected one of: {candidates}"
     )
 
 

--- a/tests/unit/test_gallery_demos.py
+++ b/tests/unit/test_gallery_demos.py
@@ -28,7 +28,9 @@ def test_marker_becomes_iframe_and_source():
     )
     assert '<iframe src="../../demos/badge.html"' in out
     assert "```python" in out
-    assert "def badge" in out
+    assert 'Badge(label="Active"' in out
+    assert "def " not in out
+    assert "return " not in out
     assert "<!-- demo:" not in out
 
 

--- a/tests/unit/test_template_and_engine_errors.py
+++ b/tests/unit/test_template_and_engine_errors.py
@@ -43,11 +43,12 @@ def test_missing_template_error_hints_at_builtin_import():
     assert "from pyjinhx.builtins import Tooltip" in str(error)
 
 
-def test_missing_template_error_keeps_legacy_message():
+def test_missing_template_error_lists_real_candidates():
     error = _missing_template_error("UserCard")
 
     assert str(error) == (
-        "No template found for <UserCard>. Expected usercard.html or usercard.jinja"
+        "No template found for <UserCard>. Expected one of: "
+        "user_card.html, user-card.html, user_card.jinja, user-card.jinja"
     )
 
 


### PR DESCRIPTION
## Summary

Docs audit sweep + gallery snippet polish. Every finding below was verified by *executing* the docs — snippets run against the installed 0.10.0, claims diffed against source/JS, all 33 prop tables diffed programmatically against the Pydantic models, every internal link/anchor checked across the built site.

## Gallery

- Snippets now show bare component instantiations (`Badge(label="Active", color="brand").render()`) instead of factory functions — the displayed code is still byte-identical to what executes (the hook strips only the `def` line and `return` keyword).
- Gallery intro no longer claims "every builtin" (LazyPanel is deliberately absent — needs a backend).

## Audit (four slices + adversarial review, ~55 findings fixed)

**Broken examples fixed:**
- README reactivity example was missing the `@mutates` function — without it no OOB swap ever fired (verified with a live FastAPI app before/after). *(user-reported)*
- build-an-app tutorial now actually runs end-to-end (TestClient-verified): absolute imports, a working store with the functions later steps call, `int | str` load keys (cache stringifies them), `import os`, no nonexistent `Button` builtin, accurate file tree, and field composition instead of tag composition — the tag form 500s with `RecursionError`, filed as #64.
- reactivity.md's load-context example (missing `react=`) and instance-keyed example (string-key crash) repaired; migration.md's undefined `MembersList` fixed.

**Drift fixed:**
- "id is required" was stale in five files (auto-generated `px-<n>` since 0.9).
- migration.md claimed `client_script()` was removed — it moved to `pyjinhx.client`; a migrating user would have deleted working code.
- TabGroup's DOM contract was wrong on three counts vs the shipped JS; Tooltip docs promised children→`tip` mapping that v2 silently drops (possible code regression — see PR notes below).
- MRO subclassing (0.10) now reflected in base-component.md, reactive-api.md, and the Claude Code skill; stale 0.8.0 status note removed; `setup()` signature corrected to the real sentinel semantics; "13 symbols" → 11; `PJX_INVALIDATION_DB` documented; missing Progress/Breadcrumb prop rows added.
- `tags.py`'s missing-template error now lists the real snake/kebab candidates instead of `usercard.html` (the one code change; test updated).

**Tightened:** duplicated teaching trimmed in index.md, config.md, registry.md, reactivity.md (×3), builtins.md (×2) — with adversarial verification that no unique fact was lost (one was, registry exception-safety, and it was restored).

## Notes

- **Possible code regression worth a look:** `<Tooltip>text</Tooltip>` silently drops children (tag parser maps children to `content`, which Tooltip lacks). Docs now document the `tip` attribute; if children-mapping was intended, that's a code fix.
- **Filed #64**: RecursionError on tag composition inside `Registry.request_scope()` (no cycle guard).

## Testing

- 546 tests pass; `mkdocs build --strict` clean; whole-corpus snippet execution (249 blocks: 169 executed green, 59 legitimate fragments, rest intentional BEFORE-examples); zero dead links/anchors across 65 built pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
