### PR TITLE
feat: /feature implementation workflow with adversarial gates + test-integrity check

### DIFF
--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -1,0 +1,62 @@
+---
+description: Implement a feature end-to-end — brainstorm, adversarially review the spec & plan, implement, and run a test-integrity gate before finishing.
+argument-hint: <feature description>
+---
+
+# /feature — feature-implementation workflow
+
+You are driving the full feature lifecycle for: **$ARGUMENTS**
+
+Follow these steps IN ORDER. Emit a short summary after each step. Do not skip the gates. Invoking the Workflow scripts below is an explicit instruction of this command (the user opted in by running `/feature`).
+
+## 0. Branch
+- Run `git branch --show-current`.
+- If on `master`, or on a branch clearly unrelated to this feature, create one off `master`: `git checkout -b feature/<slug> master` (derive `<slug>` from the description). Otherwise confirm the current branch is the intended home and continue.
+
+## 1. Brainstorm (interactive)
+- Invoke the `superpowers:brainstorming` skill with the feature description. Participate with the human. It ends by writing a spec to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and a user-review gate.
+- Record the spec path as **SPEC**.
+
+## 2. Adversarial spec review (autonomous)
+- Dispatch: `Workflow({ name: 'adversarial-doc-review', args: { kind: 'spec', docPath: SPEC, specPath: SPEC } })`.
+- When it returns: if `findings` is non-empty, fold them into ONE revision round of the spec (edit the spec file to address each), then show the human a concise diff + a table of findings and how each was addressed. This step informs; it never blocks.
+
+## 3. Plan (interactive)
+- Invoke the `superpowers:writing-plans` skill against SPEC. It writes a plan to `docs/superpowers/plans/YYYY-MM-DD-<feature>.md`.
+- Record the plan path as **PLAN**.
+
+## 4. Adversarial plan review (autonomous)
+- Dispatch: `Workflow({ name: 'adversarial-doc-review', args: { kind: 'plan', docPath: PLAN, specPath: SPEC } })`.
+- If `findings` non-empty: fold into ONE revision round of the plan, show diff + summary. Never blocks.
+
+## 5. Implement
+- Invoke the `superpowers:subagent-driven-development` skill to implement PLAN task-by-task.
+
+## 6. Test-integrity gate (autonomous judge + remediation loop)
+This is the critical gate. Do NOT declare the feature done until it PASSES or HARD-STOPS to the human.
+
+### 6a. Compute the baseline diff
+- `BASE=$(git merge-base HEAD master)`
+- A "test file" matches `tests/**`, `test_*.py`, or `*_test.py`.
+- `git diff --name-status "$BASE" -- 'tests/**' 'test_*.py' '*_test.py'`
+- Classify by status: **M → modified**, **D → deleted**, **A → new**.
+- For each file capture its diff: `git diff "$BASE" -- <path>` (deleted → the removed content; new → the full added content).
+
+### 6b. Run the judge
+- Build `items = [{ id, category, path, diff }, ...]` and dispatch:
+  `Workflow({ name: 'test-integrity-gate', args: { specPath: SPEC, planPath: PLAN, items } })`.
+- It returns `{ items, violations }`. If `violations` is empty → gate PASSES; go to step 7.
+
+### 6c. Remediate (bounded loop, max N = 3 iterations)
+For each violation, apply ONLY the allowed remediation — NEVER satisfy the gate by weakening or re-justifying a test:
+- **modified or deleted existing test, not spec/plan-justified** → restore the original: `git checkout "$BASE" -- <path>`. Then dispatch a subagent to FIX THE IMPLEMENTATION so the restored test passes honestly. The subagent may NOT touch the test.
+- **hollow new test** → dispatch a subagent to STRENGTHEN the new test so it exercises real behavior (allowed: it is a new test, not an existing contract).
+- After remediating all violations, re-run steps 6a–6b.
+- **Genuine conflict** — a restored test fails, there is NO spec/plan basis for changing it, AND the implementation cannot pass it honestly → STOP. Report the conflicting tests, the judge's reasons, and the relevant spec sections to the human. This decision is the human's.
+- If the loop exceeds N iterations without converging → STOP and report.
+
+## 7. Finish
+- Once the gate passes, invoke the `superpowers:finishing-a-development-branch` skill to present merge/PR options and complete the work.
+
+## Reporting
+Surface every finding and every violation — never silently drop one.

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -37,10 +37,11 @@ This is the critical gate. Do NOT declare the feature done until it PASSES or HA
 
 ### 6a. Compute the baseline diff
 - `BASE=$(git merge-base HEAD master)`
