### PR TITLE
docs: document component() factory

### DIFF
--- a/docs/api/base-component.md
+++ b/docs/api/base-component.md
@@ -46,6 +46,31 @@ Enables cleaner template syntax: `{{ component }}` instead of `{{ component.rend
 
 **Returns:** The rendered HTML as a Markup object.
 
+## component
+
+```python
+def component(name: str) -> type[BaseComponent]
+```
+
+Reference an **html-only** component — a template that has no hand-written Python class — from Python. Returns a `BaseComponent` subclass bound to that template, so you can instantiate, nest, and render it like any declared component.
+
+```python
+from pyjinhx import component
+
+Card = component("Card")                  # finds card.html under the default environment
+Card(title="Hi", content="body").render()
+```
+
+The template is resolved by **scanning the default environment** by tag name (`card.html`/`card.jinja`), the same lookup used for `<Card/>` tags in templates — so set the default environment first (e.g. `setup(components_root=...)` or `Renderer.set_default_environment(...)`). Resolution is lazy: `component("Card")` works even before the environment is set; the template is located at render time.
+
+Arbitrary attributes are accepted (`extra="allow"`) and children map to the `content` slot, e.g. `component("Card")(title="Hi", content="body")`.
+
+- **`name`** must be PascalCase (so it round-trips as `<Name/>` in templates) — otherwise `ValueError`.
+- **Idempotent and non-shadowing:** if a class is already registered under `name` (previously synthesized, or a real declared component), that class is returned — `component("Card")` twice returns the same object, and it never replaces a declared component.
+- A missing template raises `FileNotFoundError` at render time.
+
+Because the returned class is registered, it also resolves as `<Card/>` inside other templates.
+
 ## NestedComponentWrapper
 
 A wrapper for nested components. Enables access to the component's properties and rendered HTML.

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -86,6 +86,27 @@ component base per class — a definition-time `TypeError` is raised if two comp
 appear in `__bases__`. Framework bases (`ReactiveComponent`) don't count toward that
 limit, so `class LiveBadge(ReactiveComponent, PJXBadge, react={...})` is valid.
 
+## HTML-only components
+
+A component doesn't always need a Python class. If you have a template with no
+behaviour or typed fields — just markup — you can reference it from Python with
+the `component()` factory instead of hand-writing a `BaseComponent` subclass:
+
+```python
+from pyjinhx import component
+
+Card = component("Card")                   # finds card.html under the default environment
+Card(title="Hi", content="body").render()
+```
+
+`component("Card")` returns a registered `BaseComponent` subclass bound to
+`card.html`, resolved by scanning the default environment (set it via
+`setup(components_root=...)` or `Renderer.set_default_environment(...)`). The
+result is a first-class component: instantiate it, pass it as a field of another
+component, or use `<Card/>` in a template — they all resolve to the same class.
+It's idempotent and never shadows a component you've actually declared. See
+[`component()`](../api/base-component.md#component).
+
 ## Extra Fields
 
 A plain Pydantic `BaseModel` rejects unknown fields with a `ValidationError`. With `BaseComponent`, **extra fields are accepted and available in the template context**. This allows you to pass dictionaries or data objects with additional fields without raising validation errors.


### PR DESCRIPTION
Closes a docs gap: the `component()` factory shipped in 0.16.0 (#82) with no user-facing documentation. The other recent additions (`setup` roots, `dirty()`, `ReactiveResponse`) were already documented.

## Changes
- **`docs/api/base-component.md`** — new `## component` API reference: signature, default-env tag-scan resolution (lazy), PascalCase requirement (`ValueError`), idempotent/non-shadowing behavior, missing-template `FileNotFoundError`, and that the returned class also resolves as `<Name/>` in templates.
- **`docs/guide/components.md`** — new "HTML-only components" section after Template Discovery, with an example and a cross-link to the API reference.

Verified `mkdocs build --strict` passes (anchors/links resolve). Docs-only — no release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)