### PR TITLE
fix: reactive lazy fragments deliver their own not-yet-loaded assets (#184 reopen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.28.5 — Reactive lazy fragments deliver their own assets (2026-06-25)
+
+### Fixed
+- A reactive component rendered as a **lazy fragment** in a reactive context (a
+  non-empty mounted manifest) with no pending mutations delivered its nested
+  builtin CSS/JS **neither inline nor OOB**, so the content rendered unstyled.
+  The reactive primary render passed `emit_assets=False` and relied on the OOB
+  tail (`_finish_with_oob`) for asset delivery — but that tail only emits assets
+  for dirtied *non-primary* regions (the primary is excluded), so the primary's
+  own not-yet-loaded assets fell through. `emit_assets=False` predated the
+  `0.28.3` OOB-`<head>` path in `inject_assets` and is now obsolete; the primary
+  renders normally and routes its missing assets through `inject_assets`, which
+  emits OOB-to-`<head>` when a manifest is present (never inline) and inline only
+  on a truly cold render — matching the non-reactive lazy path. Surfaced by
+  nori's reactive `TableWorkbench` lazy preview (the #184 reopen).
+
 ## 0.28.4 — Fix eager asset durability across region swaps (2026-06-24)
 
 ### Fixed

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -134,11 +134,11 @@ class _ReactiveRender:
 
         if not _reactive_context_active():
             instance = cls.load(*args, **kwargs) if keyed else cls.load(**kwargs)
-            return Markup(instance._render(emit_assets=False))
+            return Markup(instance._render())
 
         def build_primary() -> str:
             instance = cls.load(*args, **kwargs) if keyed else cls.load(**kwargs)
-            return instance._render(emit_assets=False)
+            return instance._render()
 
         return reactive_render_bundle(
             primary_html=build_primary,
@@ -165,7 +165,7 @@ class _ReactiveRender:
             if not _reactive_context_active():
                 return instance._render()
             return reactive_render_bundle(
-                primary_html=lambda: instance._render(emit_assets=False),
+                primary_html=lambda: instance._render(),
                 invalidate_before_primary=False,
             )
 

--- a/tests/ui/reactive/breadcrumb_panel.html
+++ b/tests/ui/reactive/breadcrumb_panel.html
@@ -1,0 +1,1 @@
+<div id="{{ id }}" class="breadcrumb-panel">{{ breadcrumb }}</div>

--- a/tests/ui/reactive/breadcrumb_panel.py
+++ b/tests/ui/reactive/breadcrumb_panel.py
@@ -1,0 +1,24 @@
+from typing import Annotated, Any
+
+from pyjinhx import PjxKey, ReactiveComponent
+
+from pyjinhx.builtins import PJXBreadcrumb
+
+from tests.reactive_test_support import Keys
+
+
+class BreadcrumbPanel(ReactiveComponent, react={Keys.TODOS}):
+    """Reactive component whose nested builtin (PJXBreadcrumb) supplies a CSS asset
+    that may not yet be on the page — mirrors nori's reactive TableWorkbench, the
+    #184 reopen case."""
+
+    panel_id: Annotated[str, PjxKey()]
+    breadcrumb: Any = None
+
+    @classmethod
+    def load(cls, panel_id: str) -> "BreadcrumbPanel":
+        return cls(
+            id=f"breadcrumb-panel-{panel_id}",
+            panel_id=panel_id,
+            breadcrumb=PJXBreadcrumb(items=[("Library", None), ("Finance", None)]),
+        )

--- a/tests/unit/test_reactive_lazy_assets.py
+++ b/tests/unit/test_reactive_lazy_assets.py
@@ -1,0 +1,53 @@
+"""#184 (reopen) — a reactive component rendered as a lazy fragment must deliver
+its own not-yet-loaded builtin assets through the OOB ``<head>`` channel.
+
+The reactive primary render used ``emit_assets=False`` and relied on ``_finish_with_oob``
+for asset delivery — but that path only emits assets for *dirtied non-primary*
+regions, so a reactive component's *own* assets fell through when it was rendered
+in a reactive context (a non-empty mounted manifest) with no pending mutations —
+exactly a lazy-loaded reactive fragment. nori's reactive ``TableWorkbench`` lazy
+fragment hit this: its nested ``PJXBreadcrumb`` CSS was delivered neither inline nor
+OOB, so the breadcrumb rendered unstyled. The primary now emits via the same
+``inject_assets`` OOB path the non-reactive lazy render uses (#183).
+"""
+
+import os
+
+from pyjinhx.assets import asset_token
+from pyjinhx.client import PJX_ASSETS_HEADER
+from pyjinhx.finder import Finder
+from pyjinhx.builtins import PJXBreadcrumb
+from tests.reactive_test_support import reactive_client
+from tests.ui.reactive.breadcrumb_panel import BreadcrumbPanel
+
+_BC_DIR = Finder.get_class_directory(PJXBreadcrumb)
+_BC_TOKEN = asset_token(os.path.join(_BC_DIR, "pjx-breadcrumb.css"))
+
+# A non-empty manifest (some other mounted reactive region) makes the request a
+# reactive context — the condition that triggered the bug. The lazy panel itself
+# is fresh (not yet mounted), and no mutation is pending.
+_MANIFEST = [{"id": "other", "type": "ReactiveCounter", "hash": "h"}]
+
+
+def test_lazy_reactive_render_delivers_nested_builtin_oob():
+    """The reactive fragment ships its breadcrumb CSS as an OOB head injection."""
+    with reactive_client(_MANIFEST):
+        out = str(BreadcrumbPanel.render("p1"))
+
+    assert 'data-pjx-id="breadcrumb-panel-p1"' in out  # the primary rendered
+    # The breadcrumb CSS is delivered, and as an OOB head injection (not inline).
+    assert (
+        f'<style data-pjx-asset="{_BC_TOKEN}" hx-swap-oob="beforeend:head">' in out
+    ), "reactive lazy fragment did not deliver its nested builtin CSS OOB"
+    assert f'<style data-pjx-asset="{_BC_TOKEN}">' not in out, "must be OOB, not inline"
+
+
+def test_lazy_reactive_render_dedups_already_loaded_builtin():
+    """When the client already has the breadcrumb CSS, it is not re-delivered."""
+    with reactive_client(
+        _MANIFEST, extra_headers={PJX_ASSETS_HEADER: f'["{_BC_TOKEN}"]'}
+    ):
+        out = str(BreadcrumbPanel.render("p1"))
+
+    assert 'data-pjx-id="breadcrumb-panel-p1"' in out
+    assert _BC_TOKEN not in out, "already-loaded asset should be deduped away"


### PR DESCRIPTION
## Summary

Follow-up to the #184 reopen. v0.28.4 fixed the **non-reactive** lazy/eager cases, but nori's reactive **`TableWorkbench`** lazy fragment still rendered its `PJXBreadcrumb` unstyled. This is a **distinct bug** in the reactive asset path.

## Root cause

A reactive component's *primary* render passes `emit_assets=False` and relies on the OOB tail (`_finish_with_oob`) for asset delivery. But that tail only emits assets for **dirtied non-primary** regions (the primary is explicitly excluded from `oob_swaps`). So a reactive component's **own** not-yet-loaded assets are never delivered when it is rendered in a reactive context (non-empty mounted manifest) with **no pending mutations** — i.e. a lazy-loaded reactive fragment.

Confirmed matrix:

| Render form | manifest | before | after |
|---|---|---|---|
| `Cls.render(id)` | empty / non-empty | **0 styles** | OOB ✅ |
| `instance.render()` | empty | OOB ✅ | OOB ✅ |
| `instance.render()` | **non-empty** | **0 styles** (nori) | OOB ✅ |

`emit_assets=False` **predates** the `0.28.3` (#183) OOB-`<head>` path in `inject_assets` — it was a workaround to avoid inline injection in fragments, now obsolete and buggy.

## Fix

Remove `emit_assets=False` from the three reactive-primary call sites so the primary renders normally and routes its missing assets through `inject_assets`, which already:
- emits **OOB-to-`<head>`** when a manifest is present (never inline → no #182 regression), and
- emits inline only on a truly cold render.

Identical to the non-reactive lazy path. Only explicit `.render()`/`Cls.render()` route entries are affected (nested tags and `{{ comp }}` interpolation bypass this dispatch).

## Tests

`tests/unit/test_reactive_lazy_assets.py` (+ a `BreadcrumbPanel` reactive fixture): a reactive lazy fragment with a non-empty manifest must ship its nested builtin CSS **OOB to `<head>`** (not inline), and dedup when already loaded. Red without the fix (0 styles), green with it. Full suite: **1119 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)