-- A "test file" matches `tests/**`, `test_*.py`, or `*_test.py`.
-- `git diff --name-status "$BASE" -- 'tests/**' 'test_*.py' '*_test.py'`
-- Classify by status: **M → modified**, **D → deleted**, **A → new**.
-- For each file capture its diff: `git diff "$BASE" -- <path>` (deleted → the removed content; new → the full added content).
+- List every changed file. Pass `--no-renames` so a renamed test decomposes into a delete + an add and BOTH halves are judged (otherwise an `R` status would slip the gate):
+  `git diff --no-renames --name-status "$BASE"`
+- A "test file" is a changed `.py` file whose BASENAME matches pytest discovery — `test_*.py` or `*_test.py` (these typically live under `tests/`). EXCLUDE non-test files even under `tests/`: fixtures and assets (`.html`, `.css`, `.js`, data files), `__init__.py`, `conftest.py`, and helper/app modules with no test functions. If unsure whether a changed file is a real test, open it and check for test functions before including it.
+- Keep only the test files and classify by status: **M → modified**, **D → deleted**, **A → new** (with `--no-renames`, only these three occur).
+- For each kept file capture its diff: `git diff "$BASE" -- <path>` (deleted → the removal hunk; modified/new → the change hunk with its `+`/`-` lines).
 
 ### 6b. Run the judge
 - Build `items = [{ id, category, path, diff }, ...]` and dispatch:

--- a/.claude/workflows/adversarial-doc-review.js
+++ b/.claude/workflows/adversarial-doc-review.js
@@ -9,14 +9,16 @@ export const meta = {
   ],
 }
 
