### PR TITLE
Inject PjxContext into any component method declaring it

### DIFF
--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -74,7 +74,7 @@ class PjxContext:
     ...
 ```
 
-Opaque base for request-scoped data available inside reactive `load()`. Subclass with your own frozen dataclass fields (database session, user id, feature flags).
+Opaque base for request-scoped data available inside reactive `load()` and any component method that declares a `PjxContext` parameter. Subclass with your own frozen dataclass fields (database session, user id, feature flags).
 
 ## PjxContext.current / PjxContext.bind
 
@@ -83,7 +83,7 @@ PjxContext.current() -> Any | None
 PjxContext.bind(ctx) -> ContextManager[None]
 ```
 
-Return or set the load context for the current scope. Reactive `load()` methods receive a parameter annotated with `PjxContext` (or a subclass) when the context is set.
+Return or set the load context for the current scope. Any component method that declares a parameter annotated with `PjxContext` (or a subclass) — including reactive `load()` — receives the current context when the parameter is left unbound; an explicitly passed argument takes precedence. At most one such parameter is allowed per method.
 
 Prefer `Registry.request_scope(load_context=ctx)` in web apps — it combines registry isolation, request cache, mutation tracking, and load context in one call.
 

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any, ClassVar, Optional
 from markupsafe import Markup
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator
 
+from .context import wrap_context_methods
 from .registry import Registry
 from .renderer import Renderer
 from .assets import RenderSession
@@ -200,6 +201,7 @@ class BaseComponent(BaseModel):
                 f"{cls.__name__}: subclass one component at a time; got {names}"
             )
         Registry.register_class(cls, replace=pjx_replace)
+        wrap_context_methods(cls)
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/pyjinhx/context.py
+++ b/pyjinhx/context.py
@@ -164,6 +164,8 @@ def wrap_context_methods(cls: type[Any]) -> None:
         if ctx_param is None:
             continue
         wrapped = _make_context_wrapper(func, ctx_param.name)
+        # ``func`` retains its leading ``self``/``cls`` arg; the descriptor re-wrap
+        # below restores it, so ``bind_partial`` sees the same args as a raw call.
         if isinstance(attr, classmethod):
             wrapped = classmethod(wrapped)
         elif isinstance(attr, staticmethod):

--- a/pyjinhx/context.py
+++ b/pyjinhx/context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import inspect
 import sys
 from collections.abc import Callable, Generator
