### PR TITLE
test: doc-lint enforcing builtin examples use real fields

### DIFF
--- a/docs/api/parser.md
+++ b/docs/api/parser.md
@@ -54,6 +54,6 @@ Represents a parsed PascalCase component tag.
 Inner text between opening and closing tags becomes string children. Self-closing tags have an empty `children` list.
 
 ```python
-# <PJXCard title="Note">Hello</PJXCard>
-# Tag(name="PJXCard", attrs={"title": "Note"}, children=["Hello"])
+# <PJXCard class_name="note">Hello</PJXCard>
+# Tag(name="PJXCard", attrs={"class_name": "note"}, children=["Hello"])
 ```

--- a/docs/guide/builtin-conventions.md
+++ b/docs/guide/builtin-conventions.md
@@ -18,7 +18,7 @@ Every pyjinhx builtin follows the same contract, so knowing one means knowing al
    through to the root, but the dict-style `extra_attrs={...}` API is not available on them; use
    inline attributes or `class_name` instead.
 4. **All copy is props.** Every user-visible string, aria-labels included, has an English default
-   you can replace: `PJXModal(title="Excluir?", close_label="Fechar")`.
+   you can replace: `PJXModalHeader(title="Excluir?", close_label="Fechar")`.
 5. **JS is headless.** Builtin JavaScript never writes inline styles for state — visibility and variants are classes/attributes; computed positioning coordinates (tooltip/popover placement) are the one sanctioned inline-style use. Communication is through `pjx:*` DOM events and `data-pjx-*` attributes; programmatic APIs live under the single `window.pjx` namespace.
    Async-state JS follows the runtime's concurrency pattern: a ref-count per scope,
    release keyed to each request's `loadend` (terminal on load, error, abort, and

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -176,11 +176,11 @@ Every builtin component is renamed with a `PJX` prefix, in Python and in tag for
 ```python
 # BEFORE (0.11)
 from pyjinhx.builtins import Avatar, Modal
-html = renderer.render('<Modal id="m" title="Hi"/>')
+html = renderer.render('<Modal id="m"/>')
 
 # AFTER (0.12)
 from pyjinhx.builtins import PJXAvatar, PJXModal
-html = renderer.render('<PJXModal id="m" title="Hi"/>')
+html = renderer.render('<PJXModal id="m"/>')
 ```
 
 Related renames, all mechanical:

