### PR TITLE
refactor(renderer): single root-attr stamp pass

### DIFF
--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -20,7 +20,6 @@ from .tags import Parser, expand_custom_tags, render_tag_node
 from .utils import (
     component_resolution_classes,
     detect_root_directory,
-    stamp_root_attributes,
     tag_name_to_template_filenames,
 )
 
@@ -112,9 +111,11 @@ def build_render_context(context: dict[str, Any]) -> dict[str, Any]:
     return render_context
 
 
-def stamp_reactive_markup(markup: str, component: BaseComponent) -> str:
+def reactive_root_attrs(component: BaseComponent) -> dict[str, str]:
+    """The ``data-pjx-*`` attributes to stamp onto a reactive component's root
+    tag, or an empty dict for a non-reactive component."""
     if not getattr(type(component), "_pjx_reactive", False):
-        return markup
+        return {}
 
     from pyjinhx.reactive import pjx_load_value
 
@@ -129,7 +130,7 @@ def stamp_reactive_markup(markup: str, component: BaseComponent) -> str:
     reacts = getattr(type(component), "_pjx_reacts_to", frozenset())
     if reacts:
         attrs["data-pjx-reacts"] = " ".join(sorted(reacts))
-    return stamp_root_attributes(markup, attrs)
+    return attrs
 
 
 class Renderer:
@@ -262,16 +263,15 @@ class Renderer:
             session=session,
             emit_assets=emit_assets,
         )
-        rendered_markup = stamp_reactive_markup(rendered_markup, component)
-
         from .base import collect_extra_attrs
         from .root_attrs import apply_root_attrs
 
+        attrs = {**collect_extra_attrs(component), **reactive_root_attrs(component)}
         rendered_markup = Markup(
             apply_root_attrs(
                 str(rendered_markup),
                 component_name=type(component).__name__,
-                attrs=collect_extra_attrs(component),
+                attrs=attrs,
             )
         )
 

--- a/tests/unit/test_reactive_render.py
+++ b/tests/unit/test_reactive_render.py
@@ -4,6 +4,7 @@ from markupsafe import Markup
 
 from pyjinhx.client import PJX_MOUNTED_HEADER
 from pyjinhx.reactive import oob_swaps
+from pyjinhx.renderer import reactive_root_attrs
 from tests.reactive_test_support import reactive_client, record_mutation
 from tests.ui.reactive import store
 from tests.ui.reactive.reactive_counter import ReactiveCounter  # noqa: F401
@@ -118,3 +119,26 @@ def test_reactive_render_does_not_escape_primary_html():
         out = str(primary.render())
     assert "&lt;span" not in out and "&#34;" not in out
     assert '<span class="counter" data-pjx-id="counter"' in out
+
+
+def test_reactive_root_attrs_returns_pjx_dict():
+    attrs = reactive_root_attrs(ReactiveCounter(id="counter", remaining=0))
+    assert attrs["data-pjx-id"] == "counter"
+    assert attrs["data-pjx-type"] == "ReactiveCounter"
+    assert "data-pjx-hash" in attrs
+    assert "data-pjx-reacts" in attrs  # ReactiveCounter declares react={Keys.TODOS}
+
+
+def test_reactive_root_attrs_empty_for_non_reactive():
+    from pyjinhx.builtins import PJXBadge
+
+    assert reactive_root_attrs(PJXBadge(id="b", label="x")) == {}
+
+
+def test_reactive_root_carries_both_pjx_and_extra_attrs_on_one_root():
+    counter = ReactiveCounter(id="counter", remaining=0, **{"hx-get": "/inc"})
+    out = str(counter.render())
+    root_tag = out[: out.index(">") + 1]  # the single root's opening tag
+    assert 'data-pjx-id="counter"' in root_tag
+    assert 'hx-get="/inc"' in root_tag
+    assert out.count('data-pjx-id="counter"') == 1  # stamped once, not twice


### PR DESCRIPTION
## Summary

Implements the one "worth fixing" item from the architecture map: the **double root-attribute splice on every render**.

`Renderer.render_component_with_context` used to locate the root tag and rebuild the markup string **twice** — `stamp_reactive_markup` (lightweight splice of `data-pjx-*` for reactive components) then `apply_root_attrs` (full single-root-validating splice of `extra_attrs`). This collapses them into **one pass**.

### Change
- `stamp_reactive_markup(markup, component) -> str` becomes a pure `reactive_root_attrs(component) -> dict[str, str]` (the `data-pjx-*` dict, or `{}` for non-reactive) — it no longer touches markup.
- One `apply_root_attrs` call now stamps the union `{**collect_extra_attrs(component), **reactive_root_attrs(component)}` (framework `data-pjx-*` win on collision). `apply_root_attrs` still runs the single-root validation first, so that invariant is preserved.
- Removed the now-unused `stamp_root_attributes` import from `renderer.py`. **`utils.stamp_root_attributes` itself is kept** — the OOB-swap path (`reactive.py`) still uses it for `hx-swap-oob`.

### Behavior
Behavior-preserving: non-reactive output is byte-identical; reactive roots carry the same attributes (only their order may differ, since they're now applied in one merged pass). No golden snapshots shifted.

### Testing
`uv run pytest` — 790 passed, 5 skipped, pristine; ruff clean. New tests: `reactive_root_attrs` returns the dict for reactive / `{}` for non-reactive, and a reactive component carries both `data-pjx-id` and `extra_attrs` (`hx-get`) on a single root, stamped once (proves the double-pass is gone).

### Notes
Internal refactor of the render hot path; no public API or behavior change → a patch release when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
