### PR TITLE
docs(gallery): multi-variation boxes, Skeleton fix, notification replay + dropdown/popover defaults

### DIFF
--- a/docs/demos/base.css
+++ b/docs/demos/base.css
@@ -76,3 +76,17 @@ body {
   color: var(--text);
   cursor: pointer;
 }
+
+.pjx-demo-stage {
+  width: min(360px, 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pjx-demo-stage--row {
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+}

--- a/docs/demos/overlays.py
+++ b/docs/demos/overlays.py
@@ -56,23 +56,25 @@ def prompt_dialog():
 
 
 def notification():
-    return PJXNotification(
-        id="demo-notification",
-        content="Your changes have been saved.",
-        corner="top-right",
-        timeout=4000,
-        autoshow=True,
-    ).render()
+    return [
+        PJXNotification(
+            id="demo-notification",
+            content="Your changes have been saved.",
+            corner="top-right",
+            timeout=4000,
+        ).render(),
+        '<button class="pjx-demo-btn" onclick="pjx.notification.show(\'demo-notification\')">'
+        "Show notification</button>",
+    ]
 
 
 def alert():
-    return PJXAlert(
-        id="demo-alert",
-        variant="warning",
-        title="Storage almost full",
-        body="You have used 90% of your storage quota. Consider removing old files.",
-        dismissible=True,
-    ).render()
+    return [
+        PJXAlert(variant="info", title="Heads up", body="A new version is available.").render(),
+        PJXAlert(variant="success", body="Your changes were saved.").render(),
+        PJXAlert(variant="warning", body="Your session expires in 5 minutes.").render(),
+        PJXAlert(variant="error", body="Could not reach the server.", dismissible=True).render(),
+    ]
 
 
 def tooltip():
@@ -92,7 +94,10 @@ def popover():
             + PJXPopoverPanel(
                 id="demo-popover-p",
                 role="dialog",
-                content="<p>Here is some extra detail about this item.</p>",
+                content=(
+                    "<strong>Keyboard shortcuts</strong>"
+                    '<p style="margin:.35rem 0 0">Press <kbd>?</kbd> anytime to reopen this panel.</p>'
+                ),
             ).render()
         ),
     ).render()
@@ -103,8 +108,8 @@ DEMOS = {
     "PJXDrawer": (drawer, 360),
     "PJXConfirmDialog": (confirm_dialog, 360),
     "PJXPromptDialog": (prompt_dialog, 360),
-    "PJXNotification": (notification, 160),
-    "PJXAlert": (alert, 160),
+    "PJXNotification": (notification, 140),
+    "PJXAlert": (alert, 280),
     "PJXTooltip": (tooltip, 160),
     "PJXPopover": (popover, 200),
 }

--- a/docs/demos/static.py
+++ b/docs/demos/static.py
@@ -20,7 +20,12 @@ def accordion():
 
 
 def badge():
-    return PJXBadge(label="Active", color="brand").render()
+    return [
+        PJXBadge(label="Active", color="brand").render(),
+        PJXBadge(label="Error", color="error").render(),
+        PJXBadge(label="Neutral", color="neutral").render(),
+        PJXBadge(label="Beta", color="muted", shape="full").render(),
+    ]
 
 
 def card():
@@ -32,11 +37,19 @@ def divider():
 
 
 def spinner():
-    return PJXSpinner(size="md", label="Loading data").render()
+    return [
+        PJXSpinner(size="sm", label="Loading data").render(),
+        PJXSpinner(size="md", label="Loading data").render(),
+        PJXSpinner(size="lg", label="Loading data").render(),
+    ]
 
 
 def avatar():
-    return PJXAvatar(initials="JD", size="md", alt="Jane Doe").render()
+    return [
+        PJXAvatar(initials="JD", size="sm", alt="Jane Doe").render(),
+        PJXAvatar(initials="JD", size="md", alt="Jane Doe").render(),
+        PJXAvatar(initials="JD", size="lg", alt="Jane Doe").render(),
+    ]
 
 
 def avatar_stack():
@@ -55,11 +68,18 @@ def breadcrumb():
 
 
 def skeleton():
