### PR TITLE
fix(assets): collect co-located CSS/JS for classless components (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Classless / `{#def#}` / `component()` components now collect co-located CSS/JS.** Assets
+  co-located with template-only components (built via the `{#def … #}` prop-header or via
+  `component("Name")`) were never inlined because the asset guard only checked for the exact
+  `BaseComponent` class name, missing the dynamically-named subclasses those paths produce.
+  Added a `_pjx_classless` ClassVar marker set on all dynamically-built subclasses and broadened
+  the guard to include it; the factory render path now also resolves the template path so
+  `apply_component_render_assets` can locate the asset directory. (#122)
+
 ## 0.23.1 — security & slot fixes (2026-06-19)
 
 ### Fixed

--- a/pyjinhx/assets.py
+++ b/pyjinhx/assets.py
@@ -387,7 +387,9 @@ def apply_component_render_assets(
     policy: AssetPolicy,
     client: object | None,
 ) -> str:
-    if template_path is not None and type(component).__name__ == "BaseComponent":
+    cls = type(component)
+    is_classless = cls.__name__ == "BaseComponent" or getattr(cls, "_pjx_classless", False)
+    if template_path is not None and is_classless:
         asset_dir: str | None = os.path.dirname(template_path)
         asset_name: str | None = os.path.splitext(os.path.basename(template_path))[
             0

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -190,6 +190,10 @@ class BaseComponent(BaseModel):
     # set, the template is resolved by scanning the default env at render time.
     _pjx_template: ClassVar[str | None] = None
 
+    # True on classes built dynamically (props_header or component() factory).
+    # Distinct from _pjx_template because file-backed classes may also set that.
+    _pjx_classless: ClassVar[bool] = False
+
     id: str = Field(
         default_factory=_auto_id,
         description="The unique ID for this component. Auto-generated when omitted.",
@@ -490,4 +494,4 @@ def component(name: str) -> type[BaseComponent]:
         if model is not None:
             return model  # auto-registered via __init_subclass__
 
-    return type(name, (BaseComponent,), {"_pjx_template": name})
+    return type(name, (BaseComponent,), {"_pjx_template": name, "_pjx_classless": True})

--- a/pyjinhx/props_header.py
+++ b/pyjinhx/props_header.py
@@ -115,4 +115,5 @@ def build_component_model(name: str, source: str) -> "type | None":
         **{field_name: (field_type, default) for field_name, field_type, default in fields},
     )
     model._pjx_template = name
+    model._pjx_classless = True
     return model

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -285,11 +285,23 @@ class Renderer:
             js_mode=self._js_mode,
             css_mode=self._css_mode,
         )
+        # For classless components built via the factory path, template_path is
+        # None (the renderer resolved the template internally via _pjx_template).
+        # Compute the effective asset path so apply_component_render_assets can
+        # find co-located CSS/JS next to the template file.
+        asset_template_path = template_path
+        if asset_template_path is None and getattr(type(component), "_pjx_classless", False):
+            pjx_template = getattr(type(component), "_pjx_template", None)
+            if pjx_template is not None:
+                try:
+                    asset_template_path = self._find_template_for_tag(pjx_template)
+                except FileNotFoundError:
+                    asset_template_path = None
         rendered_markup = apply_component_render_assets(
             component,
             rendered_markup,
             session,
-            template_path=template_path,
+            template_path=asset_template_path,
             is_root=is_root,
             collect_component_js=collect_component_js,
             policy=policy,

--- a/tests/unit/test_classless_assets_factory.py
+++ b/tests/unit/test_classless_assets_factory.py
@@ -1,0 +1,196 @@
+"""
+Tests for CSS/JS asset collection from classless components via the factory path.
+
+Issue #122: component("Foo")(title="hi").render() did not collect co-located
+CSS/JS assets.  The bug was that apply_component_render_assets checked
+`type(component).__name__ == "BaseComponent"` to detect classless components,
+but both the {#def#}-header path and the component() factory path produce
+*named* subclasses (named after the tag), so the guard never fired and assets
+were resolved against the wrong directory via Finder.get_class_directory.
+
+The fix adds a `_pjx_classless` ClassVar marker that is set on all dynamically
+built subclasses, and broadens the guard to include it.
+"""
+
+import pytest
+
+from pyjinhx import Renderer
+from pyjinhx.base import component
+
+
+@pytest.fixture(autouse=True)
+def isolate_renderer(tmp_path):
+    """Each test gets a fresh tmp_path environment; restore after."""
+    Renderer.set_default_environment(str(tmp_path))
+    yield tmp_path
+    Renderer.set_default_environment(None)
+    Renderer._default_renderers.clear()
+
+
+# ---------------------------------------------------------------------------
+# Factory path — {#def#} header with co-located assets
+# ---------------------------------------------------------------------------
+
+def test_header_classless_factory_css_collected(isolate_renderer):
+    """CSS co-located with a {#def#}-header template IS inlined via factory path."""
+    tmp_path = isolate_renderer
+    comp_dir = tmp_path / "foo"
+    comp_dir.mkdir()
+    (comp_dir / "foo.html").write_text(
+        "{#def title: str #}\n<div class='foo'>{{ title }}</div>",
+        encoding="utf-8",
+    )
+    (comp_dir / "foo.css").write_text(".foo { color: red }", encoding="utf-8")
+
+    Renderer.set_default_environment(str(tmp_path))
+    html = str(component("Foo")(title="hi").render())
+
+    assert ".foo { color: red }" in html, "CSS was not inlined via factory path"
+
+
+def test_header_classless_factory_js_collected(isolate_renderer):
+    """JS co-located with a {#def#}-header template IS inlined via factory path."""
+    tmp_path = isolate_renderer
+    comp_dir = tmp_path / "bar"
+    comp_dir.mkdir()
+    (comp_dir / "bar.html").write_text(
+        "{#def label: str #}\n<button>{{ label }}</button>",
+        encoding="utf-8",
+    )
+    (comp_dir / "bar.js").write_text("console.log('bar');", encoding="utf-8")
+
+    Renderer.set_default_environment(str(tmp_path))
+    html = str(component("Bar")(label="click me").render())
+
+    assert "console.log('bar');" in html, "JS was not inlined via factory path"
+
+
+def test_header_classless_factory_both_assets_collected(isolate_renderer):
+    """Both CSS and JS are inlined for a {#def#}-header component via factory."""
+    tmp_path = isolate_renderer
+    comp_dir = tmp_path / "gadget"
+    comp_dir.mkdir()
+    (comp_dir / "gadget.html").write_text(
+        "{#def title: str #}\n<div class='gadget'>{{ title }}</div>",
+        encoding="utf-8",
+    )
+    (comp_dir / "gadget.css").write_text(".gadget { margin: 0 }", encoding="utf-8")
+    (comp_dir / "gadget.js").write_text("console.log('gadget');", encoding="utf-8")
+
+    Renderer.set_default_environment(str(tmp_path))
+    html = str(component("Gadget")(title="test").render())
+
+    assert ".gadget { margin: 0 }" in html, "CSS not inlined"
+    assert "console.log('gadget');" in html, "JS not inlined"
+
+
+# ---------------------------------------------------------------------------
+# Factory path — no {#def#} header (bare classless) with co-located assets
+# ---------------------------------------------------------------------------
+
+def test_bare_classless_factory_css_collected(isolate_renderer):
+    """CSS co-located with a bare (no-header) template IS inlined via factory path."""
+    tmp_path = isolate_renderer
+    comp_dir = tmp_path / "baz"
+    comp_dir.mkdir()
+    (comp_dir / "baz.html").write_text(
+        "<span class='baz'>{{ content }}</span>",
+        encoding="utf-8",
+    )
+    (comp_dir / "baz.css").write_text(".baz { font-size: 2em }", encoding="utf-8")
+
+    Renderer.set_default_environment(str(tmp_path))
+    html = str(component("Baz")(content="hello").render())
+
+    assert ".baz { font-size: 2em }" in html, "CSS not inlined for bare classless factory path"
+
+
+# ---------------------------------------------------------------------------
+# Tag path — {#def#} header with co-located assets
+# ---------------------------------------------------------------------------
+
+def test_header_classless_tag_css_collected(isolate_renderer):
+    """CSS co-located with a {#def#}-header template IS inlined via tag path."""
+    tmp_path = isolate_renderer
+    comp_dir = tmp_path / "greet"
+    comp_dir.mkdir()
+    (comp_dir / "greet.html").write_text(
+        "{#def name: str #}\n<h1 class='greet'>Hello {{ name }}</h1>",
+        encoding="utf-8",
+    )
+    (comp_dir / "greet.css").write_text(".greet { color: green }", encoding="utf-8")
+
+    Renderer.set_default_environment(str(tmp_path))
+    renderer = Renderer.get_default_renderer()
+    html = renderer.render('<Greet name="world"/>')
+
+    assert ".greet { color: green }" in html, "CSS not inlined via tag path"
+
+
+def test_header_classless_tag_js_collected(isolate_renderer):
+    """JS co-located with a {#def#}-header template IS inlined via tag path."""
+    tmp_path = isolate_renderer
+    comp_dir = tmp_path / "alert"
+    comp_dir.mkdir()
+    (comp_dir / "alert.html").write_text(
+        "{#def msg: str #}\n<div class='alert'>{{ msg }}</div>",
+        encoding="utf-8",
+    )
+    (comp_dir / "alert.js").write_text("console.log('alert');", encoding="utf-8")
+
+    Renderer.set_default_environment(str(tmp_path))
+    renderer = Renderer.get_default_renderer()
+    html = renderer.render('<Alert msg="watch out"/>')
+
+    assert "console.log('alert');" in html, "JS not inlined via tag path"
+
+
+# ---------------------------------------------------------------------------
+# Regression: file-backed class-based components still collect their assets
+# ---------------------------------------------------------------------------
+
+def test_class_based_builtin_still_collects_assets():
+    """PJXButton (a real class-based builtin) still inlines its own CSS.
+
+    This guards against the fix accidentally breaking class-based components.
+    """
+    from pyjinhx.builtins.ui.pjx_button.pjx_button import PJXButton
+
+    html = str(PJXButton(label="Click me").render())
+
+    # PJXButton's CSS contains its own selectors; just assert style is present
+    assert "<style" in html, "PJXButton's CSS was not inlined (regression)"
+
+
+# ---------------------------------------------------------------------------
+# Marker check: _pjx_classless is set correctly
+# ---------------------------------------------------------------------------
+
+def test_pjx_classless_marker_set_on_header_model(isolate_renderer):
+    """{#def#} header path sets _pjx_classless = True on the dynamic subclass."""
+    tmp_path = isolate_renderer
+    (tmp_path / "mycomp.html").write_text(
+        "{#def title: str #}\n<div>{{ title }}</div>",
+        encoding="utf-8",
+    )
+    Renderer.set_default_environment(str(tmp_path))
+
+    MyComp = component("Mycomp")
+    assert getattr(MyComp, "_pjx_classless", False) is True
+
+
+def test_pjx_classless_marker_set_on_bare_factory(isolate_renderer):
+    """component() no-header fallback sets _pjx_classless = True."""
+    tmp_path = isolate_renderer
+    (tmp_path / "plain.html").write_text("<p>{{ text }}</p>", encoding="utf-8")
+    Renderer.set_default_environment(str(tmp_path))
+
+    Plain = component("Plain")
+    assert getattr(Plain, "_pjx_classless", False) is True
+
+
+def test_pjx_classless_marker_false_on_handwritten_class():
+    """A hand-written BaseComponent subclass does NOT have _pjx_classless = True."""
+    from pyjinhx.builtins.ui.pjx_button.pjx_button import PJXButton
+
+    assert getattr(PJXButton, "_pjx_classless", False) is False


### PR DESCRIPTION
## Summary

Fixes #122 — **classless components did not collect co-located CSS/JS**, so a template-only component (`{#def#}` prop-header, or one referenced via `component("Name")`) rendered unstyled.

### Root cause
Asset discovery was guarded by `type(component).__name__ == "BaseComponent"`, but `{#def#}` headers (`build_component_model` → `create_model`) and `component()` (`type(...)`) produce dynamically-**named** subclasses, so the guard missed them and fell back to `inspect.getfile(dynamic_class)` → wrong directory → no assets.

### Fix
- New `_pjx_classless` ClassVar marker, set on both dynamic-factory paths (kept distinct from `_pjx_template`, which file-backed classes may also set).
- Broadened the asset guard to include `_pjx_classless` classes.
- The `component()` factory render path (where `template_path` is None) now resolves the template path for asset discovery via `_find_template_for_tag`.

File-backed class-based components are unaffected (they keep using the class-directory path).

## Testing
New `test_classless_assets_factory.py` (factory CSS/JS, tag-path, class-based regression guard, marker checks). 863 passed / 5 skipped; ruff + `mkdocs --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)