### PR TITLE
Add component() factory for html-only components

### DIFF
--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -7,7 +7,7 @@ LoadCache`` — and are not part of this curated surface.
 """
 
 from pyjinhx.assets import AssetMode
-from pyjinhx.base import BaseComponent
+from pyjinhx.base import BaseComponent, component
 from pyjinhx.config import PjxSettings, setup
 from pyjinhx.context import PjxContext
 from pyjinhx.keys import MutationKey
@@ -19,6 +19,7 @@ from pyjinhx.renderer import Renderer
 __all__ = [
     # Components & rendering
     "BaseComponent",
+    "component",
     "ReactiveComponent",
     "Renderer",
     # App wiring

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -163,6 +163,10 @@ class BaseComponent(BaseModel):
     # Components without a `content` field can point this at their text slot.
     _pjx_children_field: ClassVar[str] = "content"
 
+    # Tag name for html-only components synthesized via `component(name)`. When
+    # set, the template is resolved by scanning the default env at render time.
+    _pjx_template: ClassVar[str | None] = None
+
     id: str = Field(
         default_factory=_auto_id,
         description="The unique ID for this component. Auto-generated when omitted.",
@@ -402,3 +406,26 @@ class BaseComponent(BaseModel):
         from pyjinhx.reactive import _finish_with_oob
 
         return _finish_with_oob(self._render())
+
+
+def component(name: str) -> type[BaseComponent]:
+    """
+    Reference an html-only component (a template with no hand-written class).
+
+    ``component("Card")`` returns a class whose template (``card.html``) is
+    resolved by scanning the default environment at render time, so it works
+    even if the default environment isn't set yet at call time::
+
+        Card = component("Card")
+        Card(title="Hi", content="body").render()
+
+    Idempotent: calling it twice returns the same class, and it never shadows
+    an already-declared component of the same name.
+    """
+    from .tags import RE_PASCAL_CASE_TAG_NAME
+
+    if not RE_PASCAL_CASE_TAG_NAME.match(name):
+        raise ValueError(f"component name {name!r} must be PascalCase")
+    if Registry.has_class(name):
+        return Registry.get_class(name)
+    return type(name, (BaseComponent,), {"_pjx_template": name})

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -64,6 +64,20 @@ def load_template_for_component(
         relative_path = os.path.relpath(template_path, loader_root)
         return environment.get_template(relative_path)
 
+    # Html-only components synthesized via `component(name)` have no real source
+    # file, so resolve their template by scanning the default env by tag name.
+    pjx_template = getattr(type(component), "_pjx_template", None)
+    if pjx_template is not None:
+        try:
+            found_path = renderer._find_template_for_tag(pjx_template)
+        except FileNotFoundError:
+            from .tags import _missing_template_error
+
+            raise _missing_template_error(pjx_template)
+        loader_root = get_loader_root(environment)
+        relative_path = os.path.relpath(found_path, loader_root)
+        return environment.get_template(relative_path)
+
     resolution_classes = component_resolution_classes(type(component))
     if not resolution_classes:
         raise FileNotFoundError(

--- a/tests/unit/test_component_factory.py
+++ b/tests/unit/test_component_factory.py
@@ -1,0 +1,90 @@
+import os
+
+import pytest
+
+from pyjinhx import BaseComponent, component
+from pyjinhx.renderer import Renderer
+
+
+@pytest.fixture
+def default_env(tmp_path):
+    """Set a tmp_path default environment and restore the previous one after."""
+    original = Renderer.peek_default_environment()
+    Renderer.set_default_environment(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        Renderer.set_default_environment(original)
+
+
+def _write(dir_path, filename, content):
+    path = os.path.join(dir_path, filename)
+    with open(path, "w") as file:
+        file.write(content)
+    return path
+
+
+def test_component_renders_html_only_template(default_env):
+    _write(default_env, "cf_card.html", '<div class="card"><h1>{{ title }}</h1>{{ content }}</div>')
+
+    CfCard = component("CfCard")
+    rendered = str(CfCard(title="Hi", content="body").render())
+
+    assert '<div class="card">' in rendered
+    assert "<h1>Hi</h1>" in rendered
+    assert "body" in rendered
+
+
+def test_component_nests_in_another_component(default_env):
+    _write(default_env, "cf_widget.html", '<span class="widget">{{ content }}</span>')
+    _write(
+        default_env,
+        "cf_host.html",
+        '<section id="{{ id }}">{{ content }}<CfWidget>inner</CfWidget></section>',
+    )
+
+    CfWidget = component("CfWidget")
+    CfHost = component("CfHost")
+
+    host = CfHost(content="head")
+    rendered = str(host.render())
+
+    assert '<span class="widget">inner</span>' in rendered
+    assert "head" in rendered
+    assert "<section" in rendered
+
+
+def test_tag_still_renders_after_factory(default_env):
+    _write(default_env, "cf_badge.html", '<b id="{{ id }}">{{ content }}</b>')
+
+    component("CfBadge")
+
+    renderer = Renderer.get_default_renderer()
+    rendered = renderer.render('<CfBadge id="b-1">tag</CfBadge>')
+    assert rendered == '<b id="b-1">tag</b>'
+
+
+def test_component_is_idempotent(default_env):
+    first = component("CfIdem")
+    second = component("CfIdem")
+    assert first is second
+
+
+def test_component_does_not_shadow_declared_class(default_env):
+    class CfDeclared(BaseComponent):
+        title: str = ""
+
+    resolved = component("CfDeclared")
+    assert resolved is CfDeclared
+
+
+@pytest.mark.parametrize("bad_name", ["cf_card", "my-card", "card", "lowercase"])
+def test_non_pascal_case_raises(bad_name):
+    with pytest.raises(ValueError):
+        component(bad_name)
+
+
+def test_missing_template_raises_file_not_found(default_env):
+    CfMissing = component("CfMissing")
+    with pytest.raises(FileNotFoundError):
+        CfMissing(content="x").render()

--- a/tests/unit/test_component_factory.py
+++ b/tests/unit/test_component_factory.py
@@ -43,7 +43,7 @@ def test_component_nests_in_another_component(default_env):
         '<section id="{{ id }}">{{ content }}<CfWidget>inner</CfWidget></section>',
     )
 
-    CfWidget = component("CfWidget")
+    component("CfWidget")  # register so the <CfWidget> tag resolves
     CfHost = component("CfHost")
 
     host = CfHost(content="head")

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -9,12 +9,14 @@ from pyjinhx import (
     ReactiveComponent,
     Registry,
     Renderer,
+    component,
     mutates,
     setup,
 )
 
 PUBLIC_API = {
     "BaseComponent",
+    "component",
     "ReactiveComponent",
     "Renderer",
     "setup",
@@ -38,7 +40,7 @@ def test_public_symbols_are_correct():
     assert issubclass(MutationKey, str)
     assert AssetMode.INLINE is not None
     assert PjxKey.__name__ == "PjxKey"
-    for fn in (setup, mutates, PjxSettings.from_env,
+    for fn in (setup, mutates, component, PjxSettings.from_env,
                Renderer.set_default_environment, Registry.request_scope,
                PjxContext.current):
         assert callable(fn)


### PR DESCRIPTION
Lets you reference an html-only component (a template under the default environment, with no hand-written Python class) directly from Python.

```python
from pyjinhx import component

Card = component("Card")                  # finds card.html under the default env
Card(title="Hi", content="body").render()
```

## What it does
- **`component(name)`** returns a real, registered `BaseComponent` subclass synthesized at call time, carrying a `_pjx_template` marker. It's idempotent (twice → same class) and never shadows an already-registered class (returns the declared one). Non-PascalCase names raise `ValueError`.
- **Template resolution:** `load_template_for_component` gains one branch — a class with `_pjx_template` set resolves its template by scanning the default env (the same path `<Tag/>` already uses), lazily at render time. Missing template raises the existing friendly `FileNotFoundError`.
- Exported from the top-level `pyjinhx` package.

Synthesized classes are first-class peers of declared ones: usable via `.render()`, as `<Card/>` in templates, and as children.

## Tests
New `tests/unit/test_component_factory.py` (render with attrs/children, tag still resolves after the factory, identity on repeat calls, no shadowing of a declared class, non-PascalCase `ValueError`, missing-template `FileNotFoundError`). `test_public_api.py` updated for the new export. Full suite green (652 passed).

## Note
Nesting an html-only component as an *undeclared/extra* field of another component doesn't render — a pre-existing `model_dump` quirk for extra fields, unrelated to this change. Idiomatic html-only nesting is via children/tags (covered by a test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)