### PR TITLE
feat: PJXLazyLoad terminal failure path (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.30.0 — PJXLazyLoad terminal failure path (2026-06-27)
+
+### Added
+- `PJXLazyLoad` now has a terminal **failure** path. htmx never swaps on a
+  non-2xx/timeout/network error and the lazy trigger is usually consumed
+  (`once`), so a failed lazy load used to strand its placeholder
+  (`PJXSkeleton`/`PJXSpinner`) reading "loading…" forever. A co-located
+  `pjx-lazy-load.js` driver now listens for the element's own terminal
+  `htmx:afterRequest` (`!detail.successful`) and replaces the placeholder with
+  an inline error affordance — either the author's `error` slot or a default
+  `role="alert"` message. Two new props: `error` (a raw-HTML `Slot` for custom
+  error markup) and `error_text` (the default message, localizable). No retry
+  is issued (#191).
+
 ## 0.29.0 — Reactive HX-Reswap and opt-in htmx redirect adaptation (2026-06-26)
 
 ### Fixed

--- a/docs/guide/loading.md
+++ b/docs/guide/loading.md
@@ -1,10 +1,11 @@
 # Loading states
 
-Six loading niches, one decision rule: *what is missing?*
+Seven loading niches, one decision rule: *what is missing?*
 
 | What's missing | Builtin | Activation |
 |---|---|---|
 | Content not loaded yet | `PJXSkeleton` | None — it IS the placeholder; the swap replaces it (`PJXLazyLoad(content=PJXSkeleton())`) |
+| Lazy load failed | `PJXLazyLoad` error path | Automatic — on the element's own terminal failure (non-2xx/timeout/network) the placeholder is replaced by its `error` slot, or a default `role="alert"` message (`error_text`); no retry is issued |
 | Reactive region refreshing | *runtime state* (`data-pjx-loading`) | Automatic — add `data-pjx-loading="skeleton"` or `data-pjx-loading="spinner"` directly in the `ReactiveComponent` template (on the root element or an inner element); the `pjx.js` runtime shimmer-skeletonizes or overlays the EXISTING content while predicted mutations are in flight |
 | Request in flight, inline | `PJXSpinner` | `PJXSpinner(class_name="htmx-indicator")` + `hx-indicator="#its-id"` — htmx toggles it, zero JS |
 | Request in flight, region-blocking | `PJXRegionLoader` | `hx-indicator` pointing at it, **or** `pjx.loader.region.show/hide/reset(id)` for non-htmx work (pick one mechanism per element), or `pjx.loader.region.wrap(id, promise)` |

--- a/pyjinhx/builtins/ui/pjx_lazy_load/pjx-lazy-load.css
+++ b/pyjinhx/builtins/ui/pjx_lazy_load/pjx-lazy-load.css
@@ -1,0 +1,13 @@
+/* ── PJXLazyLoad error affordance ───────────────────────────── */
+/* Shown by pjx-lazy-load.js when a lazy region's own request fails
+   terminally and htmx leaves the placeholder un-swapped. */
+:where(:root) {
+  --pjx-lazy-load-error-color: var(--danger, #b91c1c);
+  --pjx-lazy-load-error-pad:   0.75rem 1rem;
+}
+
+.pjx-lazy-load__error {
+  padding: var(--pjx-lazy-load-error-pad);
+  color: var(--pjx-lazy-load-error-color);
+  font-size: 0.875rem;
+}

--- a/pyjinhx/builtins/ui/pjx_lazy_load/pjx-lazy-load.html
+++ b/pyjinhx/builtins/ui/pjx_lazy_load/pjx-lazy-load.html
@@ -1,5 +1,7 @@
 <{{ tag }} id="{{ id }}"
      class="pjx-lazy-load{% if class_name %} {{ class_name }}{% endif %}"
+     data-pjx-lazy-load
      hx-get="{{ url }}"
      hx-trigger="{% if trigger %}{{ trigger }}{% elif when == 'reveal' %}pjx:reveal from:closest [data-pjx-region] once{% elif when == 'load' %}load{% else %}revealed{% endif %}"
-     hx-swap="{{ swap }}">{{ content }}</{{ tag }}>
+     hx-swap="{{ swap }}"
+     data-pjx-error-text="{{ error_text }}">{{ content }}{% if error %}<template data-pjx-lazy-error>{{ error }}</template>{% endif %}</{{ tag }}>

--- a/pyjinhx/builtins/ui/pjx_lazy_load/pjx-lazy-load.js
+++ b/pyjinhx/builtins/ui/pjx_lazy_load/pjx-lazy-load.js
@@ -1,0 +1,38 @@
+(function () {
+    window.pjx = window.pjx || {};
+    if (pjx.lazyLoad) return;
+
+    var ERROR_CLASS = 'pjx-lazy-load--error';
+
+    // Replace the placeholder of a lazy region whose own request failed
+    // terminally. htmx never swaps on a non-2xx/timeout/network error, so the
+    // placeholder (skeleton/spinner) would otherwise read "loading…" forever.
+    function showError(el) {
+        if (el.classList.contains(ERROR_CLASS)) return; // already replaced
+        var tpl = el.querySelector(':scope > template[data-pjx-lazy-error]');
+        el.classList.add(ERROR_CLASS);
+        if (tpl && tpl.innerHTML.trim()) {
+            el.innerHTML = tpl.innerHTML; // author-supplied error markup
+            return;
+        }
+        var box = document.createElement('div');
+        box.className = 'pjx-lazy-load__error';
+        box.setAttribute('role', 'alert');
+        box.textContent = el.getAttribute('data-pjx-error-text') || 'Failed to load.';
+        el.replaceChildren(box);
+    }
+
+    // afterRequest fires for every terminal outcome (success, error, abort,
+    // timeout); detail.successful is false on the failures we care about.
+    document.addEventListener('htmx:afterRequest', function (e) {
+        var d = e.detail;
+        if (!d || d.successful) return;
+        var el = d.elt && d.elt.closest && d.elt.closest('[data-pjx-lazy-load]');
+        // Only the lazy element's OWN request — not a failure bubbling up from
+        // content already swapped into it.
+        if (!el || d.elt !== el) return;
+        showError(el);
+    });
+
+    pjx.lazyLoad = { showError: showError };
+}());

--- a/pyjinhx/builtins/ui/pjx_lazy_load/pjx_lazy_load.py
+++ b/pyjinhx/builtins/ui/pjx_lazy_load/pjx_lazy_load.py
@@ -3,7 +3,7 @@ from typing import Literal
 from pydantic import Field
 
 from pyjinhx import BaseComponent
-from pyjinhx.base import AttrValue, ExtraAttrs
+from pyjinhx.base import AttrValue, ExtraAttrs, Slot
 
 
 class PJXLazyLoad(BaseComponent):
@@ -13,5 +13,7 @@ class PJXLazyLoad(BaseComponent):
     swap: str = "outerHTML"
     tag: Literal["div", "li", "tr"] = "div"
     content: str | BaseComponent = ""
+    error: Slot = ""
+    error_text: str = "Failed to load."
     class_name: AttrValue = ""
     extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/tests/reactivity/test_lazy_error_path.py
+++ b/tests/reactivity/test_lazy_error_path.py
@@ -1,0 +1,154 @@
+"""Browser contract for #191 — a ``PJXLazyLoad`` whose own request fails
+terminally must replace its placeholder with an inline error affordance.
+
+htmx never swaps on a non-2xx response, and the lazy trigger is usually
+consumed (``once``), so without a driver the placeholder (skeleton/spinner)
+reads "loading…" forever. ``pjx-lazy-load.js`` listens for the element's own
+terminal ``htmx:afterRequest`` (``!detail.successful``) and swaps in either the
+author's ``error`` slot or a default ``role="alert"`` message.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+pytest.importorskip("playwright")
+
+from fastapi import FastAPI, Request  # noqa: E402
+from playwright.sync_api import Page, expect  # noqa: E402
+
+pytestmark = [pytest.mark.pjx_runtime, pytest.mark.reactivity]
+
+# htmx in <head>; the pyjinhx runtime at the end of <body> (binds on body).
+_PAGE_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js"
+        integrity="sha384-/TgkGk7p307TH7EXJDuUlgG3Ce1UVolAOFopFekQkkXihi5u/6OCvVKyz1W+idaz"
+        crossorigin="anonymous"></script>
+</head>
+<body>
+<button id="btn-default" type="button">Load default</button>
+<button id="btn-custom" type="button">Load custom</button>
+{default_markup}
+{custom_markup}
+{runtime}
+</body>
+</html>"""
+
+
+def _make_app() -> FastAPI:
+    from fastapi.responses import HTMLResponse
+
+    from pyjinhx import PjxSettings, setup
+    from pyjinhx.builtins import PJXLazyLoad
+    from pyjinhx.client import client_script
+
+    app = FastAPI()
+    setup(app, settings=PjxSettings())
+
+    @app.get("/healthz")
+    def healthz() -> str:
+        return "ok"
+
+    @app.get("/", response_class=HTMLResponse)
+    def index() -> str:
+        default_markup = PJXLazyLoad(
+            id="lazy-default",
+            url="/fragments/fail",
+            trigger="click from:#btn-default",
+            content='<p id="ph-default">Loading…</p>',
+        ).render()
+        custom_markup = PJXLazyLoad(
+            id="lazy-custom",
+            url="/fragments/fail",
+            trigger="click from:#btn-custom",
+            content='<p id="ph-custom">Loading…</p>',
+            error='<p class="custom-error">Custom boom</p>',
+        ).render()
+        return _PAGE_HTML.format(
+            default_markup=default_markup,
+            custom_markup=custom_markup,
+            runtime=client_script(),
+        )
+
+    @app.get("/fragments/fail", response_class=HTMLResponse)
+    def fail(request: Request) -> HTMLResponse:
+        return HTMLResponse("<p>boom</p>", status_code=500)
+
+    return app
+
+
+@pytest.fixture(scope="module")
+def error_server(tmp_path_factory):
+    import uvicorn
+
+    app = _make_app()
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, name="lazy-error-app", daemon=True)
+    thread.start()
+
+    url = f"http://127.0.0.1:{port}"
+    deadline = time.monotonic() + 15
+    while True:
+        try:
+            httpx.get(f"{url}/healthz", timeout=1)
+            break
+        except httpx.HTTPError:
+            if time.monotonic() > deadline:
+                raise RuntimeError("lazy error test app did not come up within 15s")
+            time.sleep(0.05)
+
+    yield url
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+@pytest.fixture
+def error_page(page: Page, error_server: str) -> Page:
+    page.goto(f"{error_server}/")
+    return page
+
+
+def test_placeholder_present_before_any_request(error_page: Page) -> None:
+    """Guard: placeholders are shown and not yet in an error state."""
+    expect(error_page.locator("#ph-default")).to_be_visible()
+    expect(error_page.locator("#lazy-default.pjx-lazy-load--error")).to_have_count(0)
+
+
+def test_terminal_failure_shows_default_error(error_page: Page) -> None:
+    error_page.click("#btn-default")
+
+    region = error_page.locator("#lazy-default")
+    expect(region).to_have_class("pjx-lazy-load pjx-lazy-load--error")
+    alert = region.locator(".pjx-lazy-load__error")
+    expect(alert).to_be_visible()
+    expect(alert).to_have_text("Failed to load.")
+    assert alert.get_attribute("role") == "alert"
+    # The placeholder is gone — never a forever-spinner.
+    expect(error_page.locator("#ph-default")).to_have_count(0)
+
+
+def test_terminal_failure_uses_custom_error_slot(error_page: Page) -> None:
+    error_page.click("#btn-custom")
+
+    region = error_page.locator("#lazy-custom")
+    expect(region).to_have_class("pjx-lazy-load pjx-lazy-load--error")
+    custom = region.locator(".custom-error")
+    expect(custom).to_be_visible()
+    expect(custom).to_have_text("Custom boom")
+    expect(error_page.locator("#ph-custom")).to_have_count(0)

--- a/tests/reactivity/test_lazy_error_path.py
+++ b/tests/reactivity/test_lazy_error_path.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import socket
 import threading
 import time
-from pathlib import Path
 
 import httpx
 import pytest
@@ -87,7 +86,7 @@ def _make_app() -> FastAPI:
 
 
 @pytest.fixture(scope="module")
-def error_server(tmp_path_factory):
+def error_server():
     import uvicorn
 
     app = _make_app()

--- a/tests/reactivity/test_lazy_head_assets.py
+++ b/tests/reactivity/test_lazy_head_assets.py
@@ -181,11 +181,21 @@ def _asset_count(page: Page) -> int:
     return page.evaluate("document.querySelectorAll('style[data-pjx-asset]').length")
 
 
+def _has_widget_css(page: Page) -> bool:
+    """Whether any promoted style carries the widget's own rule. The eagerly
+    rendered ``PJXLazyLoad`` ships its co-located CSS as a baseline asset, so a
+    total count is no longer a clean proxy for 'the widget's CSS is present'."""
+    return page.evaluate(
+        "Array.from(document.querySelectorAll('style[data-pjx-asset]'))"
+        ".some(function (s) { return s.textContent.indexOf('lazy-widget') !== -1; })"
+    )
+
+
 def test_cold_load_has_no_widget_css(lazy_page: Page) -> None:
     """Guard: the widget's CSS is absent until the lazy swap delivers it."""
     expect(lazy_page.locator("#lazy-placeholder")).to_be_visible()
     expect(lazy_page.locator("#lazy-widget")).to_have_count(0)
-    assert _asset_count(lazy_page) == 0
+    assert not _has_widget_css(lazy_page)
 
 
 def test_lazy_swap_promotes_css_and_styles_content(lazy_page: Page) -> None:

--- a/tests/unit/golden/lazy_load.html
+++ b/tests/unit/golden/lazy_load.html
@@ -1,5 +1,7 @@
 <div id="g"
      class="pjx-lazy-load"
+     data-pjx-lazy-load
      hx-get="/load"
      hx-trigger="revealed"
-     hx-swap="outerHTML"></div>
+     hx-swap="outerHTML"
+     data-pjx-error-text="Failed to load."></div>

--- a/tests/unit/golden/lazy_load_tr.html
+++ b/tests/unit/golden/lazy_load_tr.html
@@ -1,5 +1,7 @@
 <tr id="g"
      class="pjx-lazy-load"
+     data-pjx-lazy-load
      hx-get="/rows?cursor=20"
      hx-trigger="revealed"
-     hx-swap="outerHTML"><td colspan="3">Loading…</td></tr>
+     hx-swap="outerHTML"
+     data-pjx-error-text="Failed to load."><td colspan="3">Loading…</td></tr>

--- a/tests/unit/test_lazy_load.py
+++ b/tests/unit/test_lazy_load.py
@@ -1,9 +1,19 @@
+import re
+
 from pyjinhx.builtins import PJXLazyLoad, PJXSkeleton
+
+
+def _root(html: str) -> str:
+    """The lazy-load root opening tag — the component now ships co-located
+    CSS/JS, so ``.render()`` wraps the markup in ``<style>``/``<script>``."""
+    match = re.search(r"<(?:div|tr|li)[^>]*\bpjx-lazy-load\b[^>]*>", html)
+    assert match, html
+    return match.group(0)
 
 
 def test_lazy_load_default_render():
     html = str(PJXLazyLoad(id="lp-comments", url="/posts/42/comments").render())
-    assert html.lstrip().startswith("<div")
+    assert _root(html).startswith("<div")
     assert 'id="lp-comments"' in html
     assert "pjx-lazy-load" in html
     assert 'hx-get="/posts/42/comments"' in html
@@ -28,20 +38,50 @@ def test_lazy_load_children_render_as_placeholder():
 
 def test_lazy_load_tag_tr_renders_tr_root():
     html = str(PJXLazyLoad(id="s", url="/rows?cursor=20", tag="tr").render())
-    assert html.lstrip().startswith("<tr")
+    assert _root(html).startswith("<tr")
     assert 'hx-get="/rows?cursor=20"' in html
     assert 'hx-trigger="revealed"' in html
 
 
 def test_lazy_load_tag_li_renders_li_root():
-    assert str(PJXLazyLoad(id="s", url="/x", tag="li").render()).lstrip().startswith("<li")
+    assert _root(str(PJXLazyLoad(id="s", url="/x", tag="li").render())).startswith("<li")
 
 
 def test_lazy_load_default_tag_is_div():
-    assert str(PJXLazyLoad(id="s", url="/x").render()).lstrip().startswith("<div")
+    assert _root(str(PJXLazyLoad(id="s", url="/x").render())).startswith("<div")
 
 
 def test_lazy_load_extra_attrs_inject_on_dynamic_root():
     html = str(PJXLazyLoad(id="s", url="/x", tag="tr", extra_attrs={"data-k": "v"}).render())
-    assert html.lstrip().startswith("<tr")
-    assert 'data-k="v"' in html
+    assert _root(html).startswith("<tr")
+    assert 'data-k="v"' in _root(html)
+
+
+# --- terminal failure path (#191) ------------------------------------------
+
+
+def test_lazy_load_carries_error_marker_and_default_text():
+    """The driver scopes on the marker and reads its default message from the
+    element, so every lazy load can show an error instead of spinning forever."""
+    html = str(PJXLazyLoad(id="s", url="/x").render())
+    assert "data-pjx-lazy-load" in html
+    assert 'data-pjx-error-text="Failed to load."' in html
+
+
+def test_lazy_load_custom_error_text():
+    html = str(PJXLazyLoad(id="s", url="/x", error_text="Could not load comments").render())
+    assert 'data-pjx-error-text="Could not load comments"' in html
+
+
+def test_lazy_load_error_slot_renders_raw_in_template():
+    """A custom error slot rides in an inert <template> the driver reveals on
+    failure; it must render raw (Slot), not HTML-escaped."""
+    html = str(PJXLazyLoad(id="s", url="/x", error="<p>Boom</p>").render())
+    assert "<template data-pjx-lazy-error><p>Boom</p></template>" in html
+
+
+def test_lazy_load_without_error_slot_omits_template():
+    # The driver references the selector ``template[data-pjx-lazy-error]``, so
+    # assert the actual <template> element is absent, not the bare token.
+    html = str(PJXLazyLoad(id="s", url="/x").render())
+    assert "<template data-pjx-lazy-error" not in html


### PR DESCRIPTION
Closes #191.

## What

`PJXLazyLoad` had no terminal **failure** path. htmx never swaps on a non-2xx/timeout/network error, and the lazy trigger is usually consumed (`once`), so a failed lazy load stranded its placeholder (`PJXSkeleton`/`PJXSpinner`) reading "loading…" forever — the classic "spinner that spins forever".

This adds a co-located `pjx-lazy-load.js` driver that listens for the element's **own** terminal `htmx:afterRequest` (`!detail.successful`) and replaces the placeholder with an inline error affordance.

## Design

- **`error` prop** — a raw-HTML `Slot` for custom error markup. Rendered into an inert `<template data-pjx-lazy-error>` the driver reveals on failure. `<template>` is script-supporting content, so it's valid inside `div`/`li`/`tr` alike.
- **`error_text` prop** — the default message (localizable), default `"Failed to load."`. Rendered as `data-pjx-error-text` and shown via `textContent` in a `role="alert"` box when no custom slot is given.
- **`data-pjx-lazy-load` marker** — the driver scopes on it and reacts only to the lazy element's *own* request (`detail.elt === el`), never a failure bubbling up from content already swapped into it.
- **No retry**, per scope decision — a failed load shows a terminal error, it does not re-arm.

## Tests

- `tests/reactivity/test_lazy_error_path.py` — real-browser (Playwright): a 500 response replaces the placeholder with the default `role="alert"` message, and a custom `error` slot is used when provided; the placeholder is gone in both cases.
- `tests/unit/test_lazy_load.py` — render-level: marker + default/custom `error_text`, raw-HTML error slot in `<template>`, template omitted when no slot. Structural assertions now extract the root tag (the builtin ships co-located CSS/JS, mirroring `test_page_loader.py`).
- Goldens regenerated (additive: `data-pjx-lazy-load` + `data-pjx-error-text`).
- The #182 cold-load guard now checks for the widget's own CSS instead of a total asset count (PJXLazyLoad now ships a baseline stylesheet).

Full suite: **1147 passed, 5 skipped**.

## Notes

This is independent of #192 (already-implemented, commented + left open) — the driver ships with the eagerly-rendered placeholder, so it doesn't rely on lazy-swap JS delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)