### PR TITLE
feat(templates): add .pjx as a supported template extension

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.23.2
+current_version = 0.24.0
 commit = True
 tag = True
 message = Bump version: {current_version} → {new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.24.0 — .pjx template extension (2026-06-19)
+
+### Added
+
+- **`.pjx` template extension.** Templates can now use the `.pjx` extension alongside
+  `.html` and `.jinja`. `.pjx` is tried first during auto-discovery, so a `widget.pjx`
+  takes precedence over a co-located `widget.html`/`widget.jinja`. The extension list is
+  centralized in `pyjinhx.utils.TEMPLATE_EXTENSIONS`.
+
 ## 0.23.2 — classless component assets (2026-06-19)
 
 ### Fixed

--- a/docs/api/finder.md
+++ b/docs/api/finder.md
@@ -40,7 +40,7 @@ Find a file by name under the root directory.
 def find_template_for_tag(tag_name: str) -> str
 ```
 
-Resolve a PascalCase tag name to its template file path. Tries candidates in order: `snake_case.html`, `kebab-case.html`, `snake_case.jinja`, `kebab-case.jinja`.
+Resolve a PascalCase tag name to its template file path. Tries candidates in order: `snake_case.pjx`, `kebab-case.pjx`, `snake_case.html`, `kebab-case.html`, `snake_case.jinja`, `kebab-case.jinja`.
 
 **Parameters:**
 - `tag_name` (str): The PascalCase component name (e.g., `"ButtonGroup"`).
@@ -115,7 +115,7 @@ def get_relative_template_paths(
     search_root: str,
     component_name: str,
     *,
-    extensions: tuple[str, ...] = (".html", ".jinja"),
+    extensions: tuple[str, ...] = (".pjx", ".html", ".jinja"),
 ) -> list[str]
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -47,7 +47,7 @@ Create `components/ui/button.html` (same directory as the class):
 !!! info "Template Discovery"
     PyJinHx automatically finds templates by converting the class name to snake_case.
     `Button` → `button.html`, `ActionButton` → `action_button.html` — kebab-case
-    (`action-button.html`) and `.jinja` candidates are also tried; see
+    (`action-button.html`), `.pjx`, and `.jinja` candidates are also tried; see
     [PascalCase tags](../guide/tags.md) for the full list.
 
 ## Step 3: Render the Component

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -73,9 +73,9 @@ Templates are automatically discovered based on the class name:
 
 | Class Name | Template File |
 |------------|---------------|
-| `Button` | `button.html` or `button.jinja` |
-| `ActionButton` | `action_button.html`, `action-button.html`, or `.jinja` variants |
-| `UserCard` | `user_card.html`, `user-card.html`, or `.jinja` variants |
+| `Button` | `button.pjx`, `button.html`, or `button.jinja` |
+| `ActionButton` | `action_button.pjx`, `action-button.pjx`, or `.html`/`.jinja` variants |
+| `UserCard` | `user_card.pjx`, `user-card.pjx`, or `.html`/`.jinja` variants |
 
 !!! warning "Template Location Requirement"
     Templates must be in the same directory as the Python class file.

--- a/docs/guide/tags.md
+++ b/docs/guide/tags.md
@@ -57,12 +57,14 @@ html = renderer.render("""
 
 PascalCase tag names are converted to candidate template filenames in this order:
 
-1. `snake_case.html`
-2. `kebab-case.html`
-3. `snake_case.jinja`
-4. `kebab-case.jinja`
+1. `snake_case.pjx`
+2. `kebab-case.pjx`
+3. `snake_case.html`
+4. `kebab-case.html`
+5. `snake_case.jinja`
+6. `kebab-case.jinja`
 
-For example, `<ActionButton/>` searches for: `action_button.html`, `action-button.html`, `action_button.jinja`, `action-button.jinja`.
+For example, `<ActionButton/>` searches for: `action_button.pjx`, `action-button.pjx`, `action_button.html`, `action-button.html`, `action_button.jinja`, `action-button.jinja`.
 
 Templates are searched under the root directory of your Jinja `FileSystemLoader` (see [Configuration](configuration.md)).
 

--- a/pyjinhx/finder.py
+++ b/pyjinhx/finder.py
@@ -7,6 +7,7 @@ from jinja2 import FileSystemLoader
 from markupsafe import Markup
 
 from .utils import (
+    TEMPLATE_EXTENSIONS,
     normalize_path_separators,
     pascal_case_to_kebab_case,
     pascal_case_to_snake_case,
@@ -114,7 +115,7 @@ class Finder:
         search_root: str,
         component_name: str,
         *,
-        extensions: tuple[str, ...] = (".html", ".jinja"),
+        extensions: tuple[str, ...] = TEMPLATE_EXTENSIONS,
     ) -> list[str]:
         """
         Compute candidate template paths relative to the Jinja loader root.
@@ -170,7 +171,7 @@ class Finder:
         """
         Resolve a PascalCase component tag name to its template path.
 
-        Tries multiple extensions (.html, .jinja) in order of preference.
+        Tries multiple extensions (.pjx, .html, .jinja) in order of preference.
 
         Args:
             tag_name: The PascalCase component tag name (e.g., "ButtonGroup").

--- a/pyjinhx/utils.py
+++ b/pyjinhx/utils.py
@@ -47,8 +47,12 @@ def component_resolution_classes(component_class: type) -> list[type]:
     ]
 
 
+TEMPLATE_EXTENSIONS: tuple[str, ...] = (".pjx", ".html", ".jinja")
+"""Template file extensions to try, in order of preference."""
+
+
 def tag_name_to_template_filenames(
-    tag_name: str, *, extensions: tuple[str, ...] = (".html", ".jinja")
+    tag_name: str, *, extensions: tuple[str, ...] = TEMPLATE_EXTENSIONS
 ) -> list[str]:
     """
     Convert a component tag name into candidate template filenames.
@@ -60,8 +64,8 @@ def tag_name_to_template_filenames(
         extensions: File extensions to use, in order of preference.
 
     Returns:
-        List of candidate filenames (e.g., ["button_group.html", "button-group.html",
-        "button_group.jinja", "button-group.jinja"]).
+        List of candidate filenames (e.g., ["button_group.pjx", "button-group.pjx",
+        "button_group.html", "button-group.html", ...]).
     """
     snake_name = pascal_case_to_snake_case(tag_name)
     kebab_name = snake_name.replace("_", "-")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyjinhx"
-version = "0.23.2"
+version = "0.24.0"
 description = "UI components for Python using Pydantic and Jinja2 templates"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/unit/test_builtin_conventions.py
+++ b/tests/unit/test_builtin_conventions.py
@@ -4,6 +4,7 @@ import os
 import re
 
 import pyjinhx.builtins as b
+from pyjinhx.utils import TEMPLATE_EXTENSIONS
 
 SWEPT: list[type] = [getattr(b, name) for name in b.__all__]
 
@@ -29,7 +30,7 @@ def test_swept_templates_have_no_literal_aria_labels():
     for cls in SWEPT:
         directory = _component_dir(cls)
         for name in os.listdir(directory):
-            if not name.endswith((".html", ".jinja")):
+            if not name.endswith(TEMPLATE_EXTENSIONS):
                 continue
             content = _read(os.path.join(directory, name))
             for match in re.finditer(r'aria-label="([^"]*)"', content):

--- a/tests/unit/test_jinja_template_auto_lookup.py
+++ b/tests/unit/test_jinja_template_auto_lookup.py
@@ -61,6 +61,42 @@ def test_class_template_auto_lookup_supports_jinja_extension():
     Renderer.set_default_environment(original_environment)
 
 
+def test_tag_template_auto_lookup_supports_pjx_extension():
+    original_environment = Renderer.peek_default_environment()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        child_template_path = os.path.join(temp_dir, "pjx_child.pjx")
+        with open(child_template_path, "w") as file:
+            file.write('<span id="{{ id }}">from pjx</span>\n')
+
+        Renderer.set_default_environment(temp_dir)
+
+        renderer = Renderer.get_default_renderer()
+        rendered = renderer.render('<PjxChild id="child-1"/>')
+        assert rendered == '<span id="child-1">from pjx</span>'
+
+    Renderer.set_default_environment(original_environment)
+
+
+def test_pjx_extension_preferred_over_html():
+    """A .pjx template wins when a .html sibling also exists."""
+    original_environment = Renderer.peek_default_environment()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "widget.pjx"), "w") as file:
+            file.write('<div id="{{ id }}">pjx</div>\n')
+        with open(os.path.join(temp_dir, "widget.html"), "w") as file:
+            file.write('<div id="{{ id }}">html</div>\n')
+
+        Renderer.set_default_environment(temp_dir)
+
+        renderer = Renderer.get_default_renderer()
+        rendered = renderer.render('<Widget id="w-1"/>')
+        assert rendered == '<div id="w-1">pjx</div>'
+
+    Renderer.set_default_environment(original_environment)
+
+
 def test_tag_template_lookup_supports_hyphen_separator():
     """Test that templates with hyphen separators (kebab-case) are found."""
     original_environment = Renderer.peek_default_environment()

--- a/tests/unit/test_template_and_engine_errors.py
+++ b/tests/unit/test_template_and_engine_errors.py
@@ -48,7 +48,8 @@ def test_missing_template_error_lists_real_candidates():
 
     assert str(error) == (
         "No template found for <UserCard>. Expected one of: "
-        "user_card.html, user-card.html, user_card.jinja, user-card.jinja"
+        "user_card.pjx, user-card.pjx, user_card.html, user-card.html, "
+        "user_card.jinja, user-card.jinja"
     )
 
 


### PR DESCRIPTION
## Summary

Adds `.pjx` as a first-class template extension alongside `.html` and `.jinja`. `.pjx` is tried first in auto-discovery precedence, so `widget.pjx` wins over a co-located `widget.html` or `widget.jinja`. The extension list is centralized in `pyjinhx.utils.TEMPLATE_EXTENSIONS`, removing the previously duplicated tuple in `finder.py`.

## Changes

- `pyjinhx/utils.py` — added shared constant `TEMPLATE_EXTENSIONS = (".pjx", ".html", ".jinja")`; `tag_name_to_template_filenames` now uses it as its default
- `pyjinhx/finder.py` — `get_relative_template_paths` references `TEMPLATE_EXTENSIONS` instead of a local duplicate tuple
- `tests/unit/test_jinja_template_auto_lookup.py` — new `.pjx` lookup test and precedence test over co-located `.html`/`.jinja`
- `tests/unit/test_builtin_conventions.py`, `tests/unit/test_template_and_engine_errors.py` — updated to the new extension set
- `docs/guide/tags.md`, `docs/api/finder.md`, `docs/guide/components.md`, `docs/getting-started/quickstart.md` — updated lookup-order enumerations
- `CHANGELOG.md` — added 0.24.0 release entry

## Type of Change

- [x] New feature (minor)

## Version Bump

`0.23.2` → `0.24.0`

## Notes

- Autoescape required no change — it remains unconditionally `True` and applies to all extensions equally.
- Full unit suite passes: 790 passed, 5 skipped.

## Testing

- Run `pytest tests/unit/test_jinja_template_auto_lookup.py -v` to exercise the new `.pjx` lookup and precedence tests directly.
- Run the full suite (`pytest`) to confirm no regressions.