### PR TITLE
Fix gallery demo sizing + button/dropdown/drawer polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@
   (+`hx-push-url`) only when a `target` is set, so it degrades to plain navigation. Ships no JS.
   Pairs with `PJXTable`.
 
+### Fixed
+- **`PJXButton` loading state:** the embedded region loader no longer renders an oversized
+  spinner that overflows the button — the spinner is now sized to the button (the veil still
+  masks the label).
+- **`PJXDropdown` trigger:** the trigger button is now themed (surface/border, like the menu)
+  instead of rendering as an unstyled browser button.
+- **`PJXDrawer`:** the open dialog now clips its sliding box (`overflow: hidden`), so the page
+  no longer shows a transient horizontal scrollbar during the open/close animation.
+
 ## 0.27.1 — tab group width + CSS fixes (2026-06-22)
 
 ### Fixed

--- a/docs/demos/interaction.py
+++ b/docs/demos/interaction.py
@@ -35,9 +35,23 @@ def tab_group():
             + PJXTabPanel(id="tg-p2", tab="tg-t2", content="<p>Repository configuration.</p>").render()
         ),
     ).render()
+    # A PJXTab used OUTSIDE a PJXTabList becomes a standalone "panel mode"
+    # trigger: it drives the group's panels from anywhere (resolved via the
+    # panel its `panel=` points at). Wrap inert content — the PJXTab is itself
+    # the control.
+    standalone = PJXTab(
+        panel="tg-p2", content='<span class="pjx-demo-btn">Jump to Settings &darr;</span>'
+    ).render()
     # The group fills its container (width:100%); the centering demo page would
     # otherwise shrink-wrap it, so give it a definite width to render against.
-    return f'<div style="width: 340px; max-width: 100%;">{group}</div>'
+    return (
+        '<div style="width: 340px; max-width: 100%;">'
+        f"{group}"
+        '<p style="margin:0.75rem 0 0.35rem;font-size:0.8rem;opacity:0.7">'
+        "Standalone trigger (outside the tab list):</p>"
+        f"{standalone}"
+        "</div>"
+    )
 
 
 def toast_host():