-if (args && args.selfTest) {
+const ARGS = typeof args === 'string' ? JSON.parse(args || '{}') : (args || {})
+
+if (ARGS.selfTest) {
   log('adversarial-doc-review: self-test OK')
   return { ok: true, name: 'adversarial-doc-review' }
 }
 
-const KIND = (args && args.kind) || 'spec'
-const DOC = args && args.docPath
-const SPEC = (args && args.specPath) || DOC
+const KIND = ARGS.kind || 'spec'
+const DOC = ARGS.docPath
+const SPEC = ARGS.specPath || DOC
 if (!DOC) throw new Error('adversarial-doc-review: args.docPath is required')
 
 const DIMENSIONS = {

--- a/.claude/workflows/adversarial-doc-review.js
+++ b/.claude/workflows/adversarial-doc-review.js
@@ -1,0 +1,148 @@
+export const meta = {
+  name: 'adversarial-doc-review',
+  description: 'Adversarially red-team a feature spec or implementation plan: parallel critics raise falsifiable critiques across fixed dimensions, one skeptic per critique tries to refute it, and survivors are synthesized into an actionable findings list.',
+  whenToUse: 'Invoked by the /feature command after brainstorming (kind:spec) and after writing-plans (kind:plan) to stress-test the document before it is acted on.',
+  phases: [
+    { title: 'Critique', detail: 'one critic per review dimension raises falsifiable critiques of the document' },
+    { title: 'Verify', detail: 'one adversarial skeptic per critique tries to refute it; plausible-but-wrong nits die here' },
+    { title: 'Synthesize', detail: 'one editor consolidates surviving critiques into a deduped findings list' },
+  ],
+}
+
+if (args && args.selfTest) {
+  log('adversarial-doc-review: self-test OK')
+  return { ok: true, name: 'adversarial-doc-review' }
+}
+
+const KIND = (args && args.kind) || 'spec'
+const DOC = args && args.docPath
+const SPEC = (args && args.specPath) || DOC
+if (!DOC) throw new Error('adversarial-doc-review: args.docPath is required')
+
+const DIMENSIONS = {
+  spec: [
+    { key: 'ambiguity', title: 'Ambiguity', prompt: 'Find requirements with two valid readings. Quote each and state the divergent interpretations.' },
+    { key: 'edge-cases', title: 'Missing edge cases', prompt: 'Find failure modes, boundary conditions, or states the spec never addresses.' },
+    { key: 'testability', title: 'Testability', prompt: 'Find requirements that are untestable or unfalsifiable as written — no observable pass/fail.' },
+    { key: 'scope', title: 'Scope', prompt: 'Find scope creep (anything beyond the stated goal) AND any stated goal left unaddressed.' },
+    { key: 'contradiction', title: 'Internal contradiction', prompt: 'Find statements or sections that conflict with each other or with the architecture.' },
+    { key: 'assumptions', title: 'Unstated assumptions', prompt: 'Surface assumptions the design silently depends on but never states.' },
+  ],
+  plan: [
+    { key: 'fidelity', title: 'Spec fidelity', prompt: 'For each task, check it implements a real spec requirement; flag tasks that drift from or contradict the spec, and spec requirements with no task.' },
+    { key: 'verifiability', title: 'Verifiability', prompt: "Flag steps whose verification is missing, vague, or wouldn't actually prove the step works." },
+    { key: 'tdd', title: 'TDD ordering', prompt: 'Flag tasks that write implementation before a failing test, or that lack a real test cycle (where a test harness exists).' },
+    { key: 'sizing', title: 'Task sizing', prompt: 'Flag oversized tasks (multiple independent deliverables) and missing tasks.' },
+    { key: 'coupling', title: 'Hidden coupling', prompt: "Flag 'independent' tasks that secretly depend on each other's internals or ordering." },
+  ],
+}[KIND]
+if (!DIMENSIONS) throw new Error(`adversarial-doc-review: unknown kind "${KIND}"`)
+
+const CRITIQUE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    dimension: { type: 'string' },
+    critiques: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          problem: { type: 'string', description: 'The concrete, falsifiable problem.' },
+          where: { type: 'string', description: 'Section / quote / task pinpointing the location in the document.' },
+          severity: { type: 'string', enum: ['blocker', 'major', 'minor'] },
+        },
+        required: ['problem', 'where', 'severity'],
+      },
+    },
+  },
+  required: ['dimension', 'critiques'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    survives: { type: 'boolean', description: 'true ONLY if the problem is real and worth fixing.' },
+    reason: { type: 'string' },
+  },
+  required: ['survives', 'reason'],
+}
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          severity: { type: 'string', enum: ['blocker', 'major', 'minor'] },
+          where: { type: 'string' },
+          problem: { type: 'string' },
+          suggestion: { type: 'string' },
+        },
+        required: ['severity', 'where', 'problem', 'suggestion'],
+      },
+    },
+  },
+  required: ['findings'],
+}
+
+phase('Critique')
+
+const COMMON = `You are adversarially reviewing a ${KIND === 'spec' ? 'feature specification' : 'implementation plan'} BEFORE any code is written. Read the document at ${DOC}.${KIND === 'plan' ? ` It must faithfully implement the spec at ${SPEC} — read that too.` : ''}
+Raise only FALSIFIABLE, specific critiques (a skeptic could check each and confirm or refute it). No vague "could be clearer". For each: the precise location/quote, the concrete problem, and a severity (blocker|major|minor). Return an empty critiques array if your lens finds nothing real.`
+
+const critiqueBatches = (await parallel(
+  DIMENSIONS.map((d) => () =>
+    agent(`${COMMON}\n\nYOUR LENS — ${d.title}: ${d.prompt}\nReport "dimension": "${d.key}".`,
+      { label: `critique:${d.key}`, phase: 'Critique', schema: CRITIQUE_SCHEMA }),
+  ),
+)).filter(Boolean)
+
+const critiques = []
+critiqueBatches.forEach((b) =>
+  (b.critiques || []).forEach((c, i) => critiques.push({ id: `${b.dimension}-${i + 1}`, ...c })),
+)
+log(`Critique: ${critiques.length} critiques raised across ${critiqueBatches.length} lenses.`)
+
+phase('Verify')
+
+const verdicts = (await parallel(
+  critiques.map((c) => () =>
+    agent(`You are an adversarial skeptic. Try to REFUTE this critique of the ${KIND} — assume it is wrong or a non-issue until the document proves otherwise. Read ${DOC}${KIND === 'plan' ? ` and the spec ${SPEC}` : ''}.
+
+CRITIQUE ${c.id} [${c.severity}] @ ${c.where}:
+${c.problem}
+
+Return survives=true ONLY if the problem is real, present in the document, and worth fixing. Return survives=false if it is a non-issue, already handled elsewhere in the document, or out of scope. Give your reason.`,
+      { label: `verify:${c.id}`, phase: 'Verify', schema: VERDICT_SCHEMA },
+    ).then((v) => ({ ...c, ...v })),
+  ),
+)).filter(Boolean)
+
+const survivors = verdicts.filter((v) => v.survives)
+log(`Verify: ${survivors.length}/${verdicts.length} critiques survived refutation.`)
+
+phase('Synthesize')
+
+if (!survivors.length) {
+  log('Synthesize: no surviving findings — document passes adversarial review.')
+  return { kind: KIND, doc: DOC, findingsCount: 0, findings: [] }
+}
+
+const synth = await agent(
+  `You are the editor. Below are adversarially-verified critiques of the ${KIND} at ${DOC} that survived refutation:
+${JSON.stringify(survivors.map(({ id, severity, where, problem }) => ({ id, severity, where, problem })), null, 2)}
+
+Dedup overlapping critiques and turn each into an actionable finding: { severity, where, problem, suggestion }. Order blocker → major → minor. Do NOT invent new problems; only consolidate what is listed.`,
+  { phase: 'Synthesize', schema: FINDINGS_SCHEMA },
+)
+
+log(`Synthesize: ${synth.findings.length} findings.`)
+
+return { kind: KIND, doc: DOC, findingsCount: synth.findings.length, findings: synth.findings }

