### PR TITLE
fix(reactive): deliver INLINE assets to OOB swap-in components (#96)

### DIFF
--- a/pyjinhx/assets.py
+++ b/pyjinhx/assets.py
@@ -174,8 +174,9 @@ def normalize_asset_path(path: str) -> str:
 
 
 def asset_token(path: str) -> str:
-    """Stable dedup token for an asset = its normalized path."""
-    return normalize_asset_path(path)
+    """Stable opaque dedup token for an asset (hash of its normalized path)."""
+    normalized = normalize_asset_path(path)
+    return hashlib.sha1(normalized.encode("utf-8")).hexdigest()[:16]
 
 
 def should_emit_asset(

--- a/pyjinhx/assets.py
+++ b/pyjinhx/assets.py
@@ -173,6 +173,19 @@ def normalize_asset_path(path: str) -> str:
     return os.path.normpath(path).replace("\\", "/")
 
 
+def asset_token(path: str) -> str:
+    """Stable dedup token for an asset = its normalized path."""
+    return normalize_asset_path(path)
+
+
+def should_emit_asset(
+    token: str, loaded: frozenset[str], *, dedup_enabled: bool
+) -> bool:
+    if not dedup_enabled:
+        return True
+    return token not in loaded
+
+
 def register_asset(
     session: RenderSession,
     path: str,
@@ -273,22 +286,64 @@ def inject_runtime(
     if MountedManifest.is_present(client):
         return
     if policy.js_mode == AssetMode.INLINE:
+        rt_path = runtime_asset_path()
         session.scripts.insert(0, read_client_runtime())
+        session.assets.insert(0, CollectedAsset(path=rt_path, kind="js"))
+        session.collected_paths.add(normalize_asset_path(rt_path))
     session.runtime_injected = True
     if request_injected is not None:
         _runtime_injected.set(True)
 
 
+def _inline_items(
+    session: RenderSession, kind: AssetKind
+) -> list[tuple[CollectedAsset, str]]:
+    """Return (asset, content) pairs for all INLINE assets of ``kind``, in order."""
+    payloads = session.scripts if kind == "js" else session.styles
+    assets = [a for a in session.assets if a.kind == kind]
+    return list(zip(assets, payloads))
+
+
 def render_assets(session: RenderSession, kind: AssetKind, *, policy: AssetPolicy) -> str:
     mode = policy.mode(kind)
     if mode == AssetMode.INLINE:
-        items = session.scripts if kind == "js" else session.styles
+        items = _inline_items(session, kind)
         if not items:
             return ""
         if kind == "js":
-            return "\n".join(f"<script>{script}</script>" for script in items)
-        return "\n".join(f"<style>{style}</style>" for style in items)
+            return "\n".join(
+                f'<script data-pjx-asset="{asset_token(asset.path)}">{content}</script>'
+                for asset, content in items
+            )
+        return "\n".join(
+            f'<style data-pjx-asset="{asset_token(asset.path)}">{content}</style>'
+            for asset, content in items
+        )
     return ""
+
+
+def render_missing_assets_oob(
+    session: RenderSession, loaded: frozenset[str]
+) -> str:
+    """
+    Build an OOB head-injection for INLINE assets not yet in the client's page.
+
+    Returns an empty string when nothing needs to be injected.
+    """
+    parts: list[str] = []
+    for asset, content in _inline_items(session, "css"):
+        token = asset_token(asset.path)
+        if should_emit_asset(token, loaded, dedup_enabled=True):
+            parts.append(
+                f'<style data-pjx-asset="{token}" hx-swap-oob="beforeend:head">{content}</style>'
+            )
+    for asset, content in _inline_items(session, "js"):
+        token = asset_token(asset.path)
+        if should_emit_asset(token, loaded, dedup_enabled=True):
+            parts.append(
+                f'<script data-pjx-asset="{token}" hx-swap-oob="beforeend:head">{content}</script>'
+            )
+    return "\n".join(parts)
 
 
 def apply_component_render_assets(

--- a/pyjinhx/client.py
+++ b/pyjinhx/client.py
@@ -58,6 +58,41 @@ PJX_MOUNTED_HEADER = "X-PJX-Mounted"
 PJX_TRIGGER_HEADER = "X-PJX-Trigger"
 """Name of the HTTP header carrying the data-pjx-id of the element that started the request."""
 
+PJX_ASSETS_HEADER = "X-PJX-Assets"
+"""Name of the HTTP header carrying the client's already-loaded asset token set."""
+
+
+class LoadedAssets:
+    @staticmethod
+    def parse(client: str | list[str] | object | None) -> frozenset[str]:
+        """
+        Parse ``X-PJX-Assets`` off *client* and return a frozenset of token strings.
+
+        *client* may be a raw JSON string, a pre-parsed list, a request-like
+        object with a ``.headers`` mapping, or ``None`` / empty string — all
+        yield an empty frozenset gracefully.
+        """
+        if client is None or client == "":
+            return frozenset()
+        if isinstance(client, list):
+            return frozenset(str(t) for t in client)
+        if isinstance(client, str):
+            try:
+                parsed = json.loads(client)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Could not parse %s as JSON; ignoring.", PJX_ASSETS_HEADER
+                )
+                return frozenset()
+            if isinstance(parsed, list):
+                return frozenset(str(t) for t in parsed)
+            return frozenset()
+        try:
+            header_value = client.headers.get(PJX_ASSETS_HEADER)  # type: ignore[attr-defined]
+        except AttributeError:
+            return frozenset()
+        return LoadedAssets.parse(header_value)
+
 
 class MountedManifest:
     @staticmethod

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -25,7 +25,7 @@ from pyjinhx.utils import (
     stamp_root_attributes,
 )
 
-from .assets import RenderSession, render_missing_assets_oob
+from .assets import render_missing_assets_oob
 from .cache import LoadCache
 from .client import ClientBackend, LoadedAssets, MountedManifest
 from .dev import warn_reactive_render_without_client

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -25,8 +25,9 @@ from pyjinhx.utils import (
     stamp_root_attributes,
 )
 
+from .assets import RenderSession, render_missing_assets_oob
 from .cache import LoadCache
-from .client import ClientBackend, MountedManifest
+from .client import ClientBackend, LoadedAssets, MountedManifest
 from .dev import warn_reactive_render_without_client
 from .keys import MutationKey, ReactiveKey, coerce_load_key_str, coerce_reactive_keys
 from .mutations import MutationTracker, _require_mutation_keys
@@ -397,6 +398,9 @@ def oob_swaps(
 
     classes = Registry.get_classes()
     renderer = Renderer.get_default_renderer()
+    # Shared session accumulates assets across all swapped regions so we can
+    # emit a single deduplicated OOB head injection at the end.
+    shared_session = renderer.new_session()
 
     candidates: list[_Candidate] = []
     seen: set[tuple[str, str | None]] = set()
@@ -452,7 +456,9 @@ def oob_swaps(
         fresh_hash = instance.state_hash()
         if fresh_hash == reported_hash:
             continue
-        html = str(instance._render(_renderer=renderer, emit_assets=False))
+        # Pass shared_session so assets are collected (is_root=False → no inline
+        # injection into the fragment HTML, but collect_component_asset still runs).
+        html = str(instance._render(_renderer=renderer, _session=shared_session))
         candidates.append(
             _Candidate(
                 id=component_id,
@@ -478,7 +484,10 @@ def oob_swaps(
                     candidate.html, {"hx-swap-oob": _oob_swap_selector(candidate.id)}
                 )
             )
-    return Markup("\n".join(fragments))
+
+    loaded = LoadedAssets.parse(ClientBackend.current())
+    head = render_missing_assets_oob(shared_session, loaded)
+    return Markup("\n".join(fragments) + (("\n" + head) if head else ""))
 
 
 _PJX_ID_RE = re.compile(r'data-pjx-id="([^"]*)"')

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -213,7 +213,7 @@
       function (el) {
         var token = el.getAttribute('data-pjx-asset');
         if (pjxExecutedTokens[token]) {
-          return; // already executed or duplicated; remove the inert copy
+          return; // already executed; skip
         }
         pjxExecutedTokens[token] = true;
         var fresh = document.createElement('script');

--- a/pyjinhx/runtime/pjx.js
+++ b/pyjinhx/runtime/pjx.js
@@ -29,17 +29,12 @@
   }
 
   function pjxLoadedAssets() {
-    var urls = [];
+    var tokens = [];
     Array.prototype.forEach.call(
-      document.querySelectorAll('script[src], link[rel="stylesheet"][href]'),
-      function (el) {
-        var url = el.src || el.href;
-        if (url) {
-          urls.push(url);
-        }
-      }
+      document.querySelectorAll('[data-pjx-asset]'),
+      function (el) { tokens.push(el.getAttribute('data-pjx-asset')); }
     );
-    return urls;
+    return tokens;
   }
 
   document.body.addEventListener("htmx:configRequest", function (evt) {
@@ -207,6 +202,32 @@
     });
   }
 
+  // Re-execute <script data-pjx-asset> nodes injected into <head> via
+  // hx-swap-oob="beforeend:head".  Browsers do not run scripts inserted as
+  // parsed HTML, so we clone each one as a fresh <script> node.  The guard
+  // prevents double-execution when the same token arrives more than once.
+  var pjxExecutedTokens = {};
+  function pjxReexecHeadScripts() {
+    Array.prototype.forEach.call(
+      document.head.querySelectorAll('script[data-pjx-asset]'),
+      function (el) {
+        var token = el.getAttribute('data-pjx-asset');
+        if (pjxExecutedTokens[token]) {
+          return; // already executed or duplicated; remove the inert copy
+        }
+        pjxExecutedTokens[token] = true;
+        var fresh = document.createElement('script');
+        if (el.src) {
+          fresh.src = el.src;
+        } else {
+          fresh.textContent = el.textContent;
+        }
+        fresh.setAttribute('data-pjx-asset', token);
+        el.parentNode.replaceChild(fresh, el);
+      }
+    );
+  }
+
   pjxInjectStyle();
   document.body.addEventListener("htmx:beforeRequest", pjxBeginLoading);
   document.body.addEventListener("htmx:afterSettle", pjxReapplyLoading);
@@ -215,4 +236,6 @@
   document.body.addEventListener("htmx:timeout", pjxEndLoading);
   document.body.addEventListener("htmx:sendError", pjxEndLoading);
   document.body.addEventListener("htmx:abort", pjxEndLoading);
+  document.body.addEventListener("htmx:oobAfterSwap", pjxReexecHeadScripts);
+  document.body.addEventListener("htmx:afterSwap", pjxReexecHeadScripts);
 })();

--- a/tests/reactivity/test_head_inject_assets.py
+++ b/tests/reactivity/test_head_inject_assets.py
@@ -1,0 +1,205 @@
+"""Browser contracts for head-injection of missing INLINE assets on reactive OOB swaps.
+
+Verifies that:
+1. CSS injected into <head> via hx-swap-oob actually styles content (no FOUC).
+2. JS injected into <head> via hx-swap-oob actually executes in the browser.
+3. Duplicate tokens are NOT re-injected (idempotency guard).
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import Page, expect  # noqa: E402
+
+pytestmark = [pytest.mark.pjx_runtime, pytest.mark.reactivity]
+
+# ---------------------------------------------------------------------------
+# Minimal swap app
+# ---------------------------------------------------------------------------
+
+_BADGE_TEMPLATE = '<span id="{{ id }}" class="swap-badge">{{ count }}</span>'
+
+_PAGE_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js"
+        integrity="sha384-/TgkGk7p307TH7EXJDuUlgG3Ce1UVolAOFopFekQkkXihi5u/6OCvVKyz1W+idaz"
+        crossorigin="anonymous"></script>
+</head>
+<body>
+{badge_markup}
+<button id="inc-btn" hx-post="/increment" hx-swap="none" hx-trigger="click">Inc</button>
+</body>
+</html>"""
+
+
+def _make_swap_app(tmp_path: Path) -> object:
+    """Build a minimal FastAPI app that serves a reactive component with CSS/JS."""
+    from fastapi import FastAPI, Request
+    from fastapi.responses import HTMLResponse
+
+    from pyjinhx import MutationKey, PjxSettings, ReactiveComponent, setup
+
+    # --------------- assets -----------------------------------------------
+    css_path = tmp_path / "swap-badge.css"
+    js_path = tmp_path / "swap-badge.js"
+    css_path.write_text(
+        ".swap-badge { color: rgb(255, 0, 0); font-weight: bold; }"
+    )
+    js_path.write_text(
+        "window.__pjxHeadInjectRan = (window.__pjxHeadInjectRan || 0) + 1;"
+    )
+
+    # --------------- mutation key -----------------------------------------
+    class BadgeKey(MutationKey):
+        BADGE = "badge"
+
+    # --------------- component --------------------------------------------
+    class SwapBadge(
+        ReactiveComponent,
+        react={BadgeKey.BADGE},
+        pjx_replace=True,
+    ):
+        count: int = 0
+
+        def render(self) -> str:  # type: ignore[override]
+            return str(self._render(source=_BADGE_TEMPLATE))
+
+        @classmethod
+        def load(cls) -> "SwapBadge":  # type: ignore[override]
+            return cls(
+                id="swap-badge",
+                count=0,
+                css=[str(css_path)],
+                js=[str(js_path)],
+            )
+
+    # --------------- app --------------------------------------------------
+    app = FastAPI()
+    setup(app, settings=PjxSettings())
+
+    @app.get("/healthz")
+    def healthz() -> str:
+        return "ok"
+
+    @app.get("/", response_class=HTMLResponse)
+    def index() -> str:
+        badge = SwapBadge(
+            id="swap-badge", count=0, css=[str(css_path)], js=[str(js_path)]
+        )
+        return _PAGE_HTML.format(badge_markup=badge.render())
+
+    @app.post("/increment", response_class=HTMLResponse)
+    async def increment(request: Request) -> str:
+        from pyjinhx.client import ClientBackend
+        from pyjinhx.integrations.fastapi import FastAPIClientBackend
+        from pyjinhx.reactive import oob_swaps
+
+        backend = FastAPIClientBackend(request)
+        manifest_str = request.headers.get("X-PJX-Mounted", "[]")
+        manifest = json.loads(manifest_str)
+
+        with ClientBackend.scope(backend):
+            return str(oob_swaps({BadgeKey.BADGE}, manifest))
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped server fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def swap_server(tmp_path_factory):
+    import uvicorn
+
+    tmp_path = tmp_path_factory.mktemp("swap_app")
+    app = _make_swap_app(tmp_path)
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, name="swap-app", daemon=True)
+    thread.start()
+
+    url = f"http://127.0.0.1:{port}"
+    deadline = time.monotonic() + 15
+    while True:
+        try:
+            httpx.get(f"{url}/healthz", timeout=1)
+            break
+        except httpx.HTTPError:
+            if time.monotonic() > deadline:
+                raise RuntimeError("swap test app did not come up within 15s")
+            time.sleep(0.05)
+
+    yield url
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+@pytest.fixture
+def swap_page(page: Page, swap_server: str) -> Page:
+    page.goto(f"{swap_server}/")
+    return page
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_head_injected_css_styles_swapped_content(swap_page: Page) -> None:
+    """CSS OOB-injected into <head> must actually style the swapped element."""
+    badge = swap_page.locator("#swap-badge")
+    expect(badge).to_be_visible()
+
+    # Click the button → htmx POSTs /increment → server sends OOB assets
+    swap_page.click("#inc-btn")
+    swap_page.wait_for_timeout(800)
+
+    # The OOB style should now be in <head>; computed color must be red
+    color = swap_page.evaluate(
+        "getComputedStyle(document.querySelector('#swap-badge')).color"
+    )
+    assert color == "rgb(255, 0, 0)", f"Expected red, got {color!r}"
+
+
+def test_head_injected_script_executes(swap_page: Page) -> None:
+    """<script> OOB-injected into <head> must execute in the browser."""
+    swap_page.click("#inc-btn")
+    swap_page.wait_for_timeout(800)
+
+    ran = swap_page.evaluate("window.__pjxHeadInjectRan")
+    assert ran and ran >= 1, f"Expected JS to have run at least once, got {ran!r}"
+
+
+def test_head_injected_assets_are_idempotent(swap_page: Page) -> None:
+    """Clicking twice must not re-run the injected <script>."""
+    swap_page.click("#inc-btn")
+    swap_page.wait_for_timeout(800)
+    first_run = swap_page.evaluate("window.__pjxHeadInjectRan")
+
+    swap_page.click("#inc-btn")
+    swap_page.wait_for_timeout(800)
+    second_run = swap_page.evaluate("window.__pjxHeadInjectRan")
+
+    assert first_run == second_run, (
+        f"JS re-executed on second swap: ran {first_run} then {second_run} times"
+    )

--- a/tests/unit/test_basic_rendering.py
+++ b/tests/unit/test_basic_rendering.py
@@ -1,10 +1,18 @@
+import os
+
 import pytest
 from markupsafe import Markup
 
+from pyjinhx.assets import asset_token
+from pyjinhx.finder import Finder
 from tests.ui.unified_component import UnifiedComponent
 
-CSS = "<style>.test-component { color: red; }\n</style>\n"
-JS = "\n<script>console.log('Button loaded');</script>"
+_UI_DIR = Finder.get_class_directory(UnifiedComponent)
+_CSS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.css"))
+_JS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.js"))
+
+CSS = f'<style data-pjx-asset="{_CSS_TOKEN}">.test-component {{ color: red; }}\n</style>\n'
+JS = f'\n<script data-pjx-asset="{_JS_TOKEN}">console.log(\'Button loaded\');</script>'
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_classless_component_assets.py
+++ b/tests/unit/test_classless_component_assets.py
@@ -112,7 +112,7 @@ def test_classless_component_css_injected_before_html():
 
         rendered = renderer.render('<NavBar id="nav1">Menu</NavBar>')
 
-        style_pos = rendered.find("<style>")
+        style_pos = rendered.find("<style")
         nav_pos = rendered.find("<nav")
         assert style_pos != -1
         assert style_pos < nav_pos, "CSS <style> block should precede the HTML"
@@ -134,7 +134,7 @@ def test_classless_component_js_injected_after_html():
         rendered = renderer.render('<SideBar id="s1">Links</SideBar>')
 
         aside_pos = rendered.find("<aside")
-        script_pos = rendered.find("<script>")
+        script_pos = rendered.find("<script")
         assert script_pos != -1
         assert aside_pos < script_pos, "JS <script> block should follow the HTML"
 
@@ -152,6 +152,6 @@ def test_classless_component_no_assets_no_injection():
 
         rendered = renderer.render('<BareBlock id="p1">Words</BareBlock>')
 
-        assert "<script>" not in rendered
-        assert "<style>" not in rendered
+        assert "<script" not in rendered
+        assert "<style" not in rendered
         assert '<p id="p1">Words</p>' in rendered

--- a/tests/unit/test_client_asset_manifest.py
+++ b/tests/unit/test_client_asset_manifest.py
@@ -6,7 +6,8 @@ from tests.ui.reactive.reactive_counter import ReactiveCounter
 def test_runtime_source_reports_assets_header():
     source = read_client_runtime()
     assert "X-PJX-Assets" in source
-    assert 'link[rel="stylesheet"][href]' in source
+    # Token-based dedup: runtime reports data-pjx-asset tokens, not stylesheet URLs
+    assert "data-pjx-asset" in source
 
 
 def test_oob_swaps_emit_missing_assets():

--- a/tests/unit/test_client_asset_manifest.py
+++ b/tests/unit/test_client_asset_manifest.py
@@ -9,9 +9,11 @@ def test_runtime_source_reports_assets_header():
     assert 'link[rel="stylesheet"][href]' in source
 
 
-def test_oob_swaps_emit_no_assets():
+def test_oob_swaps_emit_missing_assets():
+    """ReactiveCounter carries no CSS/JS so no OOB asset head-injection is added."""
     manifest = [{"id": "counter", "type": ReactiveCounter.__name__, "hash": "stale"}]
     rendered = str(oob_swaps({"todos"}, manifest))
 
     assert "<link" not in rendered
-    assert "<script" not in rendered
+    # no asset OOB injection (component has no CSS/JS)
+    assert 'hx-swap-oob="beforeend:head"' not in rendered

--- a/tests/unit/test_client_runtime.py
+++ b/tests/unit/test_client_runtime.py
@@ -16,6 +16,11 @@ def test_runtime_source_reports_manifest_header():
     assert "data-pjx-id" in source
 
 
+def test_runtime_reports_asset_tokens():
+    source = read_client_runtime()
+    assert "data-pjx-asset" in source
+
+
 def test_client_script_wraps_runtime_in_script_tag():
     script = client_script()
     assert isinstance(script, Markup)

--- a/tests/unit/test_component_aliasing.py
+++ b/tests/unit/test_component_aliasing.py
@@ -21,7 +21,7 @@ class TaskBadge(PJXBadge):
 def test_subclass_renders_base_template_and_assets():
     html = str(TaskBadge(label="3 open", color="brand").render())
     assert 'class="pjx-badge' in html              # PJXBadge's template
-    assert "<style>" in html
+    assert "<style" in html
     assert "--pjx-badge-radius-sm" in html         # PJXBadge's badge.css inlined
 
 

--- a/tests/unit/test_css_collection.py
+++ b/tests/unit/test_css_collection.py
@@ -21,7 +21,7 @@ def test_css_auto_discovery():
 
     rendered = str(component.render())
 
-    assert "<style>" in rendered
+    assert "<style" in rendered
     assert ".test-component { color: red; }" in rendered
 
 
@@ -30,7 +30,7 @@ def test_css_injected_before_html():
 
     rendered = str(component.render())
 
-    style_pos = rendered.find("<style>")
+    style_pos = rendered.find("<style")
     div_pos = rendered.find("<div")
     assert style_pos < div_pos, "Styles should be injected before HTML"
 
@@ -92,7 +92,7 @@ def test_css_mode_none_disables_injection():
 
     rendered = str(component._render(_renderer=renderer))
 
-    assert "<style>" not in rendered
+    assert "<style" not in rendered
 
 
 def test_css_order_styles_before_scripts():
@@ -100,8 +100,8 @@ def test_css_order_styles_before_scripts():
 
     rendered = str(component.render())
 
-    style_pos = rendered.find("<style>")
-    script_pos = rendered.find("<script>")
+    style_pos = rendered.find("<style")
+    script_pos = rendered.find("<script")
     assert style_pos < script_pos, "Styles should come before scripts"
 
 
@@ -114,7 +114,7 @@ def test_none_mode_stays_silent():
         UnifiedComponent(id="none-1", text="Silent")._render(_renderer=renderer)
     )
 
-    assert "<style>" not in rendered
+    assert "<style" not in rendered
     assert "<script" not in rendered
     assert "<link" not in rendered
 
@@ -133,6 +133,6 @@ def test_reactive_partial_render_suppresses_assets():
         record_mutation("todos")
         rendered = str(ReactiveCounter.render())
 
-    assert "<style>" not in rendered
+    assert "<style" not in rendered
     assert "<script" not in rendered
     assert "<link" not in rendered

--- a/tests/unit/test_deep_nesting.py
+++ b/tests/unit/test_deep_nesting.py
@@ -1,7 +1,15 @@
+import os
+
+from pyjinhx.assets import asset_token
+from pyjinhx.finder import Finder
 from tests.ui.unified_component import UnifiedComponent
 
-CSS = "<style>.test-component { color: red; }\n</style>\n"
-JS = "\n<script>console.log('Button loaded');</script>"
+_UI_DIR = Finder.get_class_directory(UnifiedComponent)
+_CSS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.css"))
+_JS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.js"))
+
+CSS = f'<style data-pjx-asset="{_CSS_TOKEN}">.test-component {{ color: red; }}\n</style>\n'
+JS = f'\n<script data-pjx-asset="{_JS_TOKEN}">console.log(\'Button loaded\');</script>'
 
 
 def test_3_level_deep_nesting():

--- a/tests/unit/test_dict_field_components.py
+++ b/tests/unit/test_dict_field_components.py
@@ -1,7 +1,15 @@
+import os
+
+from pyjinhx.assets import asset_token
+from pyjinhx.finder import Finder
 from tests.ui.unified_component import UnifiedComponent
 
-CSS = "<style>.test-component { color: red; }\n</style>\n"
-JS = "\n<script>console.log('Button loaded');</script>"
+_UI_DIR = Finder.get_class_directory(UnifiedComponent)
+_CSS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.css"))
+_JS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.js"))
+
+CSS = f'<style data-pjx-asset="{_CSS_TOKEN}">.test-component {{ color: red; }}\n</style>\n'
+JS = f'\n<script data-pjx-asset="{_JS_TOKEN}">console.log(\'Button loaded\');</script>'
 
 
 def test_dict_component():

--- a/tests/unit/test_edge_cases.py
+++ b/tests/unit/test_edge_cases.py
@@ -1,7 +1,15 @@
+import os
+
+from pyjinhx.assets import asset_token
+from pyjinhx.finder import Finder
 from tests.ui.unified_component import UnifiedComponent
 
-CSS = "<style>.test-component { color: red; }\n</style>\n"
-JS = "\n<script>console.log('Button loaded');</script>"
+_UI_DIR = Finder.get_class_directory(UnifiedComponent)
+_CSS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.css"))
+_JS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.js"))
+
+CSS = f'<style data-pjx-asset="{_CSS_TOKEN}">.test-component {{ color: red; }}\n</style>\n'
+JS = f'\n<script data-pjx-asset="{_JS_TOKEN}">console.log(\'Button loaded\');</script>'
 
 
 def test_empty_list():

--- a/tests/unit/test_extra_assets.py
+++ b/tests/unit/test_extra_assets.py
@@ -1,6 +1,15 @@
+import os
+
+from pyjinhx.assets import asset_token
+from pyjinhx.finder import Finder
 from tests.ui.unified_component import UnifiedComponent
 
-CSS = "<style>.test-component { color: red; }\n</style>\n"
+_UI_DIR = Finder.get_class_directory(UnifiedComponent)
+_CSS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.css"))
+_JS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.js"))
+_EXTRA_JS_TOKEN = asset_token("tests/ui/extra_script.js")
+
+CSS = f'<style data-pjx-asset="{_CSS_TOKEN}">.test-component {{ color: red; }}\n</style>\n'
 
 
 def test_multiple_extra_js_files():
@@ -16,9 +25,8 @@ def test_multiple_extra_js_files():
         CSS + '<div id="multi-js-1" class="test-component">\n'
         '    <div class="text">Multiple JS</div>\n'
         "</div>\n"
-        "\n"
-        "<script>console.log('Button loaded');</script>\n"
-        "<script>console.log('Extra script loaded');\n"
+        f'\n<script data-pjx-asset="{_JS_TOKEN}">console.log(\'Button loaded\');</script>\n'
+        f'<script data-pjx-asset="{_EXTRA_JS_TOKEN}">console.log(\'Extra script loaded\');\n'
         "\n"
         "</script>"
     )

--- a/tests/unit/test_javascript_collection.py
+++ b/tests/unit/test_javascript_collection.py
@@ -6,7 +6,7 @@ from tests.ui.unified_component import UnifiedComponent
 
 def _extract_scripts(rendered: str) -> list[str]:
     """Return a list of script block contents (inner text of each <script>...</script>)."""
-    return re.findall(r"<script>(.*?)</script>", rendered, re.S)
+    return re.findall(r"<script[^>]*>(.*?)</script>", rendered, re.S)
 
 
 def test_js_collection_order():
@@ -93,6 +93,6 @@ def test_inline_mode_regression():
         UnifiedComponent(id="inline-1", text="Inline")._render(_renderer=renderer)
     )
 
