### PR TITLE
ci: add Docs Check workflow (strict mkdocs build + builtin-args doc-lint)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,35 @@
+name: Docs Check
+
+# Catches docs problems on every branch, BEFORE merge — the deploy workflow
+# (docs.yml) only runs mkdocs on master, so build breakage used to surface at
+# deploy time. This runs the strict build plus the builtin-field doc-lint on PRs.
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  docs-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Install dependencies
+      run: uv sync --group dev
+
+    - name: Build docs (strict)
+      run: uv run mkdocs build --strict
+
+    - name: Builtin-args doc-lint regression test
+      run: uv run pytest tests/unit/test_docs_reference_real_fields.py -q


### PR DESCRIPTION
Adds a **Docs Check** workflow that runs on every branch, closing the gap that let the `unknown demo 'PJXDrawerHeader'` build failure reach deploy after passing every PR check.

The deploy workflow (`docs.yml`) only runs `mkdocs build` on `master` (at deploy time), so doc-build breakage was invisible on PRs. This new job runs on all branches and has two steps:

1. **`mkdocs build --strict`** — catches build failures, broken demo markers, dead links, nav issues *before* merge.
2. **Builtin-args doc-lint regression test** (`tests/unit/test_docs_reference_real_fields.py`) — surfaced as an explicit, named CI gate (it also runs in the main test job; here it's a first-class docs-safety check).

Lighter than the full test job (no Playwright/Chromium install). Uses only static commands — no untrusted workflow input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)