### PR TITLE
Stop warning on plain HTML closing tags in Parser

### DIFF
--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -100,7 +100,12 @@ class Parser(HTMLParser):
             self._append_child(tag_node)
             return
 
-        logger.warning("Mismatched closing tag </%s>; emitting as raw HTML", tag)
+        # Plain HTML tags are never stacked, so their closing tags land here.
+        if any(t.name.lower() == tag.lower() for t in self._stack):
+            logger.warning(
+                "Closing tag </%s> interleaves with an open component tag; "
+                "emitting as raw HTML", tag,
+            )
         self._append_child(f"</{tag}>")
 
     def handle_data(self, data: str) -> None:

--- a/tests/unit/test_parser_endtag_warning.py
+++ b/tests/unit/test_parser_endtag_warning.py
@@ -1,0 +1,47 @@
+import logging
+import os
+import re
+import tempfile
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+from pyjinhx import Renderer
+from pyjinhx.tags import Parser
+
+
+def test_plain_html_closing_tags_do_not_warn(caplog):
+    html = "<div><span>hi</span><button>x</button></div>"
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        rendered = Renderer.get_default_renderer().render(html)
+
+    assert rendered == html
+    assert not caplog.records
+
+
+def test_plain_html_wrapping_component_does_not_warn(caplog):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "marker.html"), "w") as file:
+            file.write("<span id={{ id }}>{{ text }}</span>\n")
+
+        index_html = '<div><Marker text="New"/></div>'
+        with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+            rendered = Renderer(
+                Environment(loader=FileSystemLoader(temp_dir)),
+                auto_id=True,
+            ).render(index_html)
+
+    assert re.match(r"^<div><span id=px-\d+>New</span></div>$", rendered), (
+        f"Output does not match expected pattern. Got: {rendered!r}"
+    )
+    assert not caplog.records
+
+
+def test_interleaved_component_close_warns(caplog):
+    parser = Parser()
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        parser.feed("<Foo><Bar></Foo>")
+
+    assert any("</foo>" in r.getMessage().lower() for r in caplog.records)
+    with pytest.raises(ValueError, match="Unclosed PascalCase component tags"):
+        parser.close()


### PR DESCRIPTION
## Bug

`Parser.handle_starttag` only pushes PascalCase component tags onto the stack; plain HTML start tags are emitted as raw strings and never stacked. But `handle_endtag` warned whenever the stack top didn't match — so every plain closing tag (`</div>`, `</span>`, ...) on perfectly well-formed input logged `Mismatched closing tag </...>; emitting as raw HTML`. A real app session produced ~180k warning lines.

## Fix

A plain closing tag reaching `handle_endtag` is expected, so it's now appended silently. A warning remains only for the one case with real signal: the closing tag matches a component deeper in the stack (interleaved nesting around an open component tag). The comparison is case-insensitive since `HTMLParser` lowercases end-tag names. Genuine unclosed-component errors are still caught by `Parser.close()` (raises `ValueError`), unchanged.

## Tests

- Well-formed plain HTML renders correctly with zero `pyjinhx` warnings
- Plain HTML wrapping a component tag emits no warning for the plain closing tag
- Interleaved close (`<Foo><Bar></Foo>`) still warns, and `close()` still raises

Full suite: 537 passed (`uv run pytest -q -m "not reactivity"`).

Closes #68
Refs #67 (finding 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)