-    assert "<style>" in rendered
+    assert "<style" in rendered
     assert ".test-component { color: red; }" in rendered
-    assert "<script>console.log('Button loaded');</script>" in rendered
+    assert "console.log('Button loaded');" in rendered

--- a/tests/unit/test_list_field_components.py
+++ b/tests/unit/test_list_field_components.py
@@ -1,7 +1,15 @@
+import os
+
+from pyjinhx.assets import asset_token
+from pyjinhx.finder import Finder
 from tests.ui.unified_component import UnifiedComponent
 
-CSS = "<style>.test-component { color: red; }\n</style>\n"
-JS = "\n<script>console.log('Button loaded');</script>"
+_UI_DIR = Finder.get_class_directory(UnifiedComponent)
+_CSS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.css"))
+_JS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.js"))
+
+CSS = f'<style data-pjx-asset="{_CSS_TOKEN}">.test-component {{ color: red; }}\n</style>\n'
+JS = f'\n<script data-pjx-asset="{_JS_TOKEN}">console.log(\'Button loaded\');</script>'
 
 
 def test_nested_list_of_components():

--- a/tests/unit/test_mixed_collections.py
+++ b/tests/unit/test_mixed_collections.py
@@ -1,7 +1,15 @@
+import os
+
+from pyjinhx.assets import asset_token
+from pyjinhx.finder import Finder
 from tests.ui.unified_component import UnifiedComponent
 
