### PR TITLE
Add dirty() for imperative reactive-key dirtying

### DIFF
--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -66,6 +66,24 @@ class Store:
         ...
 ```
 
+## dirty
+
+```python
+def dirty(*keys: MutationKey) -> None
+```
+
+Imperatively dirty reactive keys — the same effect `@mutates` has, but without decorating a function. Each arg must be a **`MutationKey` member** — bare strings raise `TypeError`. Invalidates the load cache and accumulates pending dirtied keys for the next reactive `render()`. A no-arg call is a no-op.
+
+```python
+from pyjinhx import MutationKey, dirty
+
+class Keys(MutationKey):
+    TODOS = "todos"
+
+store.add_without_decorator(text)
+dirty(Keys.TODOS)
+```
+
 ## PjxContext
 
 ```python

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -11,7 +11,7 @@ from pyjinhx.base import BaseComponent, component
 from pyjinhx.config import PjxSettings, setup
 from pyjinhx.context import PjxContext
 from pyjinhx.keys import MutationKey
-from pyjinhx.mutations import mutates
+from pyjinhx.mutations import dirty, mutates
 from pyjinhx.reactive import PjxKey, ReactiveComponent
 from pyjinhx.registry import Registry
 from pyjinhx.renderer import Renderer
@@ -27,6 +27,7 @@ __all__ = [
     "Registry",
     # Reactive authoring
     "mutates",
+    "dirty",
     "MutationKey",
     "PjxKey",
     "PjxContext",

--- a/pyjinhx/mutations.py
+++ b/pyjinhx/mutations.py
@@ -55,6 +55,12 @@ class MutationTracker:
         return cls._render_consumed.get()
 
 
+def _require_mutation_keys(keys: tuple[Any, ...], caller: str) -> None:
+    invalid = sorted(repr(key) for key in keys if not isinstance(key, MutationKey))
+    if invalid:
+        raise TypeError(f"{caller} only accepts MutationKey members; got {', '.join(invalid)}")
+
+
 def mutates(*keys: MutationKey) -> Callable[[F], F]:
     """
     Decorator for store mutation methods.
@@ -63,9 +69,7 @@ def mutates(*keys: MutationKey) -> Callable[[F], F]:
     dirtied for the next reactive ``render()``. Keys must be ``MutationKey``
     members.
     """
-    invalid = sorted(repr(key) for key in keys if not isinstance(key, MutationKey))
-    if invalid:
-        raise TypeError(f"@mutates only accepts MutationKey members; got {', '.join(invalid)}")
+    _require_mutation_keys(keys, "@mutates")
 
     def decorator(func: F) -> F:
         @functools.wraps(func)
@@ -77,3 +81,15 @@ def mutates(*keys: MutationKey) -> Callable[[F], F]:
         return wrapper  # type: ignore[return-value]
 
     return decorator
+
+
+def dirty(*keys: MutationKey) -> None:
+    """
+    Imperatively dirty reactive keys, like ``@mutates`` without a decorator.
+
+    Invalidates the load cache for ``keys`` and accumulates them as pending
+    dirtied for the next reactive ``render()``. Keys must be ``MutationKey``
+    members.
+    """
+    _require_mutation_keys(keys, "dirty()")
+    MutationTracker.record(keys)

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from pyjinhx import Registry, Renderer, mutates
+import pytest
+
+from pyjinhx import MutationKey, Registry, Renderer, dirty, mutates
 from pyjinhx.cache import LoadCache
 from pyjinhx.mutations import MutationTracker
 from tests.reactive_test_support import Keys, reactive_client
@@ -9,6 +11,10 @@ from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401
 from tests.ui.reactive.store import state
 
 UI_ROOT = Path(__file__).parent.parent / "ui" / "reactive"
+
+
+class _ExtraKeys(MutationKey):
+    USERS = "users"
 
 
 @mutates(Keys.TODOS)
@@ -60,3 +66,47 @@ def test_request_scope_isolates_mutations():
         _mutate_todos()
         assert MutationTracker.pending() == {"todos"}
     assert MutationTracker.pending() == set()
+
+
+def test_dirty_records_and_invalidates(monkeypatch):
+    invalidated: list[set[str]] = []
+    monkeypatch.setattr(LoadCache, "invalidate", lambda keys: invalidated.append(set(keys)))
+    MutationTracker.clear()
+    dirty(Keys.TODOS)
+    assert MutationTracker.pending() == {"todos"}
+    assert invalidated == [{"todos"}]
+
+
+def test_dirty_records_multiple_keys():
+    MutationTracker.clear()
+    dirty(Keys.TODOS, _ExtraKeys.USERS)
+    assert MutationTracker.pending() == {"todos", "users"}
+
+
+def test_dirty_rejects_bare_strings():
+    with pytest.raises(TypeError) as excinfo:
+        dirty("todos")
+    assert str(excinfo.value).startswith("dirty()")
+
+
+def test_dirty_without_args_is_noop():
+    MutationTracker.clear()
+    dirty()
+    assert MutationTracker.pending() == set()
+
+
+def test_dirty_consumed_by_reactive_render():
+    LoadCache.clear()
+    MutationTracker.clear()
+    prev = Renderer.peek_default_environment()
+    Renderer.set_default_environment(UI_ROOT)
+    try:
+        manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+        with Registry.request_scope():
+            dirty(Keys.TODOS)
+            with reactive_client(manifest):
+                out = str(ReactiveClearButton.render())
+        assert "outerHTML:[data-pjx-id='counter']" in out
+        assert MutationTracker.pending() == set()
+    finally:
+        Renderer.set_default_environment(prev)

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -10,6 +10,7 @@ from pyjinhx import (
     Registry,
     Renderer,
     component,
+    dirty,
     mutates,
     setup,
 )
@@ -22,6 +23,7 @@ PUBLIC_API = {
     "setup",
     "Registry",
     "mutates",
+    "dirty",
     "MutationKey",
     "PjxKey",
     "PjxContext",
@@ -40,7 +42,7 @@ def test_public_symbols_are_correct():
     assert issubclass(MutationKey, str)
     assert AssetMode.INLINE is not None
     assert PjxKey.__name__ == "PjxKey"
-    for fn in (setup, mutates, component, PjxSettings.from_env,
+    for fn in (setup, mutates, component, dirty, PjxSettings.from_env,
                Renderer.set_default_environment, Registry.request_scope,
                PjxContext.current):
         assert callable(fn)


### PR DESCRIPTION
Adds a `dirty()` function so you can dirty reactive keys imperatively, without decorating a function with `@mutates`.

```python
from pyjinhx import dirty

store.add_without_decorator(text)
dirty(Keys.TODOS)        # same effect @mutates(Keys.TODOS) would have had
```

## What it does
- **`dirty(*keys: MutationKey) -> None`** — top-level function next to `mutates`, exported from `pyjinhx`. A thin front door to `MutationTracker.record(...)`: invalidates the load cache for the keys and accumulates them as pending dirtied for the next reactive `render()` (which emits the OOB swaps). No-arg call is a no-op; works with or without an active request scope.
- **Strict keys:** `MutationKey` members only; a bare string raises `TypeError` (matches `@mutates` / `react={...}`, preserves typo safety).
- **Shared validation:** extracted `_require_mutation_keys(keys, caller)` used by both `mutates` and `dirty`, so they can't drift. `@mutates`'s existing `TypeError` message is byte-identical (its test is untouched).

## Tests
`tests/unit/test_mutations.py`: record + invalidate, multi-key, bare-string `TypeError` (message starts with `dirty()`), no-arg no-op, and an OOB-swap integration test mirroring the existing `@mutates` reactivity test with a direct `dirty()` call. `test_public_api.py` updated for the new export. `docs/api/mutations-keys-context.md` documents `dirty`. Full suite green (647 passed); `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)