-    return PJXSkeleton(variant="text", lines=3).render()
+    return [
+        PJXSkeleton(variant="text", lines=3).render(),
+        PJXSkeleton(variant="circle").render(),
+        PJXSkeleton(variant="rect").render(),
+    ]
 
 
 def progress():
-    return PJXProgress(value=65, max=100, label="Upload progress").render()
+    return [
+        PJXProgress(value=65, max=100, label="Upload progress").render(),
+        PJXProgress(label="Processing").render(),
+    ]
 
 
 def empty_state():
@@ -71,25 +91,36 @@ def empty_state():
 
 
 def icon():
-    return PJXIcon(name="plus", size=24, label="Add item").render()
+    return [
+        PJXIcon(name="plus", size=24, label="Add").render(),
+        PJXIcon(name="search", size=24, label="Search").render(),
+        PJXIcon(name="trash", size=24, label="Delete").render(),
+        PJXIcon(name="settings", size=24, label="Settings").render(),
+        PJXIcon(name="chevron-right", size=24, label="Next").render(),
+    ]
 
 
 def button():
-    return PJXButton(center="Save", variant="primary").render()
+    return [
+        PJXButton(center="Save", variant="primary").render(),
+        PJXButton(center="Cancel").render(),
+        PJXButton(center="Saving", variant="primary", loading=True).render(),
+        PJXButton(center="Disabled", disabled=True).render(),
+    ]
 
 
 DEMOS = {
     "PJXAccordion": (accordion, 160),
-    "PJXBadge": (badge, 120),
+    "PJXBadge": (badge, 140),
     "PJXCard": (card, 220),
     "PJXDivider": (divider, 120),
-    "PJXSpinner": (spinner, 120),
-    "PJXAvatar": (avatar, 120),
+    "PJXSpinner": (spinner, 140),
+    "PJXAvatar": (avatar, 140),
     "PJXAvatarStack": (avatar_stack, 120),
     "PJXBreadcrumb": (breadcrumb, 120),
-    "PJXSkeleton": (skeleton, 160),
-    "PJXProgress": (progress, 120),
+    "PJXSkeleton": (skeleton, 220),
+    "PJXProgress": (progress, 170),
     "PJXEmptyState": (empty_state, 260),
-    "PJXIcon": (icon, 120),
-    "PJXButton": (button, 120),
+    "PJXIcon": (icon, 140),
+    "PJXButton": (button, 140),
 }

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,5 +1,6 @@
 """MkDocs hooks: render builtin demos into standalone pages and splice them into the docs."""
 
+import ast
 import inspect
 import os
 import re
@@ -33,19 +34,33 @@ _PAGE = """<!doctype html>
 _IFRAME_STYLE = "width:100%;border:1px solid #8884;border-radius:6px"
 
 
-def demo_markup(value):
+def first_variation_source(factory):
+    """Source of the factory's first returned variation.
+
+    If the factory returns a list/tuple, show the first element's source (the
+    first rendering in a multi-variation box); otherwise the single returned
+    expression. Never includes the def line or `return`.
+    """
+    src = textwrap.dedent(inspect.getsource(factory))
+    tree = ast.parse(src)
+    ret = next(n for n in ast.walk(tree) if isinstance(n, ast.Return))
+    node = ret.value
+    if isinstance(node, (ast.List, ast.Tuple)) and node.elts:
+        node = node.elts[0]
+    return ast.get_source_segment(src, node)
+
+
+def _render_one(value):
     if isinstance(value, BaseComponent):
         return str(value.render())
-    if isinstance(value, (list, tuple)):
-        return "\n".join(demo_markup(item) for item in value)
     return str(value)
 
 
-def demo_source(factory):
-    """The factory's body as a bare expression: drop the def line and the return keyword."""
-    lines = textwrap.dedent(inspect.getsource(factory)).strip().splitlines()
-    body = textwrap.dedent("\n".join(lines[1:]))
-    return body.removeprefix("return ")
+def demo_markup(value):
+    if isinstance(value, (list, tuple)):
+        inner = "\n".join(_render_one(item) for item in value)
+        return f'<div class="pjx-demo-stage pjx-demo-stage--row">{inner}</div>'
+    return f'<div class="pjx-demo-stage">{_render_one(value)}</div>'
 
 
 def on_page_markdown(markdown, *, page, config, files):