@@ -122,6 +123,40 @@ def invoke_raw_load(
     bound = signature.bind(component_class, **bind_kwargs)
     bound.apply_defaults()
     return raw_func(*bound.args, **bound.kwargs)
+
+
+def _make_context_wrapper(func: Callable[..., Any], ctx_name: str) -> Callable[..., Any]:
+    """Wrap ``func`` so ``ctx_name`` is filled from ``PjxContext.current()`` when
+    the caller leaves it unbound."""
+    signature = inspect.signature(func)
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        bound = signature.bind_partial(*args, **kwargs)
+        if ctx_name not in bound.arguments:
+            kwargs[ctx_name] = PjxContext.current()
+        return func(*args, **kwargs)
+
+    wrapper._pjx_ctx_injected = True  # type: ignore[attr-defined]
+    return wrapper
+
+
+def wrap_context_methods(cls: type[Any]) -> None:
+    """Wrap each of ``cls``'s own instance methods declaring a single PjxContext
+    parameter so the current load context is injected when left unbound.
+
+    ``load`` is skipped — it keeps its dedicated injection path via
+    ``LoadCache.install_cached_load``.
+    """
+    for name, attr in list(vars(cls).items()):
+        if name == "load" or not inspect.isfunction(attr):
+            continue
+        if getattr(attr, "_pjx_ctx_injected", False):
+            continue
+        ctx_param = resolve_load_context_param(attr, cls)
+        if ctx_param is None:
+            continue
+        setattr(cls, name, _make_context_wrapper(attr, ctx_param.name))
 
 
 @dataclass(frozen=True)

--- a/pyjinhx/context.py
+++ b/pyjinhx/context.py
@@ -142,21 +142,33 @@ def _make_context_wrapper(func: Callable[..., Any], ctx_name: str) -> Callable[.
 
 
 def wrap_context_methods(cls: type[Any]) -> None:
-    """Wrap each of ``cls``'s own instance methods declaring a single PjxContext
-    parameter so the current load context is injected when left unbound.
+    """Wrap each of ``cls``'s own methods declaring a single PjxContext parameter
+    so the current load context is injected when left unbound.
 
-    ``load`` is skipped — it keeps its dedicated injection path via
+    Handles instance methods, ``@classmethod`` and ``@staticmethod``. ``load`` is
+    skipped — it keeps its dedicated injection path via
     ``LoadCache.install_cached_load``.
     """
     for name, attr in list(vars(cls).items()):
-        if name == "load" or not inspect.isfunction(attr):
+        if name == "load":
             continue
-        if getattr(attr, "_pjx_ctx_injected", False):
+        if isinstance(attr, (classmethod, staticmethod)):
+            func = attr.__func__
+        elif inspect.isfunction(attr):
+            func = attr
+        else:
             continue
-        ctx_param = resolve_load_context_param(attr, cls)
+        if getattr(func, "_pjx_ctx_injected", False):
+            continue
+        ctx_param = resolve_load_context_param(func, cls)
         if ctx_param is None:
             continue
-        setattr(cls, name, _make_context_wrapper(attr, ctx_param.name))
+        wrapped = _make_context_wrapper(func, ctx_param.name)
+        if isinstance(attr, classmethod):
+            wrapped = classmethod(wrapped)
+        elif isinstance(attr, staticmethod):
+            wrapped = staticmethod(wrapped)
+        setattr(cls, name, wrapped)
 
 
 @dataclass(frozen=True)

--- a/pyjinhx/context.py
+++ b/pyjinhx/context.py
@@ -134,8 +134,8 @@ def _make_context_wrapper(func: Callable[..., Any], ctx_name: str) -> Callable[.
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         bound = signature.bind_partial(*args, **kwargs)
         if ctx_name not in bound.arguments:
-            kwargs[ctx_name] = PjxContext.current()
-        return func(*args, **kwargs)
+            bound.arguments[ctx_name] = PjxContext.current()
+        return func(*bound.args, **bound.kwargs)
 
     wrapper._pjx_ctx_injected = True  # type: ignore[attr-defined]
     return wrapper

--- a/tests/unit/test_context_injection.py
+++ b/tests/unit/test_context_injection.py
@@ -40,3 +40,13 @@ def test_instance_method_injected_inside_scope():
 def test_instance_method_none_outside_scope():
     widget = CtxWidget()
     assert widget.describe() == "none"
+
+
+def test_classmethod_injected():
+    with PjxContext.bind(Ctx(value=7)):
+        assert CtxWidget.from_ctx() == "cls:7"
+
+
+def test_staticmethod_injected():
+    with PjxContext.bind(Ctx(value=9)):
+        assert CtxWidget.stat() == "stat:9"

--- a/tests/unit/test_context_injection.py
+++ b/tests/unit/test_context_injection.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+
+import pytest
+
+from pyjinhx import BaseComponent, MutationKey, ReactiveComponent
+from pyjinhx.cache import LoadCache
+from pyjinhx.context import PjxContext
+
+
+@dataclass(frozen=True)
+class Ctx(PjxContext):
+    value: int = 0
+
+
+class CtxWidget(BaseComponent):
+    def describe(self, ctx: Ctx | None = None) -> str:
+        return f"v={ctx.value}" if ctx else "none"
+
+    @classmethod
+    def from_ctx(cls, ctx: Ctx | None = None) -> str:
+        return f"cls:{ctx.value}" if ctx else "cls:none"
+
+    @staticmethod
+    def stat(ctx: Ctx | None = None) -> str:
+        return f"stat:{ctx.value}" if ctx else "stat:none"
+
+    def greet(self, name: str, ctx: Ctx | None = None) -> str:
+        return f"{name}:{ctx.value if ctx else '-'}"
+
+    def plain(self, x: int) -> int:
+        return x * 2
+
+
+def test_instance_method_injected_inside_scope():
+    widget = CtxWidget()
+    with PjxContext.bind(Ctx(value=5)):
+        assert widget.describe() == "v=5"
+
+
+def test_instance_method_none_outside_scope():
+    widget = CtxWidget()
+    assert widget.describe() == "none"

--- a/tests/unit/test_context_injection.py
+++ b/tests/unit/test_context_injection.py
@@ -92,6 +92,24 @@ def test_multiple_ctx_params_raise_at_class_definition():
                 ...
 
 
+def test_multiple_ctx_params_classmethod_raises():
+    with pytest.raises(TypeError):
+
+        class BadMultiCtxClassmethod(BaseComponent):
+            @classmethod
+            def m(cls, a: Ctx, b: Ctx | None = None) -> None:
+                ...
+
+
+def test_multiple_ctx_params_staticmethod_raises():
+    with pytest.raises(TypeError):
+
+        class BadMultiCtxStaticmethod(BaseComponent):
+            @staticmethod
+            def m(a: Ctx, b: Ctx | None = None) -> None:
+                ...
+
+
 class CtxKeys(MutationKey):
     W = "w"
 
@@ -153,3 +171,17 @@ class CtxStrict(BaseComponent):
 def test_non_optional_subclass_param_injected():
     with PjxContext.bind(Ctx(value=6)):
         assert CtxStrict().need() == 6
+
+
+class CtxPosOnly(BaseComponent):
+    def m(self, ctx: Ctx | None = None, /) -> str:
+        return f"pos:{ctx.value if ctx else '-'}"
+
+
+def test_positional_only_ctx_param_injected():
+    with PjxContext.bind(Ctx(value=13)):
+        assert CtxPosOnly().m() == "pos:13"
+
+
+def test_positional_only_ctx_param_none_outside_scope():
+    assert CtxPosOnly().m() == "pos:-"

--- a/tests/unit/test_context_injection.py
+++ b/tests/unit/test_context_injection.py
@@ -50,3 +50,11 @@ def test_classmethod_injected():
 def test_staticmethod_injected():
     with PjxContext.bind(Ctx(value=9)):
         assert CtxWidget.stat() == "stat:9"
+
+
+def test_classmethod_none_outside_scope():
+    assert CtxWidget.from_ctx() == "cls:none"
+
+
+def test_staticmethod_none_outside_scope():
+    assert CtxWidget.stat() == "stat:none"

--- a/tests/unit/test_context_injection.py
+++ b/tests/unit/test_context_injection.py
@@ -90,3 +90,63 @@ def test_multiple_ctx_params_raise_at_class_definition():
         class BadMultiCtx(BaseComponent):
             def m(self, a: Ctx, b: Ctx | None = None) -> None:
                 ...
+
+
+class CtxKeys(MutationKey):
+    W = "w"
+
+
+class CtxReactive(ReactiveComponent, react={CtxKeys.W}):
+    value: int = 0
+
+    @classmethod
+    def load(cls, *, ctx: Ctx | None = None) -> "CtxReactive":
+        return cls(id="ctx-reactive", value=ctx.value if ctx else -1)
+
+
+def test_reactive_load_still_injects_once():
+    LoadCache.clear()
+    with PjxContext.bind(Ctx(value=11)):
+        instance = CtxReactive.load()
+    assert instance.value == 11
+
+
+def test_reactive_load_not_wrapped_by_generic_injector():
+    # load is owned by LoadCache.install_cached_load, not the generic ctx wrapper.
+    load_func = CtxReactive.__dict__["load"].__func__
+    assert getattr(load_func, "_pjx_ctx_injected", False) is False
+
+
+class CtxBase(BaseComponent):
+    def m(self, ctx: Ctx | None = None) -> str:
+        return f"base:{ctx.value if ctx else '-'}"
+
+
+class CtxSub(CtxBase):
+    def m(self, ctx: Ctx | None = None) -> str:
+        return f"sub:{ctx.value if ctx else '-'}"
+
+
+class CtxSubNoOverride(CtxBase):
+    pass
+
+
+def test_override_is_rewrapped():
+    with PjxContext.bind(Ctx(value=3)):
+        assert CtxSub().m() == "sub:3"
+
+
+def test_inherited_method_not_rewrapped():
+    assert "m" not in vars(CtxSubNoOverride)
+    with PjxContext.bind(Ctx(value=4)):
+        assert CtxSubNoOverride().m() == "base:4"
+
+
+class CtxStrict(BaseComponent):
+    def need(self, ctx: Ctx) -> int:
+        return ctx.value
+
+
+def test_non_optional_subclass_param_injected():
+    with PjxContext.bind(Ctx(value=6)):
+        assert CtxStrict().need() == 6

--- a/tests/unit/test_context_injection.py
+++ b/tests/unit/test_context_injection.py
@@ -115,6 +115,9 @@ def test_reactive_load_not_wrapped_by_generic_injector():
     # load is owned by LoadCache.install_cached_load, not the generic ctx wrapper.
     load_func = CtxReactive.__dict__["load"].__func__
     assert getattr(load_func, "_pjx_ctx_injected", False) is False
+    # Precise guard for the name-exclusion: the raw user load captured by
+    # install_cached_load (after the generic pass runs) was never injected.
+    assert getattr(CtxReactive._pjx_raw_load, "_pjx_ctx_injected", False) is False
 
 
 class CtxBase(BaseComponent):

--- a/tests/unit/test_context_injection.py
+++ b/tests/unit/test_context_injection.py
@@ -58,3 +58,35 @@ def test_classmethod_none_outside_scope():
 
 def test_staticmethod_none_outside_scope():
     assert CtxWidget.stat() == "stat:none"
+
+
+def test_explicit_positional_arg_respected():
+    widget = CtxWidget()
+    with PjxContext.bind(Ctx(value=5)):
+        assert widget.describe(Ctx(value=99)) == "v=99"
+
+
+def test_explicit_keyword_arg_respected():
+    widget = CtxWidget()
+    with PjxContext.bind(Ctx(value=5)):
+        assert widget.describe(ctx=Ctx(value=42)) == "v=42"
+
+
+def test_other_positional_args_plus_injection():
+    widget = CtxWidget()
+    with PjxContext.bind(Ctx(value=8)):
+        assert widget.greet("hi") == "hi:8"
+
+
+def test_method_without_ctx_param_not_wrapped():
+    widget = CtxWidget()
+    assert widget.plain(3) == 6
+    assert getattr(vars(CtxWidget)["plain"], "_pjx_ctx_injected", False) is False
+
+
+def test_multiple_ctx_params_raise_at_class_definition():
+    with pytest.raises(TypeError):
+
+        class BadMultiCtx(BaseComponent):
+            def m(self, a: Ctx, b: Ctx | None = None) -> None:
+                ...


### PR DESCRIPTION
## Summary
- Extend request-scoped `PjxContext` injection from `load()` only to **any** component method (instance / classmethod / staticmethod) that declares a single parameter typed `PjxContext` (or a subclass, or `PjxContext | None`).
- Injection happens by wrapping eligible methods at class-definition time in `BaseComponent.__init_subclass__` via `wrap_context_methods` (new, in `pyjinhx/context.py`). The wrapper fills the context parameter from `PjxContext.current()` only when the caller leaves it unbound — an explicitly passed argument wins.
- `load` keeps its dedicated cache+key injection path (`LoadCache.install_cached_load`) and is excluded by name from the generic pass, so it is never double-injected.
- Detection reuses the existing `resolve_load_context_param` rules (subclass + `X | None` unwrapping, name-agnostic, at most one such param → `TypeError` at class definition).
- Injection routes through a bound-arguments object (`*bound.args, **bound.kwargs`), matching the `invoke_raw_load` idiom, so positional-only parameters work correctly.

## Behavior notes
- Applies to all `BaseComponent` subclasses, not just reactive ones.
- Outside a request scope, `PjxContext.current()` is `None`, so `None` is injected — type the param as `PjxContext | None` (or give it a default) for methods callable outside a scope.
- Pydantic validators, properties, and the `_ReactiveRender` descriptor are not wrongly wrapped (only `function`/`classmethod`/`staticmethod` are eligible).

## Test Plan
- [x] `uv run pytest tests/unit` — 589 passed
- [x] New `tests/unit/test_context_injection.py` (20 tests): instance/class/static injection inside + outside scope; explicit-arg precedence; method without ctx param untouched; multiple-ctx-param `TypeError` (instance/class/static); reactive `load()` still single-injects (regression) with a precise `_pjx_raw_load` guard; override re-wrapped; inherited method not double-wrapped; non-optional `PjxContext` subclass param; positional-only param.
- [x] No regression in `test_load_context.py` / `test_load_cache.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)