### PR TITLE
fix(security): close entity-decode XSS in nested-tag components (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@
 
 - **Autoescape was defeated for components containing nested PascalCase tags.**
   HTML entities produced by autoescape were decoded during tag expansion (the
-  `HTMLParser`-based tag parser ran with `convert_charrefs=True`), re-emitting
+  `HTMLParser`-based tag parser decoded entities back into raw text), re-emitting
   escaped scalars as raw HTML and reopening the XSS hole for any component that
-  embeds a nested tag (e.g. `PJXAccordion`, `PJXButton` loading state). Entities
-  now survive the round-trip. (#120)
+  embeds a nested tag (e.g. `PJXAccordion`, `PJXButton` loading state). The tag
+  parser now re-escapes emitted text, so entities survive the round-trip while
+  slot HTML structure and attributes (passed through verbatim) are untouched.
+  (#120)
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@
   render raw). A component's children/`content` field is always a slot; nested
   `BaseComponent` values render raw via `__html__`. (#113)
 
+### Fixed
+
+- **Autoescape was defeated for components containing nested PascalCase tags.**
+  HTML entities produced by autoescape were decoded during tag expansion (the
+  `HTMLParser`-based tag parser ran with `convert_charrefs=True`), re-emitting
+  escaped scalars as raw HTML and reopening the XSS hole for any component that
+  embeds a nested tag (e.g. `PJXAccordion`, `PJXButton` loading state). Entities
+  now survive the round-trip. (#120)
+
 ### Breaking
 
 - **Scalar values are now HTML-escaped.** Strings that previously rendered raw

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -56,7 +56,10 @@ class Parser(HTMLParser):
     """
 
     def __init__(self) -> None:
-        super().__init__()
+        # convert_charrefs=False keeps entities out of handle_data so that
+        # autoescaped scalars (e.g. &lt;script&gt;) survive the tag-expansion
+        # round-trip instead of being decoded back into raw HTML (#120).
+        super().__init__(convert_charrefs=False)
         self._stack: list[Tag] = []
         self.root_nodes: list[Tag | str] = []
 
@@ -110,6 +113,14 @@ class Parser(HTMLParser):
 
     def handle_data(self, data: str) -> None:
         self._append_child(data)
+
+    def handle_entityref(self, name: str) -> None:
+        # Re-emit verbatim so escaped scalars stay escaped (e.g. &lt; stays &lt;).
+        self._append_child(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        # Re-emit verbatim so numeric refs survive (e.g. &#34; stays &#34;).
+        self._append_child(f"&#{name};")
 
     def handle_comment(self, data: str) -> None:
         self._append_child(f"<!--{data}-->")

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from markupsafe import escape
+
 from .registry import Registry
 from .utils import (
     extract_tag_name_from_raw,
@@ -56,10 +58,7 @@ class Parser(HTMLParser):
     """
 
     def __init__(self) -> None:
-        # convert_charrefs=False keeps entities out of handle_data so that
-        # autoescaped scalars (e.g. &lt;script&gt;) survive the tag-expansion
-        # round-trip instead of being decoded back into raw HTML (#120).
-        super().__init__(convert_charrefs=False)
+        super().__init__()
         self._stack: list[Tag] = []
         self.root_nodes: list[Tag | str] = []
 
@@ -112,15 +111,11 @@ class Parser(HTMLParser):
         self._append_child(f"</{tag}>")
 
     def handle_data(self, data: str) -> None:
-        self._append_child(data)
-
-    def handle_entityref(self, name: str) -> None:
-        # Re-emit verbatim so escaped scalars stay escaped (e.g. &lt; stays &lt;).
-        self._append_child(f"&{name};")
-
-    def handle_charref(self, name: str) -> None:
-        # Re-emit verbatim so numeric refs survive (e.g. &#34; stays &#34;).
-        self._append_child(f"&#{name};")
+        # Re-escape decoded text so autoescaped scalars stay escaped through the
+        # tag-expansion round-trip (e.g. &lt;script&gt; → decoded <script> →
+        # &lt;script&gt;). Slot tags/attributes go through get_starttag_text()
+        # (raw), not here, so HTML structure is preserved untouched (#120).
+        self._append_child(str(escape(data)))
 
     def handle_comment(self, data: str) -> None:
         self._append_child(f"<!--{data}-->")

--- a/tests/unit/test_autoescape_security.py
+++ b/tests/unit/test_autoescape_security.py
@@ -133,3 +133,25 @@ def test_nested_tag_component_still_renders_nested_component():
     from pyjinhx.builtins import PJXAccordion
     html = str(PJXAccordion(id="a3", label="t", content="ok").render())
     assert "pjx-icon" in html or "<svg" in html
+
+
+# --- #120 regression: bare `&word` text must not gain a spurious `;` ---
+
+def test_bare_ampersand_in_slot_text_not_corrupted():
+    """`R&D`/`Q&A` in slot text must not become `R&D;`/`Q&A;` during tag expansion."""
+    from pyjinhx.builtins import PJXAccordion
+    html = str(
+        PJXAccordion(id="r", label="t", content="<p>R&D and Q&A</p>").render()
+    )
+    assert "R&D;" not in html
+    assert "Q&A;" not in html
+
+
+def test_bare_ampersand_in_slot_attribute_not_corrupted():
+    """`href='?x=1&y=2'` must not become `?x=1&y;=2` during tag expansion."""
+    from pyjinhx.builtins import PJXAccordion
+    html = str(
+        PJXAccordion(id="r2", label="t", content="<a href='?x=1&y=2'>L</a>").render()
+    )
+    assert "&y;=2" not in html
+    assert "?x=1&y=2" in html or "?x=1&amp;y=2" in html

--- a/tests/unit/test_autoescape_security.py
+++ b/tests/unit/test_autoescape_security.py
@@ -95,3 +95,41 @@ def test_drawer_close_content_slot_renders_raw():
     from pyjinhx.builtins import PJXDrawer
     html = str(PJXDrawer(id="dr", close_content="<i class='close'></i>").render())
     assert "<i class='close'></i>" in html  # close_content is Slot → raw
+
+
+# --- Nested-tag components (#120): escaping must survive tag expansion ---
+
+def test_nested_tag_component_scalar_text_is_escaped():
+    """PJXAccordion embeds <PJXIcon/>; entities must not be decoded by tag expansion."""
+    from pyjinhx.builtins import PJXAccordion
+    html = str(
+        PJXAccordion(id="a", label="<script>alert(1)</script>", content="ok").render()
+    )
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_nested_tag_component_slot_renders_raw():
+    from pyjinhx.builtins import PJXAccordion
+    html = str(
+        PJXAccordion(id="a2", label="t", content="<p data-x='1'>hi</p>").render()
+    )
+    assert "<p data-x='1'>hi</p>" in html  # content slot stays raw
+
+
+def test_nested_tag_component_scalar_is_escaped_when_nested_tag_present():
+    """PJXButton loading state embeds <PJXRegionLoader/>; the center scalar must still
+    escape even though a nested PascalCase tag triggers tag expansion."""
+    from pyjinhx.builtins import PJXButton
+    html = str(
+        PJXButton(id="b", center="<b>x</b>", loading=True).render()
+    )
+    assert "<b>x</b>" not in html  # center stays str | BaseComponent → escaped
+    assert "&lt;b&gt;" in html
+
+
+def test_nested_tag_component_still_renders_nested_component():
+    """The accordion's <PJXIcon/> chevron must still render after the parser change."""
+    from pyjinhx.builtins import PJXAccordion
+    html = str(PJXAccordion(id="a3", label="t", content="ok").render())
+    assert "pjx-icon" in html or "<svg" in html


### PR DESCRIPTION
## Summary

Fixes #120 — a security (XSS) regression in 0.23.0. Autoescape was **silently defeated for any component whose template embeds a nested PascalCase tag** (e.g. `PJXAccordion`'s `<PJXIcon/>`), including user components that embed builtin tags.

### Root cause
`render_component_with_context` escapes `{{ scalar }}` in `template.render()`, then `expand_custom_tags()` re-parses the HTML with the `HTMLParser`-based `Parser`. The parser re-emitted text through `handle_data`, decoding the escaped entities back to raw — undoing autoescape. Repro: `PJXAccordion(label="<script>alert(1)</script>")` rendered raw `<script>`.

### Fix
`Parser.handle_data` now **re-escapes text on emit** (`markupsafe.escape`). Slot **tags and attributes** are emitted raw via `get_starttag_text()` (unaffected); only text nodes are escaped — so the XSS is closed, raw slot HTML structure is preserved, and entity-bearing text (`R&D`) is rendered safely without corruption.

## Testing
Nested-tag escaping tests added (text scalar, slot-stays-raw, nested component still renders, `R&D`/`href=?x=1&y=2` not corrupted). 853 passed / 5 skipped; 0 goldens shifted; ruff + `mkdocs --strict` clean. Reviewed on opus (which caught an interim semicolon-injection regression, fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)