--- a/.claude/workflows/test-integrity-gate.js
+++ b/.claude/workflows/test-integrity-gate.js
@@ -1,0 +1,67 @@
+export const meta = {
+  name: 'test-integrity-gate',
+  description: 'Adversarial judge for test-suite integrity. Given the branch test diff vs the merge-base, one guilty-by-default skeptic per flagged test (modified, deleted, or new) decides whether the change is legitimate (spec/plan-justified or behavior-preserving) or gaming (a weakened/deleted existing test, or a hollow new test).',
+  whenToUse: 'Invoked by the /feature command after implementation. The command computes the test diff vs merge-base and passes the flagged items; this workflow returns a per-item verdict. The remediation loop lives in the command, not here.',
+  phases: [
+    { title: 'Judge', detail: 'one adversarial, guilty-by-default skeptic per flagged test item renders a legitimacy verdict' },
+  ],
+}
+
+if (args && args.selfTest) {
+  log('test-integrity-gate: self-test OK')
+  return { ok: true, name: 'test-integrity-gate' }
+}
+
+const SPEC = args && args.specPath
+const PLAN = args && args.planPath
+const ITEMS = (args && args.items) || []
+if (!SPEC) throw new Error('test-integrity-gate: args.specPath is required')
+if (!ITEMS.length) {
+  log('test-integrity-gate: no flagged test items — PASS')
+  return { items: [], violations: [] }
+}
+
+const ASKS = {
+  modified: 'This EXISTING test was MODIFIED. Assume it was WEAKENED or retargeted to make failing code pass, until proven otherwise. Legitimate ONLY if (a) the spec or plan documents a behavior change that requires this assertion to change, OR (b) it is a provably behavior-preserving refactor (rename, fixture move, dedup) that does NOT relax what is asserted. ALSO: if the diff adds new test functions, check those are not hollow.',
+  deleted: 'This EXISTING test was DELETED. Assume an inconvenient test was removed to go green, until proven otherwise. Legitimate ONLY if the spec or plan removed or changed the behavior it covered.',
+  new: 'This is a NEW test. Assume it is HOLLOW (asserts trivia, is so mocked-out that nothing real runs, or never drives the code path it claims) until proven otherwise. Legitimate ONLY if it genuinely exercises real behavior with meaningful assertions.',
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    legitimate: { type: 'boolean', description: 'false on ANY genuine doubt (guilty-by-default).' },
+    reason: { type: 'string', description: 'Cite the spec/plan section (or its absence) and what the test actually asserts.' },
+  },
+  required: ['legitimate', 'reason'],
+}
+
+phase('Judge')
+
+const verdicts = (await parallel(
+  ITEMS.map((it) => () =>
+    agent(`You are an adversarial test-integrity judge. Be GUILTY-BY-DEFAULT: your job is to REFUTE the legitimacy of this test change.
+
+SPEC: ${SPEC}
+${PLAN ? `PLAN: ${PLAN}` : ''}
+You may read the spec, the plan, the test file, and the source under test.
+
+FLAGGED ${it.category.toUpperCase()} TEST — ${it.path} (id ${it.id}):
+${ASKS[it.category] || ASKS.modified}
+
+DIFF / CONTENT:
+<<<DIFF
+${it.diff || '(read the file at the path above)'}
+DIFF>>>
+
+Read the spec/plan and the relevant source, then decide legitimate true/false. On ANY genuine doubt, return legitimate=false. Give a concrete reason citing the spec/plan section (or its absence) and what the test actually asserts.`,
+      { label: `judge:${it.id}`, phase: 'Judge', schema: VERDICT_SCHEMA },
+    ).then((v) => ({ id: it.id, path: it.path, category: it.category, ...v })),
+  ),
+)).filter(Boolean)
+
+const violations = verdicts.filter((v) => !v.legitimate)
+log(`Judge: ${violations.length}/${verdicts.length} flagged test changes failed the integrity check.`)
+
+return { items: verdicts, violations }

