### PR TITLE
Replace reactive_response() with a ReactiveResponse class

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -34,7 +34,9 @@ def generate():
 
 Fan-out happens once per request scope and never double-swaps a region already
 present in the response body. For a response that renders no component (a raw
-string, a `204`), use `from pyjinhx.reactive import reactive_response`.
+string, a `204`), use `from pyjinhx.reactive import ReactiveResponse`. The old
+function `reactive_response(html)` is now the class `ReactiveResponse(html)`,
+and the dummy `""` is no longer needed — `ReactiveResponse()` works.
 
 ## 0.11 → 0.12 (breaking: `PJX` prefix on all builtins)
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -183,15 +183,15 @@ def generate():
 ```
 
 For a response that renders no component at all (a raw string, a `204`), use
-`from pyjinhx.reactive import reactive_response` to attach the same fan-out:
+`from pyjinhx.reactive import ReactiveResponse` to attach the same fan-out:
 
 ```python
-from pyjinhx.reactive import reactive_response
+from pyjinhx.reactive import ReactiveResponse
 
 @app.post("/dismiss")
 def dismiss():
     controller.dismiss()                # @mutates dirties mounted regions
-    return reactive_response("")        # no primary; dependents still fan out OOB
+    return ReactiveResponse()           # no primary; dependents still fan out OOB
 ```
 
 !!! note "Without ClientBackend"

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -516,12 +516,15 @@ def _finish_with_oob(html: str | Markup, *, skip_invalidate: bool = False) -> Ma
     return Markup(html) + swaps
 
 
-def reactive_response(html: str | Markup) -> Markup:
+class ReactiveResponse(Markup):
     """
-    Attach pending OOB swaps to a response that renders no component.
+    HTML response that carries pending OOB swaps for a request that renders no
+    component (raw string, ``204``, hand-assembled).
 
-    Use for raw-string, ``204``, or hand-assembled responses. Any component's
-    ``.render()`` already does this automatically; reach for this only when no
-    component render happens in the request.
+    Any component's ``.render()`` already attaches these automatically; reach
+    for this only when no component render happens in the request. The instance
+    IS the resulting markup, so return it directly as the response body.
     """
-    return _finish_with_oob(html)
+
+    def __new__(cls, html: str | Markup = "") -> "ReactiveResponse":
+        return super().__new__(cls, _finish_with_oob(html))

--- a/tests/integration/test_oob_nonreactive.py
+++ b/tests/integration/test_oob_nonreactive.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from pyjinhx import setup
 from pyjinhx.client import PJX_MOUNTED_HEADER
 from pyjinhx.mutations import MutationTracker
+from pyjinhx.reactive import ReactiveResponse
 from pyjinhx.renderer import Renderer
 from tests.ui.reactive import store
 from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401 (registers)
@@ -33,6 +34,13 @@ def _app() -> FastAPI:
         MutationTracker.record(("todos",))
         return str(ReactiveCounter.render())
 
+    @app.post("/dismiss", response_class=HTMLResponse)
+    def dismiss():
+        # Renders no component; ReactiveResponse fans out the dependents OOB.
+        store.state["remaining"] = 7
+        MutationTracker.record(("todos",))
+        return str(ReactiveResponse("<p>no component here</p>"))
+
     return app
 
 
@@ -57,3 +65,15 @@ def test_reactive_response_emits_single_swap_set():
     body = resp.text
     assert "7 left" in body
     assert "outerHTML:[data-pjx-id='counter']" not in body
+
+
+def test_dismiss_keeps_primary_and_appends_single_swap_set():
+    Renderer.set_default_environment(REPO_ROOT)
+    manifest = json.dumps([{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}])
+    with TestClient(_app()) as client:
+        resp = client.post("/dismiss", headers={PJX_MOUNTED_HEADER: manifest})
+    body = resp.text
+    assert resp.status_code == 200
+    assert "<p>no component here</p>" in body
+    assert "7 left" in body
+    assert body.count("outerHTML:[data-pjx-id='counter']") == 1

--- a/tests/unit/test_finish_with_oob.py
+++ b/tests/unit/test_finish_with_oob.py
@@ -94,16 +94,59 @@ def test_base_render_unchanged_without_backend():
 
 
 def test_reactive_response_fans_out_for_raw_string():
-    from pyjinhx.reactive import reactive_response
+    from pyjinhx.reactive import ReactiveResponse
 
     store.state["remaining"] = 9
     manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
     with reactive_client(manifest):
         record_mutation("todos")
-        out = str(reactive_response("<p>no component here</p>"))
+        out = str(ReactiveResponse("<p>no component here</p>"))
     assert "<p>no component here</p>" in out
     assert "outerHTML:[data-pjx-id='counter']" in out
     assert "9 left" in out
+
+
+def test_reactive_response_no_arg_fans_out():
+    from pyjinhx.reactive import ReactiveResponse
+
+    store.state["remaining"] = 5
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(ReactiveResponse())
+    assert "outerHTML:[data-pjx-id='counter']" in out
+    assert "5 left" in out
+
+
+def test_reactive_response_passthrough_without_backend():
+    from pyjinhx.reactive import ReactiveResponse
+
+    record_mutation("todos")
+    out = ReactiveResponse("<p>x</p>")
+    assert out == "<p>x</p>"
+
+
+def test_reactive_response_is_str_and_markup():
+    from markupsafe import Markup
+
+    from pyjinhx.reactive import ReactiveResponse
+
+    out = ReactiveResponse()
+    assert isinstance(out, str)
+    assert isinstance(out, Markup)
+
+
+def test_reactive_response_emits_once_per_scope():
+    from pyjinhx.reactive import ReactiveResponse
+
+    store.state["remaining"] = 1
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        first = str(ReactiveResponse("<div>a</div>"))
+        second = str(ReactiveResponse("<div>b</div>"))
+    assert "outerHTML:[data-pjx-id='counter']" in first
+    assert second == "<div>b</div>"
 
 
 def test_class_render_does_not_double_invalidate(monkeypatch):

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -77,4 +77,4 @@ def test_internals_remain_importable_from_submodules():
     from pyjinhx.config import configure_pyjinhx, shutdown_pyjinhx  # noqa: F401
     from pyjinhx.dev import dependency_graph, enable_reactive_dev  # noqa: F401
     from pyjinhx.integrations.fastapi import FastAPIClientBackend  # noqa: F401
-    from pyjinhx.reactive import oob_swaps, reactive_response  # noqa: F401
+    from pyjinhx.reactive import ReactiveResponse, oob_swaps  # noqa: F401


### PR DESCRIPTION
Replaces the `reactive_response(html)` function with an instantiable `ReactiveResponse` class, aligned with FastAPI's response-class idiom — without coupling to FastAPI — and dropping the dummy `""` for the common no-primary case.

Before:
```python
from pyjinhx.reactive import reactive_response
return reactive_response("")        # dummy "" required
```
After:
```python
from pyjinhx.reactive import ReactiveResponse
return ReactiveResponse()           # no argument needed
```

## What it does
- **`ReactiveResponse(Markup)`** — a `Markup` (str) subclass whose instances ARE the fanned-out markup. `__new__(cls, html: str | Markup = "")` computes the fan-out once via the existing `_finish_with_oob(html)`. Because the instance is the resulting `Markup`, it returns from an endpoint as the body exactly like the old function's return value — no FastAPI coupling, no `__init__` (Markup is immutable).
- Semantics/side-effects unchanged: once-per-scope guard, excludes already-mounted ids, passthrough outside a client scope / with no pending mutations.
- **Removed** the `reactive_response` function (pre-1.0, clean replace, no alias).

## Tests
`tests/unit/test_finish_with_oob.py` and `tests/integration/test_oob_nonreactive.py` ported + extended: no-arg fan-out, primary kept + single swap set, passthrough-without-backend equality, `isinstance` str+Markup, once-per-scope guard. `test_public_api.py` import probe updated. `docs/reactivity.md` + `docs/migration.md` updated. Full suite green (667 passed); `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)