### PR TITLE
Error on cross-module component name collisions

### DIFF
--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -103,8 +103,13 @@ class BaseComponent(BaseModel):
             return _auto_id()
         return str(v)
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        """Register the component class on subclass definition."""
+    def __init_subclass__(cls, pjx_replace: bool = False, **kwargs: Any) -> None:
+        """
+        Register the component class on subclass definition.
+
+        ``pjx_replace=True`` intentionally shadows a same-named component from
+        another module (e.g. a builtin): ``class Avatar(BaseComponent, pjx_replace=True)``.
+        """
         super().__init_subclass__(**kwargs)
         component_bases = [
             base
@@ -116,7 +121,7 @@ class BaseComponent(BaseModel):
             raise TypeError(
                 f"{cls.__name__}: subclass one component at a time; got {names}"
             )
-        Registry.register_class(cls)
+        Registry.register_class(cls, replace=pjx_replace)
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/pyjinhx/registry.py
+++ b/pyjinhx/registry.py
@@ -1,4 +1,6 @@
+import inspect
 import logging
+import os
 from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -30,21 +32,48 @@ class Registry:
     _class_registry: ClassVar[dict[str, type["BaseComponent"]]] = {}
 
     @classmethod
-    def register_class(cls, component_class: type["BaseComponent"]) -> None:
+    def register_class(
+        cls, component_class: type["BaseComponent"], *, replace: bool = False
+    ) -> None:
         """
         Register a component class by its name.
 
-        Called automatically when subclassing BaseComponent.
+        Called automatically when subclassing BaseComponent. Re-registering the
+        same name from the same source file (test reruns, hot reload,
+        autodiscovery) replaces the previous class. Registering a same-named
+        class from a *different* file raises, since `<Name/>` tags would
+        silently resolve to whichever class was imported last.
 
         Args:
             component_class: The component class to register.
+            replace: Skip the cross-file collision check and overwrite.
+                Set via ``class Avatar(BaseComponent, pjx_replace=True)``.
         """
         class_name = component_class.__name__
-        if class_name in cls._class_registry:
+        existing = cls._class_registry.get(class_name)
+        if existing is not None and existing is not component_class and not replace:
+            existing_file = cls._source_file(existing)
+            new_file = cls._source_file(component_class)
+            if existing_file and new_file and existing_file != new_file:
+                raise TypeError(
+                    f"Component class {class_name} is already registered by "
+                    f"{existing.__module__} ({existing_file}); refusing to overwrite "
+                    f"it with {component_class.__module__} ({new_file}). Rename one "
+                    f"of the classes, or shadow it intentionally with: "
+                    f"class {class_name}(BaseComponent, pjx_replace=True)"
+                )
             logger.warning(
                 f"Component class {class_name} is already registered. Overwriting..."
             )
         cls._class_registry[class_name] = component_class
+
+    @staticmethod
+    def _source_file(component_class: type) -> str | None:
+        """Resolve the file a class was defined in, or None (exec'd/REPL code)."""
+        try:
+            return os.path.realpath(inspect.getfile(component_class))
+        except (TypeError, OSError):
+            return None
 
     @classmethod
     def get_classes(cls) -> dict[str, type["BaseComponent"]]:

--- a/tests/unit/test_class_registry_behavior.py
+++ b/tests/unit/test_class_registry_behavior.py
@@ -1,4 +1,25 @@
+import importlib.util
+import sys
+
+import pytest
+
 from pyjinhx import BaseComponent, Registry
+
+_COLLISION_SRC = """\
+from pyjinhx import BaseComponent
+
+class {class_name}(BaseComponent):
+    id: str = ""
+"""
+
+
+def _import_component_file(filepath, module_name):
+    """Import a component file by path, like ComponentAutodiscover does."""
+    spec = importlib.util.spec_from_file_location(module_name, str(filepath))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_class_registered_at_definition_time():
@@ -124,3 +145,48 @@ def test_inherited_classes_registered():
     assert classes["BaseButton"] is BaseButton
     assert classes["PrimaryButton"] is PrimaryButton
     assert classes["SecondaryButton"] is SecondaryButton
+
+
+def test_same_name_from_different_files_raises(tmp_path):
+    """Two same-name classes from different source files collide loudly."""
+    first = tmp_path / "first.py"
+    second = tmp_path / "second.py"
+    first.write_text(_COLLISION_SRC.format(class_name="CollisionWidget"))
+    second.write_text(_COLLISION_SRC.format(class_name="CollisionWidget"))
+
+    _import_component_file(first, "_test_collision_first")
+    with pytest.raises(TypeError) as exc_info:
+        _import_component_file(second, "_test_collision_second")
+
+    message = str(exc_info.value)
+    assert "CollisionWidget" in message
+    assert "first.py" in message
+    assert "second.py" in message
+    assert "pjx_replace=True" in message
+
+    # The original registration survives the failed overwrite.
+    assert Registry.get_class("CollisionWidget").__module__ == "_test_collision_first"
+
+
+def test_reregistering_from_same_file_is_allowed(tmp_path):
+    """Re-executing the same module (test reruns, hot reload) does not raise."""
+    module_file = tmp_path / "reloaded.py"
+    module_file.write_text(_COLLISION_SRC.format(class_name="ReloadedWidget"))
+
+    first = _import_component_file(module_file, "_test_reload_widget")
+    second = _import_component_file(module_file, "_test_reload_widget")
+
+    assert first.ReloadedWidget is not second.ReloadedWidget
+    assert Registry.get_class("ReloadedWidget") is second.ReloadedWidget
+
+
+def test_pjx_replace_keyword_shadows_cross_file_registration(tmp_path):
+    """pjx_replace=True intentionally shadows a same-name class from elsewhere."""
+    module_file = tmp_path / "shadowed.py"
+    module_file.write_text(_COLLISION_SRC.format(class_name="ShadowedWidget"))
+    _import_component_file(module_file, "_test_shadowed_widget")
+
+    class ShadowedWidget(BaseComponent, pjx_replace=True):
+        id: str = ""
+
+    assert Registry.get_class("ShadowedWidget") is ShadowedWidget

--- a/tests/unit/test_client_asset_manifest.py
+++ b/tests/unit/test_client_asset_manifest.py
@@ -195,7 +195,7 @@ def test_oob_swaps_emit_no_assets():
     assert "<script" not in rendered
 
 
-class Page(BaseComponent):
+class ManifestPage(BaseComponent):
     pass
 
 
@@ -206,7 +206,7 @@ def test_runtime_url_skipped_when_already_loaded():
     renderer = Renderer.get_default_renderer(js_mode=AssetMode.REFERENCE)
 
     rendered = str(
-        Page(id="page")._render(
+        ManifestPage(id="page")._render(
             source="<html><body>hi</body></html>",
             _renderer=renderer,
             client=["/static/pyjinhx/pjx.js"],
@@ -224,7 +224,7 @@ def test_runtime_url_emitted_when_not_loaded():
     renderer = Renderer.get_default_renderer(js_mode=AssetMode.REFERENCE)
 
     rendered = str(
-        Page(id="page")._render(
+        ManifestPage(id="page")._render(
             source="<html><body>hi</body></html>",
             _renderer=renderer,
         )

--- a/tests/unit/test_layout_runtime.py
+++ b/tests/unit/test_layout_runtime.py
@@ -8,7 +8,7 @@ from pyjinhx.client import PJX_MOUNTED_HEADER, MountedManifest
 pytestmark = pytest.mark.pjx_runtime
 
 
-class Page(BaseComponent):
+class RuntimePage(BaseComponent):
     pass
 
 
@@ -45,7 +45,7 @@ def test_mounted_manifest_is_present():
 
 
 def test_root_render_injects_runtime_without_client():
-    html = str(Page(id="page")._render(source="<html><body>hi</body></html>"))
+    html = str(RuntimePage(id="page")._render(source="<html><body>hi</body></html>"))
     assert "htmx:configRequest" in html
     assert "X-PJX-Mounted" in html
     assert html.count("htmx:configRequest") == 1
@@ -54,7 +54,7 @@ def test_root_render_injects_runtime_without_client():
 def test_root_render_injects_runtime_when_manifest_header_missing():
     request = _Request({})
     html = str(
-        Page(id="page")._render(
+        RuntimePage(id="page")._render(
             source="<html><body>hi</body></html>",
             client=request,
         )
@@ -65,7 +65,7 @@ def test_root_render_injects_runtime_when_manifest_header_missing():
 def test_root_render_skips_runtime_when_manifest_header_present():
     request = _Request({PJX_MOUNTED_HEADER: "[]"})
     html = str(
-        Page(id="page")._render(
+        RuntimePage(id="page")._render(
             source="<html><body>hi</body></html>",
             client=request,
         )
@@ -75,11 +75,11 @@ def test_root_render_skips_runtime_when_manifest_header_present():
 
 def test_root_render_skips_runtime_for_valid_manifest():
     manifest = json.dumps(
-        [{"id": "page", "type": "Page", "hash": "abc123"}]
+        [{"id": "page", "type": "RuntimePage", "hash": "abc123"}]
     )
     request = _Request({PJX_MOUNTED_HEADER: manifest})
     html = str(
-        Page(id="page")._render(
+        RuntimePage(id="page")._render(
             source="<html><body>hi</body></html>",
             client=request,
         )

--- a/tests/unit/test_react_keyword.py
+++ b/tests/unit/test_react_keyword.py
@@ -47,26 +47,26 @@ def test_react_rejects_mixed_valid_and_invalid():
 
 def test_reacts_to_classvar_rejected():
     with pytest.raises(TypeError, match="react class keyword"):
-        class Old(ReactiveComponent):
+        class OldKeyword(ReactiveComponent):
             reacts_to: ClassVar[set] = {Keys.NAVBAR}
 
             @classmethod
-            def load(cls) -> "Old":
+            def load(cls) -> "OldKeyword":
                 return cls()
 
 
 def test_subclass_inherits_react_keys():
-    class Parent(ReactiveComponent, react={Keys.TODOS}):
+    class ReactParent(ReactiveComponent, react={Keys.TODOS}):
         @classmethod
-        def load(cls) -> "Parent":
+        def load(cls) -> "ReactParent":
             return cls()
 
-    class Child(Parent):
+    class ReactChild(ReactParent):
         @classmethod
-        def load(cls) -> "Child":
+        def load(cls) -> "ReactChild":
             return cls()
 
-    assert Child._pjx_reacts_to == frozenset({"todos"})
+    assert ReactChild._pjx_reacts_to == frozenset({"todos"})
 
 
 def test_load_without_react_keys_rejected():

--- a/tests/unit/test_reactive_surface.py
+++ b/tests/unit/test_reactive_surface.py
@@ -84,7 +84,7 @@ def test_reacts_to_is_not_a_model_field():
 def test_reacts_to_classvar_raises():
     with pytest.raises(TypeError, match="react class keyword"):
 
-        class Old(ReactiveComponent):
+        class OldSurface(ReactiveComponent):
             reacts_to: ClassVar[set[str]] = {"todos"}
 
             @classmethod

--- a/tests/unit/test_template_and_engine_errors.py
+++ b/tests/unit/test_template_and_engine_errors.py
@@ -19,7 +19,7 @@ def test_missing_template_file():
 
 
 def test_non_filesystem_loader_error():
-    class TestComponent(BaseComponent):
+    class DictLoaderComponent(BaseComponent):
         id: str
         text: str
 
@@ -28,7 +28,7 @@ def test_non_filesystem_loader_error():
     original_environment = Renderer.peek_default_environment()
     Renderer.set_default_environment(env)
 
-    component = TestComponent(id="test-1", text="Test")
+    component = DictLoaderComponent(id="test-1", text="Test")
 
     with pytest.raises(ValueError, match="Jinja2 loader must be a FileSystemLoader"):
         component.render()


### PR DESCRIPTION
## Bug

`Registry.register_class` silently overwrote on name collision (warning log only). Since `import pyjinhx.builtins` registers 33 builtins, an app class with the same name (e.g. `Avatar`) silently won or lost depending on import order — `<Avatar/>` rendered different markup per process import history.

## Fix

A blanket error would be wrong: the same component file legitimately re-registers its class as a new object (autodiscovery's synthetic `_pyjinhx_autodiscovered_*` modules, test reruns, hot reload). So on collision we compare the source files of the two classes via `inspect.getfile`:

- **Same source file**, or either class has no resolvable file (exec'd/REPL code) → old behavior: replace with a warning.
- **Different source files** → `TypeError` naming both classes' modules and files, with the escape hatch in the message.

Escape hatch for intentional shadowing (e.g. overriding a builtin):

```python
class Avatar(BaseComponent, pjx_replace=True): ...
```

threaded through `BaseComponent.__init_subclass__` the same way the `react` class keyword works.

Verified that `inspect.getfile` resolves the real file path for autodiscovered synthetic modules (loaded via `spec_from_file_location`), so re-importing the same component file stays allowed.

## Tests

- Cross-file collision raises `TypeError` mentioning both sources and the escape hatch; the original registration survives.
- Re-executing the same module (reload) does not raise.
- `pjx_replace=True` shadows a cross-file registration.
- The new check flagged real cross-file fixture collisions in our own suite (`Page` x3, `Old` x2, `Child` x2, `TestComponent` x2) — renamed those fixtures rather than weakening the check.

`uv run pytest -q -m "not reactivity"`: 537 passed.

Refs #67 (finding 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)