### PR TITLE
Remove pyjinhx_lifespan; tidy setup() and backend wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ site/
 
 # Superpowers planning artifacts
 docs/superpowers/
+
+# .claude
+.claude/worktrees/

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -82,12 +82,3 @@ shutdown_pyjinhx()            # shutdown
 
 When an `invalidation_backend` is configured, its listener starts and cross-request (process-wide) caching is enabled; otherwise caching is per-request.
 
-## pyjinhx_lifespan
-
-Sync context manager for non-ASGI tests and scripts:
-
-```python
-with pyjinhx_lifespan():
-    ...
-```
-

--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable, Generator
-from contextlib import contextmanager
+from collections.abc import Callable
 from dataclasses import dataclass, fields, replace
 from typing import Any
 
 from pyjinhx.cache import CacheScope, InvalidationBackend, InvalidationHub, LoadCache
 from pyjinhx.dev import disable_reactive_dev, enable_reactive_dev
 
-_UNSET: Any = object()  # sentinel: distinguishes "argument omitted" from None / a real value
+_UNSET: Any = (
+    object()
+)  # sentinel: distinguishes "argument omitted" from None / a real value
 
 
 @dataclass(frozen=True)
@@ -85,13 +86,13 @@ def configure_pyjinhx(
     # (e.g. Redis) makes cross-request PROCESS caching safe across workers; without
     # one, the only multi-worker-safe behavior is per-request (REQUEST) caching.
     backend = resolved.invalidation_backend
-    LoadCache.set_scope(CacheScope.PROCESS if backend is not None else CacheScope.REQUEST)
+    LoadCache.set_scope(
+        CacheScope.PROCESS if backend is not None else CacheScope.REQUEST
+    )
 
+    InvalidationHub.set_backend(backend)
     if backend is not None:
-        InvalidationHub.set_backend(backend)
         InvalidationHub.start_listener()
-    else:
-        InvalidationHub.set_backend(None)
 
     if resolved.reactive_dev:
         enable_reactive_dev()
@@ -107,19 +108,6 @@ def shutdown_pyjinhx() -> None:
     disable_reactive_dev()
 
 
-@contextmanager
-def pyjinhx_lifespan(
-    settings: PjxSettings | None = None,
-    /,
-    **kwargs: Any,
-) -> Generator[None, None, None]:
-    configure_pyjinhx(settings, **kwargs)
-    try:
-        yield
-    finally:
-        shutdown_pyjinhx()
-
-
 def _is_asgi_app(app: object) -> bool:
     return hasattr(app, "add_middleware") and hasattr(app, "router")
 
@@ -128,9 +116,9 @@ def setup(
     app: object | None = None,
     *,
     settings: PjxSettings | None = None,
+    context_factory: Callable[[Any], object | None] | None = None,
     invalidation_backend: InvalidationBackend | None = _UNSET,
     reactive_dev: bool = _UNSET,
-    context_factory: Callable[[Any], object | None] | None = None,
     **kwargs: Any,
 ) -> PjxSettings:
     """
@@ -158,6 +146,7 @@ def setup(
             "setup(app=...) requires a Starlette/FastAPI-like app "
             "with add_middleware and router"
         )
+
     from pyjinhx.integrations.fastapi import apply_setup
 
     apply_setup(app, resolved, context_factory=context_factory)

--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -5,9 +5,9 @@ from collections.abc import Callable
 from contextlib import asynccontextmanager
 from typing import Any
 
-from pyjinhx.registry import Registry
-from pyjinhx.config import PjxSettings, configure_pyjinhx, shutdown_pyjinhx
 from pyjinhx.client import ClientBackend
+from pyjinhx.config import PjxSettings, configure_pyjinhx, shutdown_pyjinhx
+from pyjinhx.registry import Registry
 
 logger = logging.getLogger("pyjinhx")
 
@@ -69,11 +69,11 @@ def _registry_middleware_class(
 ) -> type:
     from starlette.middleware.base import BaseHTTPMiddleware
 
-    factory = context_factory
-
     class RegistryScopeMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request, call_next):
-            load_context = factory(request) if factory is not None else None
+            load_context = (
+                context_factory(request) if context_factory is not None else None
+            )
             with Registry.request_scope(
                 load_context=load_context,
                 client_backend=FastAPIClientBackend(request),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from pyjinhx import PjxSettings
 from pyjinhx.cache import CacheScope, InvalidationBackend, LoadCache
-from pyjinhx.config import configure_pyjinhx, pyjinhx_lifespan, shutdown_pyjinhx
+from pyjinhx.config import configure_pyjinhx, shutdown_pyjinhx
 
 
 class _StubBackend(InvalidationBackend):
@@ -35,12 +35,6 @@ def test_configure_pyjinhx_accepts_settings_object():
     settings = PjxSettings()
     configure_pyjinhx(settings)
     assert LoadCache.scope() == CacheScope.REQUEST
-
-
-def test_pyjinhx_lifespan_context_manager():
-    with pyjinhx_lifespan():
-        assert LoadCache.scope() == CacheScope.REQUEST
-    shutdown_pyjinhx()
 
 
 def test_from_env_defaults_to_request():

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -51,7 +51,7 @@ def test_internals_are_not_in_the_public_surface():
         "InvalidationBackend", "MutationTracker", "Finder", "Parser", "Tag",
         "ClientBackend", "FastAPIClientBackend", "MountedManifest", "TriggerManifest",
         "LoadedAssets", "PJX_MOUNTED_HEADER", "PJX_ASSETS_HEADER", "PJX_TRIGGER_HEADER",
-        "configure_pyjinhx", "shutdown_pyjinhx", "pyjinhx_lifespan",
+        "configure_pyjinhx", "shutdown_pyjinhx",
         "enable_reactive_dev", "disable_reactive_dev", "dependency_graph",
         "format_dependency_graph", "AssetManifest", "RenderSession", "asset_manifest",
         "default_asset_url", "hashed_filename", "make_default_asset_url_resolver",
@@ -70,7 +70,7 @@ def test_internals_remain_importable_from_submodules():
         MountedManifest,
         client_script,
     )
-    from pyjinhx.config import configure_pyjinhx, pyjinhx_lifespan, shutdown_pyjinhx  # noqa: F401
+    from pyjinhx.config import configure_pyjinhx, shutdown_pyjinhx  # noqa: F401
     from pyjinhx.dev import dependency_graph, enable_reactive_dev  # noqa: F401
     from pyjinhx.integrations.fastapi import FastAPIClientBackend  # noqa: F401
     from pyjinhx.reactive import oob_swaps, reactive_response  # noqa: F401


### PR DESCRIPTION
Removes the `pyjinhx_lifespan` context manager and simplifies backend wiring.

## Changes
- **`config.py`** — drop the `pyjinhx_lifespan` context manager; promote `context_factory` to a leading kwarg in `setup()`; always call `InvalidationHub.set_backend`, and only start the listener when a backend is present.
- **`integrations/fastapi.py`** — inline `context_factory` use; import reorder.
- **`docs/api/config.md`** — drop the `pyjinhx_lifespan` section.
- **tests** — remove `pyjinhx_lifespan` references from `test_config.py` and `test_public_api.py`.
- **`.gitignore`** — ignore `.claude/worktrees/`.

Affected tests pass (16 passed: `test_config.py`, `test_public_api.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)