-CSS = "<style>.test-component { color: red; }\n</style>\n"
-JS = "\n<script>console.log('Button loaded');</script>"
+_UI_DIR = Finder.get_class_directory(UnifiedComponent)
+_CSS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.css"))
+_JS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.js"))
+
+CSS = f'<style data-pjx-asset="{_CSS_TOKEN}">.test-component {{ color: red; }}\n</style>\n'
+JS = f'\n<script data-pjx-asset="{_JS_TOKEN}">console.log(\'Button loaded\');</script>'
 
 
 def test_mixed_list_content():

--- a/tests/unit/test_nested_components.py
+++ b/tests/unit/test_nested_components.py
@@ -1,9 +1,16 @@
+import os
 import re
 
+from pyjinhx.assets import asset_token
+from pyjinhx.finder import Finder
 from tests.ui.unified_component import UnifiedComponent
 
-CSS = "<style>.test-component { color: red; }\n</style>\n"
-JS = "\n<script>console.log('Button loaded');</script>"
+_UI_DIR = Finder.get_class_directory(UnifiedComponent)
+_CSS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.css"))
+_JS_TOKEN = asset_token(os.path.join(_UI_DIR, "unified-component.js"))
+
+CSS = f'<style data-pjx-asset="{_CSS_TOKEN}">.test-component {{ color: red; }}\n</style>\n'
+JS = f'\n<script data-pjx-asset="{_JS_TOKEN}">console.log(\'Button loaded\');</script>'
 
 
 def test_simple_nesting():

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -54,7 +54,7 @@ def test_internals_are_not_in_the_public_surface():
         "CacheScope", "client_script", "oob_swaps", "LoadCache", "InvalidationHub",
         "InvalidationBackend", "MutationTracker", "Finder", "Parser", "Tag",
         "ClientBackend", "FastAPIClientBackend", "MountedManifest", "TriggerManifest",
