### PR TITLE
Changelog for Markup return type, :where(:root) CSS tokens, respect pinned keyed ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Docs
+
+- Retroactive note: `render()` now really returns `markupsafe.Markup` at
+  runtime, matching its long-standing annotation (older versions, 0.5.2
+  included, unescaped to a plain `str` before returning despite the `-> Markup`
+  annotation). This silently changed concatenation: `pane.render() + raw_html_str`
+  HTML-escapes the right-hand string, per markupsafe semantics. If you
+  concatenate rendered output with raw HTML strings, use
+  `str(pane.render()) + raw` or `pane.render() + Markup(raw)`.
+
 ## 0.10.1 — Render-cycle guard + Tooltip tag children (2026-06-11)
 
 ### Fixed

--- a/pyjinhx/builtins/ui/alert/alert.css
+++ b/pyjinhx/builtins/ui/alert/alert.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-alert-radius:     var(--radius-md);
   --px-alert-padding:    0.875rem 1rem;
   --px-alert-border:     var(--border);

--- a/pyjinhx/builtins/ui/avatar/avatar.css
+++ b/pyjinhx/builtins/ui/avatar/avatar.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-avatar-sm: 2rem;
   --px-avatar-md: 2.5rem;
   --px-avatar-lg: 3.25rem;

--- a/pyjinhx/builtins/ui/avatar_stack/avatar-stack.css
+++ b/pyjinhx/builtins/ui/avatar_stack/avatar-stack.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-avatar-stack-overlap: -0.5rem;
   --px-avatar-stack-ring:    var(--surface);
 }

--- a/pyjinhx/builtins/ui/badge/badge.css
+++ b/pyjinhx/builtins/ui/badge/badge.css
@@ -1,5 +1,5 @@
 /* ── Badge tokens (override --px-badge-*; defaults use common design tokens) ─ */
