### PR TITLE
Support PEP 563 string annotations in PjxKey detection

### DIFF
--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -9,7 +9,7 @@ from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Annotated, Any, ClassVar, get_args, get_origin
+from typing import Annotated, Any, ClassVar, get_args, get_origin, get_type_hints
 
 from markupsafe import Markup
 from pydantic import ConfigDict, PrivateAttr, model_validator
@@ -60,7 +60,13 @@ def pjx_load_field_names(model_cls: type[Any]) -> list[str]:
         return names
     # During __init_subclass__ pydantic has not yet populated model_fields, so
     # fall back to the raw annotations to detect the PjxKey marker at definition.
-    for name, annotation in getattr(model_cls, "__annotations__", {}).items():
+    # Under PEP 563 (from __future__ import annotations) those are strings, so
+    # resolve them first; include_extras keeps the Annotated metadata.
+    try:
+        annotations = get_type_hints(model_cls, include_extras=True)
+    except (NameError, TypeError, AttributeError):
+        annotations = getattr(model_cls, "__annotations__", {})
+    for name, annotation in annotations.items():
         if _annotation_has_pjx_load(annotation):
             names.append(name)
     return names

--- a/tests/unit/test_pep563_pjx_key.py
+++ b/tests/unit/test_pep563_pjx_key.py
@@ -1,0 +1,67 @@
+"""PjxKey detection must survive PEP 563 string annotations (issue #67, finding 1)."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import pytest
+
+from pyjinhx import MutationKey, PjxKey, ReactiveComponent
+
+
+class Keys(MutationKey):
+    ROW = "row"
+
+
+class FutureRow(ReactiveComponent, react={Keys.ROW}):
+    row_key: Annotated[str, PjxKey()]
+    label: str = ""
+
+    @classmethod
+    def load(cls, key: str) -> FutureRow:
+        return cls(row_key=str(key), label=f"row {key}")
+
+
+def test_pep563_class_definition_detects_pjx_key():
+    assert FutureRow._pjx_keyed is True
+    assert FutureRow._pjx_load_field == "row_key"
+
+
+def test_pep563_load_and_render():
+    row = FutureRow.load("7")
+    assert row.row_key == "7"
+    html = str(row._render(source="<div>{{ label }}</div>"))
+    assert 'data-pjx-load="7"' in html
+    assert "row 7" in html
+
+
+def test_pep563_subclass_inherits_single_pjx_key_field():
+    class ChildRow(FutureRow, react={Keys.ROW}):
+        @classmethod
+        def load(cls, key: str) -> ChildRow:
+            return cls(row_key=str(key), label=f"child {key}")
+
+    assert ChildRow._pjx_load_field == "row_key"
+
+
+def test_pep563_keyed_load_without_pjx_key_still_raises():
+    with pytest.raises(TypeError, match="declare exactly"):
+
+        class Missing(ReactiveComponent, react={Keys.ROW}):
+            row_key: str
+
+            @classmethod
+            def load(cls, key: str) -> Missing:
+                return cls(row_key=str(key))
+
+
+def test_pep563_multiple_pjx_key_fields_still_raise():
+    with pytest.raises(TypeError, match="declare exactly"):
+
+        class Doubled(ReactiveComponent, react={Keys.ROW}):
+            first: Annotated[str, PjxKey()]
+            second: Annotated[str, PjxKey()]
+
+            @classmethod
+            def load(cls, key: str) -> Doubled:
+                return cls(first=str(key), second=str(key))


### PR DESCRIPTION
## Bug

A module using `from __future__ import annotations` that defines a keyed reactive component with `Annotated[str, PjxKey()]` fails at class definition with:

```
TypeError: MyComponent.load() takes a resource argument; declare exactly one field as Annotated[..., PjxKey()].
```

`ReactiveComponent.__init_subclass__` runs before pydantic populates `model_fields`, so `pjx_load_field_names` falls back to raw `cls.__annotations__` — which under PEP 563 are strings, so the `PjxKey` marker is never detected.

## Fix

In the fallback path, resolve string annotations with `typing.get_type_hints(model_cls, include_extras=True)` (`include_extras` preserves the `Annotated` metadata), guarded by a try/except that falls back to the raw annotations so unresolvable forward refs don't become a new class-definition crash — the same pattern `context.py` already uses for `load()` signature resolution.

## Tests

- New `tests/unit/test_pep563_pjx_key.py` (module-level `from __future__ import annotations`): class definition succeeds, `_pjx_load_field` resolves, `load()`/render stamps `data-pjx-load`, subclassing a keyed component doesn't double-detect the inherited field, and the no-PjxKey / multiple-PjxKey error cases still raise.
- Verified the new tests fail on master without the fix.
- `uv run pytest -q -m "not reactivity"`: 539 passed.

Refs #67 (finding 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)