-        "PJX_MOUNTED_HEADER", "PJX_TRIGGER_HEADER",
+        "LoadedAssets", "PJX_MOUNTED_HEADER", "PJX_TRIGGER_HEADER", "PJX_ASSETS_HEADER",
         "configure_pyjinhx", "shutdown_pyjinhx",
         "enable_reactive_dev", "disable_reactive_dev", "dependency_graph",
         "format_dependency_graph", "AssetManifest", "RenderSession", "asset_manifest",
@@ -69,8 +69,10 @@ def test_internals_remain_importable_from_submodules():
     # still available for advanced use — just not on the curated surface
     from pyjinhx.cache import CacheScope, InvalidationHub, LoadCache  # noqa: F401
     from pyjinhx.client import (  # noqa: F401
+        PJX_ASSETS_HEADER,
         PJX_MOUNTED_HEADER,
         ClientBackend,
+        LoadedAssets,
         MountedManifest,
         client_script,
     )

--- a/tests/unit/test_swap_assets.py
+++ b/tests/unit/test_swap_assets.py
@@ -1,0 +1,225 @@
+"""Reactive OOB swaps deliver missing INLINE assets, deduped by client token."""
+import json
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+from pyjinhx import MutationKey, ReactiveComponent
+from pyjinhx.assets import asset_token, should_emit_asset
+from pyjinhx.client import ClientBackend, LoadedAssets, PJX_ASSETS_HEADER
+from pyjinhx.integrations.fastapi import FastAPIClientBackend
+from pyjinhx.reactive import oob_swaps
+from pyjinhx.renderer import Renderer
+
+
+# ---------------------------------------------------------------------------
+# Unit-level token + dedup tests (Step 2 / 4)
+# ---------------------------------------------------------------------------
+
+
+def test_asset_token_is_stable_for_same_path(tmp_path):
+    p = str(tmp_path / "x.css")
+    assert asset_token(p) == asset_token(p)
+
+
+def test_should_emit_when_token_absent():
+    assert should_emit_asset("t1", frozenset(), dedup_enabled=True) is True
+    assert should_emit_asset("t1", frozenset({"t2"}), dedup_enabled=True) is True
+
+
+def test_should_not_emit_when_token_present():
+    assert should_emit_asset("t1", frozenset({"t1"}), dedup_enabled=True) is False
+
+
+def test_dedup_disabled_always_emits():
+    assert should_emit_asset("t1", frozenset({"t1"}), dedup_enabled=False) is True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeRequest:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self.headers = headers or {}
+
+
+def _make_backend(
+    manifest: list[dict],
+    *,
+    loaded_tokens: list[str] | None = None,
+) -> FastAPIClientBackend:
+    headers: dict[str, str] = {
+        "X-PJX-Mounted": json.dumps(manifest),
+    }
+    if loaded_tokens is not None:
+        headers[PJX_ASSETS_HEADER] = json.dumps(loaded_tokens)
+    return FastAPIClientBackend(FakeRequest(headers))
+
+
+class _SwapKeys(MutationKey):
+    ITEMS = "swap_items"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def asset_env(tmp_path):
+    """Temp dir with a template, CSS, and JS file; wired as the default env."""
+    (tmp_path / "swap_widget.html").write_text(
+        '<div id="{{ id }}" class="swap-widget">{{ count }}</div>'
+    )
+    (tmp_path / "swap-widget.css").write_text(".swap-widget { color: teal; }")
+    (tmp_path / "swap-widget.js").write_text("console.log('swap-widget');")
+    env = Environment(loader=FileSystemLoader(str(tmp_path)))
+    Renderer.set_default_environment(env)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Reactive component factories
+# ---------------------------------------------------------------------------
+
+
+def _make_swap_widget(asset_env):
+    """SwapWidget: reacts to ITEMS, carries CSS + JS extra assets."""
+    css_path = str(asset_env / "swap-widget.css")
+    js_path = str(asset_env / "swap-widget.js")
+
+    class SwapWidget(ReactiveComponent, react={_SwapKeys.ITEMS}, pjx_replace=True):
+        _pjx_template = "SwapWidget"
+        count: int = 0
+
+        @classmethod
+        def load(cls) -> "SwapWidget":
+            return cls(id="swap-widget", count=1, css=[css_path], js=[js_path])
+
+    return SwapWidget, css_path, js_path
+
+
+def _make_swap_widget_css_only(asset_env):
+    """SwapWidgetCss: same but CSS only, used for the shared-asset dedup test."""
+    css_path = str(asset_env / "swap-widget.css")
+
+    class SwapWidgetCss(ReactiveComponent, react={_SwapKeys.ITEMS}, pjx_replace=True):
+        _pjx_template = "SwapWidget"
+        count: int = 0
+
+        @classmethod
+        def load(cls) -> "SwapWidgetCss":
+            return cls(id="swap-widget-css", count=1, css=[css_path])
+
+    return SwapWidgetCss, css_path
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: #96 – OOB swaps deliver missing assets
+# ---------------------------------------------------------------------------
+
+
+def test_oob_swap_delivers_css_when_absent(asset_env):
+    """#96 repro: CSS is delivered via OOB head injection when client hasn't loaded it."""
+    _cls, css_path, js_path = _make_swap_widget(asset_env)
+
+    manifest = [{"id": "swap-widget", "type": "SwapWidget", "hash": "stale"}]
+    backend = _make_backend(manifest)  # no X-PJX-Assets → nothing loaded
+
+    with ClientBackend.scope(backend):
+        result = str(oob_swaps({_SwapKeys.ITEMS}, manifest))
+
+    token = asset_token(css_path)
+    assert f'data-pjx-asset="{token}"' in result
+    assert 'hx-swap-oob="beforeend:head"' in result
+    assert ".swap-widget { color: teal; }" in result
+
+
+def test_oob_swap_delivers_js_when_absent(asset_env):
+    """JS is delivered via OOB head injection when client hasn't loaded it."""
+    _cls, css_path, js_path = _make_swap_widget(asset_env)
+
+    manifest = [{"id": "swap-widget", "type": "SwapWidget", "hash": "stale"}]
+    backend = _make_backend(manifest)
+
+    with ClientBackend.scope(backend):
+        result = str(oob_swaps({_SwapKeys.ITEMS}, manifest))
+
+    token = asset_token(js_path)
+    assert f'data-pjx-asset="{token}"' in result
+    assert "console.log('swap-widget');" in result
+
+
+def test_oob_swap_skips_already_loaded_css(asset_env):
+    """CSS token reported by client in X-PJX-Assets is not re-emitted."""
+    _cls, css_path, js_path = _make_swap_widget(asset_env)
+
+    css_token = asset_token(css_path)
+    manifest = [{"id": "swap-widget", "type": "SwapWidget", "hash": "stale"}]
+    backend = _make_backend(manifest, loaded_tokens=[css_token])
+
+    with ClientBackend.scope(backend):
+        result = str(oob_swaps({_SwapKeys.ITEMS}, manifest))
+
+    # CSS must NOT be re-injected
+    assert ".swap-widget { color: teal; }" not in result
+    # JS is still missing so it must appear
+    js_token = asset_token(js_path)
+    assert f'data-pjx-asset="{js_token}"' in result
+
+
+def test_oob_swap_emits_nothing_when_all_loaded(asset_env):
+    """No OOB asset injection when the client already has every asset token."""
+    _cls, css_path, js_path = _make_swap_widget(asset_env)
+
+    css_token = asset_token(css_path)
+    js_token = asset_token(js_path)
+    manifest = [{"id": "swap-widget", "type": "SwapWidget", "hash": "stale"}]
+    backend = _make_backend(manifest, loaded_tokens=[css_token, js_token])
+
+    with ClientBackend.scope(backend):
+        result = str(oob_swaps({_SwapKeys.ITEMS}, manifest))
+
+    assert ".swap-widget { color: teal; }" not in result
+    assert "console.log('swap-widget');" not in result
+
+
+def test_two_regions_sharing_asset_emit_it_once(asset_env):
+    """Two swapped regions that share a CSS asset emit that asset exactly once."""
+    _cls, css_path = _make_swap_widget_css_only(asset_env)
+
+    manifest = [
+        {"id": "swap-widget-css-a", "type": "SwapWidgetCss", "hash": "stale-a"},
+        {"id": "swap-widget-css-b", "type": "SwapWidgetCss", "hash": "stale-b"},
+    ]
+    backend = _make_backend(manifest)
+
+    with ClientBackend.scope(backend):
+        result = str(oob_swaps({_SwapKeys.ITEMS}, manifest))
+
+    css_content = ".swap-widget { color: teal; }"
+    assert result.count(css_content) == 1
+
+
+# ---------------------------------------------------------------------------
+# LoadedAssets.parse unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_loaded_assets_parse_from_request_header(tmp_path):
+    """LoadedAssets.parse reads tokens from a request-like object's header."""
+    css_path = str(tmp_path / "x.css")
+    token = asset_token(css_path)
+    request = FakeRequest({PJX_ASSETS_HEADER: json.dumps([token])})
+    backend = FastAPIClientBackend(request)
+    loaded = LoadedAssets.parse(backend)
+    assert token in loaded
+
+
+def test_loaded_assets_parse_returns_empty_frozenset_when_absent():
+    """LoadedAssets.parse returns frozenset() for None / empty / missing header."""
+    assert LoadedAssets.parse(None) == frozenset()
+    assert LoadedAssets.parse("") == frozenset()
+    assert LoadedAssets.parse(FakeRequest()) == frozenset()


