### PR TITLE
feat(builtins): Avatar px sizing, AvatarStack data, EmptyState chips (#77)

### DIFF
--- a/docs/guide/builtins.md
+++ b/docs/guide/builtins.md
@@ -506,10 +506,39 @@ Centered empty view. **Assets:** `pjx-empty-state.css` only (template file **`pj
 | `description` | `str \| BaseComponent` | `""` | Supporting text. |
 | `action` | `str \| BaseComponent` | `""` | Optional slot (e.g. button markup). |
 | `actions` | `list[str \| BaseComponent]` | `[]` | Optional flex row of slots; renders after `action` when both are set. |
+| `suggestions` | `list[dict]` | `[]` | Interactive suggestion chips; each dict dispatches a custom event on click. See below. |
 
-**DOM contract.** Root `.pjx-empty-state`; no JS API.
+**Suggestion chips** (`suggestions`) provide a first-class "click a chip → dispatch an event" pattern — the common use case of filling an input or triggering a quick action without navigation.
 
-**Classes:** `pjx-empty-state`, `pjx-empty-state__image`, `pjx-empty-state__title`, `pjx-empty-state__desc`, `pjx-empty-state__action`, `pjx-empty-state__actions`. Theming: see [PJXEmptyState tokens](#pjxemptystate-tokens).
+Each item in `suggestions` is a dict with:
+
+| Key | Type | Required | Description |
+| --- | --- | --- | --- |
+| `label` | `str` | yes | Visible chip text. |
+| `value` | `str` | no | Value dispatched in the event payload; defaults to `label`. |
+| `event` | `str` | no | Custom event name; defaults to `"pjx:suggestion"`. |
+
+The rendered chip uses Alpine's `$dispatch`, so any parent can listen with `@pjx:suggestion.window="..."` (or the custom event name). The dispatched detail is `{ value: "<chip value>" }`.
+
+```python
+PJXEmptyState(
+    id="chat-empty",
+    title="What would you like to do?",
+    suggestions=[
+        {"label": "Draft a message", "value": "Draft a message"},
+        {"label": "Summarise a thread", "event": "fill-input"},
+    ],
+)
+```
+
+```html
+<!-- Listener in a parent template -->
+<textarea @pjx:suggestion.window="$el.value = $event.detail.value"></textarea>
+```
+
+**DOM contract.** Root `.pjx-empty-state`; no JS API (suggestion chips require Alpine for `$dispatch`).
+
+**Classes:** `pjx-empty-state`, `pjx-empty-state__image`, `pjx-empty-state__title`, `pjx-empty-state__desc`, `pjx-empty-state__action`, `pjx-empty-state__actions`, `pjx-empty-state__suggestions`, `pjx-empty-state__chip`. Theming: see [PJXEmptyState tokens](#pjxemptystate-tokens).
 
 ---
 
@@ -588,12 +617,25 @@ Image or initials in a circle. **Assets:** `pjx_avatar.css` only.
 | `src` | `str` | `""` | Image URL; when empty, initials fallback is shown. |
 | `alt` | `str` | `""` | `img` alt text; also used as `title` on initials. |
 | `initials` | `str` | `""` | Up to two characters (trimmed/capped in validation). |
-| `size` | literal | `"md"` | `sm`, `md`, or `lg`. |
-| `color` | `str` | `""` | Extra class or inline color hint (appended to root classes). |
+| `size` | `str \| int` | `"md"` | Named token (`sm`, `md`, `lg`) **or** an arbitrary pixel size (`int`) or CSS length string (`"36px"`, `"2.5rem"`). Named tokens emit the BEM modifier class; an int/CSS length renders `width`/`height` inline. |
+| `color` | `str` | `""` | Inline `background` color (e.g. `"#4f46e5"`, `"hsl(240 60% 50%)"` ). |
+
+**Arbitrary pixel sizing:** pass an `int` for a pixel size or any CSS length string for a custom size. This bypasses the named-token classes so the avatar can be sized by data rather than the three design-system tokens.
+
+```python
+# Named token (emits .pjx-avatar--md)
+PJXAvatar(id="a1", initials="AB")
+
+# Pixel size — 36 px circle, no BEM modifier
+PJXAvatar(id="a2", initials="AB", size=36)
+
+# Arbitrary CSS length
+PJXAvatar(id="a3", initials="AB", size="2.5rem")
+```
 
 **DOM contract.** Root `.pjx-avatar`; no JS API.
 
-**Classes:** `pjx-avatar`, `pjx-avatar--sm|md|lg`, `pjx-avatar__img`, `pjx-avatar__initials`. Theming: see [PJXAvatar tokens](#pjxavatar-tokens).
+**Classes:** `pjx-avatar`, `pjx-avatar--sm|md|lg` (named tokens only), `pjx-avatar__img`, `pjx-avatar__initials`. Theming: see [PJXAvatar tokens](#pjxavatar-tokens).
 
 ---
 
@@ -817,11 +859,35 @@ Overlapping row of avatars with optional overflow count. **Assets:** `pjx-avatar
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `avatars` | `list[str \| BaseComponent]` | `[]` | PJXAvatar items (typically `PJXAvatar` components or HTML strings). |
+| `avatars` | `list[dict \| str \| BaseComponent]` | `[]` | Per-avatar items — see below for the two accepted shapes. |
 | `extra_count` | `int` | `0` | When `> 0`, renders a `+N` overflow chip. |
 | `empty_label` | `str` | `""` | When no avatars and `empty_label` is set, renders a fallback label. |
 
+**Two item shapes are accepted in `avatars`:**
+
+1. **Structured data dict** — the stack renders its own pill; no child `PJXAvatar` needed.
+
+   | Key | Type | Required | Description |
+   | --- | --- | --- | --- |
+   | `initials` | `str` | yes | Up to two characters shown in the pill. |
+   | `color` | `str` | no | Inline `background` color. |
+   | `alt` | `str` | no | `title` tooltip (takes precedence over `name`). |
+   | `name` | `str` | no | Fallback tooltip when `alt` is not set. |
+
+2. **Pre-built item** — an HTML string or any `BaseComponent` instance (original interface, still fully supported).
+
 ```python
+# Structured data — stack owns rendering; no PJXAvatar required
+PJXAvatarStack(
+    id="team",
+    avatars=[
+        {"initials": "AB", "color": "#4f46e5", "name": "Alice"},
+        {"initials": "CD", "color": "#16a34a", "name": "Charlie"},
+    ],
+    extra_count=3,
+)
+
+# Pre-built components (original interface)
 PJXAvatarStack(
     id="team",
     avatars=[
@@ -834,7 +900,7 @@ PJXAvatarStack(
 
 **DOM contract.** Root `.pjx-avatar-stack`; no JS API.
 
-**Classes:** `pjx-avatar-stack`, `pjx-avatar-stack__more`, `pjx-avatar-stack__empty`. Theming: see [PJXAvatarStack tokens](#pjxavatarstack-tokens).
+**Classes:** `pjx-avatar-stack`, `pjx-avatar-stack__pill` (dict-rendered pills), `pjx-avatar-stack__more`, `pjx-avatar-stack__empty`. Theming: see [PJXAvatarStack tokens](#pjxavatarstack-tokens).
 
 ---
 

--- a/pyjinhx/builtins/ui/pjx_avatar/pjx_avatar.html
+++ b/pyjinhx/builtins/ui/pjx_avatar/pjx_avatar.html
@@ -1,5 +1,5 @@
 <div id="{{ id }}"
-     class="pjx-avatar pjx-avatar--{{ size }}{% if class_name %} {{ class_name }}{% endif %}"{% if color %} style="background:{{ color }};"{% endif %}>
+     class="pjx-avatar{% if size_is_token %} pjx-avatar--{{ size }}{% endif %}{% if class_name %} {{ class_name }}{% endif %}"{% if not size_is_token %} style="width:{{ size_css }};height:{{ size_css }};{% if color %}background:{{ color }};{% endif %}"{% elif color %} style="background:{{ color }};"{% endif %}>
   {% if src %}
   <img class="pjx-avatar__img" src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" />
   {% else %}

--- a/pyjinhx/builtins/ui/pjx_avatar/pjx_avatar.py
+++ b/pyjinhx/builtins/ui/pjx_avatar/pjx_avatar.py
@@ -1,16 +1,19 @@
-from typing import Literal
-
-from pydantic import Field, field_validator
+from pydantic import Field, computed_field, field_validator
 
 from pyjinhx import BaseComponent
 from pyjinhx.base import AttrValue, ExtraAttrs
+
+_NAMED_SIZES = {"sm", "md", "lg"}
 
 
 class PJXAvatar(BaseComponent):
     src: str = ""
     alt: str = ""
     initials: str = ""
-    size: Literal["sm", "md", "lg"] = "md"
+    # Named tokens ("sm", "md", "lg") emit a BEM modifier class.
+    # An int (px) or any other CSS length string (e.g. "36px", "2.5rem")
+    # renders inline width/height instead and omits the modifier class.
+    size: str | int = "md"
     class_name: AttrValue = ""
     color: AttrValue = ""
     extra_attrs: ExtraAttrs = Field(default_factory=dict)
@@ -22,3 +25,17 @@ class PJXAvatar(BaseComponent):
             return ""
         text = str(value).strip()
         return text[:2] if len(text) > 2 else text
+
+    @computed_field
+    @property
+    def size_is_token(self) -> bool:
+        return str(self.size) in _NAMED_SIZES
+
+    @computed_field
+    @property
+    def size_css(self) -> str:
+        """CSS length string for inline style when size is not a named token."""
+        val = self.size
+        if isinstance(val, int):
+            return f"{val}px"
+        return str(val)

--- a/pyjinhx/builtins/ui/pjx_avatar_stack/pjx-avatar-stack.css
+++ b/pyjinhx/builtins/ui/pjx_avatar_stack/pjx-avatar-stack.css
@@ -9,8 +9,28 @@
 }
 
 .pjx-avatar-stack > .pjx-avatar,
+.pjx-avatar-stack > .pjx-avatar-stack__pill,
 .pjx-avatar-stack > .pjx-avatar-stack__more {
   box-shadow: 0 0 0 2px var(--pjx-avatar-stack-ring);
+}
+
+.pjx-avatar-stack__pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: var(--pjx-avatar-sm, 2rem);
+  height: var(--pjx-avatar-sm, 2rem);
+  border-radius: var(--radius-full, 9999px);
+  overflow: hidden;
+  background: var(--pjx-avatar-bg, var(--surface-alt));
+  border: 1px solid var(--pjx-avatar-border, var(--border));
+  font-size: var(--pjx-avatar-font-size-sm, var(--font-size-xs));
+  font-weight: 600;
+  color: var(--pjx-avatar-fg, var(--text-muted));
+  text-transform: uppercase;
+  user-select: none;
+  line-height: 1;
 }
 
 .pjx-avatar-stack > * + * {

--- a/pyjinhx/builtins/ui/pjx_avatar_stack/pjx_avatar_stack.html
+++ b/pyjinhx/builtins/ui/pjx_avatar_stack/pjx_avatar_stack.html
@@ -1,5 +1,5 @@
 <div id="{{ id }}" class="pjx-avatar-stack{% if class_name %} {{ class_name }}{% endif %}">
-  {% for avatar in avatars %}{{ avatar }}{% endfor %}
+  {% for avatar in avatars %}{% if avatar is mapping %}{% set tooltip = avatar.alt or avatar.name or "" %}<span class="pjx-avatar pjx-avatar-stack__pill"{% if avatar.color %} style="background:{{ avatar.color }};"{% endif %}{% if tooltip %} title="{{ tooltip }}"{% endif %}>{{ (avatar.initials or "?")[:2] }}</span>{% else %}{{ avatar }}{% endif %}{% endfor %}
   {% if extra_count > 0 %}<span class="pjx-avatar-stack__more">+{{ extra_count }}</span>{% endif %}
   {% if not avatars and empty_label %}<span class="pjx-avatar-stack__empty">{{ empty_label }}</span>{% endif %}
 </div>

--- a/pyjinhx/builtins/ui/pjx_avatar_stack/pjx_avatar_stack.py
+++ b/pyjinhx/builtins/ui/pjx_avatar_stack/pjx_avatar_stack.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import Field
 
 from pyjinhx import BaseComponent
@@ -5,7 +7,13 @@ from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class PJXAvatarStack(BaseComponent):
-    avatars: list[str | BaseComponent] = Field(default_factory=list)
+    # Pre-built items (original interface): HTML strings or BaseComponent instances.
+    # Structured data (new interface): dicts with keys initials, color, alt, name.
+    #   - initials (str): text shown in the pill
+    #   - color    (str, optional): inline background color
+    #   - alt      (str, optional): tooltip/title on the pill
+    #   - name     (str, optional): alias for alt; alt takes precedence if both given
+    avatars: list[Any] = Field(default_factory=list)
     extra_count: int = 0
     empty_label: str = ""
     class_name: AttrValue = ""

--- a/pyjinhx/builtins/ui/pjx_empty_state/pjx-empty-state.css
+++ b/pyjinhx/builtins/ui/pjx_empty_state/pjx-empty-state.css
@@ -7,6 +7,9 @@
   --pjx-empty-state-desc-color:  var(--text-muted);
   --pjx-empty-state-gap:       0.5rem;
   --pjx-empty-state-actions-gap: 0.5rem;
+  --pjx-empty-state-chip-bg:    var(--surface-alt);
+  --pjx-empty-state-chip-color: var(--text-muted);
+  --pjx-empty-state-chip-border: var(--border);
 }
 
 .pjx-empty-state {
@@ -48,4 +51,30 @@
   justify-content: center;
   gap: var(--pjx-empty-state-actions-gap);
   margin-top: 0.75rem;
+}
+
+.pjx-empty-state__suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--pjx-empty-state-actions-gap);
+  margin-top: 0.75rem;
+}
+
+.pjx-empty-state__chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: var(--radius-full, 9999px);
+  border: 1px solid var(--pjx-empty-state-chip-border);
+  background: var(--pjx-empty-state-chip-bg);
+  color: var(--pjx-empty-state-chip-color);
+  font-size: var(--font-size-sm, 0.875rem);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.pjx-empty-state__chip:hover {
+  background: var(--surface-hover, var(--surface-alt));
+  color: var(--text);
 }

--- a/pyjinhx/builtins/ui/pjx_empty_state/pjx-empty-state.html
+++ b/pyjinhx/builtins/ui/pjx_empty_state/pjx-empty-state.html
@@ -10,4 +10,7 @@
     {% if actions %}
     <div class="pjx-empty-state__actions">{% for item in actions %}{{ item }}{% endfor %}</div>
     {% endif %}
+    {% if suggestions %}
+    <div class="pjx-empty-state__suggestions">{% for chip in suggestions %}<button type="button" class="pjx-empty-state__chip" data-pjx-suggestion="{{ chip.value if chip.value is defined else chip.label }}" @click="$dispatch('{{ chip.event if chip.event is defined else 'pjx:suggestion' }}', { value: $el.dataset.pjxSuggestion })">{{ chip.label }}</button>{% endfor %}</div>
+    {% endif %}
 </div>

--- a/pyjinhx/builtins/ui/pjx_empty_state/pjx-empty-state.html
+++ b/pyjinhx/builtins/ui/pjx_empty_state/pjx-empty-state.html
@@ -11,6 +11,6 @@
     <div class="pjx-empty-state__actions">{% for item in actions %}{{ item }}{% endfor %}</div>
     {% endif %}
     {% if suggestions %}
-    <div class="pjx-empty-state__suggestions">{% for chip in suggestions %}<button type="button" class="pjx-empty-state__chip" data-pjx-suggestion="{{ chip.value if chip.value is defined else chip.label }}" @click="$dispatch('{{ chip.event if chip.event is defined else 'pjx:suggestion' }}', { value: $el.dataset.pjxSuggestion })">{{ chip.label }}</button>{% endfor %}</div>
+    <div class="pjx-empty-state__suggestions">{% for chip in suggestions %}<button type="button" class="pjx-empty-state__chip" data-pjx-suggestion="{{ chip.value if chip.value is defined else chip.label }}" data-pjx-event="{{ chip.event if chip.event is defined else 'pjx:suggestion' }}" @click="$dispatch($el.dataset.pjxEvent, { value: $el.dataset.pjxSuggestion })">{{ chip.label }}</button>{% endfor %}</div>
     {% endif %}
 </div>

--- a/pyjinhx/builtins/ui/pjx_empty_state/pjx_empty_state.py
+++ b/pyjinhx/builtins/ui/pjx_empty_state/pjx_empty_state.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import Field
 
 from pyjinhx import BaseComponent
@@ -10,5 +12,11 @@ class PJXEmptyState(BaseComponent):
     description: str | BaseComponent = ""
     action: str | BaseComponent = ""
     actions: list[str | BaseComponent] = Field(default_factory=list)
+    # First-class interactive suggestion chips (option a from issue #77).
+    # Each item is a dict with:
+    #   - label      (str): button text
+    #   - value      (str, optional): dispatched with the event; defaults to label
+    #   - event      (str, optional): custom event name; defaults to "pjx:suggestion"
+    suggestions: list[Any] = Field(default_factory=list)
     class_name: AttrValue = ""
     extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/tests/unit/golden/empty_state.html
+++ b/tests/unit/golden/empty_state.html
@@ -6,4 +6,5 @@
     <div class="pjx-empty-state__action"><button>A</button></div>
     
     
+    
 </div>

--- a/tests/unit/test_avatar_stack.py
+++ b/tests/unit/test_avatar_stack.py
@@ -21,3 +21,75 @@ def test_stack_no_empty_label_when_avatars_present():
     html = str(PJXAvatarStack(id="st", avatars=[PJXAvatar(id="a1", initials="AB")],
                            empty_label="Sem membros").render())
     assert "Sem membros" not in html
+
+
+# --- Avatar arbitrary pixel size (issue #77) ---
+
+def test_avatar_named_token_emits_bem_class():
+    for token in ("sm", "md", "lg"):
+        html = str(PJXAvatar(id="a", initials="AB", size=token).render())
+        assert f"pjx-avatar--{token}" in html
+        assert "style=" not in html
+
+
+def test_avatar_int_size_emits_inline_style_no_bem():
+    html = str(PJXAvatar(id="a", initials="AB", size=36).render())
+    assert "width:36px" in html
+    assert "height:36px" in html
+    # BEM modifier must not appear on the root element; it may appear in the
+    # embedded <style> block, so check the div tag specifically.
+    assert 'class="pjx-avatar"' in html or 'class="pjx-avatar ' in html
+    assert 'class="pjx-avatar pjx-avatar--' not in html
+
+
+def test_avatar_css_length_string_emits_inline_style():
+    html = str(PJXAvatar(id="a", initials="AB", size="2.5rem").render())
+    assert "width:2.5rem" in html
+    assert "height:2.5rem" in html
+    assert 'class="pjx-avatar pjx-avatar--' not in html
+
+
+def test_avatar_int_size_with_color():
+    html = str(PJXAvatar(id="a", initials="AB", size=40, color="#ff0").render())
+    assert "width:40px" in html
+    assert "background:#ff0" in html
+
+
+# --- AvatarStack structured dict data (issue #77) ---
+
+def test_stack_dict_avatars_renders_pills():
+    html = str(PJXAvatarStack(
+        id="st",
+        avatars=[
+            {"initials": "AB", "color": "#f00", "name": "Alice"},
+            {"initials": "CD"},
+        ],
+    ).render())
+    assert "AB" in html
+    assert "CD" in html
+    assert 'style="background:#f00;"' in html
+    assert 'title="Alice"' in html
+    assert 'class="pjx-avatar pjx-avatar-stack__pill"' in html
+
+
+def test_stack_dict_avatar_alt_takes_precedence_over_name():
+    html = str(PJXAvatarStack(
+        id="st",
+        avatars=[{"initials": "XY", "color": "", "alt": "Explicit", "name": "Fallback"}],
+    ).render())
+    assert 'title="Explicit"' in html
+    assert "Fallback" not in html
+
+
+def test_stack_mixed_dict_and_component():
+    html = str(PJXAvatarStack(
+        id="st",
+        avatars=[
+            {"initials": "DT", "color": "#0f0"},
+            PJXAvatar(id="a1", initials="EF"),
+        ],
+        extra_count=1,
+    ).render())
+    assert "DT" in html
+    assert 'id="a1"' in html
+    assert ">+1<" in html

--- a/tests/unit/test_empty_state_slots.py
+++ b/tests/unit/test_empty_state_slots.py
@@ -1,6 +1,8 @@
 from pyjinhx.builtins import PJXBadge, PJXEmptyState
 
 
+
+
 def test_empty_state_default_render_has_no_image_or_actions():
     html = str(
         PJXEmptyState(
@@ -55,3 +57,67 @@ def test_empty_state_action_renders_before_actions():
     assert "<button>Use a template</button>" in html
     assert "<button>Import</button>" in html
     assert html.index('class="pjx-empty-state__action"') < html.index('class="pjx-empty-state__actions"')
+
+
+# --- Suggestion chips (issue #77) ---
+
+def test_empty_state_suggestions_renders_chips():
+    html = str(
+        PJXEmptyState(
+            id="es-chips",
+            title="What would you like to do?",
+            suggestions=[
+                {"label": "Draft a message"},
+                {"label": "Summarise a thread"},
+            ],
+        ).render()
+    )
+    assert '<div class="pjx-empty-state__suggestions">' in html
+    assert "Draft a message" in html
+    assert "Summarise a thread" in html
+    assert 'class="pjx-empty-state__chip"' in html
+
+
+def test_empty_state_chip_default_event_and_value():
+    html = str(
+        PJXEmptyState(
+            id="es-chip-defaults",
+            title="T",
+            suggestions=[{"label": "Fill me in"}],
+        ).render()
+    )
+    assert 'data-pjx-suggestion="Fill me in"' in html
+    assert "@click=" in html
+    assert "pjx:suggestion" in html
+
+
+def test_empty_state_chip_custom_event_and_value():
+    html = str(
+        PJXEmptyState(
+            id="es-chip-custom",
+            title="T",
+            suggestions=[{"label": "Click me", "value": "fill-input-value", "event": "fill-input"}],
+        ).render()
+    )
+    assert 'data-pjx-suggestion="fill-input-value"' in html
+    assert "fill-input" in html
+    assert "Click me" in html
+
+
+def test_empty_state_no_suggestions_block_when_empty():
+    html = str(
+        PJXEmptyState(id="es-no-chips", title="T").render()
+    )
+    assert 'class="pjx-empty-state__suggestions"' not in html
+
+
+def test_empty_state_suggestions_after_actions():
+    html = str(
+        PJXEmptyState(
+            id="es-order",
+            title="T",
+            actions=["<button>Act</button>"],
+            suggestions=[{"label": "Chip"}],
+        ).render()
+    )
+    assert html.index('class="pjx-empty-state__actions"') < html.index('class="pjx-empty-state__suggestions"')

--- a/tests/unit/test_empty_state_slots.py
+++ b/tests/unit/test_empty_state_slots.py
@@ -121,3 +121,26 @@ def test_empty_state_suggestions_after_actions():
         ).render()
     )
     assert html.index('class="pjx-empty-state__actions"') < html.index('class="pjx-empty-state__suggestions"')
+
+
+def test_empty_state_chip_event_is_not_interpolated_into_click_handler():
+    # Security regression: the event name must never be interpolated into the
+    # @click JS string literal. It is carried in a data attribute and read via
+    # $el.dataset, so a quote in the event name cannot break out and inject JS.
+    payload = "x');alert(1);('"
+    html = str(
+        PJXEmptyState(
+            id="es-xss",
+            title="T",
+            suggestions=[{"label": "x", "event": payload}],
+        ).render()
+    )
+    # @click is a fixed expression that reads the event from the dataset — the
+    # event name is never interpolated into the JS string literal.
+    assert (
+        '@click="$dispatch($el.dataset.pjxEvent, { value: $el.dataset.pjxSuggestion })"'
+        in html
+    )
+    # The old vulnerable JS-context form ($dispatch('<event>', ...)) is gone, so a
+    # quote in the event name cannot break out of the JS string and execute.
+    assert "$dispatch('" not in html


### PR DESCRIPTION
## Summary

Fixes #77 — three backward-compatible builtin gaps:
- **PJXAvatar:** `size: str | int` — int/CSS-length renders inline `width`/`height`; named tokens (`sm`/`md`/`lg`) still emit the `pjx-avatar--{size}` class.
- **PJXAvatarStack:** `avatars` now also accepts structured `dict` items (`initials`/`color`/`alt`/`name`) rendered as pills, alongside the existing str/component shapes.
- **PJXEmptyState:** first-class `suggestions` chips that dispatch an event. The chip event is read via `$el.dataset.pjxEvent` (not interpolated into the `@click` JS — XSS-safe).

Backward compatible throughout.

## Testing
Full suite 821 passed / 5 skipped; ruff clean; mkdocs OK.

## Known non-blocking notes
- Chips use Alpine `$dispatch` (need Alpine on the page).
- Separate, framework-wide: pyjinhx renders with Jinja autoescape off, so scalar values in attributes (e.g. `alt`, chip `value`) can break out via `"`. Pre-existing across all builtins — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)