### PR TITLE
fix(builtins): annotate missed icon/element slots as Slot (#118)

### DIFF
--- a/pyjinhx/builtins/ui/pjx_accordion/pjx_accordion.py
+++ b/pyjinhx/builtins/ui/pjx_accordion/pjx_accordion.py
@@ -1,13 +1,17 @@
-from pyjinhx import BaseComponent, Slot
-from pyjinhx.base import AttrValue
+from typing import Annotated
+
+from pyjinhx import BaseComponent
+from pyjinhx.base import AttrValue, PjxSlot
 
 
 class PJXAccordion(BaseComponent):
     label: str = ""
-    header: Slot | None = None
+    # `Slot | None` (Optional[Annotated[...]]) drops the PjxSlot metadata at the
+    # field level, so the marker must sit on the outer Annotated. See #118.
+    header: Annotated[str | BaseComponent | None, PjxSlot()] = None
     open: bool = True
     disabled: bool = False
     group: str | None = None
     content: str | BaseComponent = ""
-    actions: Slot | None = None
+    actions: Annotated[str | BaseComponent | None, PjxSlot()] = None
     class_name: AttrValue = ""

--- a/pyjinhx/builtins/ui/pjx_button/pjx_button.py
+++ b/pyjinhx/builtins/ui/pjx_button/pjx_button.py
@@ -1,13 +1,13 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import AttrValue
+from pyjinhx.base import AttrValue, PjxSlot
 
 
 class PJXButton(BaseComponent):
-    start: str | BaseComponent | None = None
+    start: Annotated[str | BaseComponent | None, PjxSlot()] = None
     center: str | BaseComponent | None = None
-    end: str | BaseComponent | None = None
+    end: Annotated[str | BaseComponent | None, PjxSlot()] = None
     variant: str = "default"
     block: bool = False
     loading: bool = False

--- a/pyjinhx/builtins/ui/pjx_drawer/pjx_drawer.py
+++ b/pyjinhx/builtins/ui/pjx_drawer/pjx_drawer.py
@@ -14,7 +14,7 @@ class PJXDrawer(BaseComponent):
     body: str | BaseComponent = ""
     footer: Slot = ""
     close_label: str = "Close"
-    close_content: str | BaseComponent = "✕"
+    close_content: Slot = "✕"
     open_on_mount: bool = False
     remove_on_close: bool = False
     class_name: AttrValue = ""

--- a/pyjinhx/builtins/ui/pjx_dropdown/pjx_dropdown.py
+++ b/pyjinhx/builtins/ui/pjx_dropdown/pjx_dropdown.py
@@ -3,12 +3,12 @@ from typing import Annotated, Literal
 
 from pydantic import Field
 
-from pyjinhx import BaseComponent
+from pyjinhx import BaseComponent, Slot
 from pyjinhx.base import AttrValue, ExtraAttrs, PjxSlot
 
 
 class PJXDropdown(BaseComponent):
-    trigger: str | BaseComponent = ""
+    trigger: Slot = ""
     items: Annotated[list[str | BaseComponent], PjxSlot()] = Field(default_factory=list)
     align: Literal["start", "end"] = "start"
     menu_label: str = "Submenu"

--- a/pyjinhx/builtins/ui/pjx_modal/pjx_modal.py
+++ b/pyjinhx/builtins/ui/pjx_modal/pjx_modal.py
@@ -14,7 +14,7 @@ class PJXModal(BaseComponent):
     body: str | BaseComponent = ""
     footer: Slot = ""
     close_label: str = "Close"
-    close_content: str | BaseComponent = "✕"
+    close_content: Slot = "✕"
     open_on_mount: bool = False
     remove_on_close: bool = False
     class_name: AttrValue = ""

--- a/pyjinhx/builtins/ui/pjx_tooltip/pjx_tooltip.py
+++ b/pyjinhx/builtins/ui/pjx_tooltip/pjx_tooltip.py
@@ -2,14 +2,14 @@ from typing import ClassVar, Literal
 
 from pydantic import Field
 
-from pyjinhx import BaseComponent
+from pyjinhx import BaseComponent, Slot
 from pyjinhx.base import AttrValue, ExtraAttrs
 
 
 class PJXTooltip(BaseComponent):
     _pjx_children_field: ClassVar[str] = "tip"
 
-    trigger: str | BaseComponent = ""
+    trigger: Slot = ""
     tip: str | BaseComponent = ""
     placement: Literal["top", "bottom", "start", "end"] = "top"
     class_name: AttrValue = ""

--- a/tests/unit/test_autoescape_security.py
+++ b/tests/unit/test_autoescape_security.py
@@ -57,3 +57,41 @@ def test_markup_value_on_scalar_field_is_still_escaped():
     html = str(PJXCard(id="c", title=Markup("<b>x</b>"), body="ok").render())
     assert "<b>x</b>" not in html   # still escaped — Markup hatch does NOT work here
     assert "&lt;b&gt;" in html
+
+
+def test_button_start_end_slot_render_raw():
+    from pyjinhx.builtins import PJXButton
+    html = str(PJXButton(id="b", start="<svg data-x='1'>i</svg>", center="Save").render())
+    assert "<svg data-x='1'>i</svg>" in html  # start is Slot → raw
+    assert "Save" in html
+
+
+def test_button_center_label_is_escaped():
+    from pyjinhx.builtins import PJXButton
+    html = str(PJXButton(id="b2", center="<b>x</b>").render())
+    assert "<b>x</b>" not in html   # center stays str | BaseComponent → escaped
+    assert "&lt;b&gt;" in html
+
+
+def test_dropdown_trigger_slot_renders_raw():
+    from pyjinhx.builtins import PJXDropdown
+    html = str(PJXDropdown(id="d", trigger="<b>menu</b>", items=[]).render())
+    assert "<b>menu</b>" in html  # trigger is Slot → raw
+
+
+def test_modal_close_content_slot_renders_raw():
+    from pyjinhx.builtins import PJXModal
+    html = str(PJXModal(id="m", body="x", close_content="<i class='x'></i>").render())
+    assert "<i class='x'></i>" in html  # close_content is Slot → raw
+
+
+def test_tooltip_trigger_slot_renders_raw():
+    from pyjinhx.builtins import PJXTooltip
+    html = str(PJXTooltip(id="t", trigger="<b>hover</b>", tip="hint").render())
+    assert "<b>hover</b>" in html  # trigger is Slot → raw
+
+
+def test_drawer_close_content_slot_renders_raw():
+    from pyjinhx.builtins import PJXDrawer
+    html = str(PJXDrawer(id="dr", close_content="<i class='close'></i>").render())
+    assert "<i class='close'></i>" in html  # close_content is Slot → raw

--- a/tests/unit/test_slot_type.py
+++ b/tests/unit/test_slot_type.py
@@ -1,12 +1,15 @@
+from typing import Annotated
+
 from markupsafe import Markup
 
 from pyjinhx import BaseComponent, Slot
-from pyjinhx.base import _is_slot_field
+from pyjinhx.base import PjxSlot, _is_slot_field
 
 
 class _Demo(BaseComponent):
     label: str = ""               # scalar
     body: Slot = ""               # explicit slot
+    nullable_slot: Annotated[str | BaseComponent | None, PjxSlot()] = None
     _pjx_children_field = "kids"
     kids: str = ""                # children field (auto-slot)
 
@@ -15,6 +18,19 @@ def test_is_slot_field_detects_annotation_and_children_field():
     assert _is_slot_field(_Demo, "body") is True
     assert _is_slot_field(_Demo, "kids") is True
     assert _is_slot_field(_Demo, "label") is False
+
+
+def test_nullable_slot_metadata_survives():
+    # `Slot | None` (Optional[Annotated[...]]) drops the PjxSlot metadata at the
+    # field level; the marker must sit on the outer Annotated (#118).
+    assert _is_slot_field(_Demo, "nullable_slot") is True
+
+
+def test_accordion_optional_slots_are_detected():
+    from pyjinhx.builtins import PJXAccordion
+
+    assert _is_slot_field(PJXAccordion, "header") is True
+    assert _is_slot_field(PJXAccordion, "actions") is True
 
 
 def test_slot_string_value_becomes_markup_in_context(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #118 — icon/element slots missed in the 0.23.0 `Slot` migration, so **string** values to them HTML-escaped instead of rendering.

- Annotated as `Slot`: `PJXButton.start`/`end`, `PJXDropdown.trigger`, `PJXTooltip.trigger`, `PJXModal.close_content`, `PJXDrawer.close_content`.
- Also fixed `PJXAccordion.header`/`actions`: they were `Slot | None` in 0.23.0, but `Optional[Annotated[..., PjxSlot()]]` **drops the marker metadata** at the field level, so they were never detected as slots. Moved the marker to the outer `Annotated[str | BaseComponent | None, PjxSlot()]` (same form as the button fix). Added regression tests.

`center`/`title`/`description` intentionally stay escaped (text). `BaseComponent` values already render raw, so only the string path was affected.

## Testing
847 passed / 5 skipped; ruff clean. No goldens shifted (existing fixtures pass text/components, which render identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)