### PR DESCRIPTION
## Summary

Fixes #96 — reactive OOB swap-in components now receive their CSS/JS in INLINE mode. **PR 2 of 2; stacked on #97** (remove REFERENCE mode) — merge #97 first.

Previously, asset injection was render-driven and `oob_swaps` re-rendered swapped-in regions with `emit_assets=False`, so a component living only in a non-default reactive branch rendered unstyled after a swap.

### How it works
- INLINE asset tags now carry `data-pjx-asset="<token>"`, where the token is an **opaque hash** of the asset's normalized path (no server paths leak to the client).
- The client runtime reports the `data-pjx-asset` tokens it already has via `X-PJX-Assets` (stateless server; correct across refresh/tabs).
- `oob_swaps` collects the swapped regions' assets (shared session, `is_root=False`) and emits only the **missing** ones (token not in the client set) as an OOB head-injection: `<style/script data-pjx-asset hx-swap-oob="beforeend:head">`, threaded through `_finish_with_oob`/`ReactiveResponse`.
- Client runtime re-creates head-injected `<script>` nodes so they execute, with a token idempotency guard.

### Testing
`uv run pytest` — 753 passed, 5 skipped, pristine. New: `tests/unit/test_swap_assets.py` (token/dedup + #96 repro) and **3 Playwright browser tests** (`tests/reactivity/test_head_inject_assets.py`) verifying head-injected CSS actually styles the swapped-in component, the JS executes, and a second swap doesn't re-execute it.

### Stack
remove-REFERENCE (#97) → **#96 fix (this PR)**. GitHub retargets this to `master` once #97 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
