### PR TITLE
fix: clear all IDE type-checker errors (186 → 0)

### DIFF
--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -47,6 +47,7 @@ def first_variation_source(factory):
     node = ret.value
     if isinstance(node, (ast.List, ast.Tuple)) and node.elts:
         node = node.elts[0]
+    assert node is not None
     return ast.get_source_segment(src, node)
 
 

--- a/examples/reactive_todo/components.py
+++ b/examples/reactive_todo/components.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
 from pyjinhx import BaseComponent, PjxContext, PjxKey, ReactiveComponent
 
@@ -10,10 +10,10 @@ from .keys import Keys
 class AppLoadContext:
     """Request-scoped access to the demo store module."""
 
-    store: object
+    store: Any
 
 
-def _store():
+def _store() -> Any:
     ctx = PjxContext.current()
     if isinstance(ctx, AppLoadContext):
         return ctx.store

--- a/pyjinhx/assets.py
+++ b/pyjinhx/assets.py
@@ -144,7 +144,7 @@ def make_default_asset_url_resolver(root: str) -> AssetUrlResolver:
     return resolve
 
 
-_hash_filename_cache: dict[tuple[str, float], str] = {}
+_hash_filename_cache: dict[tuple[str, float, int], str] = {}
 
 
 def hashed_filename(path: str, *, hash_len: int = 8) -> str:

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -480,8 +480,9 @@ def component(name: str) -> type[BaseComponent]:
 
     if not RE_PASCAL_CASE_TAG_NAME.match(name):
         raise ValueError(f"component name {name!r} must be PascalCase")
-    if Registry.has_class(name):
-        return Registry.get_class(name)
+    existing = Registry.get_class(name)
+    if existing is not None:
+        return existing
 
     # If the template is resolvable now and carries a {#def#} header, build a
     # validated-field model; otherwise fall back to a permissive placeholder

--- a/pyjinhx/cache.py
+++ b/pyjinhx/cache.py
@@ -165,7 +165,9 @@ class LoadCache:
 
     @classmethod
     def _indexed_keys(cls, instance: BaseComponent) -> set[str]:
-        if hasattr(instance, "depends_on"):
+        from .reactive import ReactiveComponent
+
+        if isinstance(instance, ReactiveComponent):
             return instance.depends_on()
         return set(getattr(instance.__class__, "_pjx_reacts_to", frozenset()))
 
@@ -211,7 +213,10 @@ class LoadCache:
 
     @staticmethod
     def _with_key(instance: BaseComponent, key: str | None) -> BaseComponent:
-        instance._pjx_key = key
+        from .reactive import ReactiveComponent
+
+        if isinstance(instance, ReactiveComponent):
+            instance._pjx_key = key
         return instance
 
     @classmethod

--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import os
 from collections.abc import Callable
 from dataclasses import dataclass, fields, replace
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from pyjinhx.cache import CacheScope, InvalidationBackend, InvalidationHub, LoadCache
 from pyjinhx.dev import disable_reactive_dev, enable_reactive_dev
