### PR TITLE
feat: {#def#} prop headers for classless components

### DIFF
--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -158,6 +158,34 @@ component, or use `<Card/>` in a template — they all resolve to the same class
 It's idempotent and never shadows a component you've actually declared. See
 [`component()`](../api/base-component.md#component).
 
+## Prop headers for classless components
+
+A template-only component can declare its props in a `{#def ... #}` header — the
+first thing in the file. pyjinhx parses it into a validated pydantic model, so a
+classless component gets defaults, required-checks, and type coercion without a
+Python class:
+
+    {#def title: str, count: int = 0, variant: str = "primary" #}
+    <article class="pjx-card pjx-card--{{ variant }}">
+      <h3>{{ title }}</h3>
+      <span class="badge">{{ count }}</span>
+      <div>{{ content }}</div>
+    </article>
+
+- The signature is Python-style: `name`, `name: type`, `name = default`, or
+  `name: type = default`. A prop with no default is **required**.
+- Supported types: `str`, `int`, `float`, `bool`, `list`, `dict`, and `T | None`;
+  anything else (or no annotation) is treated as `Any` (no coercion).
+- Declared props are validated (`<Card/>` with a missing required prop, or a
+  value that can't coerce, raises a clear error). **Undeclared** attributes still
+  pass through to the root element (`hx-*`, `data-*`, `@click`, `class`).
+- The header is a normal Jinja comment, so it never appears in the output.
+- A hand-written Python class always takes precedence over a header.
+
+On the `component()` factory, the header is applied when the template is
+resolvable at call time (set the default environment first); the `<Tag/>` path
+always applies it.
+
 ## Extra Fields
 
 A plain Pydantic `BaseModel` rejects unknown fields with a `ValidationError`. With `BaseComponent`, **extra fields are accepted and available in the template context**. This allows you to pass dictionaries or data objects with additional fields without raising validation errors.

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -408,4 +408,21 @@ def component(name: str) -> type[BaseComponent]:
         raise ValueError(f"component name {name!r} must be PascalCase")
     if Registry.has_class(name):
         return Registry.get_class(name)
+
+    # If the template is resolvable now and carries a {#def#} header, build a
+    # validated-field model; otherwise fall back to a permissive placeholder
+    # (header is applied lazily on the tag-render path instead).
+    from .props_header import build_component_model
+    from .renderer import Renderer
+
+    try:
+        template_path = Renderer.get_default_renderer()._find_template_for_tag(name)
+    except FileNotFoundError:
+        template_path = None
+    if template_path is not None:
+        with open(template_path, encoding="utf-8") as template_file:
+            model = build_component_model(name, template_file.read())
+        if model is not None:
+            return model  # auto-registered via __init_subclass__
+
     return type(name, (BaseComponent,), {"_pjx_template": name})

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -417,7 +417,7 @@ def component(name: str) -> type[BaseComponent]:
 
     try:
         template_path = Renderer.get_default_renderer()._find_template_for_tag(name)
-    except FileNotFoundError:
+    except (FileNotFoundError, ValueError):
         template_path = None
     if template_path is not None:
         with open(template_path, encoding="utf-8") as template_file:

--- a/pyjinhx/props_header.py
+++ b/pyjinhx/props_header.py
@@ -1,0 +1,119 @@
+"""Parse a template's leading ``{#def ... #}`` prop header into a pydantic model.
+
+A classless component template may declare its props in a header that is the
+first non-whitespace in the file::
+
+    {#def title: str, count: int = 0, variant: str = "primary" #}
+
+The header is a valid (inert) Jinja comment; pyjinhx parses it out-of-band and
+builds a ``BaseComponent`` subclass whose declared props are validated fields.
+"""
+import ast
+import re
+from typing import Any, Optional
+
+from pydantic import create_model
+
+_HEADER_RE = re.compile(r"\A\s*\{#\s*def\s+(?P<sig>.*?)\s*#\}", re.DOTALL)
+
+_TYPES: dict[str, Any] = {
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "list": list,
+    "dict": dict,
+    "None": type(None),
+    "Any": Any,
+}
+
+
+def _resolve_annotation(node: "ast.expr | None") -> Any:
+    if node is None:
+        return Any
+    if isinstance(node, ast.Name):
+        return _TYPES.get(node.id, Any)
+    if isinstance(node, ast.Constant) and node.value is None:
+        return type(None)
+    # T | None  ->  Optional[T]
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left = _resolve_annotation(node.left)
+        right = _resolve_annotation(node.right)
+        if right is type(None):
+            return Optional[left]
+        if left is type(None):
+            return Optional[right]
+        return Any
+    # Optional[T]
+    if (
+        isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "Optional"
+    ):
+        return Optional[_resolve_annotation(node.slice)]
+    return Any
+
+
+def parse_props_header(source: str) -> "list[tuple[str, Any, Any]] | None":
+    """Parse a ``{#def ... #}`` header; return ``[(name, type, default), ...]`` or None.
+
+    ``default`` is ``Ellipsis`` (``...``) for a required prop. Raises ``ValueError``
+    for a malformed signature, a non-literal default, or a duplicate prop.
+    """
+    match = _HEADER_RE.match(source)
+    if match is None:
+        return None
+    signature = match.group("sig")
+    try:
+        tree = ast.parse(f"def __pjx_props__({signature}): pass")
+    except SyntaxError as exc:
+        raise ValueError(f"invalid {{#def#}} header signature {signature!r}: {exc.msg}") from exc
+    func = tree.body[0]
+    arguments = func.args
+    if (
+        arguments.vararg
+        or arguments.kwarg
+        or arguments.kwonlyargs
+        or arguments.posonlyargs
+    ):
+        raise ValueError(f"{{#def#}} header may only use simple named props: {signature!r}")
+    args = arguments.args
+    defaults = arguments.defaults
+    offset = len(args) - len(defaults)
+    seen: set[str] = set()
+    fields: list[tuple[str, Any, Any]] = []
+    for index, arg in enumerate(args):
+        name = arg.arg
+        if name in seen:
+            raise ValueError(f"{{#def#}} header has duplicate prop {name!r}")
+        seen.add(name)
+        annotation = _resolve_annotation(arg.annotation)
+        if index >= offset:
+            default_node = defaults[index - offset]
+            try:
+                default = ast.literal_eval(default_node)
+            except (ValueError, SyntaxError) as exc:
+                raise ValueError(
+                    f"{{#def#}} header default for {name!r} must be a literal: "
+                    f"{ast.unparse(default_node)!r}"
+                ) from exc
+        else:
+            default = ...
+        fields.append((name, annotation, default))
+    return fields
+
+
+def build_component_model(name: str, source: str) -> "type | None":
+    """Build a ``BaseComponent`` subclass from a template's header, or None if absent."""
+    fields = parse_props_header(source)
+    if fields is None:
+        return None
+    from pyjinhx.base import BaseComponent
+
+    model = create_model(
+        name,
+        __base__=BaseComponent,
+        **{field_name: (field_type, default) for field_name, field_type, default in fields},
+    )
+    model._pjx_template = name
+    return model

--- a/pyjinhx/props_header.py
+++ b/pyjinhx/props_header.py
@@ -23,7 +23,6 @@ _TYPES: dict[str, Any] = {
     "bool": bool,
     "list": list,
     "dict": dict,
-    "None": type(None),
     "Any": Any,
 }
 

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -323,6 +323,15 @@ def render_tag_node(
     if not Registry.has_class(node.name):
         ComponentAutodiscover.try_for_tag(node.name, template_path)
 
+    if not Registry.has_class(node.name) and template_path is not None:
+        from .props_header import build_component_model
+
+        with open(template_path, encoding="utf-8") as template_file:
+            build_component_model(node.name, template_file.read())
+        # build_component_model auto-registers the generated class via
+        # BaseComponent.__init_subclass__; if there's no header it returns None
+        # and we fall through to the bare-BaseComponent path below.
+
     component_class = Registry.get_class(node.name)
     if component_class is not None:
         init_kwargs: dict[str, Any] = dict(attrs_without_id)

--- a/tests/unit/test_props_header.py
+++ b/tests/unit/test_props_header.py
@@ -1,0 +1,65 @@
+from typing import Any, Optional
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx.base import BaseComponent
+from pyjinhx.props_header import build_component_model, parse_props_header
+
+
+def test_no_header_returns_none():
+    assert parse_props_header("<div>{{ x }}</div>") is None
+
+
+def test_parses_names_types_defaults():
+    src = '{#def title: str, count: int = 0, variant: str = "primary" #}\n<div></div>'
+    assert parse_props_header(src) == [
+        ("title", str, ...),
+        ("count", int, 0),
+        ("variant", str, "primary"),
+    ]
+
+
+def test_untyped_prop_is_any():
+    assert parse_props_header("{#def x, y=1 #}") == [("x", Any, ...), ("y", Any, 1)]
+
+
+def test_optional_via_union():
+    assert parse_props_header("{#def note: str | None = None #}") == [
+        ("note", Optional[str], None)
+    ]
+
+
+def test_multiline_header():
+    src = "{#def\n  title: str,\n  count: int = 0,\n#}\n<div></div>"
+    assert parse_props_header(src) == [("title", str, ...), ("count", int, 0)]
+
+
+def test_non_literal_default_errors():
+    with pytest.raises(ValueError, match="must be a literal"):
+        parse_props_header("{#def x = some_func() #}")
+
+
+def test_malformed_signature_errors():
+    with pytest.raises(ValueError, match="invalid"):
+        parse_props_header("{#def : : : #}")
+
+
+def test_duplicate_prop_errors():
+    with pytest.raises(ValueError, match="duplicate"):
+        parse_props_header("{#def x, x = 1 #}")
+
+
+def test_build_model_validates_required_and_coerces():
+    src = '{#def title: str, count: int = 0 #}\n<div>{{ title }}</div>'
+    model = build_component_model("CardBuildA", src)
+    assert issubclass(model, BaseComponent)
+    assert model._pjx_template == "CardBuildA"
+    inst = model(id="i", title="Hi", count="3")  # "3" coerced to int
+    assert inst.count == 3
+    with pytest.raises(ValidationError):
+        model(id="i")  # missing required 'title'
+
+
+def test_build_model_none_without_header():
+    assert build_component_model("CardBuildB", "<div></div>") is None

--- a/tests/unit/test_props_header_factory.py
+++ b/tests/unit/test_props_header_factory.py
@@ -1,0 +1,34 @@
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx import Renderer
+from pyjinhx.base import BaseComponent, component
+
+
+@pytest.fixture()
+def env(tmp_path):
+    (tmp_path / "widget_fac.html").write_text(
+        '{#def title: str, count: int = 0 #}\n<div>{{ title }}-{{ count }}</div>',
+        encoding="utf-8",
+    )
+    (tmp_path / "bare_fac.html").write_text("<div>{{ foo }}</div>", encoding="utf-8")
+    Renderer.set_default_environment(str(tmp_path))
+
+
+def test_factory_builds_validated_fields(env):
+    WidgetFac = component("WidgetFac")
+    assert issubclass(WidgetFac, BaseComponent)
+    assert WidgetFac(id="i", title="x", count="7").count == 7  # coerced
+    with pytest.raises(ValidationError):
+        WidgetFac(id="i")  # missing required title
+
+
+def test_factory_defaults_apply(env):
+    WidgetFac = component("WidgetFac")
+    assert WidgetFac(id="i", title="x").count == 0
+
+
+def test_factory_no_header_is_permissive(env):
+    BareFac = component("BareFac")
+    inst = BareFac(id="i", foo="bar")  # extra='allow' keeps undeclared props
+    assert "bar" in str(inst.render())

--- a/tests/unit/test_props_header_factory.py
+++ b/tests/unit/test_props_header_factory.py
@@ -1,4 +1,5 @@
 import pytest
+from jinja2 import DictLoader, Environment
 from pydantic import ValidationError
 
 from pyjinhx import Renderer
@@ -32,3 +33,19 @@ def test_factory_no_header_is_permissive(env):
     BareFac = component("BareFac")
     inst = BareFac(id="i", foo="bar")  # extra='allow' keeps undeclared props
     assert "bar" in str(inst.render())
+
+
+def test_factory_dictloader_env_does_not_raise():
+    """Regression: component() must not raise when the default env uses a
+    non-FileSystemLoader (e.g. DictLoader).  _find_template_for_tag() raises
+    ValueError("Jinja2 loader must be a FileSystemLoader") for such loaders;
+    the except clause in component() must catch it and fall back to a bare
+    placeholder class instead of propagating the error.
+    """
+    Renderer.set_default_environment(Environment(loader=DictLoader({})))
+    try:
+        result = component("SomeUnresolvable")
+        assert issubclass(result, BaseComponent)
+    finally:
+        # Restore a clean state so other tests are not affected.
+        Renderer.set_default_environment(None)

--- a/tests/unit/test_props_header_tag.py
+++ b/tests/unit/test_props_header_tag.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 
 from pyjinhx import Renderer
 
@@ -26,7 +27,7 @@ def test_header_coerces_declared_prop(env):
 
 
 def test_header_required_missing_errors(env):
-    with pytest.raises(Exception) as exc:  # pydantic ValidationError surfaces
+    with pytest.raises(ValidationError) as exc:
         env.render("<CardHdr/>")
     assert "title" in str(exc.value)
 

--- a/tests/unit/test_props_header_tag.py
+++ b/tests/unit/test_props_header_tag.py
@@ -1,0 +1,41 @@
+import pytest
+
+from pyjinhx import Renderer
+
+
+@pytest.fixture()
+def env(tmp_path):
+    (tmp_path / "card_hdr.html").write_text(
+        '{#def title: str, count: int = 0 #}\n'
+        '<div class="card">{{ title }}-{{ count }}</div>',
+        encoding="utf-8",
+    )
+    (tmp_path / "plain_hdr.html").write_text("<div>{{ foo }}</div>", encoding="utf-8")
+    Renderer.set_default_environment(str(tmp_path))
+    return Renderer.get_default_renderer()
+
+
+def test_header_applies_defaults(env):
+    out = env.render('<CardHdr title="Hi"/>')
+    assert "Hi-0" in out
+
+
+def test_header_coerces_declared_prop(env):
+    out = env.render('<CardHdr title="x" count="5"/>')
+    assert "x-5" in out
+
+
+def test_header_required_missing_errors(env):
+    with pytest.raises(Exception) as exc:  # pydantic ValidationError surfaces
+        env.render("<CardHdr/>")
+    assert "title" in str(exc.value)
+
+
+def test_undeclared_attr_passes_through_to_root(env):
+    out = env.render('<CardHdr title="x" data-y="z"/>')
+    assert 'data-y="z"' in out
+
+
+def test_template_without_header_still_renders(env):
+    out = env.render('<PlainHdr foo="bar"/>')
+    assert "bar" in out


### PR DESCRIPTION
## Summary

Lets a **classless** (template-only) component declare its props in a leading `{#def … #}` header, parsed into a validated pydantic model — so a component gets defaults, required-checks, and type coercion with no Python class.

```jinja
{#def title: str, count: int = 0, variant: str = "primary" #}
<article class="pjx-card pjx-card--{{ variant }}">
  <h3>{{ title }}</h3>
  <span class="badge">{{ count }}</span>
  <div>{{ content }}</div>
</article>
```

### How it works
- **`pyjinhx/props_header.py`** — `parse_props_header` reads the signature via stdlib `ast` (wrapped as a fake `def`; **no code execution** — defaults are `literal_eval`-only). `build_component_model` turns it into `pydantic.create_model(name, __base__=BaseComponent, …)` with `_pjx_template` set.
- **Tag path** (`render_tag_node`) — when a `<Tag/>` has no class but a template with a header, the generated (auto-registered) model flows through the existing class-backed render path.
- **`component()` factory** — eagerly resolves the template and applies the header into a validated model when resolvable; otherwise returns today's permissive placeholder.
- `extra="allow"` retained → undeclared attrs (`hx-*`, `data-*`, `@click`, `class`) still pass through to the root. Type vocab: `str/int/float/bool/list/dict`, `T | None`, else `Any`. A hand-written class always wins.

### Testing
`uv run pytest` — 778 passed, 5 skipped, pristine. New: `test_props_header.py` (parser), `test_props_header_tag.py` (tag path), `test_props_header_factory.py` (factory, incl. a non-FileSystemLoader regression). `mkdocs build` succeeds; docs section added to `components.md`.

### Notes
Shipped feature → rides a future release. The parser executes no arbitrary code (ast + `literal_eval` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
