### PR TITLE
OOB swaps ride along any component's render()

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.0
+current_version = 0.13.0
 commit = True
 tag = True
 message = Bump version: {current_version} → {new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.13.0 — OOB swaps ride along any render (2026-06-13)
+
+### Added
+
+- Any component's `.render()` now appends out-of-band swaps for dirtied mounted
+  reactive regions when a client backend is active and mutations occurred — not
+  only `ReactiveComponent.render()`. A route that mutates state and returns a
+  non-reactive command-result view now updates mounted read-models with no
+  wrapper. Fan-out happens once per request scope and never double-swaps a
+  region already present in the response body.
+- `pyjinhx.reactive.reactive_response(html)` — escape hatch attaching the same
+  fan-out to responses that render no component (raw strings, `204`).
+
+### Breaking changes (0.12.x → 0.13.0)
+
+- `setup()` keyword `load_context_factory` is renamed `context_factory`. The
+  old name is silently ignored (absorbed by `**kwargs`), so update call sites.
+
 ## 0.12.0 — PJX prefix on all builtins (2026-06-12)
 
 ### Breaking changes (0.11.x → 0.12.0)

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -11,7 +11,7 @@ def setup(
     settings: PjxSettings | None = None,
     invalidation_backend: InvalidationBackend | None = ...,  # unset sentinel
     reactive_dev: bool = ...,  # unset sentinel
-    load_context_factory: Callable[[Any], object | None] | None = None,
+    context_factory: Callable[[Any], object | None] | None = None,
     **kwargs: Any,
 ) -> PjxSettings
 ```
@@ -25,7 +25,7 @@ from fastapi import FastAPI
 from pyjinhx import setup
 
 app = FastAPI()
-setup(app, load_context_factory=lambda req: AppLoadContext(db=get_db(req)))
+setup(app, context_factory=lambda req: AppLoadContext(db=get_db(req)))
 ```
 
 | `app` | Behavior |

--- a/docs/api/integrations-redis.md
+++ b/docs/api/integrations-redis.md
@@ -39,7 +39,7 @@ setup(
     settings=PjxSettings(
         invalidation_backend=RedisInvalidationBackend("redis://localhost:6379/0"),
     ),
-    load_context_factory=...,
+    context_factory=...,
 )
 ```
 

--- a/docs/api/integrations-sqlite.md
+++ b/docs/api/integrations-sqlite.md
@@ -44,7 +44,7 @@ setup(
     settings=PjxSettings(
         invalidation_backend=SqliteInvalidationBackend("/var/lib/myapp/pjx.db"),
     ),
-    load_context_factory=...,
+    context_factory=...,
 )
 ```
 

--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -249,7 +249,7 @@ For a real app, use **`setup(app, ...)`** so lifespan and middleware are wired a
 from pyjinhx import setup
 
 app = FastAPI()
-setup(app, load_context_factory=lambda request: AppLoadContext(store=store))  # AppLoadContext defined in Step 12
+setup(app, context_factory=lambda request: AppLoadContext(store=store))  # AppLoadContext defined in Step 12
 ```
 
 See [Configuration API](../api/config.md) and [FastAPI integration](../integrations/fastapi.md).
@@ -480,7 +480,7 @@ def _store():
 Pass a factory to `setup()` (Step 6):
 
 ```python
-setup(app, load_context_factory=lambda request: AppLoadContext(store=store))
+setup(app, context_factory=lambda request: AppLoadContext(store=store))
 ```
 
 ???+ question "Why PjxContext?"

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -84,7 +84,7 @@ For web apps, use a single call:
 ```python
 from pyjinhx import setup
 
-setup(app, load_context_factory=lambda req: AppLoadContext(db=get_db(req)))
+setup(app, context_factory=lambda req: AppLoadContext(db=get_db(req)))
 ```
 
 `PjxSettings` has two fields:

--- a/docs/guide/usage-tiers.md
+++ b/docs/guide/usage-tiers.md
@@ -86,7 +86,7 @@ OOB swaps require an **active `ClientBackend`** so the renderer can read the cli
 ```python
 from pyjinhx import setup
 
-setup(app, load_context_factory=lambda request: AppLoadContext(db=get_db(request)))
+setup(app, context_factory=lambda request: AppLoadContext(db=get_db(request)))
 ```
 
 See [FastAPI integration § Middleware](../integrations/fastapi.md#middleware-recommended).

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -115,7 +115,7 @@ from fastapi import FastAPI
 from pyjinhx import setup
 
 app = FastAPI(lifespan=my_existing_lifespan)  # optional — chained, not replaced
-setup(app, load_context_factory=lambda req: AppLoadContext(db=get_db(req)))
+setup(app, context_factory=lambda req: AppLoadContext(db=get_db(req)))
 ```
 
 `setup(app, ...)` chains your lifespan (if any), wires optional invalidation, and registers registry middleware with `ClientBackend` for header auto-resolution. By default (no `invalidation_backend`) the load cache is per-request — multi-worker safe; pass a backend to opt into cross-request caching. See [Configuration](../api/config.md) and [Reactivity → load() results are cached](../reactivity.md#load-results-are-cached).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,5 +1,41 @@
 # Migration guide
 
+## 0.12 → 0.13
+
+### `setup()` keyword `load_context_factory` → `context_factory`
+
+The `setup()` keyword `load_context_factory` is renamed `context_factory`:
+
+```python
+# BEFORE (0.12)
+setup(app, load_context_factory=lambda: AppContext(db=...))
+
+# AFTER (0.13)
+setup(app, context_factory=lambda: AppContext(db=...))
+```
+
+The old name is **silently ignored** (absorbed by `**kwargs`) — no error is
+raised, so your context factory simply stops being installed. Update every call
+site.
+
+### Non-reactive renders now fan out OOB swaps
+
+Any component's `.render()` now appends out-of-band swaps for dirtied mounted
+reactive regions when a client backend is active and mutations occurred — not
+only `ReactiveComponent.render()`. A command-result view returned from a mutating
+route now updates mounted read-models with no wrapper:
+
+```python
+@app.post("/generate")
+def generate():
+    report = controller.generate()      # @mutates dirties "reports", "quota"
+    return ReportSummary(report=report).render()   # non-reactive; counters fan out OOB
+```
+
+Fan-out happens once per request scope and never double-swaps a region already
+present in the response body. For a response that renders no component (a raw
+string, a `204`), use `from pyjinhx.reactive import reactive_response`.
+
 ## 0.11 → 0.12 (breaking: `PJX` prefix on all builtins)
 
 Every builtin component is renamed with a `PJX` prefix, in Python and in tag form:

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -229,7 +229,7 @@ setup(
     app,
     settings=PjxSettings.from_env(),   # REDIS_URL / PJX_INVALIDATION_DB / PJX_REACTIVE_DEV
     # Inject per-request data reachable inside reactive load():
-    load_context_factory=lambda request: AppLoadContext(db=get_db(request)),
+    context_factory=lambda request: AppLoadContext(db=get_db(request)),
 )
 ```
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -167,6 +167,33 @@ it excludes only the primary id and gates everything else on `react` keys and ha
 A **plain, non-reactive** primary has no `load()` to call, so you build it and render
 the instance: `MyFragment(id=..., ...).render()`.
 
+### OOB swaps ride along any render
+
+The fan-out is not exclusive to `ReactiveComponent.render()`. **Any** component's
+`.render()` appends OOB swaps for dirtied mounted reactive regions when a client
+backend is active and mutations occurred in the request — including a non-reactive
+command-result view. Fan-out happens once per request scope and never double-swaps a
+region already present in the response body.
+
+```python
+@app.post("/generate")
+def generate():
+    report = controller.generate()      # @mutates dirties "reports", "quota"
+    return ReportSummary(report=report).render()   # non-reactive; counters fan out OOB
+```
+
+For a response that renders no component at all (a raw string, a `204`), use
+`from pyjinhx.reactive import reactive_response` to attach the same fan-out:
+
+```python
+from pyjinhx.reactive import reactive_response
+
+@app.post("/dismiss")
+def dismiss():
+    controller.dismiss()                # @mutates dirties mounted regions
+    return reactive_response("")        # no primary; dependents still fan out OOB
+```
+
 !!! note "Without ClientBackend"
     Wire `ClientBackend` in middleware (via `setup()`) so `render()` reads manifest and asset headers automatically. Without a backend, reactive OOB is skipped when mutations are pending.
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -322,7 +322,7 @@ class Counter(ReactiveComponent, react={Keys.TODOS}):
         return cls(remaining=ctx.db.remaining())
 ```
 
-Set context per request via `setup(app, load_context_factory=...)` or
+Set context per request via `setup(app, context_factory=...)` or
 `Registry.request_scope(load_context=AppContext(db=...))`. Cache keys remain
 `(class, load_arg)` — context is not part of the cache identity.
 

--- a/examples/reactive_todo/app.py
+++ b/examples/reactive_todo/app.py
@@ -29,7 +29,7 @@ app = FastAPI(title="pyjinhx reactive todo demo")
 setup(
     app,
     settings=PjxSettings.from_env(),
-    load_context_factory=lambda _request: AppLoadContext(store=store),
+    context_factory=lambda _request: AppLoadContext(store=store),
 )
 
 

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -388,11 +388,15 @@ class BaseComponent(BaseModel):
         """
         Render this component to HTML using its associated Jinja template.
 
-        The template is auto-discovered based on the component class name (e.g., `MyButton` looks
-        for `my_button.html` or `my_button.jinja`). All component fields are available in the
-        template context, and nested components are rendered recursively.
+        The template is auto-discovered from the component class name (e.g.,
+        ``MyButton`` looks for ``my_button.html``/``my_button.jinja``). All
+        fields are available in the template context, and nested components
+        render recursively.
 
-        Returns:
-            The rendered HTML as a Markup object (safe for direct use in templates).
+        When mutations occurred in the current request scope and a client
+        backend is active, OOB swaps for the dirtied mounted reactive regions
+        are appended (once per scope). Returns plain rendered HTML otherwise.
         """
-        return self._render()
+        from pyjinhx.reactive import _finish_with_oob
+
+        return _finish_with_oob(self._render())

--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -130,7 +130,7 @@ def setup(
     settings: PjxSettings | None = None,
     invalidation_backend: InvalidationBackend | None = _UNSET,
     reactive_dev: bool = _UNSET,
-    load_context_factory: Callable[[Any], object | None] | None = None,
+    context_factory: Callable[[Any], object | None] | None = None,
     **kwargs: Any,
 ) -> PjxSettings:
     """
@@ -160,5 +160,5 @@ def setup(
         )
     from pyjinhx.integrations.fastapi import apply_setup
 
-    apply_setup(app, resolved, load_context_factory=load_context_factory)
+    apply_setup(app, resolved, context_factory=context_factory)
     return resolved

--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -34,7 +34,7 @@ def apply_setup(
     app: object,
     settings: PjxSettings,
     *,
-    load_context_factory: Callable[[Any], object | None] | None = None,
+    context_factory: Callable[[Any], object | None] | None = None,
 ) -> None:
     if getattr(app.state, "pyjinhx_setup", False):
         logger.warning(
@@ -42,7 +42,7 @@ def apply_setup(
         )
         return
     _chain_lifespan(app, settings)
-    app.add_middleware(_registry_middleware_class(load_context_factory))
+    app.add_middleware(_registry_middleware_class(context_factory))
     app.state.pyjinhx_setup = True
 
 
@@ -65,11 +65,11 @@ def _chain_lifespan(app: object, settings: PjxSettings) -> None:
 
 
 def _registry_middleware_class(
-    load_context_factory: Callable[[Any], object | None] | None,
+    context_factory: Callable[[Any], object | None] | None,
 ) -> type:
     from starlette.middleware.base import BaseHTTPMiddleware
 
-    factory = load_context_factory
+    factory = context_factory
 
     class RegistryScopeMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request, call_next):

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -322,7 +322,7 @@ def reactive_render_bundle(
         LoadCache.invalidate(MutationTracker.pending())
 
     primary = primary_html() if callable(primary_html) else primary_html
-    return _finish_with_oob(primary)
+    return _finish_with_oob(primary, skip_invalidate=invalidate_before_primary)
 
 
 @dataclass
@@ -489,7 +489,7 @@ def _mounted_ids_in(html: str | Markup) -> set[str]:
     return set(_PJX_ID_RE.findall(str(html)))
 
 
-def _finish_with_oob(html: str | Markup) -> Markup:
+def _finish_with_oob(html: str | Markup, *, skip_invalidate: bool = False) -> Markup:
     """
     Append OOB swaps for dirtied mounted regions to a rendered response.
 
@@ -498,6 +498,10 @@ def _finish_with_oob(html: str | Markup) -> Markup:
     itself and any embedded reactive child — are excluded so nothing is swapped
     twice. Returns ``html`` unchanged outside a client scope or when no
     mutations are pending.
+
+    ``skip_invalidate=True`` when the caller already invalidated the dirtied
+    keys' load cache (the reactive class-render path), avoiding a redundant
+    second invalidation/publish.
     """
     if MutationTracker.render_was_consumed():
         return Markup(html)
@@ -505,7 +509,9 @@ def _finish_with_oob(html: str | Markup) -> Markup:
     pending = MutationTracker.pending()
     if backend is None or not pending:
         return Markup(html)
-    swaps = oob_swaps(pending, backend, exclude_ids=_mounted_ids_in(html))
+    swaps = oob_swaps(
+        pending, backend, exclude_ids=_mounted_ids_in(html), skip_invalidate=skip_invalidate
+    )
     MutationTracker.mark_render_consumed()
     return Markup(html) + swaps
 

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -503,3 +503,24 @@ _PJX_ID_RE = re.compile(r'data-pjx-id="([^"]*)"')
 def _mounted_ids_in(html: str | Markup) -> set[str]:
     """Every ``data-pjx-id`` already present in a rendered fragment."""
     return set(_PJX_ID_RE.findall(str(html)))
+
+
+def _finish_with_oob(html: str | Markup) -> Markup:
+    """
+    Append OOB swaps for dirtied mounted regions to a rendered response.
+
+    Fans out at most once per request scope (guarded by
+    ``render_was_consumed``). Regions already present in ``html`` — the primary
+    itself and any embedded reactive child — are excluded so nothing is swapped
+    twice. Returns ``html`` unchanged outside a client scope or when no
+    mutations are pending.
+    """
+    if MutationTracker.render_was_consumed():
+        return Markup(html)
+    backend = ClientBackend.current()
+    pending = MutationTracker.pending()
+    if backend is None or not pending:
+        return Markup(html)
+    swaps = oob_swaps(pending, backend, exclude_ids=_mounted_ids_in(html))
+    MutationTracker.mark_render_consumed()
+    return Markup(html) + swaps

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -508,3 +508,14 @@ def _finish_with_oob(html: str | Markup) -> Markup:
     swaps = oob_swaps(pending, backend, exclude_ids=_mounted_ids_in(html))
     MutationTracker.mark_render_consumed()
     return Markup(html) + swaps
+
+
+def reactive_response(html: str | Markup) -> Markup:
+    """
+    Attach pending OOB swaps to a response that renders no component.
+
+    Use for raw-string, ``204``, or hand-assembled responses. Any component's
+    ``.render()`` already does this automatically; reach for this only when no
+    component render happens in the request.
+    """
+    return _finish_with_oob(html)

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -136,16 +136,12 @@ class _ReactiveRender:
             instance = cls.load(*args, **kwargs) if keyed else cls.load(**kwargs)
             return Markup(instance._render(emit_assets=False))
 
-        loaded: list[ReactiveComponent] = []
-
-        def build_primary_tracked() -> str:
+        def build_primary() -> str:
             instance = cls.load(*args, **kwargs) if keyed else cls.load(**kwargs)
-            loaded.append(instance)
             return instance._render(emit_assets=False)
 
         return reactive_render_bundle(
-            primary_html=build_primary_tracked,
-            exclude_ids=lambda: {loaded[0].id} if loaded else set(),
+            primary_html=build_primary,
             invalidate_before_primary=True,
         )
 
@@ -162,7 +158,6 @@ class _ReactiveRender:
                 return instance._render()
             return reactive_render_bundle(
                 primary_html=lambda: instance._render(emit_assets=False),
-                exclude_ids={instance.id},
                 invalidate_before_primary=False,
             )
 
@@ -311,34 +306,23 @@ def _reactive_context_active() -> bool:
 def reactive_render_bundle(
     *,
     primary_html: Markup | Callable[[], Markup | str],
-    exclude_ids: set[str] | Callable[[], set[str]],
     invalidate_before_primary: bool,
 ) -> Markup:
     """
-    Shared reactive render orchestration for class and instance ``render()`` paths.
-    """
-    backend = ClientBackend.current()
-    warn_reactive_render_without_client(backend=backend)
+    Shared reactive render orchestration for class and instance ``render()``.
 
-    effective_dirtied = MutationTracker.pending()
+    The only reactive-specific step is invalidating dirtied keys *before*
+    rendering the primary, so the primary itself reflects fresh state. The OOB
+    tail (compute swaps, exclude regions already in the body, mark consumed) is
+    the shared ``_finish_with_oob`` path.
+    """
+    warn_reactive_render_without_client(backend=ClientBackend.current())
+
     if invalidate_before_primary:
-        LoadCache.invalidate(effective_dirtied)
+        LoadCache.invalidate(MutationTracker.pending())
 
     primary = primary_html() if callable(primary_html) else primary_html
-    MutationTracker.mark_render_consumed()
-
-    # Exclude only the primary (htmx swaps it as the main response). The trigger is
-    # NOT excluded: a clicked region that depends on the dirtied keys must update
-    # out-of-band like any other dependent (e.g. a "Clear (N)" button updating itself).
-    resolved_exclude = set(exclude_ids() if callable(exclude_ids) else exclude_ids)
-
-    swaps = oob_swaps(
-        effective_dirtied,
-        backend,
-        exclude_ids=resolved_exclude,
-        skip_invalidate=invalidate_before_primary,
-    )
-    return Markup(primary) + swaps
+    return _finish_with_oob(primary)
 
 
 @dataclass

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import re
 from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -494,3 +495,11 @@ def oob_swaps(
                 )
             )
     return Markup("\n".join(fragments))
+
+
+_PJX_ID_RE = re.compile(r'data-pjx-id="([^"]*)"')
+
+
+def _mounted_ids_in(html: str | Markup) -> set[str]:
+    """Every ``data-pjx-id`` already present in a rendered fragment."""
+    return set(_PJX_ID_RE.findall(str(html)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyjinhx"
-version = "0.12.0"
+version = "0.13.0"
 description = "UI components for Python using Pydantic and Jinja2 templates"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/integration/test_oob_nonreactive.py
+++ b/tests/integration/test_oob_nonreactive.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from fastapi.testclient import TestClient
+
+from pyjinhx import setup
+from pyjinhx.client import PJX_MOUNTED_HEADER
+from pyjinhx.mutations import MutationTracker
+from pyjinhx.renderer import Renderer
+from tests.ui.reactive import store
+from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401 (registers)
+from tests.ui.unified_component import UnifiedComponent  # noqa: F401 (registers)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    setup(app)
+
+    @app.post("/act", response_class=HTMLResponse)
+    def act():
+        # A controller dirties a key, then returns a NON-reactive result view.
+        store.state["remaining"] = 7
+        MutationTracker.record(("todos",))
+        return str(UnifiedComponent(id="result", text="done").render())
+
+    @app.post("/reactive", response_class=HTMLResponse)
+    def reactive():
+        store.state["remaining"] = 7
+        MutationTracker.record(("todos",))
+        return str(ReactiveCounter.render())
+
+    return app
+
+
+def test_nonreactive_response_carries_oob_swaps():
+    Renderer.set_default_environment(REPO_ROOT)
+    manifest = json.dumps([{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}])
+    with TestClient(_app()) as client:
+        resp = client.post("/act", headers={PJX_MOUNTED_HEADER: manifest})
+    body = resp.text
+    assert resp.status_code == 200
+    assert 'id="result"' in body
+    assert "done" in body
+    assert "outerHTML:[data-pjx-id='counter']" in body
+    assert "7 left" in body
+
+
+def test_reactive_response_emits_single_swap_set():
+    Renderer.set_default_environment(REPO_ROOT)
+    manifest = json.dumps([{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}])
+    with TestClient(_app()) as client:
+        resp = client.post("/reactive", headers={PJX_MOUNTED_HEADER: manifest})
+    body = resp.text
+    assert "7 left" in body
+    assert "outerHTML:[data-pjx-id='counter']" not in body

--- a/tests/integration/test_setup_fastapi.py
+++ b/tests/integration/test_setup_fastapi.py
@@ -77,3 +77,17 @@ def test_setup_is_idempotent():
 def test_setup_rejects_non_asgi_app():
     with pytest.raises(TypeError, match="Starlette/FastAPI-like app"):
         setup(object())
+
+
+def test_setup_context_factory_threads_context():
+    from pyjinhx.context import PjxContext
+
+    app = FastAPI()
+    setup(app, context_factory=lambda _request: "CTX")
+
+    @app.get("/ctx")
+    def ctx_route():
+        return PjxContext.current()
+
+    with TestClient(app) as client:
+        assert client.get("/ctx").text == '"CTX"'

--- a/tests/unit/test_finish_with_oob.py
+++ b/tests/unit/test_finish_with_oob.py
@@ -69,3 +69,30 @@ def test_excludes_region_already_in_body():
         out = str(_finish_with_oob('<div data-pjx-id="counter">3 left</div>'))
     assert "outerHTML:[data-pjx-id='counter']" not in out
     assert "outerHTML:[data-pjx-id='clear-btn']" in out
+
+
+from pathlib import Path
+
+from pyjinhx.renderer import Renderer
+from tests.ui.unified_component import UnifiedComponent  # noqa: F401 (registers)
+
+_UI_DIR = Path(__file__).resolve().parents[1] / "ui"
+
+
+def test_base_render_fans_out_for_nonreactive():
+    Renderer.set_default_environment(_UI_DIR)
+    store.state["remaining"] = 4
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(UnifiedComponent(id="result", text="done").render())
+    assert "result" in out
+    assert "outerHTML:[data-pjx-id='counter']" in out
+    assert "4 left" in out
+
+
+def test_base_render_unchanged_without_backend():
+    Renderer.set_default_environment(_UI_DIR)
+    record_mutation("todos")
+    out = str(UnifiedComponent(id="result", text="done").render())
+    assert "outerHTML:" not in out

--- a/tests/unit/test_finish_with_oob.py
+++ b/tests/unit/test_finish_with_oob.py
@@ -1,0 +1,16 @@
+from markupsafe import Markup
+
+from pyjinhx.reactive import _mounted_ids_in
+
+
+def test_mounted_ids_extracts_double_quoted_markers():
+    html = '<div data-pjx-id="counter"></div><span data-pjx-id="clear-btn"></span>'
+    assert _mounted_ids_in(html) == {"counter", "clear-btn"}
+
+
+def test_mounted_ids_empty_on_plain_html():
+    assert _mounted_ids_in("<div>no markers</div>") == set()
+
+
+def test_mounted_ids_accepts_markup():
+    assert _mounted_ids_in(Markup('<div data-pjx-id="x"></div>')) == {"x"}

--- a/tests/unit/test_finish_with_oob.py
+++ b/tests/unit/test_finish_with_oob.py
@@ -1,6 +1,16 @@
+from pathlib import Path
+
 from markupsafe import Markup
 
-from pyjinhx.reactive import _mounted_ids_in
+from pyjinhx.reactive import _finish_with_oob, _mounted_ids_in
+from pyjinhx.renderer import Renderer
+from tests.reactive_test_support import reactive_client, record_mutation
+from tests.ui.reactive import store
+from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401 (registers)
+from tests.ui.reactive.reactive_clear_button import ReactiveClearButton  # noqa: F401
+from tests.ui.unified_component import UnifiedComponent  # noqa: F401 (registers)
+
+_UI_DIR = Path(__file__).resolve().parents[1] / "ui"
 
 
 def test_mounted_ids_extracts_double_quoted_markers():
@@ -14,13 +24,6 @@ def test_mounted_ids_empty_on_plain_html():
 
 def test_mounted_ids_accepts_markup():
     assert _mounted_ids_in(Markup('<div data-pjx-id="x"></div>')) == {"x"}
-
-
-from pyjinhx.reactive import _finish_with_oob
-from tests.reactive_test_support import reactive_client, record_mutation
-from tests.ui.reactive import store
-from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401 (registers)
-from tests.ui.reactive.reactive_clear_button import ReactiveClearButton  # noqa: F401
 
 
 def test_appends_swaps_for_dirtied_mounted_region():
@@ -69,14 +72,6 @@ def test_excludes_region_already_in_body():
         out = str(_finish_with_oob('<div data-pjx-id="counter">3 left</div>'))
     assert "outerHTML:[data-pjx-id='counter']" not in out
     assert "outerHTML:[data-pjx-id='clear-btn']" in out
-
-
-from pathlib import Path
-
-from pyjinhx.renderer import Renderer
-from tests.ui.unified_component import UnifiedComponent  # noqa: F401 (registers)
-
-_UI_DIR = Path(__file__).resolve().parents[1] / "ui"
 
 
 def test_base_render_fans_out_for_nonreactive():

--- a/tests/unit/test_finish_with_oob.py
+++ b/tests/unit/test_finish_with_oob.py
@@ -96,3 +96,16 @@ def test_base_render_unchanged_without_backend():
     record_mutation("todos")
     out = str(UnifiedComponent(id="result", text="done").render())
     assert "outerHTML:" not in out
+
+
+def test_reactive_response_fans_out_for_raw_string():
+    from pyjinhx.reactive import reactive_response
+
+    store.state["remaining"] = 9
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(reactive_response("<p>no component here</p>"))
+    assert "<p>no component here</p>" in out
+    assert "outerHTML:[data-pjx-id='counter']" in out
+    assert "9 left" in out

--- a/tests/unit/test_finish_with_oob.py
+++ b/tests/unit/test_finish_with_oob.py
@@ -109,3 +109,29 @@ def test_reactive_response_fans_out_for_raw_string():
     assert "<p>no component here</p>" in out
     assert "outerHTML:[data-pjx-id='counter']" in out
     assert "9 left" in out
+
+
+def test_class_render_does_not_double_invalidate(monkeypatch):
+    # The class-render path invalidates before rendering the primary, so the
+    # OOB tail must NOT invalidate again (avoids a redundant publish).
+    from pyjinhx import cache as cache_mod
+
+    calls = []
+    original = cache_mod.LoadCache.invalidate
+
+    def counting_invalidate(keys):
+        calls.append(set(keys))
+        return original(keys)
+
+    monkeypatch.setattr(cache_mod.LoadCache, "invalidate", counting_invalidate)
+
+    store.state["remaining"] = 2
+    manifest = [{"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"}]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(ReactiveCounter.render())
+
+    assert "outerHTML:[data-pjx-id='clear-btn']" in out
+    # one invalidate from record_mutation, one from the bundle's pre-primary
+    # step; the OOB tail must NOT add a third (it skips invalidation).
+    assert len(calls) == 2

--- a/tests/unit/test_finish_with_oob.py
+++ b/tests/unit/test_finish_with_oob.py
@@ -14,3 +14,58 @@ def test_mounted_ids_empty_on_plain_html():
 
 def test_mounted_ids_accepts_markup():
     assert _mounted_ids_in(Markup('<div data-pjx-id="x"></div>')) == {"x"}
+
+
+from pyjinhx.reactive import _finish_with_oob
+from tests.reactive_test_support import reactive_client, record_mutation
+from tests.ui.reactive import store
+from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401 (registers)
+from tests.ui.reactive.reactive_clear_button import ReactiveClearButton  # noqa: F401
+
+
+def test_appends_swaps_for_dirtied_mounted_region():
+    store.state["remaining"] = 2
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(_finish_with_oob("<div id='result'>done</div>"))
+    assert "<div id='result'>done</div>" in out
+    assert "outerHTML:[data-pjx-id='counter']" in out
+    assert "2 left" in out
+
+
+def test_passthrough_without_backend():
+    record_mutation("todos")
+    out = _finish_with_oob("<div>x</div>")
+    assert str(out) == "<div>x</div>"
+
+
+def test_passthrough_without_pending_mutations():
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    with reactive_client(manifest):
+        out = _finish_with_oob("<div>x</div>")
+    assert str(out) == "<div>x</div>"
+
+
+def test_emits_once_per_scope():
+    store.state["remaining"] = 1
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        first = str(_finish_with_oob("<div>a</div>"))
+        second = str(_finish_with_oob("<div>b</div>"))
+    assert "outerHTML:[data-pjx-id='counter']" in first
+    assert second == "<div>b</div>"
+
+
+def test_excludes_region_already_in_body():
+    store.state["remaining"] = 3
+    manifest = [
+        {"id": "counter", "type": "ReactiveCounter", "hash": "stale"},
+        {"id": "clear-btn", "type": "ReactiveClearButton", "hash": "stale"},
+    ]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(_finish_with_oob('<div data-pjx-id="counter">3 left</div>'))
+    assert "outerHTML:[data-pjx-id='counter']" not in out
+    assert "outerHTML:[data-pjx-id='clear-btn']" in out

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -73,4 +73,4 @@ def test_internals_remain_importable_from_submodules():
     from pyjinhx.config import configure_pyjinhx, pyjinhx_lifespan, shutdown_pyjinhx  # noqa: F401
     from pyjinhx.dev import dependency_graph, enable_reactive_dev  # noqa: F401
     from pyjinhx.integrations.fastapi import FastAPIClientBackend  # noqa: F401
-    from pyjinhx.reactive import oob_swaps  # noqa: F401
+    from pyjinhx.reactive import oob_swaps, reactive_response  # noqa: F401

--- a/tests/unit/test_reactive_render_defaults.py
+++ b/tests/unit/test_reactive_render_defaults.py
@@ -30,7 +30,7 @@ def test_no_pending_mutations_skips_oob():
     assert "outerHTML:[data-pjx-id='clear-btn']" not in out
 
 
-def test_non_reactive_primary_defaults_to_no_swaps():
+def test_non_reactive_primary_fans_out_swaps():
     store.state["completed"] = 4
     primary = UnifiedComponent(id="u1", text="hi")
     manifest = [
@@ -39,5 +39,6 @@ def test_non_reactive_primary_defaults_to_no_swaps():
     with reactive_client(manifest):
         record_mutation("todos")
         out = str(primary.render())
-    assert "outerHTML:[data-pjx-id='clear-btn']" not in out
+    assert "outerHTML:[data-pjx-id='clear-btn']" in out
+    assert "Clear (4)" in out
     assert "hi" in out


### PR DESCRIPTION
## Summary

Any component's `.render()` now appends OOB swaps for dirtied mounted reactive regions when a client backend is active and mutations occurred — not only `ReactiveComponent.render()`. A mutating route that returns a non-reactive command-result view now updates mounted read-models with no extra wrapper code.

## Changes

- **OOB fan-out at the render boundary**: guarded helper `_finish_with_oob` ensures OOB swaps are emitted at most once per response (via `render_was_consumed`) and never doubled (via a `data-pjx-id` body scan). `reactive_render_bundle` simplified to delegate to it; its primary self-exclude is now a special case of the body scan.
- **`skip_invalidate` forwarded**: the class-render path no longer invalidates/publishes twice.
- **New escape hatch `pyjinhx.reactive.reactive_response(html)`**: for component-less responses (raw strings, 204s) that still need OOB fan-out.
- **Breaking — `setup()` keyword rename**: `load_context_factory` → `context_factory` (old name is silently ignored).
- **Tests**: full suite green (622 passed, incl. playwright reactivity). New unit + integration coverage added.
- **Docs**: changelog 0.13.0 entry and migration guide added.

## Type of Change

- [ ] Bug fix (patch)
- [x] New feature (minor)
- [ ] Breaking change (major)
- [x] Refactor / cleanup
- [ ] Documentation

## Version Bump

`0.12.0` → `0.13.0`

## Testing

- `pytest` — 622 passed, 0 failures
- Playwright reactivity integration tests included and passing
- New unit tests cover `_finish_with_oob` guard logic
- New integration test verifies non-reactive route fans out OOB swaps to mounted reactive regions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)