@@ -55,7 +70,7 @@ def on_page_markdown(markdown, *, page, config, files):
             raise ValueError(f"unknown demo {name!r} in {page.file.src_path}")
         factory, height = DEMOS[name]
         prefix = "../" * page.url.count("/")
-        source = demo_source(factory)
+        source = first_variation_source(factory)
         return (
             f'<iframe src="{prefix}demos/{pascal_case_to_kebab_case(name)}.html" height="{height}" '
             f'style="{_IFRAME_STYLE}" loading="lazy" title="{name} demo"></iframe>\n\n'

--- a/pyjinhx/builtins/ui/pjx_dropdown/pjx-dropdown.css
+++ b/pyjinhx/builtins/ui/pjx_dropdown/pjx-dropdown.css
@@ -7,6 +7,9 @@
   --pjx-dropdown-menu-min-w:    10rem;
   --pjx-dropdown-menu-max-h:    min(70dvh, 24rem);
   --pjx-dropdown-z:             350;
+  --pjx-dropdown-item-padding:  0.5rem 0.85rem;
+  --pjx-dropdown-item-radius:   var(--radius-sm);
+  --pjx-dropdown-item-bg-hover: color-mix(in srgb, var(--text) 8%, transparent);
 }
 
 .pjx-dropdown {
@@ -40,4 +43,30 @@
 .pjx-dropdown--align-end .pjx-dropdown__menu {
   left: auto;
   right: 0;
+}
+
+.pjx-dropdown__menu button,
+.pjx-dropdown__menu a,
+.pjx-dropdown__menu .pjx-dropdown__item {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding: var(--pjx-dropdown-item-padding);
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: var(--pjx-dropdown-item-radius);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.pjx-dropdown__menu button:hover,
+.pjx-dropdown__menu a:hover,
+.pjx-dropdown__menu button:focus-visible,
+.pjx-dropdown__menu a:focus-visible {
+  background: var(--pjx-dropdown-item-bg-hover);
+  outline: none;
 }

--- a/pyjinhx/builtins/ui/pjx_popover/pjx-popover.css
+++ b/pyjinhx/builtins/ui/pjx_popover/pjx-popover.css
@@ -5,6 +5,7 @@
   --pjx-popover-shadow:  var(--shadow-md);
   --pjx-popover-min-w:   12rem;
   --pjx-popover-z:       300;
+  --pjx-popover-padding: var(--space-3, 0.75rem);
 }
 
 .pjx-popover {
@@ -33,6 +34,7 @@
   left: 0;
   z-index: var(--pjx-popover-z);
   min-width: var(--pjx-popover-min-w);
+  padding: var(--pjx-popover-padding);
   background: var(--pjx-popover-bg);
   border: 1px solid var(--pjx-popover-border);
   border-radius: var(--pjx-popover-radius);

--- a/tests/unit/test_dropdown_popover_css.py
+++ b/tests/unit/test_dropdown_popover_css.py
@@ -1,0 +1,25 @@
+"""Dropdown menu items and popover panels carry sensible default styling."""
+import pytest
+
+from pyjinhx import Renderer
+from pyjinhx.builtins import PJXDropdown, PJXPopover, PJXPopoverPanel, PJXPopoverTrigger
+
+
+@pytest.fixture(autouse=True)
+def _env(tmp_path):
+    Renderer.set_default_environment(str(tmp_path))
+
+
+def test_dropdown_inlines_menu_item_styling():
+    html = str(PJXDropdown(trigger="Actions", items=["<button>Edit</button>"]).render())
+    assert ".pjx-dropdown__menu button" in html  # default item rule is shipped + inlined
+
+
+def test_popover_panel_has_padding_token():
+    html = str(
+        PJXPopover(
+            id="p",
+            content=PJXPopoverPanel(id="p-p", content="x").render(),
+        ).render()
+    )
+    assert "--pjx-popover-padding" in html

--- a/tests/unit/test_dropdown_popover_css.py
+++ b/tests/unit/test_dropdown_popover_css.py
@@ -2,7 +2,7 @@
 import pytest
 
 from pyjinhx import Renderer
-from pyjinhx.builtins import PJXDropdown, PJXPopover, PJXPopoverPanel, PJXPopoverTrigger
+from pyjinhx.builtins import PJXDropdown, PJXPopover, PJXPopoverPanel
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_gallery_demos.py
+++ b/tests/unit/test_gallery_demos.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 import pyjinhx.builtins
+from pyjinhx.builtins import PJXBadge  # noqa: E402
 
 DOCS = Path(__file__).resolve().parents[2] / "docs"
 sys.path.insert(0, str(DOCS))
@@ -57,3 +58,35 @@ def test_every_factory_renders():
 def test_registry_covers_all_builtins():
     folded = {"PJXLazyPanel", "PJXPanelTrigger", "PJXPopoverTrigger", "PJXPopoverPanel"}
     assert set(DEMOS) == set(pyjinhx.builtins.__all__) - folded
+
+
+def test_first_variation_source_picks_first_list_element():
+    def f():
+        return [
+            PJXBadge(label="A", color="brand").render(),
+            PJXBadge(label="B", color="error").render(),
+        ]
+    assert hooks.first_variation_source(f) == 'PJXBadge(label="A", color="brand").render()'
+
+
+def test_first_variation_source_single_expression():
+    def f():
+        return PJXBadge(label="A").render()
+    assert hooks.first_variation_source(f) == 'PJXBadge(label="A").render()'
+
+
+def test_demo_markup_wraps_in_stage():
+    assert hooks.demo_markup("<b>x</b>") == '<div class="pjx-demo-stage"><b>x</b></div>'
+    row = hooks.demo_markup(["<b>x</b>", "<i>y</i>"])
+    assert 'class="pjx-demo-stage pjx-demo-stage--row"' in row
+    assert "<b>x</b>" in row and "<i>y</i>" in row
+
+
+def test_all_demo_factories_render(tmp_path):
+    from pyjinhx import Registry, Renderer
+    Renderer.set_default_environment(str(tmp_path))
+    for name, (factory, _h) in DEMOS.items():
+        with Registry.request_scope():
+            markup = hooks.demo_markup(factory())
+        assert "pjx-demo-stage" in markup, name
+        assert markup.strip(), name


### PR DESCRIPTION
## Summary

Improves the component gallery and fixes two shipped-component CSS defects the gallery surfaced.

### Shipped CSS (rides next release)
- **PJXDropdown:** default menu-item styling (`block`, full-width, padding, hover/focus) via new `--pjx-dropdown-item-*` tokens, scoped to `.pjx-dropdown__menu` children. Previously items were raw native buttons (a real default-quality defect for all users).
- **PJXPopover:** `--pjx-popover-padding` token applied to `.pjx-popover__panel` (content no longer touches the edges).

### Gallery (docs)
- **Multi-variation boxes:** Badge/Button/Icon/Spinner/Avatar/Progress/Skeleton and Alert now show a curated row of variations in one box.
- **Faithful code:** the code block shows only the **first variation**, extracted from the factory's source via AST (`first_variation_source`) — copy-pasteable by construction.
- **Skeleton renders correctly:** demo output is wrapped in a width-bounded `.pjx-demo-stage`, so the skeleton's `width:100%` lines stop collapsing; it now shows text/circle/rect.
- **Notification replay button:** the toast is button-driven (`pjx.notification.show('demo-notification')`) so it can be replayed.
- **Popover/Dropdown demos** showcase the improved component defaults.

## Testing

`uv run pytest` — 759 passed, 5 skipped, pristine. New: `test_dropdown_popover_css.py` (CSS delivery), extended `test_gallery_demos.py` (`first_variation_source`, stage wrapping, render-all). `uv run mkdocs build` succeeds. CSS changes don't touch golden HTML snapshots.

## Notes

Includes shipped CSS (dropdown/popover defaults), so this is a release-bearing change for the next version (0.19.0 is already published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
