### PR TITLE
docs: post-roadmap correctness sweep

### DIFF
--- a/docs/getting-started/build-an-app.md
+++ b/docs/getting-started/build-an-app.md
@@ -576,7 +576,7 @@ from pyjinhx.builtins import PJXAlert, PJXCard, PJXModal
 ```
 
 ???+ question "Why builtins?"
-    Optional ready-made components (PJXAlert, PJXCard, PJXModal, PJXPanel, …) with co-located CSS/JS. Use when you want a consistent kit without building every primitive. Your app components follow the same `BaseComponent` rules.
+    Optional ready-made components (PJXAlert, PJXCard, PJXModal, PJXTable, …) with co-located CSS/JS. Use when you want a consistent kit without building every primitive. Your app components follow the same `BaseComponent` rules.
 
     See: [Built-in UI components](../guide/builtins.md).
 

--- a/docs/guide/builtin-conventions.md
+++ b/docs/guide/builtin-conventions.md
@@ -43,8 +43,8 @@ Interactive builtins fire a two-tier event vocabulary on their root element (all
   `detail = {reason, trigger}` with `reason ∈ {"escape","backdrop","api","trigger"}`.
 - `pjx:<component>:<verb>` — fired after the DOM change. Not cancelable.
 
-Shared vocabulary: `pjx:before-reveal` / `pjx:reveal` fire on any `[data-pjx-region]` (PJXPanel panels,
-PJXTabGroup bodies) when it is shown — `PJXLazyLoad(when="reveal")` builds on it; `pjx:toast` is the
+Shared vocabulary: `pjx:before-reveal` / `pjx:reveal` fire on any `[data-pjx-region]`
+(PJXTabPanel bodies) when it is shown — `PJXLazyLoad(when="reveal")` builds on it; `pjx:toast` is the
 input event PJXToastHost listens for (htmx fires it from `HX-Trigger` response headers).
 
 ```js

--- a/docs/guide/builtins.md
+++ b/docs/guide/builtins.md
@@ -1,6 +1,6 @@
 # Built-in UI components
 
-Optional package **`pyjinhx.builtins`** registers forty [`BaseComponent`](../api/base-component.md) subclasses. Import:
+Optional package **`pyjinhx.builtins`** registers a family of [`BaseComponent`](../api/base-component.md) subclasses (the authoritative list is `pyjinhx.builtins.__all__`). A representative import:
 
 ```python
 from pyjinhx.builtins import (
@@ -26,6 +26,7 @@ from pyjinhx.builtins import (
     PJXModal,
     PJXNotification,
     PJXPageLoader,
+    PJXPaginator,
     PJXPasswordInput,
     PJXPopover,
     PJXPopoverPanel,
@@ -39,6 +40,12 @@ from pyjinhx.builtins import (
     PJXTabGroup,
     PJXTabList,
     PJXTabPanel,
+    PJXTable,
+    PJXTableHead,
+    PJXTableBody,
+    PJXTableRow,
+    PJXTableHeaderCell,
+    PJXTableCell,
     PJXToastHost,
     PJXToggleSwitch,
     PJXTooltip,
@@ -47,7 +54,7 @@ from pyjinhx.builtins import (
 )
 ```
 
-`__all__` matches that set of forty-two names.
+The full registered set is `pyjinhx.builtins.__all__` (the import above is a representative selection, omitting some compound parts).
 
 **Conventions:** Markup classes use the **`pjx-`** prefix; overrides use **`--pjx-`** custom properties. Builtin CSS also references **theme variables** (`--surface`, `--border`, `--text`, `--radius-md`, `--shadow-md`, `--transition`, `--brand`, …)—define those in your global CSS or map them to your design system. See [builtin-conventions.md](./builtin-conventions.md) for the full per-component contract (auto-id, `class_name`, `extra_attrs`, `js`/`css`, headless IIFE JS under `window.pjx`, cancelable `pjx:*:before-*` events).
 
