### PR TITLE
setup(): wire default environment and static mount

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -12,11 +12,20 @@ def setup(
     invalidation_backend: InvalidationBackend | None = ...,  # unset sentinel
     reactive_dev: bool = ...,  # unset sentinel
     context_factory: Callable[[Any], object | None] | None = None,
+    components_root: str | os.PathLike[str] | None = None,
+    static_root: str | os.PathLike[str] | None = None,
     **kwargs: Any,
 ) -> PjxSettings
 ```
 
 When omitted, `invalidation_backend` and `reactive_dev` never override a value already present in `settings` — their defaults are unset sentinels, so only explicitly passed values are applied.
+
+`components_root` sets the renderer's default environment to a `FileSystemLoader` rooted there; it works with or without an `app`. `static_root` mounts a `StaticFiles` app at `/static` (name `"static"`) and therefore requires an `app` — passing it with `app=None` raises `TypeError`. Both default to `None` (no-op), and the static mount is covered by the idempotency guard, so a second `setup()` won't double-mount.
+
+```python
+app = FastAPI()
+setup(app, components_root=COMPONENTS_ROOT, static_root=STATIC_ROOT)
+```
 
 **Single call** for typical web apps:
 

--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -119,6 +119,8 @@ def setup(
     context_factory: Callable[[Any], object | None] | None = None,
     invalidation_backend: InvalidationBackend | None = _UNSET,
     reactive_dev: bool = _UNSET,
+    components_root: str | os.PathLike[str] | None = None,
+    static_root: str | os.PathLike[str] | None = None,
     **kwargs: Any,
 ) -> PjxSettings:
     """
@@ -128,10 +130,21 @@ def setup(
     With a FastAPI/Starlette app, lifespan is chained and registry middleware
     is registered.
 
+    ``components_root`` sets the renderer's default environment to a
+    ``FileSystemLoader`` rooted there (works with or without an ``app``).
+    ``static_root`` mounts a ``StaticFiles`` app at ``/static`` and therefore
+    requires an ``app``.
+
     The load-cache scope is derived from ``invalidation_backend``: cross-request
     ``PROCESS`` caching when a backend is set (kept consistent across workers by
     the backend), per-request ``REQUEST`` caching otherwise.
     """
+    if components_root is not None:
+        from pyjinhx.renderer import Renderer
+
+        Renderer.set_default_environment(components_root)
+    if static_root is not None and app is None:
+        raise TypeError("setup(static_root=...) requires an app to mount it on")
     resolved = _merge_settings(
         settings,
         invalidation_backend=invalidation_backend,
@@ -149,5 +162,5 @@ def setup(
 
     from pyjinhx.integrations.fastapi import apply_setup
 
-    apply_setup(app, resolved, context_factory=context_factory)
+    apply_setup(app, resolved, context_factory=context_factory, static_root=static_root)
     return resolved

--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from typing import Any
@@ -35,6 +36,7 @@ def apply_setup(
     settings: PjxSettings,
     *,
     context_factory: Callable[[Any], object | None] | None = None,
+    static_root: str | os.PathLike[str] | None = None,
 ) -> None:
     if getattr(app.state, "pyjinhx_setup", False):
         logger.warning(
@@ -43,6 +45,10 @@ def apply_setup(
         return
     _chain_lifespan(app, settings)
     app.add_middleware(_registry_middleware_class(context_factory))
+    if static_root is not None:
+        from starlette.staticfiles import StaticFiles
+
+        app.mount("/static", StaticFiles(directory=static_root), name="static")
     app.state.pyjinhx_setup = True
 
 

--- a/tests/integration/test_setup_fastapi.py
+++ b/tests/integration/test_setup_fastapi.py
@@ -3,10 +3,31 @@ from contextlib import asynccontextmanager
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from jinja2 import FileSystemLoader
+from starlette.routing import Mount
+from starlette.staticfiles import StaticFiles
 
 from pyjinhx import setup
 from pyjinhx.cache import CacheScope, InvalidationBackend, LoadCache
 from pyjinhx.client import ClientBackend
+from pyjinhx.renderer import Renderer
+
+
+@pytest.fixture
+def restore_default_environment():
+    # save/restore the process-wide default environment so components_root tests
+    # don't leak state into the rest of the suite
+    original = Renderer.peek_default_environment()
+    yield
+    Renderer.set_default_environment(original)
+
+
+def _static_mounts(app):
+    return [
+        route
+        for route in app.routes
+        if isinstance(route, Mount) and route.path == "/static" and route.name == "static"
+    ]
 
 
 class _StubBackend(InvalidationBackend):
@@ -91,3 +112,53 @@ def test_setup_context_factory_threads_context():
 
     with TestClient(app) as client:
         assert client.get("/ctx").text == '"CTX"'
+
+
+def test_setup_components_root_sets_default_environment(
+    tmp_path, restore_default_environment
+):
+    app = FastAPI()
+    setup(app, components_root=tmp_path)
+
+    env = Renderer.peek_default_environment()
+    assert isinstance(env.loader, FileSystemLoader)
+    assert env.loader.searchpath[0] == str(tmp_path)
+
+
+def test_setup_components_root_without_app(tmp_path, restore_default_environment):
+    setup(components_root=tmp_path)
+
+    env = Renderer.peek_default_environment()
+    assert isinstance(env.loader, FileSystemLoader)
+    assert env.loader.searchpath[0] == str(tmp_path)
+
+
+def test_setup_static_root_mounts_static_files(tmp_path):
+    app = FastAPI()
+    setup(app, static_root=tmp_path)
+
+    mounts = _static_mounts(app)
+    assert len(mounts) == 1
+    assert isinstance(mounts[0].app, StaticFiles)
+
+
+def test_setup_static_root_without_app_raises():
+    with pytest.raises(TypeError, match="static_root"):
+        setup(static_root="/tmp")
+
+
+def test_setup_no_roots_leaves_environment_and_no_mount(restore_default_environment):
+    before = Renderer.peek_default_environment()
+    app = FastAPI()
+    setup(app)
+
+    assert Renderer.peek_default_environment() is before
+    assert _static_mounts(app) == []
+
+
+def test_setup_static_root_idempotent_no_double_mount(tmp_path):
+    app = FastAPI()
+    setup(app, static_root=tmp_path)
+    setup(app, static_root=tmp_path)
+
+    assert len(_static_mounts(app)) == 1


### PR DESCRIPTION
Collapses the FastAPI boilerplate for wiring pyjinhx into the single `setup()` call.

Before:
```python
app.mount("/static", StaticFiles(directory=STATIC_ROOT), name="static")
setup(app)
Renderer.set_default_environment(COMPONENTS_ROOT)
```
After:
```python
setup(app, components_root=COMPONENTS_ROOT, static_root=STATIC_ROOT)
```

## What it does
- **`components_root`** → `Renderer.set_default_environment(...)` (lazy import to avoid a cycle). Runs on both the `app=None` and app paths.
- **`static_root`** → mounts `StaticFiles` at `/static` (name `static`), inside `apply_setup` so the existing `pyjinhx_setup` idempotency guard prevents double-mounting. Requires an app — passing it with `app=None` raises `TypeError`.
- Both omitted → byte-for-byte current behavior.
- Mounts only the user's `static_root`; does not auto-serve pyjinhx's packaged runtime (by design).

## Tests
6 new cases in `tests/integration/test_setup_fastapi.py` (env set with/without app, static mount present, `TypeError` without app, both-omitted backward-compat, idempotent no-double-mount) plus a save/restore fixture for the process-wide default env. `docs/api/config.md` updated. Full suite green (648 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)