### PR TITLE
ReactiveResponse: accept mutation keys (dirty + fan out in one call)

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -35,8 +35,13 @@ def generate():
 Fan-out happens once per request scope and never double-swaps a region already
 present in the response body. For a response that renders no component (a raw
 string, a `204`), use `from pyjinhx.reactive import ReactiveResponse`. The old
-function `reactive_response(html)` is now the class `ReactiveResponse(html)`,
-and the dummy `""` is no longer needed — `ReactiveResponse()` works.
+function `reactive_response(html)` is now the class `ReactiveResponse`, and the
+dummy `""` is no longer needed — `ReactiveResponse()` works.
+
+`ReactiveResponse`'s `html` is now **keyword-only** — pass it as
+`ReactiveResponse(html="<p>…</p>")`, not positionally. The positional slots now
+take mutation keys, so you can dirty and fan out in one call:
+`ReactiveResponse(Keys.TODOS)` (or `ReactiveResponse(Keys.TODOS, html="<p>…</p>")`).
 
 ## 0.11 → 0.12 (breaking: `PJX` prefix on all builtins)
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -194,6 +194,19 @@ def dismiss():
     return ReactiveResponse()           # no primary; dependents still fan out OOB
 ```
 
+`ReactiveResponse` can also dirty keys and fan out in one call — pass the
+mutation keys positionally, folding the `dirty()` into the response:
+
+```python
+@app.post("/dismiss")
+def dismiss():
+    controller.dismiss()                # plain mutation, no @mutates
+    return ReactiveResponse(Keys.TODOS) # dirty TODOS + fan out dependents OOB
+```
+
+Pass `html=` for a primary body alongside the keys, e.g.
+`ReactiveResponse(Keys.TODOS, html="<p>dismissed</p>")`.
+
 !!! note "Without ClientBackend"
     Wire `ClientBackend` in middleware (via `setup()`) so `render()` reads manifest and asset headers automatically. Without a backend, reactive OOB is skipped when mutations are pending.
 

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -29,7 +29,7 @@ from .cache import LoadCache
 from .client import ClientBackend, MountedManifest
 from .dev import warn_reactive_render_without_client
 from .keys import MutationKey, ReactiveKey, coerce_load_key_str, coerce_reactive_keys
-from .mutations import MutationTracker
+from .mutations import MutationTracker, _require_mutation_keys
 
 
 class PjxKey:
@@ -524,7 +524,12 @@ class ReactiveResponse(Markup):
     Any component's ``.render()`` already attaches these automatically; reach
     for this only when no component render happens in the request. The instance
     IS the resulting markup, so return it directly as the response body.
+
+    Pass mutation keys positionally to dirty them and fan out in one call, e.g.
+    ``ReactiveResponse(Keys.TODOS)`` — no separate ``dirty()``/``@mutates`` needed.
     """
 
-    def __new__(cls, html: str | Markup = "") -> "ReactiveResponse":
+    def __new__(cls, *keys: MutationKey, html: str | Markup = "") -> "ReactiveResponse":
+        _require_mutation_keys(keys, "ReactiveResponse()")
+        MutationTracker.record(keys)  # no-op when keys is empty
         return super().__new__(cls, _finish_with_oob(html))

--- a/tests/integration/test_oob_nonreactive.py
+++ b/tests/integration/test_oob_nonreactive.py
@@ -39,7 +39,7 @@ def _app() -> FastAPI:
         # Renders no component; ReactiveResponse fans out the dependents OOB.
         store.state["remaining"] = 7
         MutationTracker.record(("todos",))
-        return str(ReactiveResponse("<p>no component here</p>"))
+        return str(ReactiveResponse(html="<p>no component here</p>"))
 
     return app
 

--- a/tests/unit/test_finish_with_oob.py
+++ b/tests/unit/test_finish_with_oob.py
@@ -100,7 +100,7 @@ def test_reactive_response_fans_out_for_raw_string():
     manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
     with reactive_client(manifest):
         record_mutation("todos")
-        out = str(ReactiveResponse("<p>no component here</p>"))
+        out = str(ReactiveResponse(html="<p>no component here</p>"))
     assert "<p>no component here</p>" in out
     assert "outerHTML:[data-pjx-id='counter']" in out
     assert "9 left" in out
@@ -122,7 +122,7 @@ def test_reactive_response_passthrough_without_backend():
     from pyjinhx.reactive import ReactiveResponse
 
     record_mutation("todos")
-    out = ReactiveResponse("<p>x</p>")
+    out = ReactiveResponse(html="<p>x</p>")
     assert out == "<p>x</p>"
 
 
@@ -143,10 +143,99 @@ def test_reactive_response_emits_once_per_scope():
     manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
     with reactive_client(manifest):
         record_mutation("todos")
-        first = str(ReactiveResponse("<div>a</div>"))
-        second = str(ReactiveResponse("<div>b</div>"))
+        first = str(ReactiveResponse(html="<div>a</div>"))
+        second = str(ReactiveResponse(html="<div>b</div>"))
     assert "outerHTML:[data-pjx-id='counter']" in first
     assert second == "<div>b</div>"
+
+
+def test_reactive_response_key_dirties_and_fans_out():
+    from pyjinhx.mutations import MutationTracker
+    from pyjinhx.reactive import ReactiveResponse
+    from tests.reactive_test_support import Keys
+
+    # No client scope: record() runs but the fan-out (which would consume the
+    # pending set) is a no-op, so we can observe the dirtied key directly.
+    ReactiveResponse(Keys.TODOS)
+    assert "todos" in MutationTracker.pending()
+
+    store.state["remaining"] = 6
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    with reactive_client(manifest):
+        out = str(ReactiveResponse(Keys.TODOS))
+    assert "outerHTML:[data-pjx-id='counter']" in out
+    assert "6 left" in out
+
+
+def test_reactive_response_records_multiple_keys():
+    from pyjinhx import MutationKey
+    from pyjinhx.mutations import MutationTracker
+    from pyjinhx.reactive import ReactiveResponse
+    from tests.reactive_test_support import Keys
+
+    class OtherKeys(MutationKey):
+        QUOTA = "quota"
+
+    ReactiveResponse(Keys.TODOS, OtherKeys.QUOTA)
+    assert MutationTracker.pending() == {"todos", "quota"}
+
+
+def test_reactive_response_html_keyword_keeps_primary_and_fans_out():
+    from pyjinhx.reactive import ReactiveResponse
+
+    store.state["remaining"] = 8
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    with reactive_client(manifest):
+        record_mutation("todos")
+        out = str(ReactiveResponse(html="<p>x</p>"))
+    assert "<p>x</p>" in out
+    assert "outerHTML:[data-pjx-id='counter']" in out
+    assert "8 left" in out
+
+
+def test_reactive_response_key_and_html():
+    from pyjinhx.reactive import ReactiveResponse
+    from tests.reactive_test_support import Keys
+
+    store.state["remaining"] = 8
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    with reactive_client(manifest):
+        out = str(ReactiveResponse(Keys.TODOS, html="<p>x</p>"))
+    assert "<p>x</p>" in out
+    assert out.count("outerHTML:[data-pjx-id='counter']") == 1
+    assert "8 left" in out
+
+
+def test_reactive_response_bare_string_positional_raises():
+    import pytest
+
+    from pyjinhx.reactive import ReactiveResponse
+
+    with pytest.raises(TypeError) as exc:
+        ReactiveResponse("<p>oops</p>")
+    assert str(exc.value).startswith("ReactiveResponse()")
+
+
+def test_reactive_response_record_invalidates_load_cache(monkeypatch):
+    from pyjinhx import cache as cache_mod
+    from pyjinhx.reactive import ReactiveResponse
+    from tests.reactive_test_support import Keys
+
+    calls = []
+    original = cache_mod.LoadCache.invalidate
+
+    def counting_invalidate(keys):
+        calls.append(set(keys))
+        return original(keys)
+
+    monkeypatch.setattr(cache_mod.LoadCache, "invalidate", counting_invalidate)
+
+    store.state["remaining"] = 2
+    manifest = [{"id": "counter", "type": "ReactiveCounter", "hash": "stale"}]
+    with reactive_client(manifest):
+        str(ReactiveResponse(Keys.TODOS))
+
+    assert any("todos" in keys for keys in calls)
 
 
 def test_class_render_does_not_double_invalidate(monkeypatch):


### PR DESCRIPTION
Lets `ReactiveResponse` take `MutationKey`s as positional arguments so it dirties them and fans out the OOB swaps in a single call — no separate `dirty()`/`@mutates` needed for the no-component response.

```python
return ReactiveResponse(Keys.TODOS, Keys.QUOTA)   # dirties both, fans out OOB
```

## What it does
- New signature: `__new__(cls, *keys: MutationKey, html: str | Markup = "")`. Order: validate keys → `MutationTracker.record(keys)` (dirty + cache-invalidate, no-op when empty) → `_finish_with_oob(html)`, so the pending set includes the new keys before fan-out reads it.
- Strict `MutationKey`-only, reusing the shared `_require_mutation_keys(keys, "ReactiveResponse()")` helper (bare string → `TypeError`). Multiple keys via the variadic form.
- `ReactiveResponse()` unchanged (no-op record; fans out already-pending). `dirty()` stays for the component-render path.

## Breaking change
`html` is now **keyword-only**: `ReactiveResponse(html="<p>…</p>")` (was positional). `ReactiveResponse` only shipped in 0.16.0 (today), pre-1.0. All call sites + docs updated; `docs/migration.md` notes it.

## Tests
`tests/unit/test_finish_with_oob.py` + `tests/integration/test_oob_nonreactive.py`: single-key dirty+fan-out, multi-key record, `html=` primary+fan-out, key+html combined single swap set, bare-string positional `TypeError`, load-cache invalidation, plus existing guarantees (isinstance str/Markup, once-per-scope). Positional-`html` usages migrated to `html=`. Full suite green (673 passed); `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)