### PR TITLE
fix(builtins): PJXTabGroup fills width + consolidate tab CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **`PJXTabGroup` no longer jumps around / leaves stale space.** The group now fills its container
+  (`width: 100%`) instead of shrink-wrapping to content, so it stays put when a tab is closed or a
+  different panel is shown. The tab CSS was also consolidated — the dead dict-era `.pjx-tab-group__tab`
+  rules were removed and the duplicate `.pjx-tab-group__list`/`__panel` rules (one of which left the
+  panel body without horizontal padding) now live in a single file each, giving the panel body
+  deterministic styling. (#135)
+
 ## 0.27.0 — resizable px/content floors + compound tabs (2026-06-22)
 
 ### Added

--- a/docs/demos/interaction.py
+++ b/docs/demos/interaction.py
@@ -25,7 +25,7 @@ def dropdown():
 
 
 def tab_group():
-    return PJXTabGroup(
+    group = PJXTabGroup(
         content=(
             PJXTabList(content=(
                 PJXTab(id="tg-t0", panel="tg-p0", selected=True, content="Overview").render()
@@ -37,6 +37,9 @@ def tab_group():
             + PJXTabPanel(id="tg-p2", tab="tg-t2", content="<p>Repository configuration.</p>").render()
         ),
     ).render()
+    # The group fills its container (width:100%); the centering demo page would
+    # otherwise shrink-wrap it, so give it a definite width to render against.
+    return f'<div style="width: 340px; max-width: 100%;">{group}</div>'
 
 
 def panel():

--- a/pyjinhx/builtins/ui/pjx_tab/pjx-tab.css
+++ b/pyjinhx/builtins/ui/pjx_tab/pjx-tab.css
@@ -1,5 +1,60 @@
-.pjx-tab { display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.4rem 0.75rem; cursor: pointer; border: none; background: none; color: var(--text-muted); border-bottom: 2px solid transparent; user-select: none; }
-.pjx-tab--selected { color: var(--text); border-bottom-color: var(--brand); }
-.pjx-tab:focus-visible { outline: 2px solid var(--brand-muted); outline-offset: -2px; }
-.pjx-tab__close { display: inline-flex; border: none; background: none; cursor: pointer; color: inherit; padding: 0 0.15rem; border-radius: var(--radius-sm, 4px); line-height: 1; }
-.pjx-tab__close:hover { background: var(--surface-alt); }
+.pjx-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0.55rem 1.1rem;
+  font: inherit;
+  font-size: var(--font-size-sm, 0.875rem);
+  line-height: 1.4;
+  color: var(--pjx-tab-group-tab-fg);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    color var(--transition, 0.15s ease),
+    border-color var(--transition, 0.15s ease),
+    background var(--transition, 0.15s ease);
+}
+
+.pjx-tab:hover {
+  color: var(--pjx-tab-group-tab-active-fg);
+  background: color-mix(in srgb, var(--surface) 35%, var(--pjx-tab-group-bg));
+}
+
+.pjx-tab--selected {
+  color: var(--pjx-tab-group-tab-active-fg);
+  border-bottom-color: var(--pjx-tab-group-tab-active-border);
+}
+
+.pjx-tab:focus-visible {
+  outline: 2px solid var(--pjx-tab-group-tab-active-border);
+  outline-offset: -2px;
+}
+
+.pjx-tab__icon {
+  flex: 0 0 auto;
+}
+
+.pjx-tab__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.15rem;
+  padding: 0 0.2rem;
+  border: none;
+  background: none;
+  color: inherit;
+  font-size: 1.15em;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: var(--radius-sm, 4px);
+  opacity: 0.65;
+}
+
+.pjx-tab__close:hover {
+  opacity: 1;
+  background: color-mix(in srgb, var(--text) 12%, transparent);
+}

--- a/pyjinhx/builtins/ui/pjx_tab_group/pjx-tab-group.css
+++ b/pyjinhx/builtins/ui/pjx_tab_group/pjx-tab-group.css
@@ -3,79 +3,22 @@
   --pjx-tab-group-bg: var(--surface-alt);
   --pjx-tab-group-tab-fg: var(--text-muted);
   --pjx-tab-group-tab-active-fg: var(--text);
-  --pjx-tab-group-tab-active-bg: color-mix(in srgb, var(--surface) 55%, var(--surface-alt));
   --pjx-tab-group-tab-active-border: var(--brand);
   --pjx-tab-group-panel-bg: var(--surface);
   --pjx-tab-group-radius: var(--radius-md);
   --pjx-tab-group-padding: var(--space-4, 1rem);
 }
 
+/* The group fills its container so its width stays stable as tabs/panels
+   change — without this it shrink-wraps to content and visibly jumps when a
+   tab is closed or a different (wider/narrower) panel is shown. */
 .pjx-tab-group {
   display: flex;
   flex-direction: column;
+  width: 100%;
   min-width: 0;
   border: 1px solid var(--pjx-tab-group-border);
   border-radius: var(--pjx-tab-group-radius);
   overflow: hidden;
   background: var(--pjx-tab-group-panel-bg);
-}
-
-.pjx-tab-group__list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0;
-  margin: 0;
-  padding: 0;
-  background: var(--pjx-tab-group-bg);
-  border-bottom: 1px solid var(--pjx-tab-group-border);
-}
-
-.pjx-tab-group__tab {
-  margin: 0;
-  padding: 0.55rem 1.1rem;
-  font: inherit;
-  font-size: var(--font-size-sm);
-  font-family: inherit;
-  line-height: 1.4;
-  color: var(--pjx-tab-group-tab-fg);
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  border-radius: 0;
-  cursor: pointer;
-  appearance: none;
-  -webkit-appearance: none;
-  transition:
-    color var(--transition, 0.15s ease),
-    border-color var(--transition, 0.15s ease),
-    background var(--transition, 0.15s ease);
-}
-
-.pjx-tab-group__tab:hover {
-  color: var(--pjx-tab-group-tab-active-fg);
-  background: color-mix(in srgb, var(--surface) 35%, var(--pjx-tab-group-bg));
-}
-
-.pjx-tab-group__tab:focus {
-  outline: none;
-}
-
-.pjx-tab-group__tab:focus-visible {
-  outline: 2px solid var(--pjx-tab-group-tab-active-border);
-  outline-offset: -2px;
-}
-
-.pjx-tab-group__tab[aria-selected="true"] {
-  color: var(--pjx-tab-group-tab-active-fg);
-  background: var(--pjx-tab-group-tab-active-bg);
-  border-bottom-color: var(--pjx-tab-group-tab-active-border);
-}
-
-.pjx-tab-group__panel {
-  padding: var(--pjx-tab-group-padding);
-  min-height: 0;
-}
-
-.pjx-tab-group__panel[hidden] {
-  display: none;
 }

