### PR TITLE
chore: add docs/ to pyright extraPaths so gallery-test imports resolve

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,12 @@ markers = [
     "reactivity: browser-based tests for the builtin JS contracts (needs playwright chromium)",
 ]
 
+[tool.pyright]
+# `docs/` holds the mkdocs demo registry (`demos/`) and `hooks.py`, which the
+# gallery tests add to sys.path at runtime. Put it on the type-checker's import
+# roots so those imports resolve in the editor.
+extraPaths = ["docs"]
+
 [project.optional-dependencies]
 redis = ["redis>=5.0.0", "fakeredis>=2.26.0"]
 


### PR DESCRIPTION
`tests/unit/test_gallery_demos.py` adds `docs/` to `sys.path` at runtime to import the mkdocs demo registry (`demos/`) and `hooks.py`. The type checker can't follow runtime `sys.path` edits, so it flagged those imports as unresolved in the editor. This puts `docs/` on pyright's `extraPaths` so they resolve.

(Re-land of a fix that was committed after #129 was opened and didn't make it into that PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)