--- a/tests/unit/test_docs_reference_real_fields.py
+++ b/tests/unit/test_docs_reference_real_fields.py
@@ -1,0 +1,199 @@
+"""Doc-lint: builtin examples in docs/ must only use real component fields.
+
+Catches stale documentation — e.g. ``PJXCard(title=...)`` after ``title`` was
+removed in the composable-parts refactor. Builtins use ``extra="allow"``, so a
+removed field silently becomes an HTML attribute at runtime; nothing raises, and
+the gallery-demo test (which only validates ``<!-- demo: -->`` markers, not prose
+examples) cannot see it. This test parses every ``PJXFoo(...)`` Python call and
+``<PJXFoo ...>`` tag in the docs and asserts each bare-word keyword/attribute is a
+declared field on that builtin.
+
+Intentional HTML pass-through attrs are skipped: anything hyphenated (``data-*``,
+``hx-*``, ``aria-*``) and the small set of bare-word global HTML attributes in
+``HTML_GLOBALS`` below. If a real builtin field ever collides with one of those
+names, the collision is documented inline.
+"""
+import re
+from pathlib import Path
+
+import pyjinhx.builtins as b
+from pyjinhx.base import BaseComponent
+
+_ROOT = Path(__file__).resolve().parents[2]
+_DOCS = _ROOT / "docs"
+
+# Builtin classes keyed by their tag/class name.
+_BUILTINS: dict[str, type] = {
+    name: getattr(b, name)
+    for name in b.__all__
+    if isinstance(getattr(b, name), type) and issubclass(getattr(b, name), BaseComponent)
+}
+
+# Bare-word HTML attributes that legitimately pass through to a builtin's root
+# as extras (they are not component fields). Hyphenated attrs are always skipped
+# separately. Deliberately excludes ``title``/``body``/etc. so a stale field
+# reference is still caught.
+HTML_GLOBALS = {
+    "role",
+    "style",
+    "tabindex",
+    "lang",
+    "dir",
+    "hidden",
+    "slot",
+    "part",
+    "popover",
+    "inert",
+    "draggable",
+    "spellcheck",
+    "translate",
+    "contenteditable",
+    "accesskey",
+    "enterkeyhint",
+    "autocapitalize",
+    "onclick",
+}
+
+# Published documentation that carries builtin usage examples. The
+# ``superpowers/`` tree is excluded: it holds gitignored local design specs and
+# plans that intentionally show "before" (old-API) migration snippets.
+_DOC_FILES = [
+    p
+    for p in sorted(_DOCS.rglob("*.md")) + sorted((_DOCS / "demos").rglob("*.py"))
+    if "superpowers" not in p.parts
+]
+
+_PY_CALL = re.compile(r"\b(PJX[A-Za-z0-9]+)\(")
+_TAG_OPEN = re.compile(r"<(PJX[A-Za-z0-9]+)(?=[\s/>])")
+_PY_KWARG = re.compile(r"([A-Za-z_]\w*)\s*=")
+
+
+def _tag_attr_names(text: str, body_start: int) -> set[str]:
+    """Attribute names of a ``<PJXFoo ...>`` open tag, starting just after the
+    tag name. Quote-aware: an attribute value may contain a nested tag (e.g.
+    ``start="<PJXIcon name='plus'/>"``), so ``>`` and ``=`` inside a quoted value
+    are skipped rather than mistaken for the tag end or another attribute.
+    """
+    names: set[str] = set()
+    i, n = body_start, len(text)
+    while i < n:
+        c = text[i]
+        if c == ">":
+            break
+        if c.isspace() or c == "/":
+            i += 1
+            continue
+        # read an attribute name
+        start = i
+        while i < n and (text[i].isalnum() or text[i] in "-_:"):
+            i += 1
+        name = text[start:i]
+        # skip whitespace, then check for '='
+        j = i
+        while j < n and text[j].isspace():
+            j += 1
+        if j < n and text[j] == "=":
+            j += 1
+            while j < n and text[j].isspace():
+                j += 1
+            if j < n and text[j] in "\"'":  # quoted value — skip to matching quote
+                quote = text[j]
+                j += 1
+                while j < n and text[j] != quote:
+                    j += 1
+                j += 1
+            else:  # unquoted value — to next whitespace or '>'
+                while j < n and not text[j].isspace() and text[j] != ">":
+                    j += 1
+            if name:
+                names.add(name)
+        i = j if j > i else i + 1
+    return names
+
+
+def _line_of(text: str, index: int) -> int:
+    return text.count("\n", 0, index) + 1
+
+
+def _py_call_kwargs(text: str, open_paren_index: int) -> set[str]:
+    """Top-level (depth-1) keyword names of a ``PJXFoo(...)`` call.
+
+    Scans from the opening paren tracking depth so nested calls
+    (``PJXCard(content=PJXCardHeader(title=...))``) contribute their kwargs to
+    their own component, not the outer one.
+    """
+    depth = 0
+    i = open_paren_index
+    n = len(text)
+    segment_start = open_paren_index + 1
+    names: set[str] = set()
+    while i < n:
+        c = text[i]
+        if c == "(":
+            depth += 1
+            if depth == 1:
+                segment_start = i + 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                break
+        elif c == "," and depth == 1:
+            seg = text[segment_start:i]
+            m = _PY_KWARG.match(seg.lstrip())
+            if m:
+                names.add(m.group(1))
+            segment_start = i + 1
+        i += 1
+    # last segment before the closing paren
+    if segment_start <= i:
+        seg = text[segment_start:i]
+        m = _PY_KWARG.match(seg.lstrip())
+        if m:
+            names.add(m.group(1))
+    return names
+
+
+def _collect_violations() -> list[str]:
+    violations: list[str] = []
+    for path in _DOC_FILES:
+        text = path.read_text(encoding="utf-8")
+        rel = path.relative_to(_ROOT)
+
+        # Python-call form: PJXFoo(kwarg=...)
+        for m in _PY_CALL.finditer(text):
+            comp = m.group(1)
+            cls = _BUILTINS.get(comp)
+            if cls is None:
+                continue
+            for kw in _py_call_kwargs(text, m.end() - 1):
+                if "-" in kw or kw in HTML_GLOBALS or kw in cls.model_fields:
+                    continue
+                violations.append(
+                    f"{rel}:{_line_of(text, m.start())}: {comp}({kw}=...) — "
+                    f"'{kw}' is not a field of {comp}"
+                )
+
+        # Tag form: <PJXFoo attr=...>
+        for m in _TAG_OPEN.finditer(text):
+            comp = m.group(1)
+            cls = _BUILTINS.get(comp)
+            if cls is None:
+                continue
+            for attr in _tag_attr_names(text, m.end()):
+                if "-" in attr or ":" in attr or attr in HTML_GLOBALS or attr in cls.model_fields:
+                    continue
+                violations.append(
+                    f"{rel}:{_line_of(text, m.start())}: <{comp} {attr}=...> — "
+                    f"'{attr}' is not a field of {comp}"
+                )
+    return violations
+
+
+def test_docs_examples_use_real_builtin_fields():
+    violations = _collect_violations()
+    assert not violations, (
+        "Docs reference builtin keyword(s)/attribute(s) that are not declared "
+        "fields (likely a removed/renamed field documented by mistake). Fix the "
+        "example, or — if it is a deliberate HTML pass-through attribute — add the "
+        "bare-word name to HTML_GLOBALS in this test.\n\n" + "\n".join(violations)
+    )


### PR DESCRIPTION
Adds a CI doc-lint that catches stale builtin examples in the docs — the class of bug that slipped past the test suite during the composable-parts refactors (both fan-out agents left removed fields in `docs/guide/builtins.md` because nothing executes prose examples, and builtins' `extra="allow"` means a removed field silently becomes an HTML attribute instead of erroring).

## What it does
`tests/unit/test_docs_reference_real_fields.py` parses every `PJXFoo(...)` Python call and `<PJXFoo ...>` tag in the published docs and asserts each **bare-word** keyword/attribute is a declared field on that builtin.

- Hyphenated attrs (`data-*`, `hx-*`, `aria-*`) and a small `HTML_GLOBALS` set (`role`, `style`, `tabindex`, …) are skipped as intentional pass-throughs.
- The tag parser is **quote-aware**, so a nested tag inside an attribute value (`start="<PJXIcon name='plus'/>"`) isn't misread as an attribute of the outer tag.
- The gitignored `docs/superpowers/` design specs/plans are excluded (they intentionally show "before"/old-API migration snippets).
- Runs in the existing `test` CI job — no new workflow.

## Stale docs it already caught (and this PR fixes)
- `docs/api/parser.md` — `<PJXCard title=…>` (removed) → `class_name`
- `docs/guide/builtin-conventions.md` — `PJXModal(title=…, close_label=…)` → `PJXModalHeader(...)`
- `docs/migration.md` — historical rename example using a since-removed `title`

Verified: the lint passes on the fixed docs and fails on a deliberately-injected `<PJXCard title="x"/>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)