### PR TITLE
Make registry peer injection lazy to fix render explosion

### DIFF
--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
 import re
+from functools import cached_property
 from typing import Annotated, Any, ClassVar, Optional
 
 from markupsafe import Markup
@@ -60,6 +61,48 @@ class NestedComponentWrapper(BaseModel):
     props: Optional["BaseComponent"]
 
     def __str__(self) -> Markup:
+        return self.html
+
+
+class LazyNestedComponentWrapper:
+    """
+    A registry peer injected into a render context by id. Same interface as
+    `NestedComponentWrapper` (`html`, `props`, string conversion) but renders
+    only when a template actually references it.
+
+    Holds the live render session so the deferred render happens inside the
+    originating render call and the render-cycle guard still applies.
+    """
+
+    def __init__(
+        self,
+        instance: "BaseComponent",
+        context: dict[str, Any],
+        *,
+        renderer: Renderer,
+        session: RenderSession,
+    ) -> None:
+        self._instance = instance
+        self._context = context
+        self._renderer = renderer
+        self._session = session
+
+    @cached_property
+    def html(self) -> str:
+        return self._instance._render(
+            base_context=self._context,
+            _renderer=self._renderer,
+            _session=self._session,
+        )
+
+    @property
+    def props(self) -> "BaseComponent":
+        return self._instance
+
+    def __html__(self) -> Markup:
+        return Markup(self.html)
+
+    def __str__(self) -> str:
         return self.html
 
 
@@ -257,6 +300,14 @@ class BaseComponent(BaseModel):
             declared_fields = set(type(self).model_fields.keys())
             for field_name, field_value in context.items():
                 if field_name in declared_fields:
+                    continue
+                if isinstance(field_value, BaseComponent):
+                    # Registry peers injected by id. Rendering them eagerly
+                    # multiplied across every registered instance (issue #67),
+                    # so defer until a template actually references them.
+                    context[field_name] = LazyNestedComponentWrapper(
+                        field_value, context, renderer=renderer, session=session
+                    )
                     continue
                 context = self._update_context_(
                     context,

--- a/tests/unit/test_lazy_peer_injection.py
+++ b/tests/unit/test_lazy_peer_injection.py
@@ -1,0 +1,148 @@
+"""Registry peers injected into render contexts are consumed lazily.
+
+Repro for https://github.com/paulomtts/pyjinhx/issues/67 (finding 2) — every
+registered instance is injected into every render context by id, and the
+undeclared-keys loop in ``BaseComponent._render`` used to render all of them
+eagerly. With N registered siblings whose template expands a tag, render counts
+grew worse than factorially (N=4 -> 136 renders, N=5 -> 32k+), because tags
+without an explicit id register new instances mid-render.
+
+Peers must only render when a template actually references them, and the
+referenced renders must keep the session-aware cycle guard.
+"""
+
+import importlib.util
+import sys
+import time
+
+from pyjinhx import Registry
+from pyjinhx.renderer import Renderer
+
+
+def _load_module(tmp_path, name: str, source: str):
+    """Write and import a component module so template lookup (which is
+    relative to the class's defining file) resolves inside ``tmp_path``."""
+    module_path = tmp_path / f"{name}.py"
+    module_path.write_text(source)
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_many_registered_peers_render_bounded(tmp_path, monkeypatch):
+    """N registered Shell siblings: rendering one stays at a handful of renders."""
+
+    (tmp_path / "explosion_shell.html").write_text(
+        '<div class="shell-marker"><ExplosionInner/></div>'
+    )
+    (tmp_path / "explosion_inner.html").write_text('<span class="inner-marker">inner</span>')
+    module = _load_module(
+        tmp_path,
+        "explosion_components",
+        "from pyjinhx import BaseComponent\n\n"
+        "class ExplosionShell(BaseComponent):\n"
+        "    pass\n\n"
+        "class ExplosionInner(BaseComponent):\n"
+        "    pass\n",
+    )
+
+    Renderer.set_default_environment(str(tmp_path))
+
+    calls = {"count": 0}
+    original = Renderer.render_component_with_context
+
+    def counting(self, *args, **kwargs):
+        calls["count"] += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Renderer, "render_component_with_context", counting)
+
+    sibling_count = 5
+    with Registry.request_scope():
+        shells = [module.ExplosionShell(id=f"shell_{i}") for i in range(sibling_count)]
+        started = time.perf_counter()
+        rendered = str(shells[0].render())
+        elapsed = time.perf_counter() - started
+
+    assert "shell-marker" in rendered
+    assert "inner-marker" in rendered
+    # Eager peer injection hit 32k+ renders here; lazy injection needs 2.
+    assert calls["count"] <= 3 * sibling_count
+    assert elapsed < 1.0
+
+
+def test_lazy_peer_renders_when_template_references_it(tmp_path):
+    """``{{ peer_id }}``, ``{{ peer_id.html }}`` and ``{{ peer_id.props.x }}``
+    all keep working for injected peers."""
+
+    (tmp_path / "ref_host.html").write_text(
+        '<section class="host-marker"><RefChild id="ref_child"/></section>'
+    )
+    (tmp_path / "ref_child.html").write_text(
+        '<div class="child-marker">{{ ref_peer }}|{{ ref_peer.html }}|{{ ref_peer.props.label }}</div>'
+    )
+    (tmp_path / "ref_peer.html").write_text('<span class="peer-marker">{{ label }}</span>')
+    module = _load_module(
+        tmp_path,
+        "ref_components",
+        "from pyjinhx import BaseComponent\n\n"
+        "class RefHost(BaseComponent):\n"
+        "    pass\n\n"
+        "class RefChild(BaseComponent):\n"
+        "    pass\n\n"
+        "class RefPeer(BaseComponent):\n"
+        "    label: str = ''\n",
+    )
+
+    Renderer.set_default_environment(str(tmp_path))
+
+    with Registry.request_scope():
+        module.RefPeer(id="ref_peer", label="hello")
+        module.RefChild(id="ref_child")
+        host = module.RefHost(id="ref_host")
+        rendered = str(host.render())
+
+    assert "host-marker" in rendered
+    assert "child-marker" in rendered
+    assert rendered.count("peer-marker") == 2  # {{ ref_peer }} and {{ ref_peer.html }}
+    assert rendered.count("hello") == 3  # two rendered spans + props.label
+
+
+def test_mutual_template_reference_by_id_is_cycle_guarded(tmp_path):
+    """Two peers referencing each other via ``{{ id }}`` render once each;
+    the cyclic back-reference renders empty instead of recursing forever."""
+
+    (tmp_path / "jinja_cycle_host.html").write_text(
+        '<main class="cycle-host-marker"><JinjaCycleLeft id="cycle_left"/></main>'
+    )
+    (tmp_path / "jinja_cycle_left.html").write_text(
+        '<div class="left-marker">{{ cycle_right }}</div>'
+    )
+    (tmp_path / "jinja_cycle_right.html").write_text(
+        '<p class="right-marker">{{ cycle_left }}</p>'
+    )
+    module = _load_module(
+        tmp_path,
+        "jinja_cycle_components",
+        "from pyjinhx import BaseComponent\n\n"
+        "class JinjaCycleHost(BaseComponent):\n"
+        "    pass\n\n"
+        "class JinjaCycleLeft(BaseComponent):\n"
+        "    pass\n\n"
+        "class JinjaCycleRight(BaseComponent):\n"
+        "    pass\n",
+    )
+
+    Renderer.set_default_environment(str(tmp_path))
+
+    with Registry.request_scope():
+        module.JinjaCycleLeft(id="cycle_left")
+        module.JinjaCycleRight(id="cycle_right")
+        host = module.JinjaCycleHost(id="cycle_host")
+        rendered = str(host.render())
+
+    assert rendered.count("left-marker") == 1
+    assert rendered.count("right-marker") == 1


