### PR TITLE
fix(builtins): narrow text-field types from str | BaseComponent to str (#127)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.24.0
+current_version = 0.25.0
 commit = True
 tag = True
 message = Bump version: {current_version} → {new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.25.0 — slot-escaping consistency (2026-06-19)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
   and `PJXEmptyState.description` no longer accept a `BaseComponent` value (they are now `str`).
   Pass rich/markup content through the components' slot fields instead.
 
+### Docs
+
+- Brought the `/pyjinhx` Claude Code skill (`docs/integrations/claude-code.md`) up to date: added an
+  **Escaping & slots** section (autoescape-by-default, `Slot` opt-in, the "type matches escaping"
+  convention), `Slot` in the public-API import block, `.pjx` in template auto-discovery, and
+  corrected the builtins roster (37 components; added the missing `PJXAccordion`,
+  `PJXAccordionGroup`, `PJXButton`, `PJXIcon`).
+
 ## 0.24.0 — .pjx template extension (2026-06-19)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Builtin text fields no longer carry a misleading `str | BaseComponent` type.** Several
+  builtin fields (`PJXButton.center`, `PJXModal`/`PJXDrawer`/`PJXCard`/`PJXEmptyState.title`,
+  `PJXEmptyState.description`) were typed `str | BaseComponent` but rendered their string value
+  **escaped** — so a passed component rendered raw while a markup string escaped, an inconsistency
+  and a latent XSS footgun. These are now plain `str` (text, escaped by default), matching their
+  actual behavior and the autoescape-by-default security posture. Icons/markup go in the adjacent
+  `Slot` fields (`start`/`end`, `header`, `image`/`action`). A new convention test
+  (`test_swept_fields_holding_components_are_slots`) enforces the invariant: any builtin field
+  whose type can hold a `BaseComponent` must be a slot (children field or `Slot`-typed).
+
+### Breaking
+
+- `PJXButton.center`, `PJXModal.title`, `PJXDrawer.title`, `PJXCard.title`, `PJXEmptyState.title`,
+  and `PJXEmptyState.description` no longer accept a `BaseComponent` value (they are now `str`).
+  Pass rich/markup content through the components' slot fields instead.
+
 ## 0.24.0 — .pjx template extension (2026-06-19)
 
 ### Added

--- a/docs/guide/builtin-conventions.md
+++ b/docs/guide/builtin-conventions.md
@@ -30,6 +30,11 @@ Every pyjinhx builtin follows the same contract, so knowing one means knowing al
    HTML-escaped. A builtin's children/`content` field and any field typed `Slot` (e.g. a card's
    `body`, a tab group's `tabs`) render raw HTML, as do nested `BaseComponent` values. See
    [Escaping & slots](components.md#escaping-and-slots) for the full rule and escape hatches.
+8. **Type matches escaping.** A field's annotation must reflect whether it renders raw: text
+   fields (titles, labels, descriptions) are plain `str` and stay escaped; raw-HTML/icon/component
+   fields are `Slot` (or the children field). A field is never typed `str | BaseComponent` unless
+   it is a slot — otherwise a component renders raw while a string escapes, an inconsistency that
+   is also an XSS footgun. `test_swept_fields_holding_components_are_slots` enforces this.
 
 ## Events and hooks
 

--- a/docs/guide/builtins.md
+++ b/docs/guide/builtins.md
@@ -150,7 +150,7 @@ Structural, themeable button. Composes [`PJXRegionLoader`](#pjxregionloader) for
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `start` | `str \| BaseComponent \| None` | `None` | Leading slot (e.g. an icon); the `.pjx-button__start` span is omitted when empty. |
-| `center` | `str \| BaseComponent \| None` | `None` | Label slot (`.pjx-button__center`), omitted when empty. |
+| `center` | `str \| None` | `None` | Label text (`.pjx-button__center`), HTML-escaped; omitted when empty. Use `start`/`end` for icon slots. |
 | `end` | `str \| BaseComponent \| None` | `None` | Trailing slot (icon/badge, `.pjx-button__end`), omitted when empty. |
 | `variant` | `str` | `"default"` | Class hook only → `pjx-button--{variant}`. No baked palette; style it yourself. |
 | `block` | `bool` | `False` | Full-width (`pjx-button--block`) instead of content-width. |
@@ -242,7 +242,7 @@ Native `<dialog>`. **Assets:** `pjx_modal.css`, `pjx_modal.js`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `title` | `str \| BaseComponent` | `""` | Default header title when `header` is empty. |
+| `title` | `str` | `""` | Default header title (text, escaped) when `header` is empty; use the `header` slot for custom markup. |
 | `header` | `str \| BaseComponent` | `""` | If set, replaces the built-in title row. |
 | `body` | `str \| BaseComponent` | `""` | Main content; wrapper id `{{ id }}-body`. |
 | `footer` | `str \| BaseComponent` | `""` | If non-empty, renders `<footer class="pjx-modal__footer">`. |
@@ -445,7 +445,7 @@ Trigger id is `{{ id }}-trigger`, menu is `{{ id }}-menu`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `side` | literal | `"right"` | `left`, `right`, or `bottom` → `pjx-drawer--{side}`. |
-| `title` | `str \| BaseComponent` | `""` | Header title. |
+| `title` | `str` | `""` | Header title (text, escaped). |
 | `body` | `str \| BaseComponent` | `""` | Scrollable body. |
 | `footer` | `str \| BaseComponent` | `""` | Optional footer strip. |
 | `close_label` | `str` | `"Close"` | `aria-label` for the close button. |
@@ -507,8 +507,8 @@ Centered empty view. **Assets:** `pjx-empty-state.css` only (template file **`pj
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `image` | `str \| BaseComponent` | `""` | Optional slot above the heading (e.g. illustration markup). |
-| `title` | `str \| BaseComponent` | `""` | Heading. |
-| `description` | `str \| BaseComponent` | `""` | Supporting text. |
+| `title` | `str` | `""` | Heading (text, escaped). |
+| `description` | `str` | `""` | Supporting text (escaped). |
 | `action` | `str \| BaseComponent` | `""` | Optional slot (e.g. button markup). |
 | `actions` | `list[str \| BaseComponent]` | `[]` | Optional flex row of slots; renders after `action` when both are set. |
 | `suggestions` | `list[dict]` | `[]` | Interactive suggestion chips; each dict dispatches a custom event on click. See below. |
@@ -652,7 +652,7 @@ Grouped content with optional header and footer. **Assets:** `pjx_card.css` only
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `title` | `str \| BaseComponent` | `""` | Default header title (ignored if `header` is set). |
+| `title` | `str` | `""` | Default header title (text, escaped; ignored if `header` is set). |
 | `header` | `str \| BaseComponent` | `""` | Custom header slot; replaces `title` block when set. |
 | `body` | `str \| BaseComponent` | `""` | Main content. |
 | `footer` | `str \| BaseComponent` | `""` | Optional footer. |

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -27,7 +27,7 @@ class Card(BaseComponent):
     subtitle: str = ""   # optional
 ```
 
-The template is auto-discovered from the class name: `Card` → `card.html`/`card.jinja`; `ActionButton` → `action_button` or `action-button` (`.html` or `.jinja`). Subclasses with no adjacent template inherit the nearest ancestor's template and assets through the MRO (first found per kind), so do **not** duplicate templates for every subclass; a class may have at most one concrete component base (definition-time `TypeError`).
+The template is auto-discovered from the class name: `Card` → `card.pjx`/`card.html`/`card.jinja`; `ActionButton` → `action_button` or `action-button` (`.pjx`, `.html`, or `.jinja`, tried in that order — `.pjx` wins). Subclasses with no adjacent template inherit the nearest ancestor's template and assets through the MRO (first found per kind), so do **not** duplicate templates for every subclass; a class may have at most one concrete component base (definition-time `TypeError`).
 
 ## Rendering
 
@@ -44,6 +44,28 @@ Templates receive all component fields as variables and support full Jinja2. Pas
     {% if subtitle %}<p>{{ subtitle }}</p>{% endif %}
     <Button id="card-action" text="Click me"/>
 </div>
+```
+
+## Escaping & slots (security)
+
+Template output is **HTML-escaped by default** (Jinja runs with `autoescape=True`). Scalar props, text, attribute values, and loop-derived values are escaped — so user-supplied data can't inject markup. This is the secure default; do **not** defeat it for untrusted content.
+
+What renders **raw** (unescaped):
+
+- The component's children/`content` field (tag inner content).
+- Any field declared `Slot` (`from pyjinhx import Slot`) — `Slot` is `str | BaseComponent`; its string value renders raw. `Slot` collections work too (string elements inside a `Slot`-annotated `list`/`dict`).
+- Nested `BaseComponent` values (they render raw via `__html__`).
+
+To intentionally render raw HTML / an icon / a snippet, opt in: declare the field as `Slot` (`badge: Slot = ""`), use `{{ value|safe }}` in the template, or pass a `BaseComponent`.
+
+**Type matches escaping (convention).** A field's annotation must reflect how it renders. Text fields (titles, labels, descriptions) are plain `str` and stay escaped; raw-HTML/icon/component fields are `Slot`. **Never** type a text field `str | BaseComponent` unless it's a real slot — otherwise a component renders raw while a string escapes (inconsistent, and an XSS footgun).
+
+```python
+from pyjinhx import BaseComponent, Slot
+
+class Callout(BaseComponent):
+    title: str = ""      # text → escaped (safe default)
+    body: Slot = ""      # raw HTML / icon / nested component → rendered as-is
 ```
 
 ## Nesting
@@ -135,7 +157,7 @@ Full guide: [docs/reactivity.md](../reactivity.md).
 
 ## Builtins (`pyjinhx.builtins`)
 
-`import pyjinhx.builtins` registers thirty-three optional components: `PJXAlert`, `PJXAvatar`, `PJXAvatarStack`, `PJXBadge`, `PJXBreadcrumb`, `PJXCard`, `PJXChipInput`, `PJXConfirmDialog`, `PJXDivider`, `PJXDrawer`, `PJXDropdown`, `PJXEmptyState`, `PJXFormField`, `PJXLazyPanel`, `PJXModal`, `PJXNotification`, `PJXPageLoader`, `PJXPasswordInput`, `PJXPopover`, `PJXPopoverPanel`, `PJXPopoverTrigger`, `PJXProgress`, `PJXPromptDialog`, `PJXRegionLoader`, `PJXPanel`, `PJXPanelTrigger`, `PJXSegmentedControl`, `PJXSkeleton`, `PJXSpinner`, `PJXTabGroup`, `PJXToastHost`, `PJXToggleSwitch`, `PJXTooltip`. Same `BaseComponent` rules; templates/CSS/JS live under `pyjinhx/builtins/ui/pjx_<component>/`, and the renderer falls back to on-disk templates if the app's Jinja loader can't see package templates. **Do not** register user subclasses with the same class name as a builtin — the global `Registry` is one class per name.
+`import pyjinhx.builtins` registers thirty-seven optional components: `PJXAccordion`, `PJXAccordionGroup`, `PJXAlert`, `PJXAvatar`, `PJXAvatarStack`, `PJXBadge`, `PJXBreadcrumb`, `PJXButton`, `PJXCard`, `PJXChipInput`, `PJXConfirmDialog`, `PJXDivider`, `PJXDrawer`, `PJXDropdown`, `PJXEmptyState`, `PJXFormField`, `PJXIcon`, `PJXLazyPanel`, `PJXModal`, `PJXNotification`, `PJXPageLoader`, `PJXPasswordInput`, `PJXPopover`, `PJXPopoverPanel`, `PJXPopoverTrigger`, `PJXProgress`, `PJXPromptDialog`, `PJXRegionLoader`, `PJXPanel`, `PJXPanelTrigger`, `PJXSegmentedControl`, `PJXSkeleton`, `PJXSpinner`, `PJXTabGroup`, `PJXToastHost`, `PJXToggleSwitch`, `PJXTooltip`. Same `BaseComponent` rules; templates/CSS/JS live under `pyjinhx/builtins/ui/pjx_<component>/`, and the renderer falls back to on-disk templates if the app's Jinja loader can't see package templates. **Do not** register user subclasses with the same class name as a builtin — the global `Registry` is one class per name.
 
 - **Host theme** (set on `:root` or a wrapper): builtin CSS reads shared tokens — define at least `--surface`, `--surface-alt`, `--text`, `--text-muted`, `--border`, `--brand`, `--brand-subtle`, `--brand-muted`, `--error`, `--success`, `--warning`, `--font-size-{xs,sm,md}`, `--radius-{sm,md,lg,full}`, `--shadow-md`, `--transition`, `--space-3`, `--space-4`. Optional `--error-bg` / `--error-border` for error surfaces (badge/alert fall back with `color-mix`).
 - **Per-component tokens:** each stylesheet declares `--pjx-<widget>-*` properties on `:root` — override to tune one component without editing package files (e.g. `--pjx-modal-width`, `--pjx-dropdown-z`, `--pjx-drawer-width`).
@@ -159,6 +181,7 @@ from pyjinhx import (
     BaseComponent,      # base class for all components
     ReactiveComponent,  # react={...} + load(); Cls.render(*args) is the route entry point
     Renderer, Registry,
+    Slot,               # field type for raw-HTML/icon/component values (opt out of escaping)
     PjxKey,             # Annotated[..., PjxKey()] marker for keyed regions
     mutates,            # decorator on store methods; state keys only
     setup,              # wires FastAPI middleware (request_scope, ClientBackend, PjxContext)

--- a/pyjinhx/builtins/ui/pjx_button/pjx_button.py
+++ b/pyjinhx/builtins/ui/pjx_button/pjx_button.py
@@ -6,7 +6,7 @@ from pyjinhx.base import AttrValue, PjxSlot
 
 class PJXButton(BaseComponent):
     start: Annotated[str | BaseComponent | None, PjxSlot()] = None
-    center: str | BaseComponent | None = None
+    center: str | None = None  # label text — escaped; use start/end slots for icons
     end: Annotated[str | BaseComponent | None, PjxSlot()] = None
     variant: str = "default"
     block: bool = False

--- a/pyjinhx/builtins/ui/pjx_card/pjx_card.py
+++ b/pyjinhx/builtins/ui/pjx_card/pjx_card.py
@@ -9,7 +9,7 @@ from pyjinhx.base import AttrValue, ExtraAttrs
 class PJXCard(BaseComponent):
     _pjx_children_field: ClassVar[str] = "body"
 
-    title: str | BaseComponent = ""
+    title: str = ""  # text — escaped; use the header slot for custom markup
     header: Slot = ""
     body: str | BaseComponent = ""
     footer: Slot = ""

--- a/pyjinhx/builtins/ui/pjx_drawer/pjx_drawer.py
+++ b/pyjinhx/builtins/ui/pjx_drawer/pjx_drawer.py
@@ -10,7 +10,7 @@ class PJXDrawer(BaseComponent):
     _pjx_children_field: ClassVar[str] = "body"
 
     side: Literal["left", "right", "bottom"] = "right"
-    title: str | BaseComponent = ""
+    title: str = ""  # heading text — escaped
     body: str | BaseComponent = ""
     footer: Slot = ""
     close_label: str = "Close"

--- a/pyjinhx/builtins/ui/pjx_empty_state/pjx_empty_state.py
+++ b/pyjinhx/builtins/ui/pjx_empty_state/pjx_empty_state.py
@@ -8,8 +8,8 @@ from pyjinhx.base import AttrValue, ExtraAttrs, PjxSlot
 
 class PJXEmptyState(BaseComponent):
     image: Slot = ""
-    title: str | BaseComponent = ""
-    description: str | BaseComponent = ""
+    title: str = ""  # heading text — escaped
+    description: str = ""  # body text — escaped
     action: Slot = ""
     actions: Annotated[list[str | BaseComponent], PjxSlot()] = Field(
         default_factory=list

--- a/pyjinhx/builtins/ui/pjx_modal/pjx_modal.py
+++ b/pyjinhx/builtins/ui/pjx_modal/pjx_modal.py
@@ -9,7 +9,7 @@ from pyjinhx.base import AttrValue, ExtraAttrs
 class PJXModal(BaseComponent):
     _pjx_children_field: ClassVar[str] = "body"
 
-    title: str | BaseComponent = ""
+    title: str = ""  # text — escaped; use the header slot for custom markup
     header: Slot = ""
     body: str | BaseComponent = ""
     footer: Slot = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyjinhx"
-version = "0.24.0"
+version = "0.25.0"
 description = "UI components for Python using Pydantic and Jinja2 templates"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/unit/test_autoescape_security.py
+++ b/tests/unit/test_autoescape_security.py
@@ -69,7 +69,7 @@ def test_button_start_end_slot_render_raw():
 def test_button_center_label_is_escaped():
     from pyjinhx.builtins import PJXButton
     html = str(PJXButton(id="b2", center="<b>x</b>").render())
-    assert "<b>x</b>" not in html   # center stays str | BaseComponent → escaped
+    assert "<b>x</b>" not in html   # center is text (str) → escaped; use start/end for icons
     assert "&lt;b&gt;" in html
 
 
@@ -124,7 +124,7 @@ def test_nested_tag_component_scalar_is_escaped_when_nested_tag_present():
     html = str(
         PJXButton(id="b", center="<b>x</b>", loading=True).render()
     )
-    assert "<b>x</b>" not in html  # center stays str | BaseComponent → escaped
+    assert "<b>x</b>" not in html  # center is text (str) → escaped through tag expansion
     assert "&lt;b&gt;" in html
 
 

--- a/tests/unit/test_builtin_conventions.py
+++ b/tests/unit/test_builtin_conventions.py
@@ -4,6 +4,7 @@ import os
 import re
 
 import pyjinhx.builtins as b
+from pyjinhx.base import _is_slot_field
 from pyjinhx.utils import TEMPLATE_EXTENSIONS
 
 SWEPT: list[type] = [getattr(b, name) for name in b.__all__]
@@ -24,6 +25,24 @@ def _read(path: str) -> str:
 def test_swept_builtins_declare_contract_fields():
     for cls in SWEPT:
         assert "class_name" in cls.model_fields, cls.__name__
+
+
+def test_swept_fields_holding_components_are_slots():
+    # A builtin field whose annotation can hold a BaseComponent must be a slot —
+    # either the component's children field or marked PjxSlot — so a raw-HTML
+    # string renders the same (raw) as a passed component instead of being
+    # autoescaped. Guards the #118 / PJXButton.center class of oversight.
+    # (Fields that deliberately escape string items use list[Any], which does
+    # not name BaseComponent and is intentionally exempt — e.g. PJXAvatarStack.)
+    for cls in SWEPT:
+        for name, field in cls.model_fields.items():
+            if "BaseComponent" not in str(field.annotation):
+                continue
+            assert _is_slot_field(cls, name), (
+                f"{cls.__name__}.{name}: annotation accepts a BaseComponent but the "
+                f"field is not a slot (children field or PjxSlot) — a markup string "
+                f"would be HTML-escaped. Declare it as Slot."
+            )
 
 
 def test_swept_templates_have_no_literal_aria_labels():

--- a/uv.lock
+++ b/uv.lock
@@ -660,7 +660,7 @@ wheels = [
 
 [[package]]
 name = "pyjinhx"
-version = "0.24.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Several builtin fields (`PJXButton.center`, `PJXModal.title`, `PJXDrawer.title`, `PJXCard.title`, `PJXEmptyState.title`, `PJXEmptyState.description`) were typed `str | BaseComponent` but rendered their string value **escaped** — meaning a passed component rendered raw while a markup string was HTML-escaped. That is an internal inconsistency and a latent XSS footgun.

These fields are conceptually text (labels, headings, descriptions). The correct fix is to make the **type honest**: narrow to `str` so the annotation matches the actual behavior (escaped). Rich/markup content goes through the adjacent slot fields (`start`/`end`, `header`, `image`/`action`).

A new convention test (`test_swept_fields_holding_components_are_slots`) enforces the invariant going forward: any builtin field whose annotation can hold a `BaseComponent` must be a slot (children field or `PjxSlot`-typed). Prevents recurrence of the #118 class of bug.

## Changes

- `PJXButton.center`: `str | BaseComponent | None` → `str | None` (label text, escaped; `start`/`end` remain icon slots)
- `PJXModal.title`, `PJXDrawer.title`, `PJXCard.title`: `str | BaseComponent` → `str`
- `PJXEmptyState.title`, `PJXEmptyState.description`: `str | BaseComponent` → `str`
- `tests/unit/test_builtin_conventions.py`: new `test_swept_fields_holding_components_are_slots` sweeps all builtins and asserts any field that can hold `BaseComponent` is a slot
- `tests/unit/test_autoescape_security.py`: updated two stale comments (`center` now `str`)
- `docs/guide/builtins.md`: prop tables updated to narrowed types
- `docs/guide/builtin-conventions.md`: added convention #8 ("type matches escaping" invariant)
- `CHANGELOG.md`: version section for 0.25.0 with Fixed + Breaking notes

**Not changed:** `body`/`content`/`tip` children fields legitimately stay `str | BaseComponent` (they are slots via the children-field rule). `PJXAvatarStack.avatars` (`list[Any]`) is intentionally exempt — it escapes string items and does not name `BaseComponent`.

## Type of Change

- [x] Bug fix (patch)
- [ ] New feature (minor)
- [x] Breaking change (major)
- [ ] Refactor / cleanup
- [ ] Documentation

> Version bump is **minor** (pre-1.0 repo; breaking changes bump minor per project convention).

## Version Bump

`0.24.0` → `0.25.0`

## Testing

- Full non-browser test suite: 825 passed, 5 skipped (all green before commit)
- New convention test `test_swept_fields_holding_components_are_slots` added — sweeps all SWEPT builtins
- `mkdocs --strict` builds clean
- No internal usage, examples, or tests passed a `BaseComponent` to any of the narrowed fields (verified before narrowing)

> Note: PR #126 (the #125 fix) is also open against master and untouched by this branch — they do not conflict.