@@ -69,8 +83,8 @@ def page_loader():
 
 
 DEMOS = {
-    "PJXDropdown": (dropdown, 200),
-    "PJXTabGroup": (tab_group, 320),
+    "PJXDropdown": (dropdown, 320),
+    "PJXTabGroup": (tab_group, 440),
     "PJXToastHost": (toast_host, 160),
     "PJXRegionLoader": (region_loader, 220),
     "PJXPageLoader": (page_loader, 160),

--- a/docs/demos/overlays.py
+++ b/docs/demos/overlays.py
@@ -125,11 +125,11 @@ def popover():
 
 DEMOS = {
     "PJXModal": (modal, 520),
-    "PJXDrawer": (drawer, 360),
+    "PJXDrawer": (drawer, 420),
     "PJXConfirmDialog": (confirm_dialog, 360),
     "PJXPromptDialog": (prompt_dialog, 360),
     "PJXNotification": (notification, 140),
     "PJXAlert": (alert, 280),
     "PJXTooltip": (tooltip, 160),
-    "PJXPopover": (popover, 200),
+    "PJXPopover": (popover, 320),
 }

--- a/docs/demos/static.py
+++ b/docs/demos/static.py
@@ -109,11 +109,18 @@ def breadcrumb():
 
 
 def skeleton():
-    return [
-        PJXSkeleton(variant="text", lines=3).render(),
-        PJXSkeleton(variant="circle").render(),
-        PJXSkeleton(variant="rect").render(),
-    ]
+    # A horizontal "avatar + lines" loading row — compact, fits a short box.
+    # Build via f-string over str()-wrapped renders: concatenating a plain str
+    # with a Markup via `+` would trigger Markup.__radd__ and escape the str.
+    circle = str(PJXSkeleton(variant="circle").render())
+    lines = str(PJXSkeleton(variant="text", lines=2).render())
+    # The circle's own .pjx-skeleton is width:100%, so cap it in a fixed box;
+    # the lines take the remaining space.
+    return (
+        '<div style="display:flex;align-items:center;gap:0.85rem;width:280px;max-width:100%">'
+        f'<div style="width:2.5rem;flex:none">{circle}</div>'
+        f'<div style="flex:1;min-width:0">{lines}</div></div>'
+    )
 
 
 def progress():
@@ -174,7 +181,10 @@ def table():
         bordered="horizontal",
         content=(
             PJXTableHead(content=PJXTableRow(content=(
-                PJXTableHeaderCell(sortable=True, sort="asc", content="Name").render()
+                # Leading header cell aligns the column with the body rows'
+                # auto-prepended selection checkbox (see the select-all rule).
+                PJXTableHeaderCell(content="").render()
+                + PJXTableHeaderCell(sortable=True, sort="asc", content="Name").render()
                 + PJXTableHeaderCell(content="Role").render()
             )).render()).render()
             + PJXTableBody(content=(
@@ -199,9 +209,9 @@ DEMOS = {
     "PJXAvatar": (avatar, 140),
     "PJXAvatarStack": (avatar_stack, 120),
     "PJXBreadcrumb": (breadcrumb, 120),
-    "PJXSkeleton": (skeleton, 220),
+    "PJXSkeleton": (skeleton, 150),
     "PJXProgress": (progress, 170),
-    "PJXEmptyState": (empty_state, 260),
+    "PJXEmptyState": (empty_state, 340),
     "PJXIcon": (icon, 140),
     "PJXButton": (button, 140),
     "PJXResizableGroup": (resizable_group, 160),

--- a/pyjinhx/builtins/ui/pjx_button/pjx-button.css
+++ b/pyjinhx/builtins/ui/pjx_button/pjx-button.css
@@ -37,4 +37,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  /* A button is small: the veil masks the label; shrink the spinner so it fits
+     inside the button instead of overflowing it. */
+  --pjx-region-loader-spinner-size: 1.1em;
+  --pjx-region-loader-spinner-width: 2px;
 }

--- a/pyjinhx/builtins/ui/pjx_drawer/pjx-drawer.css
+++ b/pyjinhx/builtins/ui/pjx_drawer/pjx-drawer.css
@@ -30,6 +30,9 @@
   max-height: 100dvh;
   background: transparent;
   z-index: var(--pjx-drawer-z);
+  /* Clip the box while it slides in from off-screen so the page never gets a
+     transient scrollbar during the open/close animation. */
+  overflow: hidden;
   animation: pjx-drawer-root-in 200ms ease forwards;
 }
 

--- a/pyjinhx/builtins/ui/pjx_dropdown/pjx-dropdown.css
+++ b/pyjinhx/builtins/ui/pjx_dropdown/pjx-dropdown.css
@@ -18,7 +18,20 @@
 }
 
 .pjx-dropdown__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: var(--pjx-dropdown-trigger-padding, 0.5rem 0.85rem);
+  font: inherit;
+  color: var(--text);
+  background: var(--pjx-dropdown-trigger-bg, var(--surface-alt));
+  border: 1px solid var(--pjx-dropdown-trigger-border, var(--border));
+  border-radius: var(--pjx-dropdown-trigger-radius, var(--radius-md));
   cursor: pointer;
+}
+
+.pjx-dropdown__trigger:hover {
+  background: var(--pjx-dropdown-trigger-bg-hover, color-mix(in srgb, var(--text) 6%, var(--surface-alt)));
 }
 
 .pjx-dropdown__menu {


### PR DESCRIPTION
## Gallery demo polish + component fixes

Fixes a batch of issues found while reviewing the docs component gallery.

### Component fixes (library)
- **`PJXButton` loading:** the embedded region loader rendered a 2.5rem spinner that overflowed the button. Sized it to the button (the veil still masks the label).
- **`PJXDropdown` trigger:** the trigger had only `cursor: pointer` and rendered as an unstyled browser button (white in dark mode). Now themed (surface/border, matching the menu), via overridable `--pjx-dropdown-trigger-*` tokens.
- **`PJXDrawer`:** the open `<dialog>` now clips its sliding box (`overflow: hidden`), so the page no longer flashes a horizontal scrollbar during the open/close animation.

### Gallery demo fixes (docs)
- **Table demo:** added a leading header cell so the header columns align with the selectable rows' checkbox column (it was violating the documented select-all alignment rule).
- **Tab/Panel:** the `PJXTabGroup` demo now also shows a **standalone (panel-mode) trigger** — a `PJXTab` outside the tab list driving a panel.
- **Skeleton demo:** reworked into a horizontal avatar+lines row (was a tall vertical stack that overflowed). Also fixed an escaping bug (`str + Markup` triggers `Markup.__radd__`, escaping the literal tags).
- **Iframe heights:** sized so the *triggered* content fully fits (empty-state, dropdown menu, popover panel, open drawer, tab-group with the added trigger) — no clipped content, no scrollbars.

All changes verified with dark-mode chromium screenshots of each affected demo.

### Verification
- Full suite **1101 passed, 5 skipped** · `ruff` clean · `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
