### PR TITLE
feat: warn when a {#def#} header is shadowed by a registered class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased — stale `{#def#}` header warning
+
+### Added
+
+- **Stale `{#def#}` header warning.** When a hand-written `BaseComponent` subclass is rendered
+  and its template contains a `{#def#}` header, pyjinhx now emits a one-time `logger.warning`
+  explaining that the header is ignored (the class's declared fields take precedence). The warning
+  fires at most once per component name (module-level dedup set) and is silenced for classless
+  components (`_pjx_classless = True`), so header-driven and factory components are unaffected.
+  The check uses a cheap leading-regex on the template source file — no full header parse.
+
+  Warning message:
+  ```
+  <Card>: a {#def#} header is present but a Python class is registered —
+  the header is ignored. Remove the header (or the class).
+  ```
+
 ## 0.25.0 — slot-escaping consistency (2026-06-19)
 
 ### Fixed

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import logging
 import os
+import re
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from jinja2 import Environment, FileSystemLoader, Template
@@ -25,6 +27,14 @@ from .utils import (
 
 if TYPE_CHECKING:
     from .base import BaseComponent
+
+logger = logging.getLogger("pyjinhx")
+
+# Dedup set: component names for which the stale-def-header warning has fired.
+_warned_stale_def_header: set[str] = set()
+
+# Cheap regex — mirrors _HEADER_RE in props_header.py, without the full parse.
+_STALE_DEF_HEADER_RE = re.compile(r"\A\s*\{#\s*def\s", re.DOTALL)
 
 
 def get_loader_root(environment: Environment) -> str:
@@ -131,6 +141,48 @@ def reactive_root_attrs(component: BaseComponent) -> dict[str, str]:
     if reacts:
         attrs["data-pjx-reacts"] = " ".join(sorted(reacts))
     return attrs
+
+
+def _warn_if_stale_def_header(component: "BaseComponent", template: Template) -> None:
+    """Emit a one-time warning when a hand-written class has a {#def#} header in its template.
+
+    The header is silently ignored by the engine (the class's declared fields take over),
+    so a warning helps developers notice the dead code.  Skips classless components
+    (_pjx_classless = True) and fires at most once per component name.
+    """
+    if getattr(type(component), "_pjx_classless", False):
+        return
+
+    component_name = type(component).__name__
+    if component_name in _warned_stale_def_header:
+        return
+
+    # Read the template source cheaply: file-backed templates expose .filename;
+    # in-memory (from_string) templates expose .source (Jinja2 >=3.1 sets it
+    # only when Environment.keep_trailing_newline is used, so prefer .filename).
+    source: str | None = None
+    filename = getattr(template, "filename", None)
+    if filename is not None and os.path.isfile(filename):
+        try:
+            with open(filename, encoding="utf-8") as f:
+                source = f.read()
+        except OSError:
+            return
+    else:
+        source = getattr(template, "source", None)
+
+    if source is None:
+        return
+
+    if not _STALE_DEF_HEADER_RE.match(source):
+        return
+
+    _warned_stale_def_header.add(component_name)
+    logger.warning(
+        "<%s>: a {#def#} header is present but a Python class is registered — "
+        "the header is ignored. Remove the header (or the class).",
+        component_name,
+    )
 
 
 class Renderer:
@@ -256,6 +308,8 @@ class Renderer:
         template = load_template_for_component(
             self, component, template_source=template_source, template_path=template_path
         )
+
+        _warn_if_stale_def_header(component, template)
 
         render_context = build_render_context(context)
         rendered_markup = template.render(render_context)

--- a/tests/unit/stale_badge.html
+++ b/tests/unit/stale_badge.html
@@ -1,0 +1,1 @@
+<span class="badge">{{ text }}</span>

--- a/tests/unit/stale_card.html
+++ b/tests/unit/stale_card.html
@@ -1,0 +1,2 @@
+{#def title: str #}
+<div class="card">{{ title }}</div>

--- a/tests/unit/test_stale_def_header_warning.py
+++ b/tests/unit/test_stale_def_header_warning.py
@@ -1,0 +1,129 @@
+"""Tests for the stale {#def#} header warning.
+
+A hand-written BaseComponent subclass should emit a one-time logger.warning
+when its resolved template contains a {#def#} header (the header is silently
+ignored by the engine because the class-based path overrides it).
+
+Classless components and hand-written classes whose templates lack a header
+must remain silent.
+
+Fixture templates (co-located with this test file so Finder.get_class_directory
+resolves them correctly):
+  - stale_card.html    — has a {#def#} header (triggers warning for StaleCard)
+  - stale_badge.html   — no header (silent for StaleBadge)
+"""
+import logging
+import os
+
+import pytest
+
+from pyjinhx import Renderer
+from pyjinhx.base import BaseComponent
+
+# ---------------------------------------------------------------------------
+# Module-level classes — defined here so inspect.getfile points to this file
+# and Finder.get_class_directory returns the tests/unit/ directory (where the
+# fixture templates live).
+# ---------------------------------------------------------------------------
+
+_HERE = os.path.dirname(__file__)
+
+
+class StaleCard(BaseComponent):
+    """Hand-written class whose template has a {#def#} header."""
+    title: str = "default"
+
+
+class StaleBadge(BaseComponent):
+    """Hand-written class whose template has NO {#def#} header."""
+    text: str = "OK"
+
+
+@pytest.fixture(autouse=True)
+def isolate_renderer():
+    """Point the default environment at tests/unit/ so templates are found."""
+    Renderer.set_default_environment(_HERE)
+    yield
+    Renderer.set_default_environment(None)
+    Renderer._default_renderers.clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_stale_warning_set():
+    """Reset the dedup set between tests so warnings are fresh."""
+    from pyjinhx import renderer as renderer_mod
+    renderer_mod._warned_stale_def_header.clear()
+    yield
+    renderer_mod._warned_stale_def_header.clear()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Hand-written class + {#def#} header → warns once, then deduplicates
+# ---------------------------------------------------------------------------
+
+def test_warns_once_for_hand_written_class_with_header(caplog):
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        StaleCard(title="Hello").render()
+
+    # Should have emitted exactly one warning mentioning the stale header
+    stale_warnings = [r for r in caplog.records if "{#def#}" in r.message]
+    assert len(stale_warnings) == 1, (
+        f"Expected exactly 1 stale-header warning, got {len(stale_warnings)}: "
+        f"{[r.message for r in stale_warnings]}"
+    )
+    assert "StaleCard" in stale_warnings[0].message
+
+    # Second render must NOT emit another warning (dedup)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        StaleCard(title="World").render()
+
+    second_stale = [r for r in caplog.records if "{#def#}" in r.message]
+    assert len(second_stale) == 0, (
+        f"Expected no second warning (dedup), got {len(second_stale)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Classless component (header-only, _pjx_classless=True) → silent
+# ---------------------------------------------------------------------------
+
+def test_no_warning_for_classless_component(tmp_path, caplog):
+    from pyjinhx.base import component
+
+    comp_dir = tmp_path / "staleclassless"
+    comp_dir.mkdir()
+    (comp_dir / "staleclassless.html").write_text(
+        "{#def label: str #}\n<span class=\"staleclassless\">{{ label }}</span>",
+        encoding="utf-8",
+    )
+
+    Renderer.set_default_environment(str(tmp_path))
+
+    StaleClassless = component("Staleclassless")
+    # Verify it IS classless so the test is testing the right thing
+    assert getattr(StaleClassless, "_pjx_classless", False) is True
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        StaleClassless(label="test").render()
+
+    stale_warnings = [r for r in caplog.records if "{#def#}" in r.message]
+    assert len(stale_warnings) == 0, (
+        f"Classless component should not trigger stale-header warning, "
+        f"got: {[r.message for r in stale_warnings]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Hand-written class WITHOUT a {#def#} header → silent
+# ---------------------------------------------------------------------------
+
+def test_no_warning_for_hand_written_class_without_header(caplog):
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        StaleBadge(text="Active").render()
+
+    stale_warnings = [r for r in caplog.records if "{#def#}" in r.message]
+    assert len(stale_warnings) == 0, (
+        f"No warning expected for class without header, "
+        f"got: {[r.message for r in stale_warnings]}"
+    )


### PR DESCRIPTION
## Problem

When a component has **both** a hand-written Python class registered in the component registry **and** a `{#def#}` prop-header in its template, the header is silently ignored — the class always wins. This creates a confusing footgun: a developer adds a `{#def#}` block, changes nothing, and wonders why their props aren't validated.

## What this PR adds

A **one-time `logger.warning`** emitted at render time whenever the renderer detects a `{#def#}` header on a component that is already covered by a registered class.

Key design points:
- Fires for both call paths: tag expansion (`<Tag/>`) **and** direct `.render()`.
- Skips the legitimate classless path (`_pjx_classless`) — no false positives for plain template components.
- Deduped per component name so the warning appears only once per session, not on every render.
- `{#def#}` behaviour is **unchanged** — this is purely a diagnostic signal.

## Tests

Three new tests in `tests/unit/test_stale_def_header_warning.py` (+ 2 HTML fixtures):

1. Warning fires when a registered class coexists with a `{#def#}` header.
2. Warning is **not** fired for a classless component that legitimately uses `{#def#}`.
3. Warning fires only **once** across multiple renders of the same component.

Full suite: **871 passed, 5 skipped**.

## Changelog

Entry added under the next release section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)