### PR TITLE
fix(base): slot-wrap undeclared children field so classless content renders raw (#125)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.24.0
+current_version = 0.24.1
 commit = True
 tag = True
 message = Bump version: {current_version} → {new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Classless / undeclared `content` children no longer render HTML-escaped.** When a
+  component received inner content but did not *declare* a `content` field (a classless
+  `{#def … #}` component, or a subclass without `content`), `{{ content }}` was autoescaped,
+  forcing `{{ content | safe }}`. `_build_template_context` only slot-wrapped *declared*
+  fields; the children field arriving as a pydantic extra was missed. The extras loop now
+  slot-wraps it too (via the existing `_is_slot_field` check), so inner content renders raw
+  regardless of whether the receiving component declares `content`. (#125)
+
 ## 0.24.0 — .pjx template extension (2026-06-19)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.24.1 — classless content escape fix (2026-06-19)
 
 ### Fixed
 

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -382,6 +382,11 @@ class BaseComponent(BaseModel):
                 renderer=_renderer,
                 session=_session,
             )
+            # The children field can arrive here as a pydantic extra (classless /
+            # undeclared `content`); slot-wrap it too so it renders raw without
+            # `| safe`, matching a declared children field (#125).
+            if _is_slot_field(type(self), field_name):
+                context[field_name] = _wrap_slot_value(context.get(field_name))
 
         return context
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyjinhx"
-version = "0.24.0"
+version = "0.24.1"
 description = "UI components for Python using Pydantic and Jinja2 templates"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/unit/test_props_header_tag.py
+++ b/tests/unit/test_props_header_tag.py
@@ -12,6 +12,13 @@ def env(tmp_path):
         encoding="utf-8",
     )
     (tmp_path / "plain_hdr.html").write_text("<div>{{ foo }}</div>", encoding="utf-8")
+    (tmp_path / "box_hdr.html").write_text(
+        '{#def #}\n<section class="box">{{ content }}</section>',
+        encoding="utf-8",
+    )
+    (tmp_path / "inner_hdr.html").write_text(
+        '{#def #}\n<div class="inner">hi</div>', encoding="utf-8"
+    )
     Renderer.set_default_environment(str(tmp_path))
     return Renderer.get_default_renderer()
 
@@ -40,3 +47,11 @@ def test_undeclared_attr_passes_through_to_root(env):
 def test_template_without_header_still_renders(env):
     out = env.render('<PlainHdr foo="bar"/>')
     assert "bar" in out
+
+
+def test_classless_children_render_raw_without_safe(env):
+    # Issue #125: a classless component's inner content (the children → `content`
+    # field, undeclared) must render raw, not HTML-escaped, without `| safe`.
+    out = env.render("<BoxHdr><InnerHdr/></BoxHdr>")
+    assert '<div class="inner">hi</div>' in out
+    assert "&lt;div" not in out

--- a/tests/unit/test_slot_type.py
+++ b/tests/unit/test_slot_type.py
@@ -44,3 +44,19 @@ def test_slot_string_value_becomes_markup_in_context(tmp_path):
     assert isinstance(built["body"], Markup)
     assert isinstance(built["kids"], Markup)
     assert not isinstance(built["label"], Markup)
+
+
+def test_undeclared_children_field_becomes_markup_in_context(tmp_path):
+    # Issue #125: the children field arriving as a pydantic *extra* (classless /
+    # undeclared `content`) must still be slot-wrapped, not autoescaped — the same
+    # as a declared children field. Otherwise `{{ content }}` forces `| safe`.
+    from pyjinhx import Renderer
+    Renderer.set_default_environment(str(tmp_path))
+
+    class _Classless(BaseComponent):
+        pass  # no declared `content`; _pjx_children_field defaults to "content"
+
+    inst = _Classless(id="c", content="<div>inner</div>")
+    assert "content" not in type(inst).model_fields  # sanity: it's an extra
+    built = inst._build_template_context()
+    assert isinstance(built["content"], Markup)

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ wheels = [
 
 [[package]]
 name = "pyjinhx"
-version = "0.24.0"
+version = "0.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Fixes #125: inner content of a classless (or `content`-undeclared) component rendered HTML-escaped when used without `| safe`. A declared `content` field always rendered raw, making the behaviour inconsistent. The fix adds the same slot-wrap guard to the pydantic-extras loop in `_build_template_context`, mirroring the existing declared-field path.

## Changes

- `pyjinhx/base.py` — extras loop now calls `_is_slot_field` / `_wrap_slot_value` on each extra, so the children field arriving as a pydantic extra is wrapped as `Markup` before Jinja sees it.
- `tests/unit/test_slot_type.py` — unit test: undeclared `content` extra becomes `Markup` in the built context (fails without the fix).
- `tests/unit/test_props_header_tag.py` — end-to-end test: classless `<BoxHdr><InnerHdr/></BoxHdr>` renders inner HTML raw, no `&lt;div` in output (fails without the fix).
- `CHANGELOG.md` — "Unreleased" → 0.24.1 fixed entry.

## Type of Change

- [x] Bug fix (patch)
- [ ] New feature (minor)
- [ ] Breaking change (major)
- [ ] Refactor / cleanup
- [ ] Documentation

## Version Bump

`0.24.0` → `0.24.1`

## Testing

All 792 unit tests pass (5 skipped). The two new tests specifically cover the regression: one checks `Markup` wrapping at the context-build level, the other checks end-to-end HTML output without `| safe`.