### PR TITLE
docs: backfill CHANGELOG 0.14-0.18 + gallery showcases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,8 +92,53 @@
   `{INLINE, NONE}`. For external/CSP/CDN delivery, render in `NONE` and serve a
   bundle built from `Finder.all_assets()`.
 
-> Note: CHANGELOG entries for **0.14.0–0.18.0** are not yet backfilled — they
-> predate this changelog-maintenance pass. See the git tags for their history.
+## 0.18.0 — single-root invariant + universal attribute pass-through (2026-06-17)
+
+### Added
+
+- Inline attributes on any PascalCase tag are injected onto the component's
+  root element automatically (new `root_attrs` module), and every component is
+  enforced to render exactly one root element.
+
+### Changed
+
+- `collect_extra_attrs` now returns a dict (replacing `render_extra_attrs`); the
+  `extra_attrs_html` template token is dropped from builtins. `class_name`
+  guidance scoped to builtins in the docs.
+
+## 0.17.0 — ReactiveResponse accepts mutation keys (2026-06-17)
+
+### Added
+
+- `ReactiveResponse(*keys)` dirties the given mutation keys and fans out the
+  OOB swaps in one call.
+
+## 0.16.0 — ReactiveResponse class (2026-06-17)
+
+### Changed (breaking)
+
+- `reactive_response()` is replaced by the `ReactiveResponse` class.
+
+## 0.15.0 — `component()` factory + setup wiring (2026-06-17)
+
+### Added
+
+- `component(name)` factory for html-only (classless) components.
+- `dirty()` for imperative reactive-key dirtying.
+- `setup()` wires the `components_root` Jinja environment and mounts
+  `static_root`.
+
+### Changed
+
+- Removed `pyjinhx_lifespan`; `setup()` and backend wiring tidied.
+
+## 0.14.0 — PjxContext method injection (2026-06-15)
+
+### Added
+
+- `PjxContext` is injected into component instance methods, classmethods, and
+  staticmethods that declare it (threaded through bound args, so positional-only
+  params work).
 
 ## 0.13.0 — OOB swaps ride along any render (2026-06-13)
 

--- a/docs/demos/static.py
+++ b/docs/demos/static.py
@@ -17,7 +17,11 @@ from pyjinhx.builtins import (
 
 
 def accordion():
-    return PJXAccordion(label="What is pyjinhx?", content="<p>A Python/Jinja HTML component framework.</p>").render()
+    return PJXAccordion(
+        label="What is pyjinhx?",
+        actions='<button class="pjx-demo-btn" type="button">Archive</button>',
+        content="<p>A Python/Jinja HTML component framework.</p>",
+    ).render()
 
 
 def accordion_group():
@@ -62,6 +66,7 @@ def avatar():
         PJXAvatar(initials="JD", size="sm", alt="Jane Doe").render(),
         PJXAvatar(initials="JD", size="md", alt="Jane Doe").render(),
         PJXAvatar(initials="JD", size="lg", alt="Jane Doe").render(),
+        PJXAvatar(initials="JD", size=64, alt="Jane Doe").render(),
     ]
 
 
@@ -100,6 +105,10 @@ def empty_state():
         title="No results",
         description="Try a different search term.",
         actions=['<button class="pjx-demo-btn">Clear filters</button>'],
+        suggestions=[
+            {"label": "Draft a message"},
+            {"label": "Summarise a thread"},
+        ],
     ).render()
 
 


### PR DESCRIPTION
## Summary

Ties up the remaining doc loose ends after the 0.22.0 batch:
- **CHANGELOG backfill** for 0.14.0–0.18.0 (mined from git history per tag) — the changelog is now continuous from 0.13.0 → 0.22.0.
- **Gallery showcases** for the new builtin features: the accordion demo now shows the `actions` slot, the avatar demo shows arbitrary px sizing, and the empty-state demo shows suggestion chips.

Docs/demos only — no package change, so no release. Full suite 821 passed; ruff + `mkdocs --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)