-:root {
+:where(:root) {
   --px-badge-font-size:       var(--font-size-xs);
   --px-badge-radius-sm:       var(--radius-sm);
   --px-badge-radius-md:       var(--radius-md);

--- a/pyjinhx/builtins/ui/breadcrumb/breadcrumb.css
+++ b/pyjinhx/builtins/ui/breadcrumb/breadcrumb.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-breadcrumb-gap: 0.35rem;
   --px-breadcrumb-sep: "/";
   --px-breadcrumb-sep-color: var(--text-muted);

--- a/pyjinhx/builtins/ui/card/card.css
+++ b/pyjinhx/builtins/ui/card/card.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-card-bg: var(--surface-alt);
   --px-card-border: var(--border);
   --px-card-radius: var(--radius-md);

--- a/pyjinhx/builtins/ui/chip_input/chip-input.css
+++ b/pyjinhx/builtins/ui/chip_input/chip-input.css
@@ -1,5 +1,5 @@
 /* ── ChipInput tokens ──────────────────────────────────────────────────────── */
-:root {
+:where(:root) {
   --px-chip-input-gap:        0.375rem;
   --px-chip-input-chip-bg:    var(--surface-alt);
   --px-chip-input-chip-fg:    var(--text);

--- a/pyjinhx/builtins/ui/confirm_dialog/confirm-dialog.css
+++ b/pyjinhx/builtins/ui/confirm_dialog/confirm-dialog.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-confirm-dialog-bg:       var(--surface);
   --px-confirm-dialog-border:   var(--border);
   --px-confirm-dialog-radius:   var(--radius-md);

--- a/pyjinhx/builtins/ui/divider/divider.css
+++ b/pyjinhx/builtins/ui/divider/divider.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-divider-color: var(--border);
   --px-divider-thickness: 1px;
   --px-divider-gap: 0.75rem;

--- a/pyjinhx/builtins/ui/drawer/drawer.css
+++ b/pyjinhx/builtins/ui/drawer/drawer.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-drawer-width:        min(24rem, 100vw);
   --px-drawer-height-bottom: min(50dvh, 28rem);
   --px-drawer-bg:           var(--surface);

--- a/pyjinhx/builtins/ui/dropdown/dropdown.css
+++ b/pyjinhx/builtins/ui/dropdown/dropdown.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-dropdown-menu-bg:       var(--surface-alt);
   --px-dropdown-menu-border:   var(--border);
   --px-dropdown-menu-radius:   var(--radius-md);

--- a/pyjinhx/builtins/ui/empty_state/empty-state.css
+++ b/pyjinhx/builtins/ui/empty_state/empty-state.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-empty-state-padding:   2rem 1.5rem;
   --px-empty-state-max-width: 28rem;
   --px-empty-state-title-size: var(--font-size-md);

--- a/pyjinhx/builtins/ui/form_field/form-field.css
+++ b/pyjinhx/builtins/ui/form_field/form-field.css
@@ -1,5 +1,5 @@
 /* ── FormField tokens ─────────────────────────────────────────────────────── */
-:root {
+:where(:root) {
   --px-form-field-gap:        0.375rem;
   --px-form-field-label-size: 0.875em;
   --px-form-field-label-color: var(--text, inherit);

--- a/pyjinhx/builtins/ui/modal/modal.css
+++ b/pyjinhx/builtins/ui/modal/modal.css
@@ -1,5 +1,5 @@
 /* ── Modal tokens (defaults wire to common design tokens) ─── */
-:root {
+:where(:root) {
   --px-modal-width:        52rem;
   --px-modal-min-height:   28rem;
   --px-modal-bg:           var(--surface);

--- a/pyjinhx/builtins/ui/notification/notification.css
+++ b/pyjinhx/builtins/ui/notification/notification.css
@@ -1,5 +1,5 @@
 /* ── Notification tokens ────────────────────────────────────── */
-:root {
+:where(:root) {
   --px-notification-width:       22rem;
   --px-notification-gap:         1.25rem;
   --px-notification-bg:          var(--surface-alt);

--- a/pyjinhx/builtins/ui/page_loader/page-loader.css
+++ b/pyjinhx/builtins/ui/page_loader/page-loader.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-page-loader-backdrop: rgb(0 0 0 / 0.15);
   --px-page-loader-z:        9999;
   --px-page-loader-size:     2rem;

--- a/pyjinhx/builtins/ui/password_input/password-input.css
+++ b/pyjinhx/builtins/ui/password_input/password-input.css
@@ -1,5 +1,5 @@
 /* ── PasswordInput tokens ─────────────────────────────────────────────────── */
-:root {
+:where(:root) {
   --px-password-input-border:       var(--border, #ccc);
   --px-password-input-radius:       var(--radius-md, 0.375rem);
   --px-password-input-focus:        var(--border-focus, var(--brand, #0d6efd));

--- a/pyjinhx/builtins/ui/popover/popover.css
+++ b/pyjinhx/builtins/ui/popover/popover.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-popover-bg:      var(--surface-alt);
   --px-popover-border:  var(--border);
   --px-popover-radius:  var(--radius-md);

--- a/pyjinhx/builtins/ui/progress/progress.css
+++ b/pyjinhx/builtins/ui/progress/progress.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-progress-height:     0.5rem;
   --px-progress-radius:     var(--radius-full);
   --px-progress-track:      var(--surface-alt);

--- a/pyjinhx/builtins/ui/prompt_dialog/prompt-dialog.css
+++ b/pyjinhx/builtins/ui/prompt_dialog/prompt-dialog.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-prompt-dialog-bg:       var(--surface);
   --px-prompt-dialog-border:   var(--border);
   --px-prompt-dialog-radius:   var(--radius-md);

--- a/pyjinhx/builtins/ui/region_loader/region-loader.css
+++ b/pyjinhx/builtins/ui/region_loader/region-loader.css
@@ -1,5 +1,5 @@
 /* ── RegionLoader tokens ──────────────────────────────────── */
-:root {
+:where(:root) {
   --px-region-loader-bg:            rgb(0 0 0 / 0.55);
   --px-region-loader-backdrop:      blur(2px);
   --px-region-loader-z:             100;

--- a/pyjinhx/builtins/ui/segmented_control/segmented-control.css
+++ b/pyjinhx/builtins/ui/segmented_control/segmented-control.css
@@ -1,5 +1,5 @@
 /* ── SegmentedControl tokens ──────────────────────────────────────────────── */
-:root {
+:where(:root) {
   --px-segmented-control-bg:        var(--surface-alt, #f0f0f0);
   --px-segmented-control-border:    var(--border, #ddd);
   --px-segmented-control-radius:    var(--radius-full, 9999px);

--- a/pyjinhx/builtins/ui/skeleton/skeleton.css
+++ b/pyjinhx/builtins/ui/skeleton/skeleton.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-skeleton-bg:         var(--surface-alt);
   --px-skeleton-shine:      color-mix(in srgb, var(--text) 8%, var(--surface-alt));
   --px-skeleton-line-height: 0.65rem;

--- a/pyjinhx/builtins/ui/spinner/spinner.css
+++ b/pyjinhx/builtins/ui/spinner/spinner.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-spinner-sm: 1.25rem;
   --px-spinner-md: 2rem;
   --px-spinner-lg: 2.75rem;

--- a/pyjinhx/builtins/ui/tab_group/tab-group.css
+++ b/pyjinhx/builtins/ui/tab_group/tab-group.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-tab-group-border: var(--border);
   --px-tab-group-bg: var(--surface-alt);
   --px-tab-group-tab-fg: var(--text-muted);

--- a/pyjinhx/builtins/ui/toast_host/toast-host.css
+++ b/pyjinhx/builtins/ui/toast_host/toast-host.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-toast-bg:      var(--surface);
   --px-toast-border:  var(--border);
   --px-toast-radius:  var(--radius-md);

--- a/pyjinhx/builtins/ui/toggle_switch/toggle-switch.css
+++ b/pyjinhx/builtins/ui/toggle_switch/toggle-switch.css
@@ -1,5 +1,5 @@
 /* ── ToggleSwitch tokens ──────────────────────────────────────────────────── */
-:root {
+:where(:root) {
   --px-toggle-switch-width:    2.75rem;
   --px-toggle-switch-height:   1.5rem;
   --px-toggle-switch-track:    var(--border, #ccc);

--- a/pyjinhx/builtins/ui/tooltip/tooltip.css
+++ b/pyjinhx/builtins/ui/tooltip/tooltip.css
@@ -1,4 +1,4 @@
-:root {
+:where(:root) {
   --px-tooltip-gap:         6px;
   --px-tooltip-bg:          var(--surface-alt);
   --px-tooltip-border:      var(--border);

--- a/pyjinhx/cache.py
+++ b/pyjinhx/cache.py
@@ -133,7 +133,7 @@ class LoadCache:
             from .utils import pascal_case_to_kebab_case
 
             default_id = pascal_case_to_kebab_case(component_class.__name__)
-            if result.id == default_id:
+            if result.id == default_id and getattr(result, "_pjx_id_defaulted", True):
                 result.id = f"{default_id}-{key}"
 
         if cls.scope() != CacheScope.NONE:

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -12,7 +12,7 @@ from functools import partial
 from typing import Annotated, Any, ClassVar, get_args, get_origin
 
 from markupsafe import Markup
-from pydantic import ConfigDict, PrivateAttr, model_validator
+from pydantic import ConfigDict, ModelWrapValidatorHandler, PrivateAttr, model_validator
 from pydantic.fields import FieldInfo
 
 from pyjinhx.base import BaseComponent
@@ -189,15 +189,21 @@ class ReactiveComponent(BaseComponent):
     state_hash_exclude: ClassVar[frozenset[str]] = frozenset({"id"})
 
     _pjx_key: str | None = PrivateAttr(default=None)
+    _pjx_id_defaulted: bool = PrivateAttr(default=False)
 
     render = _ReactiveRender()
 
-    @model_validator(mode="before")
+    @model_validator(mode="wrap")
     @classmethod
-    def _default_id_from_type(cls, data: Any) -> Any:
-        if isinstance(data, dict) and not data.get("id"):
-            return {**data, "id": pascal_case_to_kebab_case(cls.__name__)}
-        return data
+    def _default_id_from_type(
+        cls, data: Any, handler: ModelWrapValidatorHandler[ReactiveComponent]
+    ) -> ReactiveComponent:
+        defaulted = isinstance(data, dict) and not data.get("id")
+        if defaulted:
+            data = {**data, "id": pascal_case_to_kebab_case(cls.__name__)}
+        instance = handler(data)
+        instance._pjx_id_defaulted = defaulted
+        return instance
 
     @classmethod
     @abstractmethod

--- a/tests/unit/test_instance_key_cache.py
+++ b/tests/unit/test_instance_key_cache.py
@@ -21,6 +21,22 @@ class Row(ReactiveComponent, react={Keys.ROW, Keys.ROWS}):
         return cls(row_key=str(key), title=f"row {key}")
 
 
+class PinnedRow(ReactiveComponent, react={Keys.ROW}):
+    row_key: Annotated[str, PjxKey()]
+
+    @classmethod
+    def load(cls, key: str) -> "PinnedRow":
+        return cls(id="pinned-row", row_key=str(key))
+
+
+class CustomIdRow(ReactiveComponent, react={Keys.ROW}):
+    row_key: Annotated[str, PjxKey()]
+
+    @classmethod
+    def load(cls, key: str) -> "CustomIdRow":
+        return cls(id=f"my-row-{key}", row_key=str(key))
+
+
 def _reset():
     LoadCache.clear()
     load_calls["n"] = 0
@@ -42,6 +58,20 @@ def test_key_is_coerced_to_string():
     _reset()
     r = Row.load(42)
     assert r.id == "row-42" and r._pjx_key == "42"
+
+
+def test_explicitly_pinned_default_id_is_not_suffixed():
+    _reset()
+    r = PinnedRow.load("7")
+    assert r.id == "pinned-row"
+    assert r._pjx_key == "7"
+
+
+def test_custom_id_is_preserved():
+    _reset()
+    r = CustomIdRow.load("7")
+    assert r.id == "my-row-7"
+    assert r._pjx_key == "7"
 
 
 def test_cache_is_per_key():


### PR DESCRIPTION
Three low-risk items. Refs #67 (findings 4, 8, 14).

## F4 — Document the `render() -> Markup` behavior change (docs only)

`render()` was always annotated `-> Markup`, but older versions (0.5.2 included) unescaped to a plain `str` before returning. Current code really returns `Markup`, which silently changed concatenation: `pane.render() + raw_html_str` now HTML-escapes the right-hand string. Adds an Unreleased CHANGELOG entry documenting the change and the migration idioms (`str(pane.render()) + raw` or `pane.render() + Markup(raw)`). No new API.

## F8 — Zero-specificity builtin token defaults

The 28 builtin stylesheets declared their `--px-*` token defaults in `:root { ... }`, tying app-level `:root` overrides on specificity so bundle order decided who won — and inline asset mode prepends builtin styles, so apps routinely lost. The token blocks now use `:where(:root)` (zero specificity), so any app `:root` override wins regardless of load order. Selector-only change, one line per file.

## F14 — Don't rewrite explicitly-pinned keyed instance ids

`LoadCache._cached_load` suffixed a keyed instance's id with the load key whenever it equaled the kebab-cased class-name default — including when `load()` had explicitly set that id (`cls(id="invites-pane", ...)` became `invites-pane-<key>`). The before-validator that injects the default id erased the distinction, so it is now a wrap validator that stamps `_pjx_id_defaulted` (a `PrivateAttr`), and `_cached_load` only suffixes defaulted ids. Collision protection for multiple keyed instances leaving the default untouched is preserved.

New tests: explicitly-pinned default id stays unsuffixed; custom ids stay preserved; existing suffixing tests still pass.

## Tests

`uv run pytest -q -m "not reactivity"` — 536 passed, 24 deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)