### PR TITLE
feat(security): autoescape template output by default; raw HTML via Slot (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@
 
 - **Scalar values are now HTML-escaped.** Strings that previously rendered raw
   (`<b>x</b>`) now escape to entities. Raw HTML in a scalar field requires an
-  opt-in: declare the field as `Slot`, pass a `markupsafe.Markup(...)` value, or
-  use `{{ value|safe }}`. Builtin slot fields are pre-typed `Slot` and are
+  opt-in: declare the field as `Slot`, use `{{ value|safe }}` in the template, or
+  pass a `BaseComponent` instance. Builtin slot fields are pre-typed `Slot` and are
   unaffected. See the [migration guide](docs/migration.md). (#113)
 
 ## 0.22.0 — issue batch: AccordionGroup, accordion actions, avatar/empty-state data, icons; swap-asset fix (2026-06-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Autoescape by default.** Template output is now HTML-escaped (Jinja runs with
+  `autoescape=True`): scalar props, text, attribute values, and loop-derived
+  values are escaped, closing the default XSS hole. (#113)
+- **`Slot` type** (`from pyjinhx import Slot`) — declares a raw-HTML field
+  (`str | BaseComponent`) whose string value renders unescaped. Works on scalar
+  fields and on `Slot`-annotated `list`/`dict` collections (string elements
+  render raw). A component's children/`content` field is always a slot; nested
+  `BaseComponent` values render raw via `__html__`. (#113)
+
+### Breaking
+
+- **Scalar values are now HTML-escaped.** Strings that previously rendered raw
+  (`<b>x</b>`) now escape to entities. Raw HTML in a scalar field requires an
+  opt-in: declare the field as `Slot`, pass a `markupsafe.Markup(...)` value, or
+  use `{{ value|safe }}`. Builtin slot fields are pre-typed `Slot` and are
+  unaffected. See the [migration guide](docs/migration.md). (#113)
+
 ## 0.22.0 — issue batch: AccordionGroup, accordion actions, avatar/empty-state data, icons; swap-asset fix (2026-06-18)
 
 ### Added

--- a/docs/guide/builtin-conventions.md
+++ b/docs/guide/builtin-conventions.md
@@ -26,6 +26,10 @@ Every pyjinhx builtin follows the same contract, so knowing one means knowing al
    mid-flight.
 6. **The DOM contract is API.** Each builtin's documentation ends with a "DOM contract" block —
    stable classes, `data-pjx-*` attributes, events, state attributes. We version those like code.
+7. **Output is escaped by default.** Scalar props, text, attributes, and loop values are
+   HTML-escaped. A builtin's children/`content` field and any field typed `Slot` (e.g. a card's
+   `body`, a tab group's `tabs`) render raw HTML, as do nested `BaseComponent` values. See
+   [Escaping & slots](components.md#escaping-and-slots) for the full rule and escape hatches.
 
 ## Events and hooks
 

--- a/docs/guide/builtins.md
+++ b/docs/guide/builtins.md
@@ -973,7 +973,7 @@ Events (bubble from root): `pjx:chip-input:before-add`* (detail `{value}`), `pjx
 
 **Notes:**
 
-- `values` render verbatim (the renderer unescapes markup by design) — sanitize user-supplied tag text server-side before re-rendering it.
+- `values` are plain-text chip labels and are **HTML-escaped** on render (output is escaped by default — see [Escaping & slots](components.md#escaping-and-slots)). Passing markup shows it as literal text, not HTML.
 - Duplicate entries are silently dropped (the field clears).
 - Chips added client-side exist only in the DOM until the form posts; an htmx swap of the surrounding region re-renders from server state.
 

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -172,11 +172,11 @@ PJXCard(id="c", title="T", body="<p data-x='1'>hi</p>")
 field, choose one:
 
 - Declare the field as `Slot` (`field: Slot = ""`).
-- Pass a `markupsafe.Markup(...)` value — `Markup` is treated as already-safe.
 - Mark it safe in the template: `{{ value|safe }}`.
+- Pass a `BaseComponent` instance — it renders raw via `__html__`.
 
-> Raw HTML is only as safe as its source. Reserve slots / `Markup` / `|safe` for
-> markup you control; never wrap unsanitized user input.
+> Raw HTML is only as safe as its source. Reserve slots / `|safe` / nested
+> components for markup you control; never pass unsanitized user input raw.
 
 Prop-header props (`{#def ... #}`, below) follow the same rule: a header-declared
 prop is **escaped** unless you mark it safe in the template (`{{ prop|safe }}`) or

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -137,6 +137,52 @@ not injected. Non-declared ("stray") attributes and the explicit `extra_attrs` d
 injected. For template-only components (no Python class, or created with `component()`), all
 attributes inject onto the root and are also available as template variables.
 
+## Escaping and slots
+
+Template output is **HTML-escaped by default**. pyjinhx runs Jinja with
+`autoescape=True`, so the special characters `& < > " '` in a value are turned
+into entities (`&amp; &lt; &gt; &#34; &#39;`) before they reach the page. This is
+the safe default: a scalar prop, text, an attribute value, or a value derived in
+a `{% for %}` loop is escaped, so user-supplied data can't inject markup or break
+out of an attribute.
+
+```python
+PJXCard(id="c", title="<script>alert(1)</script>", body="ok")
+# title renders as &lt;script&gt;alert(1)&lt;/script&gt; — not executable
+```
+
+**What renders as raw HTML (not escaped):**
+
+- A component's **children**/`content` field (the `_pjx_children_field`, e.g.
+  `PJXCard.body`) — its string value is emitted verbatim.
+- Any field declared `Slot` (`from pyjinhx import Slot`). A `Slot` field is
+  `str | BaseComponent`; its string value renders raw. `Slot` collections work
+  too — string elements inside a `Slot`-annotated `list`/`dict` (e.g.
+  `PJXTabGroup.tabs`, `PJXDropdown.items`) render raw.
+- Any **`BaseComponent`** value — a nested component always renders its own HTML
+  raw via the `__html__` protocol, whether passed directly or inside a list/dict.
+
+```python
+# body is the children field → raw HTML
+PJXCard(id="c", title="T", body="<p data-x='1'>hi</p>")
+# renders <p data-x='1'>hi</p> verbatim
+```
+
+**Escape hatches** — when you trust the markup and want it raw in a *scalar*
+field, choose one:
+
+- Declare the field as `Slot` (`field: Slot = ""`).
+- Pass a `markupsafe.Markup(...)` value — `Markup` is treated as already-safe.
+- Mark it safe in the template: `{{ value|safe }}`.
+
+> Raw HTML is only as safe as its source. Reserve slots / `Markup` / `|safe` for
+> markup you control; never wrap unsanitized user input.
+
+Prop-header props (`{#def ... #}`, below) follow the same rule: a header-declared
+prop is **escaped** unless you mark it safe in the template (`{{ prop|safe }}`) or
+the prop is the component's children field. Header props can't be typed `Slot`
+directly, so use `|safe` for intentional raw HTML there.
+
 ## HTML-only components
 
 A component doesn't always need a Python class. If you have a template with no
@@ -180,6 +226,9 @@ Python class:
   value that can't coerce, raises a clear error). **Undeclared** attributes still
   pass through to the root element (`hx-*`, `data-*`, `@click`, `class`).
 - The header is a normal Jinja comment, so it never appears in the output.
+- Header-declared props are **HTML-escaped** like any scalar value (see
+  [Escaping & slots](#escaping-and-slots)). For intentional raw HTML, mark it safe
+  in the template with `{{ prop|safe }}` — header props can't be typed `Slot`.
 - A hand-written Python class always takes precedence over a header.
 
 On the `component()` factory, the header is applied when the template is

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,6 +2,48 @@
 
 ## 0.18 → 0.19
 
+### Template output is escaped by default (breaking)
+
+Rendered output is now **HTML-escaped by default** (Jinja runs with
+`autoescape=True`). Previously the renderer emitted markup raw (it called
+`Markup(...).unescape()` on the final output), so any string value passed through
+verbatim. Now scalar props, text, attribute values, and loop-derived values are
+escaped — `& < > " '` become entities — which closes the default XSS hole.
+
+**What changed for you:**
+
+- **Scalar props that contained HTML now escape.** A `title`, `label`, `alt`, etc.
+  holding `<b>x</b>` now renders `&lt;b&gt;x&lt;/b&gt;`.
+- **Raw HTML now requires an opt-in.** To emit raw markup in a *scalar* field, do
+  one of: declare the field as `Slot` (`from pyjinhx import Slot`), pass a
+  `markupsafe.Markup(...)` value, or use `{{ value|safe }}` in the template.
+- **Children/`content` and `Slot` fields still render raw**, including `Slot`
+  collections (string elements in a `Slot`-annotated `list`/`dict`). Nested
+  `BaseComponent` values still render raw via `__html__`.
+- **`Slot` is exported from `pyjinhx`** (`from pyjinhx import Slot`) for declaring
+  raw-HTML fields on your own components.
+
+```python
+from pyjinhx import BaseComponent, Slot
+from markupsafe import Markup
+
+class Card(BaseComponent):
+    title: str = ""      # escaped
+    body: Slot = ""      # raw HTML
+
+Card(title="<b>x</b>", body="<p>ok</p>")
+# title → &lt;b&gt;x&lt;/b&gt;   body → <p>ok</p>
+
+# scalar escape hatch:
+Card(title=Markup("<b>x</b>"))   # title now raw
+```
+
+The builtins were updated for you — their slot fields (card `body`, modal/drawer
+`header`/`footer`, tab group `tabs`, dropdown `items`, empty-state `actions`, …)
+are typed `Slot` and keep rendering raw. Only *your own* scalar fields that relied
+on raw passthrough need the opt-in above. See
+[Escaping & slots](guide/components.md#escaping-and-slots).
+
 ### REFERENCE asset mode removed (breaking)
 
 `AssetMode.REFERENCE` is gone. `AssetMode` is now a two-member enum: `INLINE` and `NONE`.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -15,8 +15,9 @@ escaped — `& < > " '` become entities — which closes the default XSS hole.
 - **Scalar props that contained HTML now escape.** A `title`, `label`, `alt`, etc.
   holding `<b>x</b>` now renders `&lt;b&gt;x&lt;/b&gt;`.
 - **Raw HTML now requires an opt-in.** To emit raw markup in a *scalar* field, do
-  one of: declare the field as `Slot` (`from pyjinhx import Slot`), pass a
-  `markupsafe.Markup(...)` value, or use `{{ value|safe }}` in the template.
+  one of: declare the field as `Slot` (`from pyjinhx import Slot`), use
+  `{{ value|safe }}` in the template, or pass a `BaseComponent` instance (renders
+  raw via `__html__`).
 - **Children/`content` and `Slot` fields still render raw**, including `Slot`
   collections (string elements in a `Slot`-annotated `list`/`dict`). Nested
   `BaseComponent` values still render raw via `__html__`.
@@ -25,7 +26,6 @@ escaped — `& < > " '` become entities — which closes the default XSS hole.
 
 ```python
 from pyjinhx import BaseComponent, Slot
-from markupsafe import Markup
 
 class Card(BaseComponent):
     title: str = ""      # escaped
@@ -33,9 +33,6 @@ class Card(BaseComponent):
 
 Card(title="<b>x</b>", body="<p>ok</p>")
 # title → &lt;b&gt;x&lt;/b&gt;   body → <p>ok</p>
-
-# scalar escape hatch:
-Card(title=Markup("<b>x</b>"))   # title now raw
 ```
 
 The builtins were updated for you — their slot fields (card `body`, modal/drawer
@@ -43,6 +40,11 @@ The builtins were updated for you — their slot fields (card `body`, modal/draw
 are typed `Slot` and keep rendering raw. Only *your own* scalar fields that relied
 on raw passthrough need the opt-in above. See
 [Escaping & slots](guide/components.md#escaping-and-slots).
+
+**`PJXAvatarStack` — string items are now escaped.** If you passed pre-rendered
+HTML strings as `avatars` items, those strings are now escaped. Use structured
+dicts (`{"initials": "AB", "color": "#f00", ...}`) for pill rendering, or pass
+`BaseComponent` instances for raw markup.
 
 ---
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,6 +1,6 @@
 # Migration guide
 
-## 0.18 → 0.19
+## 0.22.x → next (autoescape by default)
 
 ### Template output is escaped by default (breaking)
 
@@ -43,6 +43,10 @@ The builtins were updated for you — their slot fields (card `body`, modal/draw
 are typed `Slot` and keep rendering raw. Only *your own* scalar fields that relied
 on raw passthrough need the opt-in above. See
 [Escaping & slots](guide/components.md#escaping-and-slots).
+
+---
+
+## 0.18 → 0.19
 
 ### REFERENCE asset mode removed (breaking)
 

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -7,7 +7,7 @@ LoadCache`` — and are not part of this curated surface.
 """
 
 from pyjinhx.assets import AssetMode
-from pyjinhx.base import BaseComponent, component
+from pyjinhx.base import BaseComponent, Slot, component
 from pyjinhx.config import PjxSettings, setup
 from pyjinhx.context import PjxContext
 from pyjinhx.keys import MutationKey
@@ -19,6 +19,7 @@ from pyjinhx.renderer import Renderer
 __all__ = [
     # Components & rendering
     "BaseComponent",
+    "Slot",
     "component",
     "ReactiveComponent",
     "Renderer",

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -71,6 +71,20 @@ def _is_slot_field(cls: type, field_name: str) -> bool:
     return bool(field) and any(isinstance(m, PjxSlot) for m in field.metadata)
 
 
+def _wrap_slot_value(value: Any) -> Any:
+    """Wrap a slot field's string value(s) as ``markupsafe.Markup`` so they
+    pass through Jinja unescaped. Recurses into list/dict slot collections
+    (e.g. ``PJXTabGroup.tabs``); non-string elements (nested components) are
+    left untouched and render raw via their own ``__html__``."""
+    if isinstance(value, str):
+        return Markup(value)
+    if isinstance(value, list):
+        return [_wrap_slot_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _wrap_slot_value(item) for key, item in value.items()}
+    return value
+
+
 def collect_extra_attrs(component: "BaseComponent") -> dict[str, str]:
     """Collect a component's pass-through HTML attributes as an ordered dict.
 
@@ -100,7 +114,10 @@ class NestedComponentWrapper(BaseModel):
     html: str
     props: Optional["BaseComponent"]
 
-    def __str__(self) -> Markup:
+    def __html__(self) -> Markup:
+        return Markup(self.html)
+
+    def __str__(self) -> str:
         return self.html
 
 
@@ -337,10 +354,8 @@ class BaseComponent(BaseModel):
                 renderer=_renderer,
                 session=_session,
             )
-            if _is_slot_field(type(self), field_name) and isinstance(
-                context.get(field_name), str
-            ):
-                context[field_name] = Markup(context[field_name])
+            if _is_slot_field(type(self), field_name):
+                context[field_name] = _wrap_slot_value(context.get(field_name))
 
         declared_fields = set(type(self).model_fields.keys())
         for field_name, field_value in context.items():

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -28,8 +28,10 @@ def _auto_id() -> str:
 def validate_attr_value(value: str) -> str:
     """Reject values that could break out of a double-quoted HTML attribute.
 
-    The renderer unescapes final markup by design, so attribute safety is
-    enforced at construction time. Post-construction mutation bypasses this.
+    Belt-and-suspenders construction-time guard complementing autoescape:
+    autoescape handles text content, but attribute quoting is structural and
+    must be caught before the value reaches the template.
+    Post-construction mutation bypasses this check.
     """
     if '"' in value:
         raise ValueError('attribute values must not contain \'"\'')

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -56,6 +56,21 @@ AttrValue = Annotated[str, AfterValidator(validate_attr_value)]
 ExtraAttrs = Annotated[dict[str, str], AfterValidator(validate_extra_attrs)]
 
 
+class PjxSlot:
+    """Marker (in a field's Annotated metadata) for a raw-HTML slot field —
+    its string value is emitted unescaped. Use via the ``Slot`` alias."""
+
+
+# Slot is defined after BaseComponent (forward-ref resolved at class definition time)
+
+
+def _is_slot_field(cls: type, field_name: str) -> bool:
+    if field_name == getattr(cls, "_pjx_children_field", None):
+        return True
+    field = cls.model_fields.get(field_name)
+    return bool(field) and any(isinstance(m, PjxSlot) for m in field.metadata)
+
+
 def collect_extra_attrs(component: "BaseComponent") -> dict[str, str]:
     """Collect a component's pass-through HTML attributes as an ordered dict.
 
@@ -288,6 +303,67 @@ class BaseComponent(BaseModel):
             context[field_name] = wrapped
         return context
 
+    def _build_template_context(
+        self,
+        base_context: dict[str, Any] | None = None,
+        *,
+        renderer: Renderer | None = None,
+        session: RenderSession | None = None,
+    ) -> dict[str, Any]:
+        """Build the template context dict for this component.
+
+        Merges ``base_context`` with the component's field values, runs
+        ``_update_context_`` for each declared field, and wraps slot-field
+        string values as ``markupsafe.Markup`` (so they pass through Jinja
+        unescaped once autoescape is enabled).
+
+        Safe to call outside an active request scope (renderer and session
+        default to the process-level defaults).
+        """
+        _renderer = renderer or Renderer.get_default_renderer()
+        _session = session or _renderer.new_session()
+
+        if base_context is None:
+            context: dict[str, Any] = self.model_dump()
+        else:
+            context = {**base_context, **self.model_dump()}
+
+        for field_name in type(self).model_fields.keys():
+            field_value = getattr(self, field_name)
+            context = self._update_context_(
+                context,
+                field_name,
+                field_value,
+                renderer=_renderer,
+                session=_session,
+            )
+            if _is_slot_field(type(self), field_name) and isinstance(
+                context.get(field_name), str
+            ):
+                context[field_name] = Markup(context[field_name])
+
+        declared_fields = set(type(self).model_fields.keys())
+        for field_name, field_value in context.items():
+            if field_name in declared_fields:
+                continue
+            if isinstance(field_value, BaseComponent):
+                # Registry peers injected by id. Rendering them eagerly
+                # multiplied across every registered instance (issue #67),
+                # so defer until a template actually references them.
+                context[field_name] = LazyNestedComponentWrapper(
+                    field_value, context, renderer=_renderer, session=_session
+                )
+                continue
+            context = self._update_context_(
+                context,
+                field_name,
+                field_value,
+                renderer=_renderer,
+                session=_session,
+            )
+
+        return context
+
     def _render(
         self,
         source: str | None = None,
@@ -317,40 +393,9 @@ class BaseComponent(BaseModel):
             return Markup("")
         session.rendering.add(_guard_key)
         try:
-            if base_context is None:
-                context: dict[str, Any] = self.model_dump()
-            else:
-                context = {**base_context, **self.model_dump()}
-
-            for field_name in type(self).model_fields.keys():
-                field_value = getattr(self, field_name)
-                context = self._update_context_(
-                    context,
-                    field_name,
-                    field_value,
-                    renderer=renderer,
-                    session=session,
-                )
-
-            declared_fields = set(type(self).model_fields.keys())
-            for field_name, field_value in context.items():
-                if field_name in declared_fields:
-                    continue
-                if isinstance(field_value, BaseComponent):
-                    # Registry peers injected by id. Rendering them eagerly
-                    # multiplied across every registered instance (issue #67),
-                    # so defer until a template actually references them.
-                    context[field_name] = LazyNestedComponentWrapper(
-                        field_value, context, renderer=renderer, session=session
-                    )
-                    continue
-                context = self._update_context_(
-                    context,
-                    field_name,
-                    field_value,
-                    renderer=renderer,
-                    session=session,
-                )
+            context = self._build_template_context(
+                base_context, renderer=renderer, session=session
+            )
 
             from pyjinhx.client import ClientBackend
 
@@ -386,6 +431,9 @@ class BaseComponent(BaseModel):
         from pyjinhx.reactive import _finish_with_oob
 
         return _finish_with_oob(self._render())
+
+
+Slot = Annotated[str | BaseComponent, PjxSlot()]
 
 
 def component(name: str) -> type[BaseComponent]:

--- a/pyjinhx/builtins/ui/pjx_accordion/pjx_accordion.py
+++ b/pyjinhx/builtins/ui/pjx_accordion/pjx_accordion.py
@@ -1,13 +1,13 @@
-from pyjinhx import BaseComponent
+from pyjinhx import BaseComponent, Slot
 from pyjinhx.base import AttrValue
 
 
 class PJXAccordion(BaseComponent):
     label: str = ""
-    header: str | BaseComponent | None = None
+    header: Slot | None = None
     open: bool = True
     disabled: bool = False
     group: str | None = None
     content: str | BaseComponent = ""
-    actions: str | BaseComponent | None = None
+    actions: Slot | None = None
     class_name: AttrValue = ""

--- a/pyjinhx/builtins/ui/pjx_avatar_stack/pjx_avatar_stack.py
+++ b/pyjinhx/builtins/ui/pjx_avatar_stack/pjx_avatar_stack.py
@@ -7,12 +7,16 @@ from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class PJXAvatarStack(BaseComponent):
-    # Pre-built items (original interface): HTML strings or BaseComponent instances.
-    # Structured data (new interface): dicts with keys initials, color, alt, name.
-    #   - initials (str): text shown in the pill
-    #   - color    (str, optional): inline background color
-    #   - alt      (str, optional): tooltip/title on the pill
-    #   - name     (str, optional): alias for alt; alt takes precedence if both given
+    # Items to render.  Two accepted shapes:
+    #   - Structured dict: keys initials, color, alt, name
+    #       - initials (str): text shown in the pill (escaped)
+    #       - color    (str, optional): inline background color
+    #       - alt      (str, optional): tooltip/title on the pill (escaped)
+    #       - name     (str, optional): alias for alt; alt takes precedence if both given
+    #   - BaseComponent instance: rendered raw via __html__
+    #
+    # Note: plain HTML *strings* are now escaped (autoescape is on).
+    # Pass a BaseComponent for raw markup instead of a string.
     avatars: list[Any] = Field(default_factory=list)
     extra_count: int = 0
     empty_label: str = ""

--- a/pyjinhx/builtins/ui/pjx_card/pjx_card.py
+++ b/pyjinhx/builtins/ui/pjx_card/pjx_card.py
@@ -2,7 +2,7 @@ from typing import ClassVar
 
 from pydantic import Field
 
-from pyjinhx import BaseComponent
+from pyjinhx import BaseComponent, Slot
 from pyjinhx.base import AttrValue, ExtraAttrs
 
 
@@ -10,8 +10,8 @@ class PJXCard(BaseComponent):
     _pjx_children_field: ClassVar[str] = "body"
 
     title: str | BaseComponent = ""
-    header: str | BaseComponent = ""
+    header: Slot = ""
     body: str | BaseComponent = ""
-    footer: str | BaseComponent = ""
+    footer: Slot = ""
     class_name: AttrValue = ""
     extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/pjx_drawer/pjx_drawer.py
+++ b/pyjinhx/builtins/ui/pjx_drawer/pjx_drawer.py
@@ -2,7 +2,7 @@ from typing import ClassVar, Literal
 
 from pydantic import Field
 
-from pyjinhx import BaseComponent
+from pyjinhx import BaseComponent, Slot
 from pyjinhx.base import AttrValue, ExtraAttrs
 
 
@@ -12,7 +12,7 @@ class PJXDrawer(BaseComponent):
     side: Literal["left", "right", "bottom"] = "right"
     title: str | BaseComponent = ""
     body: str | BaseComponent = ""
-    footer: str | BaseComponent = ""
+    footer: Slot = ""
     close_label: str = "Close"
     close_content: str | BaseComponent = "✕"
     open_on_mount: bool = False

--- a/pyjinhx/builtins/ui/pjx_dropdown/pjx_dropdown.py
+++ b/pyjinhx/builtins/ui/pjx_dropdown/pjx_dropdown.py
@@ -1,15 +1,15 @@
 import os
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import Field
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import AttrValue, ExtraAttrs
+from pyjinhx.base import AttrValue, ExtraAttrs, PjxSlot
 
 
 class PJXDropdown(BaseComponent):
     trigger: str | BaseComponent = ""
-    items: list[str | BaseComponent] = Field(default_factory=list)
+    items: Annotated[list[str | BaseComponent], PjxSlot()] = Field(default_factory=list)
     align: Literal["start", "end"] = "start"
     menu_label: str = "Submenu"
     behavior: bool = True

--- a/pyjinhx/builtins/ui/pjx_empty_state/pjx_empty_state.py
+++ b/pyjinhx/builtins/ui/pjx_empty_state/pjx_empty_state.py
@@ -2,15 +2,15 @@ from typing import Any
 
 from pydantic import Field
 
-from pyjinhx import BaseComponent
+from pyjinhx import BaseComponent, Slot
 from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class PJXEmptyState(BaseComponent):
-    image: str | BaseComponent = ""
+    image: Slot = ""
     title: str | BaseComponent = ""
     description: str | BaseComponent = ""
-    action: str | BaseComponent = ""
+    action: Slot = ""
     actions: list[str | BaseComponent] = Field(default_factory=list)
     # First-class interactive suggestion chips (option a from issue #77).
     # Each item is a dict with:

--- a/pyjinhx/builtins/ui/pjx_empty_state/pjx_empty_state.py
+++ b/pyjinhx/builtins/ui/pjx_empty_state/pjx_empty_state.py
@@ -1,9 +1,9 @@
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import Field
 
 from pyjinhx import BaseComponent, Slot
-from pyjinhx.base import AttrValue, ExtraAttrs
+from pyjinhx.base import AttrValue, ExtraAttrs, PjxSlot
 
 
 class PJXEmptyState(BaseComponent):
@@ -11,7 +11,9 @@ class PJXEmptyState(BaseComponent):
     title: str | BaseComponent = ""
     description: str | BaseComponent = ""
     action: Slot = ""
-    actions: list[str | BaseComponent] = Field(default_factory=list)
+    actions: Annotated[list[str | BaseComponent], PjxSlot()] = Field(
+        default_factory=list
+    )
     # First-class interactive suggestion chips (option a from issue #77).
     # Each item is a dict with:
     #   - label      (str): button text

--- a/pyjinhx/builtins/ui/pjx_modal/pjx_modal.py
+++ b/pyjinhx/builtins/ui/pjx_modal/pjx_modal.py
@@ -2,7 +2,7 @@ from typing import ClassVar
 
 from pydantic import Field
 
-from pyjinhx import BaseComponent
+from pyjinhx import BaseComponent, Slot
 from pyjinhx.base import AttrValue, ExtraAttrs
 
 
@@ -10,9 +10,9 @@ class PJXModal(BaseComponent):
     _pjx_children_field: ClassVar[str] = "body"
 
     title: str | BaseComponent = ""
-    header: str | BaseComponent = ""
+    header: Slot = ""
     body: str | BaseComponent = ""
-    footer: str | BaseComponent = ""
+    footer: Slot = ""
     close_label: str = "Close"
     close_content: str | BaseComponent = "✕"
     open_on_mount: bool = False

--- a/pyjinhx/builtins/ui/pjx_panel/pjx_panel.py
+++ b/pyjinhx/builtins/ui/pjx_panel/pjx_panel.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any
 from pydantic import BeforeValidator, Field, field_validator
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import AttrValue, ExtraAttrs
+from pyjinhx.base import AttrValue, ExtraAttrs, PjxSlot
 
 
 def _coerce_panels(value: Any) -> dict[str, str | BaseComponent]:
@@ -22,7 +22,7 @@ _PANEL_KEY_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 class PJXPanel(BaseComponent):
     panels: Annotated[
-        dict[str, str | BaseComponent], BeforeValidator(_coerce_panels)
+        dict[str, str | BaseComponent], BeforeValidator(_coerce_panels), PjxSlot()
     ] = Field(default_factory=dict)
     class_name: AttrValue = ""
     extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/builtins/ui/pjx_tab_group/pjx_tab_group.py
+++ b/pyjinhx/builtins/ui/pjx_tab_group/pjx_tab_group.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any
 from pydantic import BeforeValidator, Field
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import AttrValue, ExtraAttrs
+from pyjinhx.base import AttrValue, ExtraAttrs, PjxSlot
 
 
 def _coerce_tabs(value: Any) -> dict[str, str | BaseComponent]:
@@ -17,9 +17,9 @@ def _coerce_tabs(value: Any) -> dict[str, str | BaseComponent]:
 
 
 class PJXTabGroup(BaseComponent):
-    tabs: Annotated[dict[str, str | BaseComponent], BeforeValidator(_coerce_tabs)] = (
-        Field(default_factory=dict)
-    )
+    tabs: Annotated[
+        dict[str, str | BaseComponent], BeforeValidator(_coerce_tabs), PjxSlot()
+    ] = Field(default_factory=dict)
     tabs_label: str = "Tabs"
     class_name: AttrValue = ""
     extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -162,7 +162,8 @@ class Renderer:
             cls._default_environment = environment
         else:
             cls._default_environment = Environment(
-                loader=FileSystemLoader(os.fspath(environment))
+                loader=FileSystemLoader(os.fspath(environment)),
+                autoescape=True,
             )
         cls._default_renderers.clear()
 
@@ -180,7 +181,9 @@ class Renderer:
     def get_default_environment(cls) -> Environment:
         if cls._default_environment is None:
             root_dir = detect_root_directory()
-            cls._default_environment = Environment(loader=FileSystemLoader(root_dir))
+            cls._default_environment = Environment(
+                loader=FileSystemLoader(root_dir), autoescape=True
+            )
         return cls._default_environment
 
     @classmethod
@@ -276,7 +279,7 @@ class Renderer:
         )
 
         if not emit_assets:
-            return Markup(Markup(rendered_markup).unescape())
+            return Markup(rendered_markup)
 
         policy = AssetPolicy(
             js_mode=self._js_mode,
@@ -292,7 +295,7 @@ class Renderer:
             policy=policy,
             client=client,
         )
-        return Markup(Markup(rendered_markup).unescape())
+        return Markup(rendered_markup)
 
     def render(self, source: str) -> str:
         parser = Parser()

--- a/tests/unit/golden/alert_dismissible.html
+++ b/tests/unit/golden/alert_dismissible.html
@@ -7,7 +7,7 @@
             <div class="pjx-alert__body">x</div>
         </div>
         
-        <button type="button" class="pjx-alert__dismiss" data-pjx-close aria-label="Dismiss">✕</button>
+        <button type="button" class="pjx-alert__dismiss" data-pjx-close aria-label="Dismiss">&#x2715;</button>
         
     </div>
 </div>

--- a/tests/unit/golden/chip_input.html
+++ b/tests/unit/golden/chip_input.html
@@ -3,13 +3,13 @@
   <span class="pjx-chip-input__chip" data-pjx-chip>
     <span class="pjx-chip-input__label">alpha</span>
     <input type="hidden" name="tags" value="alpha">
-    <button type="button" class="pjx-chip-input__remove" data-pjx-chip-remove aria-label="Remove">✕</button>
+    <button type="button" class="pjx-chip-input__remove" data-pjx-chip-remove aria-label="Remove">&#x2715;</button>
   </span>
   
   <span class="pjx-chip-input__chip" data-pjx-chip>
     <span class="pjx-chip-input__label">beta</span>
     <input type="hidden" name="tags" value="beta">
-    <button type="button" class="pjx-chip-input__remove" data-pjx-chip-remove aria-label="Remove">✕</button>
+    <button type="button" class="pjx-chip-input__remove" data-pjx-chip-remove aria-label="Remove">&#x2715;</button>
   </span>
   
   <input type="text" class="pjx-chip-input__field" placeholder="Add…" autocomplete="off">

--- a/tests/unit/golden/notification.html
+++ b/tests/unit/golden/notification.html
@@ -7,5 +7,5 @@
     <div class="pjx-notification__content">Hi</div>
     <button type="button" class="pjx-notification__close"
             data-pjx-close
-            aria-label="Dismiss">✕</button>
+            aria-label="Dismiss">&#x2715;</button>
 </div>

--- a/tests/unit/test_autoescape_security.py
+++ b/tests/unit/test_autoescape_security.py
@@ -46,3 +46,14 @@ def test_collection_slot_text_key_is_escaped():
     assert "<script>alert(1)</script>" not in html      # label (dict key) escaped
     assert "&lt;script&gt;" in html
     assert "<b>panel</b>" in html                          # panel (dict value) raw
+
+
+def test_markup_value_on_scalar_field_is_still_escaped():
+    """Pydantic coerces markupsafe.Markup to plain str on str-typed fields,
+    so the safe marker is lost before the context builder runs.  Markup is NOT
+    a working escape hatch for scalar fields; use Slot or |safe instead."""
+    from markupsafe import Markup
+    from pyjinhx.builtins import PJXCard
+    html = str(PJXCard(id="c", title=Markup("<b>x</b>"), body="ok").render())
+    assert "<b>x</b>" not in html   # still escaped — Markup hatch does NOT work here
+    assert "&lt;b&gt;" in html

--- a/tests/unit/test_autoescape_security.py
+++ b/tests/unit/test_autoescape_security.py
@@ -38,3 +38,11 @@ def test_nested_component_renders_raw():
     from pyjinhx.builtins import PJXCard, PJXBadge
     html = str(PJXCard(id="c", title="T", body=PJXBadge(id="b", label="New")).render())
     assert "pjx-badge" in html and "&lt;span" not in html
+
+
+def test_collection_slot_text_key_is_escaped():
+    from pyjinhx.builtins import PJXTabGroup
+    html = str(PJXTabGroup(id="t", tabs={"<script>alert(1)</script>": "<b>panel</b>"}).render())
+    assert "<script>alert(1)</script>" not in html      # label (dict key) escaped
+    assert "&lt;script&gt;" in html
+    assert "<b>panel</b>" in html                          # panel (dict value) raw

--- a/tests/unit/test_autoescape_security.py
+++ b/tests/unit/test_autoescape_security.py
@@ -1,0 +1,40 @@
+import pytest
+
+from pyjinhx import Renderer
+
+
+@pytest.fixture(autouse=True)
+def _env(tmp_path):
+    Renderer.set_default_environment(str(tmp_path))
+
+
+def test_scalar_attribute_value_is_escaped():
+    from pyjinhx.builtins import PJXAvatar
+    html = str(PJXAvatar(id="a", initials="x", alt='" onmouseover="alert(1)').render())
+    assert 'onmouseover="alert(1)"' not in html
+    assert "&#34;" in html or "&quot;" in html
+
+
+def test_scalar_text_value_is_escaped():
+    from pyjinhx.builtins import PJXCard
+    html = str(PJXCard(id="c", title="<script>alert(1)</script>", body="ok").render())
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_loop_derived_value_is_escaped():
+    from pyjinhx.builtins import PJXBreadcrumb
+    html = str(PJXBreadcrumb(id="b", items=[("<script>x</script>", "/")]).render())
+    assert "<script>x</script>" not in html
+
+
+def test_slot_string_renders_raw():
+    from pyjinhx.builtins import PJXCard
+    html = str(PJXCard(id="c", title="T", body="<p data-x='1'>hi</p>").render())
+    assert "<p data-x='1'>hi</p>" in html  # slot HTML NOT escaped
+
+
+def test_nested_component_renders_raw():
+    from pyjinhx.builtins import PJXCard, PJXBadge
+    html = str(PJXCard(id="c", title="T", body=PJXBadge(id="b", label="New")).render())
+    assert "pjx-badge" in html and "&lt;span" not in html

--- a/tests/unit/test_avatar_stack.py
+++ b/tests/unit/test_avatar_stack.py
@@ -93,3 +93,27 @@ def test_stack_mixed_dict_and_component():
     assert "DT" in html
     assert 'id="a1"' in html
     assert ">+1<" in html
+
+
+# --- Autoescape safety (issue #113) ---
+
+def test_stack_dict_malicious_initials_are_escaped():
+    """Dict field values (initials) are HTML-escaped; no XSS via pill text.
+    The template slices initials to [:2], so only the first two chars render —
+    but they must be escaped, not raw."""
+    html = str(PJXAvatarStack(
+        id="st",
+        avatars=[{"initials": "<script>alert(1)</script>", "color": "red"}],
+    ).render())
+    assert "<script>" not in html
+    assert "&lt;" in html   # the < is escaped (rendered as &lt;s after [:2] slice)
+
+
+def test_stack_string_item_is_escaped():
+    """Plain HTML strings passed as avatar items are escaped (autoescape is on)."""
+    html = str(PJXAvatarStack(
+        id="st",
+        avatars=["<span class='x'>AB</span>"],
+    ).render())
+    assert "<span class='x'>AB</span>" not in html
+    assert "&lt;span" in html

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -9,6 +9,7 @@ from pyjinhx import (
     ReactiveComponent,
     Registry,
     Renderer,
+    Slot,  # noqa: F401
     component,
     dirty,
     mutates,
@@ -17,6 +18,7 @@ from pyjinhx import (
 
 PUBLIC_API = {
     "BaseComponent",
+    "Slot",
     "component",
     "ReactiveComponent",
     "Renderer",

--- a/tests/unit/test_renderer_output_contract.py
+++ b/tests/unit/test_renderer_output_contract.py
@@ -1,4 +1,4 @@
-"""The renderer's output contract: Markup objects, unescaped by design."""
+"""The renderer's output contract: Markup objects, escaped by default."""
 import importlib.util
 import os
 import sys
@@ -54,14 +54,13 @@ def test_render_returns_markup():
     )
 
 
-def test_renderer_unescapes_final_markup():
-    """body containing literal HTML tags renders them unescaped.
+def test_renderer_escapes_scalar_values_by_default():
+    """A scalar (non-slot) field containing literal HTML tags is escaped.
 
-    The renderer calls Markup(Markup(rendered_markup).unescape()) on the
-    final output (see renderer.py render_component_with_context). This is
-    load-bearing: attribute safety must be enforced at construction time,
-    not by escaping. Jinja's default autoescape is off so the template
-    renders body verbatim; the outer Markup() wraps it as safe markup.
+    Autoescape is on by default (see renderer.py Environment(autoescape=True)).
+    A plain ``str`` field is not a slot, so Jinja escapes its value: ``<em>``
+    becomes ``&lt;em&gt;`` in the output. Raw HTML requires a ``Slot`` field,
+    ``Markup(...)``, or ``{{ value|safe }}``.
     """
     original_environment = Renderer.peek_default_environment()
 
@@ -93,11 +92,55 @@ def test_renderer_unescapes_final_markup():
     Renderer.set_default_environment(original_environment)
     sys.modules.pop("output_probe2", None)
 
-    # Jinja2 default environment has autoescape=False, so <em>hi</em> passes
-    # through verbatim; the outer Markup() preserves the literal tags.
+    # Autoescape is on: a scalar str field is HTML-escaped.
+    assert "&lt;em&gt;hi&lt;/em&gt;" in rendered, (
+        "Renderer must HTML-escape scalar values by default"
+    )
+    assert "<em>hi</em>" not in rendered, (
+        "Renderer must not emit raw scalar values — raw HTML needs Slot/Markup/|safe"
+    )
+
+
+def test_renderer_renders_slot_value_raw():
+    """A ``Slot``-annotated field renders its string value as raw HTML.
+
+    Even with autoescape on, the context builder wraps slot strings as
+    ``Markup`` (see Slot machinery), so literal tags pass through verbatim.
+    """
+    original_environment = Renderer.peek_default_environment()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        module_path = os.path.join(temp_dir, "output_probe3.py")
+        with open(module_path, "w", encoding="utf-8") as fh:
+            fh.write(
+                "from pyjinhx import BaseComponent, Slot\n\n"
+                "class OutputProbe3(BaseComponent):\n"
+                "    body: Slot = ''\n"
+            )
+
+        template_path = os.path.join(temp_dir, "output_probe3.html")
+        with open(template_path, "w", encoding="utf-8") as fh:
+            fh.write('<div id="{{ id }}">{{ body }}</div>\n')
+
+        Renderer.set_default_environment(temp_dir)
+
+        spec = importlib.util.spec_from_file_location("output_probe3", module_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["output_probe3"] = module
+        spec.loader.exec_module(module)
+
+        OutputProbe3 = getattr(module, "OutputProbe3")
+        component = OutputProbe3(id="out-3", body="<em>hi</em>")
+        rendered = str(component.render())
+
+    Renderer.set_default_environment(original_environment)
+    sys.modules.pop("output_probe3", None)
+
+    # Slot field: literal tags are preserved unescaped.
     assert "<em>hi</em>" in rendered, (
-        "Renderer should preserve literal tags — '<em>hi</em>' expected in output"
+        "Slot field should render its string value as raw HTML"
     )
     assert "&lt;em&gt;" not in rendered, (
-        "Renderer must not HTML-escape the final output string"
+        "Slot field must not HTML-escape its value"
     )

--- a/tests/unit/test_slot_type.py
+++ b/tests/unit/test_slot_type.py
@@ -1,0 +1,30 @@
+from markupsafe import Markup
+
+from pyjinhx import BaseComponent, Slot
+from pyjinhx.base import _is_slot_field
+
+
+class _Demo(BaseComponent):
+    label: str = ""               # scalar
+    body: Slot = ""               # explicit slot
+    _pjx_children_field = "kids"
+    kids: str = ""                # children field (auto-slot)
+
+
+def test_is_slot_field_detects_annotation_and_children_field():
+    assert _is_slot_field(_Demo, "body") is True
+    assert _is_slot_field(_Demo, "kids") is True
+    assert _is_slot_field(_Demo, "label") is False
+
+
+def test_slot_string_value_becomes_markup_in_context(tmp_path):
+    from pyjinhx import Renderer
+    Renderer.set_default_environment(str(tmp_path))
+    inst = _Demo(id="d", label="<x>", body="<b>", kids="<k>")
+    ctx = inst.model_dump()  # sanity: model_dump gives plain str
+    assert ctx["body"] == "<b>"
+    # the builder wraps slot strings as Markup; scalars stay plain str
+    built = inst._build_template_context()  # helper exposed for testing (see Step 3)
+    assert isinstance(built["body"], Markup)
+    assert isinstance(built["kids"], Markup)
+    assert not isinstance(built["label"], Markup)


### PR DESCRIPTION
## Summary

Fixes #113 — pyjinhx rendered with Jinja autoescape **off**, a framework-wide HTML/attribute/JS injection gap. This makes template output **escaped by default**, exempting only explicitly-declared raw-HTML slots.

- `autoescape=True` (both Environment sites) + the raw-emit `Markup(...).unescape()` removed.
- New introspectable `Slot` type (`Annotated[str | BaseComponent, PjxSlot()]`); a field renders its string raw iff it is the component's `_pjx_children_field` or carries `PjxSlot()`. The context builder `Markup`-wraps slot strings (and recurses list/dict collection slots via `_wrap_slot_value`, wrapping dict *values* / escaping dict *keys*); `BaseComponent` values render raw via `__html__`.
- Scalars, text, attributes, **and loop/dict-derived values** are now escaped — including the cases the earlier contained approach could not reach — and user components are auto-covered.

## Breaking change

Scalar/text/attribute string values are now HTML-escaped. Raw HTML must come from a `Slot`-typed field, `{{ value|safe }}`, or a `BaseComponent`. `PJXAvatarStack` string items now escape (use dicts or components). See `docs/migration.md`.

## Testing

Security suite (attribute/text/loop/collection-key escaping; slots + components raw) + guards; **839 passed / 5 skipped**; ruff + `mkdocs --strict` clean. Reviewed per-task + a whole-branch opus review (which caught and fixed the `Markup()` doc claim + avatar-stack escaping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)