+
+if TYPE_CHECKING:
+    from starlette.applications import Starlette
 
 _UNSET: Any = (
     object()
@@ -183,5 +186,10 @@ def setup(
 
     from pyjinhx.integrations.fastapi import apply_setup
 
-    apply_setup(app, resolved, context_factory=context_factory, static_root=static_root)
+    apply_setup(
+        cast("Starlette", app),
+        resolved,
+        context_factory=context_factory,
+        static_root=static_root,
+    )
     return resolved

--- a/pyjinhx/dev.py
+++ b/pyjinhx/dev.py
@@ -62,11 +62,11 @@ def validate_depends_on(instance: object) -> None:
     """Ensure ``depends_on()`` is a subset of the static ``react`` superset."""
     if not _dev_config.enabled:
         return
+    from .reactive import ReactiveComponent
+
+    if not isinstance(instance, ReactiveComponent):
+        return
     component_class = type(instance)
-    if not getattr(component_class, "_pjx_reactive", False):
-        return
-    if not hasattr(instance, "depends_on"):
-        return
     superset = set(getattr(component_class, "_pjx_reacts_to", frozenset()))
     runtime = instance.depends_on()
     extra = runtime - superset

--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -4,11 +4,14 @@ import logging
 import os
 from collections.abc import Callable
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pyjinhx.client import ClientBackend
 from pyjinhx.config import PjxSettings, configure_pyjinhx, shutdown_pyjinhx
 from pyjinhx.registry import Registry
+
+if TYPE_CHECKING:
+    from starlette.applications import Starlette
 
 logger = logging.getLogger("pyjinhx")
 
@@ -32,7 +35,7 @@ class FastAPIClientBackend(ClientBackend):
 
 
 def apply_setup(
-    app: object,
+    app: Starlette,
     settings: PjxSettings,
     *,
     context_factory: Callable[[Any], object | None] | None = None,
@@ -52,7 +55,7 @@ def apply_setup(
     app.state.pyjinhx_setup = True
 
 
-def _chain_lifespan(app: object, settings: PjxSettings) -> None:
+def _chain_lifespan(app: Starlette, settings: PjxSettings) -> None:
     original = app.router.lifespan_context
 
     @asynccontextmanager
@@ -67,7 +70,8 @@ def _chain_lifespan(app: object, settings: PjxSettings) -> None:
         finally:
             shutdown_pyjinhx()
 
-    app.router.lifespan_context = pyjinhx_lifespan
+    # Replace Starlette's internal lifespan with our chained one.
+    app.router.lifespan_context = pyjinhx_lifespan  # type: ignore[assignment]
 
 
 def _registry_middleware_class(

--- a/pyjinhx/props_header.py
+++ b/pyjinhx/props_header.py
@@ -68,6 +68,7 @@ def parse_props_header(source: str) -> "list[tuple[str, Any, Any]] | None":
     except SyntaxError as exc:
         raise ValueError(f"invalid {{#def#}} header signature {signature!r}: {exc.msg}") from exc
     func = tree.body[0]
+    assert isinstance(func, ast.FunctionDef)
     arguments = func.args
     if (
         arguments.vararg
@@ -109,11 +110,10 @@ def build_component_model(name: str, source: str) -> "type | None":
         return None
     from pyjinhx.base import BaseComponent
 
-    model = create_model(
-        name,
-        __base__=BaseComponent,
-        **{field_name: (field_type, default) for field_name, field_type, default in fields},
-    )
+    field_definitions: dict[str, Any] = {
+        field_name: (field_type, default) for field_name, field_type, default in fields
+    }
+    model = create_model(name, __base__=BaseComponent, **field_definitions)
     model._pjx_template = name
     model._pjx_classless = True
     return model

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -10,7 +10,7 @@ from abc import abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import partial
-from typing import Annotated, Any, ClassVar, get_args, get_origin, get_type_hints
+from typing import Annotated, Any, ClassVar, get_args, get_origin, get_type_hints, overload
 
 from markupsafe import Markup
 from pydantic import ConfigDict, ModelWrapValidatorHandler, PrivateAttr, model_validator
@@ -146,6 +146,14 @@ class _ReactiveRender:
             invalidate_before_primary=True,
         )
 
+    @overload
+    def __get__(
+        self, instance: None, owner: type[ReactiveComponent]
+    ) -> Callable[..., Markup]: ...
+    @overload
+    def __get__(
+        self, instance: ReactiveComponent, owner: type[ReactiveComponent]
+    ) -> Callable[[], Markup]: ...
     def __get__(
         self,
         instance: ReactiveComponent | None,
@@ -194,7 +202,8 @@ class ReactiveComponent(BaseComponent):
     _pjx_key: str | None = PrivateAttr(default=None)
     _pjx_id_defaulted: bool = PrivateAttr(default=False)
 
-    render = _ReactiveRender()  # type: ignore[assignment]  # descriptor overrides BaseComponent.render
+    # Descriptor: Cls.render(*args) is the route entry, instance.render() is plain.
+    render: ClassVar[_ReactiveRender] = _ReactiveRender()  # type: ignore[override]
 
     @model_validator(mode="wrap")
     @classmethod

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -10,7 +10,7 @@ from abc import abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import partial
-from typing import Annotated, Any, ClassVar, cast, get_args, get_origin, get_type_hints
+from typing import Annotated, Any, ClassVar, get_args, get_origin, get_type_hints
 
 from markupsafe import Markup
 from pydantic import ConfigDict, ModelWrapValidatorHandler, PrivateAttr, model_validator
@@ -210,8 +210,14 @@ class ReactiveComponent(BaseComponent):
 
     @classmethod
     @abstractmethod
-    def load(cls) -> ReactiveComponent:
-        """Rebuild this component from the current world (zero-arg, type-singleton in v1)."""
+    def load(cls, *args: Any, **kwargs: Any) -> ReactiveComponent:
+        """Rebuild this component from the current world.
+
+        Type-singletons override this zero-arg; keyed regions override it with a
+        single key parameter. The ``*args``/``**kwargs`` here only let both
+        override shapes type-check — the real arity is enforced at registration
+        (``_load_param_count``) and dispatched on the ``_pjx_keyed`` flag.
+        """
         ...
 
     @staticmethod
@@ -437,12 +443,11 @@ def oob_swaps(
         reported_hash = entry.get("hash")
         # ``load`` is zero-arg on type-singletons and key-arg on keyed regions;
         # dispatch dynamically on the ``keyed`` flag determined at registration.
-        load = cast("Callable[..., ReactiveComponent]", component_class.load)
         try:
             if keyed and load_arg is not None:
-                instance = load(load_arg)
+                instance = component_class.load(load_arg)
             else:
-                instance = load()
+                instance = component_class.load()
         except LookupError:
             candidates.append(
                 _Candidate(

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -7,10 +7,10 @@ import inspect
 import json
 import re
 from abc import abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import partial
-from typing import Annotated, Any, ClassVar, get_args, get_origin, get_type_hints
+from typing import Annotated, Any, ClassVar, cast, get_args, get_origin, get_type_hints
 
 from markupsafe import Markup
 from pydantic import ConfigDict, ModelWrapValidatorHandler, PrivateAttr, model_validator
@@ -37,7 +37,7 @@ class PjxKey:
     """Marker for ``Annotated[..., PjxKey()]`` fields stamped as ``data-pjx-load``."""
 
 
-def _metadata_has_pjx_load(metadata: tuple[Any, ...]) -> bool:
+def _metadata_has_pjx_load(metadata: Iterable[Any]) -> bool:
     return any(isinstance(meta, PjxKey) for meta in metadata)
 
 
@@ -194,7 +194,7 @@ class ReactiveComponent(BaseComponent):
     _pjx_key: str | None = PrivateAttr(default=None)
     _pjx_id_defaulted: bool = PrivateAttr(default=False)
 
-    render = _ReactiveRender()
+    render = _ReactiveRender()  # type: ignore[assignment]  # descriptor overrides BaseComponent.render
 
     @model_validator(mode="wrap")
     @classmethod
@@ -246,7 +246,7 @@ class ReactiveComponent(BaseComponent):
         custom hashing.
         """
         exclude = getattr(type(self), "state_hash_exclude", frozenset({"id"}))
-        payload = self.model_dump(mode="json", exclude=exclude)
+        payload = self.model_dump(mode="json", exclude=set(exclude))
         canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
@@ -378,7 +378,7 @@ def _manifest_load_arg(entry: dict[str, Any]) -> str | None:
 
 
 def oob_swaps(
-    dirtied: set[ReactiveKey],
+    dirtied: Iterable[ReactiveKey],
     mounted: str | list[dict[str, Any]] | object | None,
     *,
     exclude_ids: set[str] | None = None,
@@ -416,7 +416,7 @@ def oob_swaps(
         component_class = classes.get(component_type)
         if component_class is None:
             continue
-        if not getattr(component_class, "_pjx_reactive", False):
+        if not issubclass(component_class, ReactiveComponent):
             continue
 
         keyed = getattr(component_class, "_pjx_keyed", False)
@@ -435,11 +435,14 @@ def oob_swaps(
         seen.add(dedup_key)
 
         reported_hash = entry.get("hash")
+        # ``load`` is zero-arg on type-singletons and key-arg on keyed regions;
+        # dispatch dynamically on the ``keyed`` flag determined at registration.
+        load = cast("Callable[..., ReactiveComponent]", component_class.load)
         try:
             if keyed and load_arg is not None:
-                instance = component_class.load(load_arg)
+                instance = load(load_arg)
             else:
-                instance = component_class.load()
+                instance = load()
         except LookupError:
             candidates.append(
                 _Candidate(

--- a/pyjinhx/registry.py
+++ b/pyjinhx/registry.py
@@ -10,6 +10,7 @@ logger = logging.getLogger("pyjinhx")
 
 if TYPE_CHECKING:
     from .base import BaseComponent
+    from .client import ClientBackend
 
 
 _registry_context: ContextVar[dict[str, "BaseComponent"] | None] = ContextVar(
@@ -156,7 +157,7 @@ class Registry:
         cls,
         *,
         load_context: object | None = None,
-        client_backend: object | None = None,
+        client_backend: "ClientBackend | None" = None,
     ) -> Generator[None, None, None]:
         """
         Context manager for request-scoped component instances.

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -124,7 +124,9 @@ def build_render_context(context: dict[str, Any]) -> dict[str, Any]:
 def reactive_root_attrs(component: BaseComponent) -> dict[str, str]:
     """The ``data-pjx-*`` attributes to stamp onto a reactive component's root
     tag, or an empty dict for a non-reactive component."""
-    if not getattr(type(component), "_pjx_reactive", False):
+    from pyjinhx.reactive import ReactiveComponent
+
+    if not isinstance(component, ReactiveComponent):
         return {}
 
     from pyjinhx.reactive import pjx_load_value
@@ -200,7 +202,9 @@ class Renderer:
     _default_environment: ClassVar[Environment | None] = None
     _default_js_mode: ClassVar[AssetMode] = AssetMode.INLINE
     _default_css_mode: ClassVar[AssetMode] = AssetMode.INLINE
-    _default_renderers: ClassVar[dict[tuple[int, bool, AssetMode, AssetMode], object]] = {}
+    _default_renderers: ClassVar[
+        dict[tuple[int, bool, AssetMode, AssetMode], "Renderer"]
+    ] = {}
 
     @classmethod
     def peek_default_environment(cls) -> Environment | None:
@@ -245,7 +249,7 @@ class Renderer:
         auto_id: bool = True,
         js_mode: AssetMode | None = None,
         css_mode: AssetMode | None = None,
-    ):
+    ) -> "Renderer":
         environment = cls.get_default_environment()
         effective_js_mode = js_mode if js_mode is not None else cls._default_js_mode
         effective_css_mode = css_mode if css_mode is not None else cls._default_css_mode
@@ -278,7 +282,7 @@ class Renderer:
         self._auto_id = auto_id
         self._js_mode = js_mode if js_mode is not None else Renderer._default_js_mode
         self._css_mode = css_mode if css_mode is not None else Renderer._default_css_mode
-        self._template_finder_cache: dict[str, object] = {}
+        self._template_finder_cache: dict[str, Finder] = {}
 
     @property
     def environment(self) -> Environment:

--- a/tests/integration/app.py
+++ b/tests/integration/app.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
+from markupsafe import Markup
 
 from pyjinhx import BaseComponent, Renderer
 from pyjinhx.builtins import (
@@ -191,8 +192,8 @@ class BuiltinsGalleryPage(BaseComponent):
     panel_trigger_beta: PJXPanelTrigger
     panel_host: PJXPanel
 
-    def render(self) -> str:
-        return str(self._render(source=_SHOWCASE_TEMPLATE.strip()))
+    def render(self) -> Markup:
+        return self._render(source=_SHOWCASE_TEMPLATE.strip())
 
 
 @lru_cache(maxsize=1)

--- a/tests/integration/test_panel_sse.py
+++ b/tests/integration/test_panel_sse.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import socket
 import threading
 import time
+from collections.abc import Iterator
 
 import httpx
 import pytest
@@ -18,7 +19,7 @@ def _find_free_port() -> int:
 
 
 @pytest.fixture
-def gallery_server_url() -> str:
+def gallery_server_url() -> Iterator[str]:
     port = _find_free_port()
     config = uvicorn.Config(
         create_app(), host="127.0.0.1", port=port, log_level="warning"

--- a/tests/integration/test_setup_fastapi.py
+++ b/tests/integration/test_setup_fastapi.py
@@ -121,6 +121,7 @@ def test_setup_components_root_sets_default_environment(
     setup(app, components_root=tmp_path)
 
     env = Renderer.peek_default_environment()
+    assert env is not None
     assert isinstance(env.loader, FileSystemLoader)
     assert env.loader.searchpath[0] == str(tmp_path)
 
@@ -129,6 +130,7 @@ def test_setup_components_root_without_app(tmp_path, restore_default_environment
     setup(components_root=tmp_path)
 
     env = Renderer.peek_default_environment()
+    assert env is not None
     assert isinstance(env.loader, FileSystemLoader)
     assert env.loader.searchpath[0] == str(tmp_path)
 

--- a/tests/reactive_test_support.py
+++ b/tests/reactive_test_support.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 
 from pyjinhx import MutationKey
@@ -23,7 +23,7 @@ class FakeRequest:
 
 @contextmanager
 def reactive_client(
-    manifest: list[dict[str, object]] | None = None,
+    manifest: Sequence[Mapping[str, object]] | None = None,
     *,
     extra_headers: dict[str, str] | None = None,
     trigger_id: str | None = None,

--- a/tests/reactivity/app.py
+++ b/tests/reactivity/app.py
@@ -13,6 +13,7 @@ import time
 
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
+from markupsafe import Markup
 
 from pyjinhx import BaseComponent, PjxSettings, setup
 from pyjinhx.builtins import (
@@ -112,8 +113,8 @@ class KitchenSinkPage(BaseComponent):
     password: PJXPasswordInput
     tabs: PJXTabGroup
 
-    def render(self) -> str:
-        return str(self._render(source=_PAGE_TEMPLATE.strip()))
+    def render(self) -> Markup:
+        return self._render(source=_PAGE_TEMPLATE.strip())
 
 
 def _popover(prefix: str, label: str) -> PJXPopover:

--- a/tests/reactivity/test_head_inject_assets.py
+++ b/tests/reactivity/test_head_inject_assets.py
@@ -35,7 +35,7 @@ pytest.importorskip("playwright")
 
 # Imported at module scope so FastAPI can resolve the ``request: Request``
 # annotation on the route below under ``from __future__ import annotations``.
-from fastapi import Request  # noqa: E402
+from fastapi import FastAPI, Request  # noqa: E402
 from playwright.sync_api import Page, expect  # noqa: E402
 
 pytestmark = [pytest.mark.pjx_runtime, pytest.mark.reactivity]
@@ -91,7 +91,7 @@ _PAGE_HTML = """<!DOCTYPE html>
 </html>"""
 
 
-def _make_swap_app(tmp_path: Path) -> object:
+def _make_swap_app(tmp_path: Path) -> FastAPI:
     """Build a minimal FastAPI app that serves a reactive component with CSS/JS."""
     from fastapi import FastAPI
     from fastapi.responses import HTMLResponse

--- a/tests/reactivity/test_head_inject_assets.py
+++ b/tests/reactivity/test_head_inject_assets.py
@@ -112,6 +112,7 @@ def _make_swap_app(tmp_path: Path) -> object:
     module_path.write_text(_COMPONENT_MODULE)
 
     spec = importlib.util.spec_from_file_location("swap_badge_component", module_path)
+    assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules["swap_badge_component"] = module
     spec.loader.exec_module(module)

--- a/tests/ui/no_js_component.py
+++ b/tests/ui/no_js_component.py
@@ -2,5 +2,4 @@ from pyjinhx import BaseComponent
 
 
 class NoJsComponent(BaseComponent):
-    id: str
     text: str

--- a/tests/ui/unified_component.py
+++ b/tests/ui/unified_component.py
@@ -5,7 +5,6 @@ from typing import Optional, Union
 
 
 class UnifiedComponent(BaseComponent):
-    id: str
     text: Optional[str] = None
     title: Optional[str] = None
     nested: Optional[UnifiedComponent] = None

--- a/tests/unit/test_accordion.py
+++ b/tests/unit/test_accordion.py
@@ -89,7 +89,7 @@ def test_actions_slot_after_label_in_trigger():
 def test_actions_accepts_component():
     from pyjinhx.builtins import PJXButton
 
-    btn = PJXButton(id="b", label="Delete")
+    btn = PJXButton(id="b", center="Delete")
     html = _html(label="X", actions=btn)
     assert "pjx-accordion__actions" in html
     assert "Delete" in html

--- a/tests/unit/test_accordion.py
+++ b/tests/unit/test_accordion.py
@@ -1,4 +1,6 @@
 """PJXAccordion: native <details> collapsible composing PJXIcon chevron."""
+from typing import Any
+
 import pytest
 
 from pyjinhx import Renderer
@@ -52,7 +54,8 @@ def test_disabled_marks_summary():
 
 
 def test_inline_attrs_pass_through():
-    html = str(PJXAccordion(id="a", label="X", **{"data-y": "z"}).render())
+    inline_attrs: dict[str, Any] = {"data-y": "z"}
+    html = str(PJXAccordion(id="a", label="X", **inline_attrs).render())
     assert 'data-y="z"' in html
 
 

--- a/tests/unit/test_accordion_group.py
+++ b/tests/unit/test_accordion_group.py
@@ -1,4 +1,6 @@
 """PJXAccordionGroup: wraps PJXAccordions in a shared layout/behavior container."""
+from typing import Any
+
 import pytest
 
 from pyjinhx import Renderer
@@ -62,7 +64,8 @@ def test_children_rendered_in_content():
 
 
 def test_inline_attrs_pass_through():
-    html = str(PJXAccordionGroup(id="g", **{"data-foo": "bar"}).render())
+    inline_attrs: dict[str, Any] = {"data-foo": "bar"}
+    html = str(PJXAccordionGroup(id="g", **inline_attrs).render())
     assert 'data-foo="bar"' in html
 
 

--- a/tests/unit/test_autodiscovery.py
+++ b/tests/unit/test_autodiscovery.py
@@ -146,7 +146,6 @@ def test_autodiscovery_skipped_when_already_registered():
     from pyjinhx import BaseComponent
 
     class AlreadyRegistered(BaseComponent):
-        id: str
         label: str = ""
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/unit/test_basecomponent_fallback_no_register.py
+++ b/tests/unit/test_basecomponent_fallback_no_register.py
@@ -52,7 +52,6 @@ def test_registered_class_still_works():
     Registry.clear_instances()
 
     class Widget(BaseComponent):
-        id: str
         label: str = ""
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/unit/test_builtin_extra_attrs.py
+++ b/tests/unit/test_builtin_extra_attrs.py
@@ -1,5 +1,7 @@
 """Builtins pass stray tag attributes through to their root element."""
 
+from typing import Any
+
 import pytest
 
 from pyjinhx import Renderer
@@ -52,5 +54,6 @@ def test_extra_attrs_value_with_both_quote_types_raises():
 def test_stray_attr_with_both_quote_types_raises_at_render(tmp_path):
     Renderer.set_default_environment(str(tmp_path))
 
+    inline_attrs: dict[str, Any] = {"data-x": "a\"b'c"}
     with pytest.raises(ValueError, match="both"):
-        str(PJXPopoverTrigger(id="t", content="go", **{"data-x": "a\"b'c"}).render())
+        str(PJXPopoverTrigger(id="t", content="go", **inline_attrs).render())

--- a/tests/unit/test_button.py
+++ b/tests/unit/test_button.py
@@ -1,4 +1,6 @@
 """PJXButton: slotted, themeable, structural button."""
+from typing import Any
+
 import pytest
 
 from pyjinhx import Renderer
@@ -51,5 +53,6 @@ def test_loading_composes_region_loader():
 
 
 def test_inline_attrs_pass_through():
-    html = str(PJXButton(id="b", center="X", **{"hx-post": "/save"}).render())
+    inline_attrs: dict[str, Any] = {"hx-post": "/save"}
+    html = str(PJXButton(id="b", center="X", **inline_attrs).render())
     assert 'hx-post="/save"' in html

--- a/tests/unit/test_class_registry_behavior.py
+++ b/tests/unit/test_class_registry_behavior.py
@@ -26,7 +26,6 @@ def test_class_registered_at_definition_time():
     """Test that classes are registered automatically when defined, before instantiation."""
 
     class TestButton(BaseComponent):
-        id: str
         text: str
 
     classes = Registry.get_classes()
@@ -38,15 +37,12 @@ def test_multiple_classes_registered():
     """Test that multiple component classes can be registered."""
 
     class RegistryButton(BaseComponent):
-        id: str
         text: str
 
     class RegistryCard(BaseComponent):
-        id: str
         title: str
 
     class RegistryModal(BaseComponent):
-        id: str
         content: str
 
     classes = Registry.get_classes()
@@ -63,7 +59,6 @@ def test_class_registry_separate_from_instance_registry():
     Registry.clear_instances()
 
     class TestComponent(BaseComponent):
-        id: str
         value: str
 
     classes_before = Registry.get_classes()
@@ -91,7 +86,6 @@ def test_class_registry_persists_across_instantiations():
     """Test that class registry persists even when instances are cleared."""
 
     class PersistentComponent(BaseComponent):
-        id: str
         data: str
 
     classes = Registry.get_classes()
@@ -111,11 +105,9 @@ def test_nested_class_registration():
     """Test that nested component classes are also registered."""
 
     class OuterComponent(BaseComponent):
-        id: str
         label: str
 
     class InnerComponent(BaseComponent):
-        id: str
         content: OuterComponent
 
     classes = Registry.get_classes()
@@ -129,7 +121,6 @@ def test_inherited_classes_registered():
     """Test that classes inheriting from BaseComponent subclasses are also registered."""
 
     class BaseButton(BaseComponent):
-        id: str
         text: str
 
     class PrimaryButton(BaseButton):

--- a/tests/unit/test_class_registry_behavior.py
+++ b/tests/unit/test_class_registry_behavior.py
@@ -16,6 +16,7 @@ class {class_name}(BaseComponent):
 def _import_component_file(filepath, module_name):
     """Import a component file by path, like ComponentAutodiscover does."""
     spec = importlib.util.spec_from_file_location(module_name, str(filepath))
+    assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     spec.loader.exec_module(module)

--- a/tests/unit/test_classless_assets_factory.py
+++ b/tests/unit/test_classless_assets_factory.py
@@ -156,7 +156,7 @@ def test_class_based_builtin_still_collects_assets():
     """
     from pyjinhx.builtins.ui.pjx_button.pjx_button import PJXButton
 
-    html = str(PJXButton(label="Click me").render())
+    html = str(PJXButton(center="Click me").render())
 
     # PJXButton's CSS contains its own selectors; just assert style is present
     assert "<style" in html, "PJXButton's CSS was not inlined (regression)"

--- a/tests/unit/test_component_template_tag_expansion.py
+++ b/tests/unit/test_component_template_tag_expansion.py
@@ -11,7 +11,6 @@ def test_component_template_can_expand_custom_tags():
     """Test that PascalCase tags inside component templates are expanded."""
 
     class Child(BaseComponent):
-        id: str
         text: str
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/unit/test_context_injection.py
+++ b/tests/unit/test_context_injection.py
@@ -135,7 +135,7 @@ def test_reactive_load_not_wrapped_by_generic_injector():
     assert getattr(load_func, "_pjx_ctx_injected", False) is False
     # Precise guard for the name-exclusion: the raw user load captured by
     # install_cached_load (after the generic pass runs) was never injected.
-    assert getattr(CtxReactive._pjx_raw_load, "_pjx_ctx_injected", False) is False
+    assert getattr(CtxReactive._pjx_raw_load, "_pjx_ctx_injected", False) is False  # type: ignore[attr-defined]  # installed at registration
 
 
 class CtxBase(BaseComponent):
@@ -170,7 +170,7 @@ class CtxStrict(BaseComponent):
 
 def test_non_optional_subclass_param_injected():
     with PjxContext.bind(Ctx(value=6)):
-        assert CtxStrict().need() == 6
+        assert CtxStrict().need() == 6  # type: ignore[call-arg]  # ctx param injected from PjxContext
 
 
 class CtxPosOnly(BaseComponent):

--- a/tests/unit/test_finish_with_oob.py
+++ b/tests/unit/test_finish_with_oob.py
@@ -212,7 +212,7 @@ def test_reactive_response_bare_string_positional_raises():
     from pyjinhx.reactive import ReactiveResponse
 
     with pytest.raises(TypeError) as exc:
-        ReactiveResponse("<p>oops</p>")
+        ReactiveResponse("<p>oops</p>")  # type: ignore[arg-type]  # deliberately misuses the signature
     assert str(exc.value).startswith("ReactiveResponse()")
 
 

--- a/tests/unit/test_html_tag_renderer.py
+++ b/tests/unit/test_html_tag_renderer.py
@@ -186,7 +186,6 @@ def test_renderer_uses_registered_class():
     """Test that Renderer uses registered BaseComponent classes when available."""
 
     class Button(BaseComponent):
-        id: str
         text: str
         variant: str = "default"
 
@@ -229,12 +228,10 @@ def test_renderer_with_registered_class_and_nested_components():
     """Test that registered classes work with nested components."""
 
     class AlbumCard(BaseComponent):
-        id: str
         title: str
         content: str = ""
 
     class AlbumButton(BaseComponent):
-        id: str
         text: str
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -263,7 +260,6 @@ def test_renderer_with_registered_class_validation():
     """Test that registered classes enforce their field types and defaults."""
 
     class Input(BaseComponent):
-        id: str
         type: str = "text"
         name: str
         placeholder: str = ""
@@ -290,7 +286,6 @@ def test_renderer_mixed_registered_and_generic():
     """Test mixing registered classes with generic components."""
 
     class Header(BaseComponent):
-        id: str
         title: str
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/unit/test_icon.py
+++ b/tests/unit/test_icon.py
@@ -1,4 +1,6 @@
 """PJXIcon renders a themeable inline SVG from the vendored set."""
+from typing import Any
+
 import pytest
 
 from pyjinhx import Renderer
@@ -57,5 +59,6 @@ def test_unknown_name_renders_nothing_and_warns(caplog):
 
 
 def test_inline_attrs_pass_through():
-    html = str(PJXIcon(id="i", name="plus", **{"data-x": "y"}).render())
+    inline_attrs: dict[str, Any] = {"data-x": "y"}
+    html = str(PJXIcon(id="i", name="plus", **inline_attrs).render())
     assert 'data-x="y"' in html

--- a/tests/unit/test_id_validation.py
+++ b/tests/unit/test_id_validation.py
@@ -9,5 +9,5 @@ def test_empty_id_autogenerates():
 
 
 def test_none_id_autogenerates():
-    comp = UnifiedComponent(id=None, text="Test")
+    comp = UnifiedComponent(id=None, text="Test")  # type: ignore[arg-type]  # None triggers auto-id
     assert re.fullmatch(r"pjx-\d+", comp.id)

--- a/tests/unit/test_load_context.py
+++ b/tests/unit/test_load_context.py
@@ -102,7 +102,8 @@ def test_resolve_load_context_param_detects_subclass_annotation():
     def without_context(cls):
         pass
 
-    assert resolve_load_context_param(with_context).name == "app"
+    resolved = resolve_load_context_param(with_context)
+    assert resolved is not None and resolved.name == "app"
     assert resolve_load_context_param(without_context) is None
 
 

--- a/tests/unit/test_load_context.py
+++ b/tests/unit/test_load_context.py
@@ -74,7 +74,7 @@ def test_keyed_load_injects_context_positionally():
     LoadCache.clear()
     ctx = AppLoadContext(value=9)
     with PjxContext.bind(ctx):
-        row = CtxKeyed.load("a")
+        row = CtxKeyed.load("a")  # type: ignore[call-arg]  # app_ctx injected from PjxContext
     assert row.label == "a:9"
     assert row.id == "ctx-keyed-a"
 

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -85,7 +85,7 @@ def test_dirty_records_multiple_keys():
 
 def test_dirty_rejects_bare_strings():
     with pytest.raises(TypeError) as excinfo:
-        dirty("todos")
+        dirty("todos")  # type: ignore[arg-type]  # deliberately passes a bare string
     assert str(excinfo.value).startswith("dirty()")
 
 

--- a/tests/unit/test_nested_component_wrapper.py
+++ b/tests/unit/test_nested_component_wrapper.py
@@ -25,5 +25,6 @@ def test_object_with_component_props():
 
     assert obj.html == "<div>Rendered</div>"
     assert obj.props == component
+    assert isinstance(obj.props, UnifiedComponent)
     assert obj.props.id == "obj-test-1"
     assert obj.props.text == "Object Test"

--- a/tests/unit/test_props_header.py
+++ b/tests/unit/test_props_header.py
@@ -53,10 +53,11 @@ def test_duplicate_prop_errors():
 def test_build_model_validates_required_and_coerces():
     src = '{#def title: str, count: int = 0 #}\n<div>{{ title }}</div>'
     model = build_component_model("CardBuildA", src)
+    assert model is not None
     assert issubclass(model, BaseComponent)
     assert model._pjx_template == "CardBuildA"
     inst = model(id="i", title="Hi", count="3")  # "3" coerced to int
-    assert inst.count == 3
+    assert inst.count == 3  # type: ignore[attr-defined]  # count is a header-defined field
     with pytest.raises(ValidationError):
         model(id="i")  # missing required 'title'
 

--- a/tests/unit/test_props_header_factory.py
+++ b/tests/unit/test_props_header_factory.py
@@ -19,14 +19,14 @@ def env(tmp_path):
 def test_factory_builds_validated_fields(env):
     WidgetFac = component("WidgetFac")
     assert issubclass(WidgetFac, BaseComponent)
-    assert WidgetFac(id="i", title="x", count="7").count == 7  # coerced
+    assert WidgetFac(id="i", title="x", count="7").count == 7  # type: ignore[attr-defined]  # coerced; header-defined field
     with pytest.raises(ValidationError):
         WidgetFac(id="i")  # missing required title
 
 
 def test_factory_defaults_apply(env):
     WidgetFac = component("WidgetFac")
-    assert WidgetFac(id="i", title="x").count == 0
+    assert WidgetFac(id="i", title="x").count == 0  # type: ignore[attr-defined]  # header-defined field
 
 
 def test_factory_no_header_is_permissive(env):

--- a/tests/unit/test_react_keyword.py
+++ b/tests/unit/test_react_keyword.py
@@ -79,7 +79,7 @@ def test_load_without_react_keys_rejected():
 
 def test_mutates_rejects_bare_strings():
     with pytest.raises(TypeError, match="MutationKey"):
-        @mutates("todos")
+        @mutates("todos")  # type: ignore[arg-type]  # deliberately passes a bare string
         def save():
             pass
 

--- a/tests/unit/test_reactive_keys_and_enum_load.py
+++ b/tests/unit/test_reactive_keys_and_enum_load.py
@@ -83,7 +83,7 @@ def test_coerce_reactive_key_unwraps_todo_id_enum():
 
 def test_load_coerces_enum_to_str_for_load():
     LoadCache.clear()
-    row = EnumRow.load(TodoId.FIRST)
+    row = EnumRow.load(TodoId.FIRST)  # type: ignore[arg-type]  # enum coerced to str key
     assert row.label == "row 1"
     assert row._pjx_key == "1"
     assert row.id == "enum-row-1"

--- a/tests/unit/test_reactive_render.py
+++ b/tests/unit/test_reactive_render.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 from markupsafe import Markup
 
@@ -136,7 +137,8 @@ def test_reactive_root_attrs_empty_for_non_reactive():
 
 
 def test_reactive_root_carries_both_pjx_and_extra_attrs_on_one_root():
-    counter = ReactiveCounter(id="counter", remaining=0, **{"hx-get": "/inc"})
+    inline_attrs: dict[str, Any] = {"hx-get": "/inc"}
+    counter = ReactiveCounter(id="counter", remaining=0, **inline_attrs)
     out = str(counter.render())
     root_tag = out[: out.index(">") + 1]  # the single root's opening tag
     assert 'data-pjx-id="counter"' in root_tag

--- a/tests/unit/test_reactive_surface.py
+++ b/tests/unit/test_reactive_surface.py
@@ -123,9 +123,9 @@ def test_react_without_load_cannot_be_instantiated():
         pass
 
     with pytest.raises(TypeError, match="abstract"):
-        NoLoad(id="n")
+        NoLoad(id="n")  # type: ignore[abstract]  # deliberately instantiates abstract class
 
 
 def test_reactive_component_base_is_abstract():
     with pytest.raises(TypeError, match="abstract"):
-        ReactiveComponent(id="r")
+        ReactiveComponent(id="r")  # type: ignore[abstract]  # deliberately instantiates abstract base

--- a/tests/unit/test_registry_behavior.py
+++ b/tests/unit/test_registry_behavior.py
@@ -60,7 +60,9 @@ def test_registry_with_multiple_components():
     for i in range(5):
         key = Registry.make_key("UnifiedComponent", f"multi-{i}")
         assert key in registry
-        assert registry[key].text == f"Component {i}"
+        component = registry[key]
+        assert isinstance(component, UnifiedComponent)
+        assert component.text == f"Component {i}"
 
 
 def test_duplicate_component_id_warning(caplog):
@@ -104,5 +106,8 @@ def test_different_component_types_same_id_no_collision():
     assert card_key in Registry.get_instances()
     assert button_key in Registry.get_instances()
 
-    assert Registry.get_instances()[card_key].label == "Card Label"
-    assert Registry.get_instances()[button_key].label == "Button Label"
+    card = Registry.get_instances()[card_key]
+    button = Registry.get_instances()[button_key]
+    assert isinstance(card, ShelfCard) and isinstance(button, ShelfButton)
+    assert card.label == "Card Label"
+    assert button.label == "Button Label"

--- a/tests/unit/test_registry_behavior.py
+++ b/tests/unit/test_registry_behavior.py
@@ -88,11 +88,9 @@ def test_different_component_types_same_id_no_collision():
     Registry.clear_instances()
 
     class ShelfCard(BaseComponent):
-        id: str
         label: str = ""
 
     class ShelfButton(BaseComponent):
-        id: str
         label: str = ""
 
     ShelfCard(id="shared", label="Card Label")

--- a/tests/unit/test_renderer_default_environment.py
+++ b/tests/unit/test_renderer_default_environment.py
@@ -13,6 +13,8 @@ def test_set_default_environment():
     Renderer.set_default_environment(custom_env)
 
     assert Renderer.get_default_environment() == custom_env
-    assert Renderer.get_default_environment().loader.searchpath[0] == custom_root
+    loader = Renderer.get_default_environment().loader
+    assert isinstance(loader, FileSystemLoader)
+    assert loader.searchpath[0] == custom_root
 
     Renderer.set_default_environment(original_environment)

--- a/tests/unit/test_root_attr_injection.py
+++ b/tests/unit/test_root_attr_injection.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from pyjinhx import BaseComponent, Renderer
@@ -6,11 +8,12 @@ from pyjinhx.builtins import PJXPopoverTrigger
 
 
 def test_collect_merges_extra_attrs_field_and_stray_attrs():
+    inline_attrs: dict[str, Any] = {"data-stray": "2", "title": "hi"}
     component = PJXPopoverTrigger(
         id="t",
         content="go",
         extra_attrs={"data-explicit": "1"},
-        **{"data-stray": "2", "title": "hi"},
+        **inline_attrs,
     )
     result = collect_extra_attrs(component)
     assert result == {"data-explicit": "1", "data-stray": "2", "title": "hi"}

--- a/tests/unit/test_slot_type.py
+++ b/tests/unit/test_slot_type.py
@@ -56,7 +56,7 @@ def test_undeclared_children_field_becomes_markup_in_context(tmp_path):
     class _Classless(BaseComponent):
         pass  # no declared `content`; _pjx_children_field defaults to "content"
 
-    inst = _Classless(id="c", content="<div>inner</div>")
+    inst = _Classless(id="c", content="<div>inner</div>")  # type: ignore[call-arg]  # content is an undeclared extra
     assert "content" not in type(inst).model_fields  # sanity: it's an extra
     built = inst._build_template_context()
     assert isinstance(built["content"], Markup)

--- a/tests/unit/test_template_and_engine_errors.py
+++ b/tests/unit/test_template_and_engine_errors.py
@@ -9,7 +9,6 @@ from pyjinhx.tags import _BUILTIN_TAG_NAMES, _missing_template_error
 
 def test_missing_template_file():
     class MissingTemplateComponent(BaseComponent):
-        id: str
         text: str
 
     component = MissingTemplateComponent(id="missing-1", text="Test")
@@ -20,7 +19,6 @@ def test_missing_template_file():
 
 def test_non_filesystem_loader_error():
     class DictLoaderComponent(BaseComponent):
-        id: str
         text: str
 
     dict_loader = DictLoader({"template.html": "<div>{{ text }}</div>"})

--- a/tests/unit/test_toggle_segmented.py
+++ b/tests/unit/test_toggle_segmented.py
@@ -140,7 +140,7 @@ def test_segmented_control_disabled():
 
 
 def test_segmented_control_json_string_coercion():
-    sc = PJXSegmentedControl(id="sc6", name="x", options='[["a", "A"], ["b", "B"]]')
+    sc = PJXSegmentedControl(id="sc6", name="x", options='[["a", "A"], ["b", "B"]]')  # type: ignore[arg-type]  # JSON string coerced by validator
     assert sc.options == [("a", "A"), ("b", "B")]
 
 


### PR DESCRIPTION
Sweeps every type error reported by the IDE (cursorpyright in **standard** mode) across the whole project — library, tests, examples, docs — from **186 → 0**. Every change is behavior-preserving: **843 tests pass** at each step.

## Approach
The IDE only reports diagnostics for open files, so I ran the equivalent checker (`uvx basedpyright` with `typeCheckingMode = "standard"`) project-wide to get the full set. Standard mode matches the IDE exactly (verified against open-file diagnostics 1:1). Bare basedpyright's default "all" ruleset adds ~2,600 strict-mode warnings the IDE never shows — those are intentionally out of scope.

## Commits (one per pool)
- **Library (57→0)** — tighten `dict[…, object]` caches (cleared the `Renderer | object` cascade), narrow reactive-attr access via `isinstance(ReactiveComponent)`, fix `assets._hash_filename_cache` key arity, type the FastAPI/Starlette app under `TYPE_CHECKING`, resolve `props_header.create_model` overload.
- **`id` fixtures** — drop redundant `id: str` redeclarations that shadowed the inherited auto-id field.
- **Optionals** — asserts for importlib/env `… | None` lookups.
- **`load` override** — widen the abstract `ReactiveComponent.load` to `(*args, **kwargs)` so both singleton and keyed overrides type-check (also fixes the editor for library users writing keyed `load`).
- **manifest** — type the `reactive_client` helper manifest as covariant `Sequence[Mapping]`.
- **`render` descriptor** — type `_ReactiveRender` as a descriptor so `Cls.render()` / `instance.render()` check correctly; replaces a broad `type: ignore`.
- **`**attrs`** — type inline HTML-attr dicts as `dict[str, Any]` for `**`-unpacking.
- **long tail** — generator-fixture annotations, `isinstance` narrowing, use the real `PJXButton.center` field, and targeted `# type: ignore` for tests that deliberately violate a type contract to exercise a runtime guard or that rely on runtime magic the checker can't model (PjxContext injection, header-defined classless fields, validator coercion).

## Notes
- `reportImportCycles` is OFF in standard mode and the package's cycles are already `TYPE_CHECKING`-guarded — no change needed.
- Two latent test bugs surfaced and were fixed: `PJXButton(label=…)` used a non-existent field (now `center`), and the assets cache-key annotation was a 2-tuple for a 3-tuple key.
- The `load` and `render` typing changes improve the public API's editor experience, not just the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)