--- a/.claude/workflows/test-integrity-gate.js
+++ b/.claude/workflows/test-integrity-gate.js
@@ -7,14 +7,16 @@ export const meta = {
   ],
 }
 
-if (args && args.selfTest) {
+const ARGS = typeof args === 'string' ? JSON.parse(args || '{}') : (args || {})
+
+if (ARGS.selfTest) {
   log('test-integrity-gate: self-test OK')
   return { ok: true, name: 'test-integrity-gate' }
 }
 
-const SPEC = args && args.specPath
-const PLAN = args && args.planPath
-const ITEMS = (args && args.items) || []
+const SPEC = ARGS.specPath
+const PLAN = ARGS.planPath
+const ITEMS = ARGS.items || []
 if (!SPEC) throw new Error('test-integrity-gate: args.specPath is required')
 if (!ITEMS.length) {
   log('test-integrity-gate: no flagged test items — PASS')


### PR DESCRIPTION
## What

Adds a reusable **`/feature`** workflow for implementing features end-to-end, with adversarial gates at each stage and a test-integrity check that catches gamed tests.

```
/feature "<description>"
 1. Skill:    superpowers:brainstorming                  ← interactive
 2. Workflow: adversarial-doc-review (kind: spec)        ← autonomous; auto-fold findings, report
 3. Skill:    superpowers:writing-plans                  ← interactive
 4. Workflow: adversarial-doc-review (kind: plan)        ← autonomous; auto-fold findings, report
 5. Skill:    superpowers:subagent-driven-development    ← implement
 6. Workflow: test-integrity-gate                        ← autonomous judge + playbook remediation loop
 7. Skill:    superpowers:finishing-a-development-branch
```

## Deliverables

- **`.claude/commands/feature.md`** — the interactive spine (playbook) that sequences the superpowers skills and dispatches the Workflows.
- **`.claude/workflows/adversarial-doc-review.js`** — one parameterized Workflow (`kind: spec | plan`) that red-teams a doc: parallel critics raise falsifiable critiques → one skeptic per critique tries to refute it → survivors synthesized into findings.
- **`.claude/workflows/test-integrity-gate.js`** — a guilty-by-default judge: one skeptic per flagged test (modified / deleted / new vs the merge-base) decides whether the change is spec/plan-justified or gaming the suite.

## The test-integrity gate (the point)

It catches the failure mode where existing tests are weakened/deleted — or hollow new tests are added — *just to go green*:

- **Baseline:** `git diff --no-renames --name-status` vs `git merge-base HEAD master`; test files selected by pytest basename (`test_*.py` / `*_test.py`), excluding fixtures/assets/`conftest.py`/`__init__.py`.
- **Judge** (stateless Workflow): guilty-by-default; a change passes only if the spec/plan documents the behavior change or it's a provably behavior-preserving refactor; new tests must exercise real behavior.
- **Remediation loop** (in the playbook, max N=3): "fix the code, not the test" — restore the original test and fix the implementation; strengthen hollow new tests. **Hard-stop** on a genuine conflict (can't pass honestly + no spec basis) — that decision is the human's.

## Notes

- Spec & plan live in `docs/superpowers/` (gitignored working notes), not in this diff.
- No `pyjinhx/` or `tests/` code touched — library + test suite unaffected.
- Built via brainstorming → writing-plans → subagent-driven-development; the acceptance smoke caught a real bug (the Workflow runtime delivers `args` as a JSON string) and the final review caught the gate's file-selection over-capture — both fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