### PR DESCRIPTION
## Problem

Every registered instance is injected by id into every component's render context (`build_render_context`, the cross-reference-by-id feature from 0.5.2). Since 2c5773b, the undeclared-keys loop in `BaseComponent._render` **eagerly** rendered every one of those injected peers via `_update_context_` -> `_wrap_component_value` -> `peer._render(...)`.

That peer-injected context is also passed as `base_context` into `expand_custom_tags`, so every tag-expanded child repeats the eager pass over all peers. Worse, a tag without an explicit `id` registers a fresh auto-id instance **mid-render**, growing the peer set being iterated. Growth is worse than factorial.

A production app with ~3 popovers measured 114k renders and 20s+ cold loads.

## Fix

In the undeclared-keys loop only (declared fields keep their eager semantics, unchanged), bare `BaseComponent` values — i.e. injected registry peers — are wrapped in a new `LazyNestedComponentWrapper` instead of being rendered on the spot. It exposes the same interface as `NestedComponentWrapper` (`html`, `props`, `__html__`/`__str__`) but renders once, on first access, only if a template actually references the peer.

The wrapper holds the live `(instance, context, renderer, session)` tuple: by the time Jinja touches it we are inside `template.render()`, so the held session is live and the `session.rendering` cycle guard from #64 / 47b14d7 still suppresses cyclic back-references. Templates that never reference a peer pay zero render cost; `{{ peer_id }}`, `{{ peer_id.html }}` and `{{ peer_id.props.x }}` all keep working.

## Measurements

`Shell` template containing `<Inner/>`, N registered Shell siblings, rendering one shell (`Renderer.render_component_with_context` call count):

| N siblings | Before (renders) | After (renders) |
|---|---|---|
| 1 | 2 | 2 |
| 3 | 12 | 2 |
| 4 | 136 | 2 |
| 5 | 32,784 (1.9s) | 2 (<0.01s) |
| 6 | never finishes | 2 |
| 50 | — | 2 |

## Tests

- `test_many_registered_peers_render_bounded` — the N=5 explosion repro completes with <= 3N renders (actual: 2) in well under a second; fails against the old code (32k+ renders)
- `test_lazy_peer_renders_when_template_references_it` — `{{ peer }}`, `{{ peer.html }}`, `{{ peer.props.label }}` from a nested template all produce the peer's HTML
- `test_mutual_template_reference_by_id_is_cycle_guarded` — two peers referencing each other via `{{ id }}` render once each, cyclic back-reference renders empty

Full suite: 537 passed (`uv run pytest -q -m "not reactivity"`).

Refs #67 (finding 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)