@@ -92,6 +99,7 @@ from pyjinhx.builtins import (
 | PJXModalFooter | `pjx-modal-footer.css` | — |
 | PJXNotification | `pjx_notification.css` | `pjx_notification.js` |
 | PJXPageLoader | `pjx-page-loader.css` | `pjx-page-loader.js` |
+| PJXPaginator | `pjx-paginator.css` | — |
 | PJXPasswordInput | `pjx-password-input.css` | `pjx-password-input.js` |
 | PJXPopover | `pjx_popover.css` | `pjx_popover.js` |
 | PJXPopoverPanel | *(from PJXPopover)* | *(from PJXPopover)* |
@@ -108,6 +116,12 @@ from pyjinhx.builtins import (
 | PJXTabGroup | `pjx-tab-group.css` | `pjx-tab-group.js` |
 | PJXTabList | `pjx-tab-list.css` | — |
 | PJXTabPanel | `pjx-tab-panel.css` | — |
+| PJXTable | `pjx-table.css` | — |
+| PJXTableHead | *(from PJXTable)* | — |
+| PJXTableBody | *(from PJXTable)* | — |
+| PJXTableRow | *(from PJXTable)* | — |
+| PJXTableHeaderCell | *(from PJXTable)* | — |
+| PJXTableCell | *(from PJXTable)* | — |
 | PJXToastHost | `pjx-toast-host.css` | `pjx-toast-host.js` |
 | PJXToggleSwitch | `pjx-toggle-switch.css` | — |
 | PJXTooltip | `pjx-tooltip.css` | `pjx-tooltip.js` (IIFE, no API) |
@@ -849,6 +863,11 @@ Trigger id is `{{ id }}-trigger`, menu is `{{ id }}-menu`.
 | `--pjx-dropdown-menu-min-w` | `10rem` |
 | `--pjx-dropdown-menu-max-h` | `min(70dvh, 24rem)` |
 | `--pjx-dropdown-z` | `350` |
+| `--pjx-dropdown-trigger-bg` | `var(--surface-alt)` |
+| `--pjx-dropdown-trigger-border` | `var(--border)` |
+| `--pjx-dropdown-trigger-radius` | `var(--radius-md)` |
+| `--pjx-dropdown-trigger-padding` | `0.5rem 0.85rem` |
+| `--pjx-dropdown-trigger-bg-hover` | `color-mix(in srgb, var(--text) 6%, var(--surface-alt))` |
 
 <!-- demo: PJXDropdown -->
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -523,7 +523,7 @@ To keep migration cheap, these 0.4.x idioms are untouched:
 - The `_update_context_(self, context, field_name, field_value, *, renderer, session)`
   context-injection hook and `RenderSession`.
 - `Registry.request_scope()` for per-request component isolation.
-- `pyjinhx.builtins` components — though as of 0.12 they carry a `PJX` prefix (`PJXCard`, `PJXTooltip`, `PJXPanel`, …).
+- `pyjinhx.builtins` components — though as of 0.12 they carry a `PJX` prefix (`PJXCard`, `PJXTooltip`, `PJXTable`, …).
 - Child components as rendered strings, `id`-based addressing, and manual `hx-swap-oob`
   strings — still valid if you are not ready to adopt `ReactiveComponent` for a given region.
 


### PR DESCRIPTION
## Docs sweep — fix mistakes & inconsistencies from the data/nav roadmap

A correctness pass over the docs for everything that drifted during Builds 1–4 + the gallery-polish PR, ahead of cutting a release.

### Fixed
- **Contradictory builtin counts** in `builtins.md` — the intro claimed "registers **forty**" while a later line said "`__all__` matches that set of **forty-two** names" (real count is 61, and both predated our +6 table / +1 paginator / −2 panel changes). Replaced the brittle counts by pointing at `pyjinhx.builtins.__all__` as the source of truth.
- **Asset-summary table + import example were missing the `PJXTable` family and `PJXPaginator`** (Builds 2/3 added the `##` sections but never the table rows / import entries). Added all 7; the asset table now matches `__all__` exactly (verified: zero missing, zero phantom).
- **Undocumented `--pjx-dropdown-trigger-*` style tokens** (added when the polish PR themed the dropdown trigger) — now listed in the PJXDropdown style-tokens table.
- **Stale `PJXPanel` prose** (removed in Build 1) in `builtin-conventions.md` (the `data-pjx-region` vocabulary → now `PJXTabPanel`), `build-an-app.md`, and `migration.md` (example component lists → swapped to `PJXTable`).

### Deliberately kept / not touched
- `builtins.md`'s "Panel mode" note that `PJXTab` *replaces the former `PJXPanel`/`PJXPanelTrigger` pair* — a correct historical/migration reference.
- The button-loading docs — still accurate (the polish change was a CSS-only spinner-size fix; the `PJXRegionLoader` composition is unchanged).

### Verification
- `mkdocs build --strict` clean · doc-lint pass · gallery-demos test pass.
- Asset table ↔ `__all__` parity check passes.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