--- a/pyjinhx/builtins/ui/pjx_tab_list/pjx-tab-list.css
+++ b/pyjinhx/builtins/ui/pjx_tab_list/pjx-tab-list.css
@@ -1,1 +1,9 @@
-.pjx-tab-group__list { display: flex; gap: var(--pjx-tab-gap, 0.25rem); border-bottom: 1px solid var(--border); }
+.pjx-tab-group__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  background: var(--pjx-tab-group-bg);
+  border-bottom: 1px solid var(--pjx-tab-group-border);
+}

--- a/pyjinhx/builtins/ui/pjx_tab_panel/pjx-tab-panel.css
+++ b/pyjinhx/builtins/ui/pjx_tab_panel/pjx-tab-panel.css
@@ -1,1 +1,9 @@
-.pjx-tab-group__panel { padding: 0.75rem 0; }
+.pjx-tab-group__panel {
+  padding: var(--pjx-tab-group-padding, 1rem);
+  min-height: 0;
+  background: var(--pjx-tab-group-panel-bg);
+}
+
+.pjx-tab-group__panel[hidden] {
+  display: none;
+}

--- a/tests/unit/test_tabs.py
+++ b/tests/unit/test_tabs.py
@@ -10,6 +10,34 @@ def _env(tmp_path):
     Renderer.set_default_environment(str(tmp_path))
 
 
+from pathlib import Path  # noqa: E402
+
+_UI = Path(__file__).resolve().parents[2] / "pyjinhx" / "builtins" / "ui"
+_TAB_CSS = {
+    "group": _UI / "pjx_tab_group" / "pjx-tab-group.css",
+    "tab": _UI / "pjx_tab" / "pjx-tab.css",
+    "list": _UI / "pjx_tab_list" / "pjx-tab-list.css",
+    "panel": _UI / "pjx_tab_panel" / "pjx-tab-panel.css",
+}
+
+
+def test_tab_group_fills_width_so_it_does_not_jump():
+    # Without an explicit width the group shrink-wraps to content and visibly
+    # resizes/shifts when a tab is closed or a different panel is shown (#bug).
+    assert "width: 100%" in _TAB_CSS["group"].read_text()
+
+
+def test_tab_css_is_consolidated_no_duplicate_or_dead_rules():
+    texts = {k: p.read_text() for k, p in _TAB_CSS.items()}
+    # the dict-era `.pjx-tab-group__tab` selector is dead (tabs are `.pjx-tab`)
+    for k, t in texts.items():
+        assert ".pjx-tab-group__tab" not in t, f"dead selector left in {k} css"
+    # each shared selector is owned by exactly one file (no conflicting dupes)
+    for sel in (".pjx-tab-group__list {", ".pjx-tab-group__panel {"):
+        owners = [k for k, t in texts.items() if sel in t]
+        assert len(owners) == 1, f"{sel} defined in {owners}, expected one owner"
+
+
 def test_tablist_role_and_label():
     html = str(PJXTabList(id="l", label="Project tabs", content="x").render())
     assert 'role="tablist"' in html


### PR DESCRIPTION
Fixes two issues reported on the 0.27.0 `PJXTabGroup` gallery demo.

## Bug 1 — the group jumps / leaves stale space
`.pjx-tab-group` had **no width**, so it shrink-wrapped to content and visibly resized + shifted on every close and every tab click (measured 276→243→212px, x 182→199→214 as you close/switch). Fix: **`width: 100%`** so it fills its container and stays put. The gallery demo wraps the now-full-width group in a definite-width container (the centering demo page would otherwise shrink-wrap it).

## Bug 2 — unstyled panel body
The rework left the old dict-era `pjx-tab-group.css` intact, so:
- a **dead `.pjx-tab-group__tab`** ruleset (tabs are now `.pjx-tab`), and
- **duplicate `.pjx-tab-group__list`/`__panel`** rules conflicting with the new part CSS — one set the panel body to `padding: 0.75rem 0` (no horizontal padding → body flush to the edge, non-deterministic by load order).

Consolidated so each selector lives in exactly one file; the panel body now has deterministic padding + background.

Verified by re-rendering the exact gallery demo page with Playwright: the group is now stable (x=150, width=340, unchanged across close + tab-click) and the body has proper padding. Regression tests guard the `width:100%` and the no-dead / no-duplicate-rule invariants.

Full suite **1010 passed**, reactivity tab+reveal 11 passed, ruff + doc-lint + `mkdocs --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)