### PR TITLE
Dedupe client runtime injection per request scope

### DIFF
--- a/pyjinhx/assets.py
+++ b/pyjinhx/assets.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 from collections.abc import Callable
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Literal
@@ -25,6 +26,12 @@ logger = logging.getLogger("pyjinhx")
 
 DEFAULT_RUNTIME_URL = "/static/pyjinhx/pjx.js"
 DEFAULT_STATIC_PREFIX = "/static/components"
+
+# Request-scoped "runtime already injected" flag, set by Registry.request_scope.
+# ``None`` means no request scope is active and per-session dedup applies alone.
+_runtime_injected: ContextVar[bool | None] = ContextVar(
+    "runtime_injected", default=None
+)
 
 
 class AssetMode(str, Enum):
@@ -269,7 +276,8 @@ def inject_runtime(
 ) -> None:
     from pyjinhx.client import MountedManifest
 
-    if session.runtime_injected:
+    request_injected = _runtime_injected.get()
+    if session.runtime_injected or request_injected:
         return
     if MountedManifest.is_present(client):
         return
@@ -281,6 +289,8 @@ def inject_runtime(
             session.collected_paths.add(runtime_path)
             session.assets.insert(0, CollectedAsset(path=runtime_path, kind="js"))
     session.runtime_injected = True
+    if request_injected is not None:
+        _runtime_injected.set(True)
 
 
 def should_emit_reference_url(

--- a/pyjinhx/registry.py
+++ b/pyjinhx/registry.py
@@ -133,8 +133,9 @@ class Registry:
         Context manager for request-scoped component instances.
 
         Creates a fresh instance registry on entry and restores
-        the previous state on exit. Also resets mutation tracking and
-        optionally sets a load context for reactive ``load()`` calls.
+        the previous state on exit. Also resets mutation tracking,
+        dedupes client runtime injection across renders in the scope,
+        and optionally sets a load context for reactive ``load()`` calls.
 
         Usage:
             with Registry.request_scope():
@@ -142,6 +143,7 @@ class Registry:
         """
         from contextlib import ExitStack
 
+        from pyjinhx.assets import _runtime_injected
         from pyjinhx.client import ClientBackend
         from pyjinhx.cache import LoadCache
         from pyjinhx.context import PjxContext
@@ -151,6 +153,7 @@ class Registry:
         MutationTracker.clear()
         LoadCache.init_request()
         token = _registry_context.set({})
+        runtime_token = _runtime_injected.set(False)
         try:
             with ExitStack() as stack:
                 if load_context is not None:
@@ -162,4 +165,5 @@ class Registry:
             warn_mutations_without_render()
             MutationTracker.clear()
             LoadCache.reset_request()
+            _runtime_injected.reset(runtime_token)
             _registry_context.reset(token)

--- a/tests/unit/test_layout_runtime.py
+++ b/tests/unit/test_layout_runtime.py
@@ -2,7 +2,8 @@ import json
 
 import pytest
 
-from pyjinhx import BaseComponent, Renderer
+from pyjinhx import BaseComponent, Registry, Renderer
+from pyjinhx.assets import _runtime_injected
 from pyjinhx.client import PJX_MOUNTED_HEADER, MountedManifest
 
 pytestmark = pytest.mark.pjx_runtime
@@ -85,6 +86,36 @@ def test_root_render_skips_runtime_for_valid_manifest():
         )
     )
     assert "htmx:configRequest" not in html
+
+
+def test_request_scope_injects_runtime_once_across_root_renders():
+    with Registry.request_scope():
+        first = str(Page(id="page-a")._render(source="<div>a</div>"))
+        second = str(Page(id="page-b")._render(source="<div>b</div>"))
+    assert first.count("htmx:configRequest") == 1
+    assert "htmx:configRequest" not in second
+
+
+def test_separate_request_scopes_each_inject_runtime():
+    with Registry.request_scope():
+        first = str(Page(id="page-a")._render(source="<div>a</div>"))
+    with Registry.request_scope():
+        second = str(Page(id="page-b")._render(source="<div>b</div>"))
+    assert first.count("htmx:configRequest") == 1
+    assert second.count("htmx:configRequest") == 1
+
+
+def test_without_request_scope_each_root_render_injects_runtime():
+    # conftest wraps every test in Registry.request_scope(); clear the
+    # request-scoped flag to exercise the no-scope fallback.
+    token = _runtime_injected.set(None)
+    try:
+        first = str(Page(id="page-a")._render(source="<div>a</div>"))
+        second = str(Page(id="page-b")._render(source="<div>b</div>"))
+    finally:
+        _runtime_injected.reset(token)
+    assert first.count("htmx:configRequest") == 1
+    assert second.count("htmx:configRequest") == 1
 
 
 def test_nested_render_does_not_inject_runtime():

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ wheels = [
 
 [[package]]
 name = "pyjinhx"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Bug

`RenderSession.runtime_injected` is per-session, and every top-level `.render()` call creates a fresh session. Pages assembled from multiple top-level renders (shell + navbar + sidebar + content) injected one full copy of the pjx.js client runtime each — a real app got 17 copies on one cold load. The `MountedManifest.is_present(client)` check only dedupes htmx partials, not cold loads.

## Fix

Request-scoped dedup via a `ContextVar` flag in `assets.py`, following the existing `_registry_context` token-reset idiom:

- `Registry.request_scope()` sets the flag to `False` on entry and restores the previous value on exit.
- `inject_runtime()` checks-and-sets it when a request scope is active, so the runtime is injected once per scope.
- When no request scope is active the flag is `None` and the existing per-session behavior applies unchanged.

No new public API, no new toggle.

## Tests

- Two top-level renders inside one `request_scope()` → runtime exactly once.
- Two separate `request_scope()` blocks → runtime once per scope.
- No request scope → runtime once per root render, as before.

`uv run pytest -q -m "not reactivity"` → 537 passed.

Refs #67 (finding 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)