### PR TITLE
docs: fix mkdocs build — drop stray demo markers from PJXDrawer parts

### DIFF
--- a/docs/guide/builtins.md
+++ b/docs/guide/builtins.md
@@ -617,8 +617,6 @@ API: `pjx.drawer.open(id)`, `pjx.drawer.close(id)`.
 
 Header bar for a `PJXDrawer`. Automatically includes a close button. **Assets:** `pjx-drawer-header.css`.
 
-<!-- demo: PJXDrawerHeader -->
-
 ```html
 <PJXDrawerHeader title="Menu"/>
 ```
@@ -641,8 +639,6 @@ Header bar for a `PJXDrawer`. Automatically includes a close button. **Assets:**
 
 Scrollable body region for a `PJXDrawer`. **Assets:** `pjx-drawer-body.css`.
 
-<!-- demo: PJXDrawerBody -->
-
 ```html
 <PJXDrawerBody>…links…</PJXDrawerBody>
 ```
@@ -661,8 +657,6 @@ Scrollable body region for a `PJXDrawer`. **Assets:** `pjx-drawer-body.css`.
 ## PJXDrawerFooter
 
 Footer strip for a `PJXDrawer`. **Assets:** `pjx-drawer-footer.css`.
-
-<!-- demo: PJXDrawerFooter -->
 
 ```html
 <PJXDrawerFooter>v1.0</PJXDrawerFooter>


### PR DESCRIPTION
Fixes the docs deploy failure:
```
ERROR - Error reading page 'guide/builtins.md': unknown demo 'PJXDrawerHeader' in guide/builtins.md
```

The `PJXDrawerHeader`/`PJXDrawerBody`/`PJXDrawerFooter` doc sections carried `<!-- demo: ... -->` markers, but those part components are `folded` (no entry in the `DEMOS` registry), so `docs/hooks.py:on_page_markdown` raised `unknown demo`. The Card/Modal/Tooltip part sections (from the other refactors) correctly omit the marker — this matches them, keeping the static `html` example.

Verified locally with `uv run mkdocs build --strict` (builds clean).

**Note:** the docs build only runs on deploy, not in the test CI, which is why this slipped through. Worth adding a `mkdocs build --strict` check to CI to catch this class — happy to follow up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)