### PR TITLE
docs: feature resizable (+ accordion group) in Gallery; guard with a test

### DIFF
--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -43,6 +43,9 @@ The builtins, rendered by pyjinhx at docs build time (PJXLazyPanel needs a backe
 ### [PJXAccordion](guide/builtins.md#pjxaccordion)
 <!-- demo: PJXAccordion -->
 
+### [PJXAccordionGroup](guide/builtins.md#pjxaccordiongroup)
+<!-- demo: PJXAccordionGroup -->
+
 ## Overlays & dialogs
 
 ### [PJXModal](guide/builtins.md#pjxmodal)
@@ -79,6 +82,9 @@ The builtins, rendered by pyjinhx at docs build time (PJXLazyPanel needs a backe
 
 ### [PJXPanel](guide/builtins.md#pjxpanel)
 <!-- demo: PJXPanel -->
+
+### [PJXResizableGroup](guide/builtins.md#pjxresizablegroup)
+<!-- demo: PJXResizableGroup -->
 
 ### [PJXToastHost](guide/builtins.md#pjxtoasthost)
 <!-- demo: PJXToastHost -->

--- a/tests/unit/test_gallery_demos.py
+++ b/tests/unit/test_gallery_demos.py
@@ -80,6 +80,25 @@ def test_registry_covers_all_builtins():
     assert set(DEMOS) == set(pyjinhx.builtins.__all__) - folded
 
 
+def test_gallery_page_features_every_demo():
+    """docs/gallery.md must feature every builtin that has a demo (DEMOS key).
+
+    The gallery page is hand-curated (one section + `<!-- demo: Name -->` per
+    builtin), so a new builtin's demo can render in the guide yet be missing from
+    the gallery — exactly what happened with PJXResizableGroup. This guards it.
+    """
+    import re
+
+    gallery = (DOCS / "gallery.md").read_text(encoding="utf-8")
+    featured = set(re.findall(r"<!--\s*demo:\s*([A-Za-z]+)\s*-->", gallery))
+    missing = sorted(set(DEMOS) - featured)
+    assert not missing, (
+        "docs/gallery.md is missing a section for these demo'd builtins — add a "
+        "`### [Name](guide/builtins.md#name)` + `<!-- demo: Name -->` for each: "
+        f"{missing}"
+    )
+
+
 def test_first_variation_source_picks_first_list_element():
     def f():
         return [


### PR DESCRIPTION
The Gallery page (`docs/gallery.md`) is hand-curated — one `### [Name]` + `<!-- demo: Name -->` per builtin — and nothing added the **`PJXResizableGroup`** entry, so it rendered in the guide but was missing from the Gallery. Adding a guard test surfaced that **`PJXAccordionGroup`** was *also* missing (a pre-existing omission from the accordion refactor).

This PR:
- Adds `PJXResizableGroup` and `PJXAccordionGroup` to `docs/gallery.md`.
- Adds `test_gallery_page_features_every_demo` asserting every `DEMOS` key appears as a `<!-- demo: -->` on the Gallery page, so a demo'd builtin can't be silently absent again.

Verified: the test fails without the entries (reporting the exact missing names) and passes with them; `mkdocs build --strict` builds clean (both new markers resolve to real `DEMOS` entries).

This closes the third doc-coverage gap class, alongside the field-reference lint and the `mkdocs --strict` PR check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)