### PR TITLE
feat: infer children slot from PjxSlot field (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.31.0 — Infer children slot from PjxSlot field (2026-06-27)
+
+### Added
+- Components now infer their nested-children target from their `PjxSlot()`
+  fields, so routing a PascalCase tag's children into a non-`content` slot no
+  longer needs the `_pjx_children_field` ClassVar override. A component with a
+  single `PjxSlot()` field receives tag children there automatically; multi-slot
+  components disambiguate locally with `PjxSlot(children=True)` (or the new
+  `Children` alias). Nesting children into a component whose target is ambiguous
+  (≥2 slots, none flagged, no `content`) now raises a clear `ValueError` naming
+  the candidate slots, instead of silently dropping them. Existing
+  `_pjx_children_field` overrides keep working, including across subclasses. New
+  public export: `Children` (#194).
+
 ## 0.30.0 — PJXLazyLoad terminal failure path (2026-06-27)
 
 ### Added

--- a/docs/components.md
+++ b/docs/components.md
@@ -1789,11 +1789,8 @@ Button + anchored panel backed by the shared popover engine. **Assets:** `pjx_dr
 <!-- demo: PJXDropdown -->
 
 ```html
-<PJXDropdown trigger="Actions" menu_label="Actions menu">
-  <button>Edit</button>
-  <button>Duplicate</button>
-  <button>Delete</button>
-</PJXDropdown>
+<!-- Menu entries are supplied via the `items` prop (a list); see the Python example below. -->
+<PJXDropdown trigger="Actions" menu_label="Actions menu" />
 ```
 
 ??? note "Props & API"

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -7,7 +7,7 @@ LoadCache`` — and are not part of this curated surface.
 """
 
 from pyjinhx.assets import AssetMode
-from pyjinhx.base import BaseComponent, Slot, component
+from pyjinhx.base import BaseComponent, Children, Slot, component
 from pyjinhx.config import PjxSettings, setup
 from pyjinhx.context import PjxContext
 from pyjinhx.keys import MutationKey
@@ -20,6 +20,7 @@ __all__ = [
     # Components & rendering
     "BaseComponent",
     "Slot",
+    "Children",
     "component",
     "ReactiveComponent",
     "Renderer",

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -60,7 +60,13 @@ ExtraAttrs = Annotated[dict[str, str], AfterValidator(validate_extra_attrs)]
 
 class PjxSlot:
     """Marker (in a field's Annotated metadata) for a raw-HTML slot field —
-    its string value is emitted unescaped. Use via the ``Slot`` alias."""
+    its string value is emitted unescaped. Use via the ``Slot`` alias.
+
+    ``children=True`` additionally flags the field as the target for a
+    PascalCase tag's nested children (use via the ``Children`` alias)."""
+
+    def __init__(self, children: bool = False) -> None:
+        self.children = children
 
 
 # Slot is defined after BaseComponent (forward-ref resolved at class definition time)
@@ -452,6 +458,7 @@ class BaseComponent(BaseModel):
 
 
 Slot = Annotated[str | BaseComponent, PjxSlot()]
+Children = Annotated[str | BaseComponent, PjxSlot(children=True)]
 
 
 def component(name: str) -> type[BaseComponent]:

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -79,6 +79,48 @@ def _is_slot_field(cls: type, field_name: str) -> bool:
     return bool(field) and any(isinstance(m, PjxSlot) for m in field.metadata)
 
 
+def _resolve_children_field(cls: type["BaseComponent"]) -> str | None:
+    """Resolve a component's effective children target (see the children-slot
+    spec for the precedence). Returns a field name, or ``None`` when the target
+    is ambiguous (>=2 slot fields, none flagged, no ``content`` field)."""
+    fields = cls.model_fields
+    flagged = [
+        name
+        for name, field in fields.items()
+        if any(isinstance(m, PjxSlot) and m.children for m in field.metadata)
+    ]
+    if len(flagged) > 1:
+        raise ValueError(
+            f"{cls.__name__}: multiple fields flagged PjxSlot(children=True) "
+            f"({', '.join(flagged)}); only one may receive tag children"
+        )
+
+    override = cls._pjx_children_field  # inherited via the MRO
+    if override != "content":
+        if flagged and flagged[0] != override:
+            raise ValueError(
+                f"{cls.__name__}: _pjx_children_field={override!r} conflicts with "
+                f"PjxSlot(children=True) on {flagged[0]!r}; declare only one"
+            )
+        return override
+
+    if flagged:
+        return flagged[0]
+    if "content" in fields:
+        return "content"
+
+    slots = [
+        name
+        for name, field in fields.items()
+        if any(isinstance(m, PjxSlot) for m in field.metadata)
+    ]
+    if len(slots) == 1:
+        return slots[0]
+    if len(slots) >= 2:
+        return None
+    return "content"
+
+
 def _wrap_slot_value(value: Any) -> Any:
     """Wrap a slot field's string value(s) as ``markupsafe.Markup`` so they
     pass through Jinja unescaped. Recurses into list/dict slot collections
@@ -192,6 +234,10 @@ class BaseComponent(BaseModel):
     # Components without a `content` field can point this at their text slot.
     _pjx_children_field: ClassVar[str] = "content"
 
+    # Resolved effective children target (see _resolve_children_field). `None`
+    # marks an ambiguous target that errors only when children are nested.
+    _pjx_children_target: ClassVar[str | None] = "content"
+
     # Tag name for html-only components synthesized via `component(name)`. When
     # set, the template is resolved by scanning the default env at render time.
     _pjx_template: ClassVar[str | None] = None
@@ -239,6 +285,11 @@ class BaseComponent(BaseModel):
             )
         Registry.register_class(cls, replace=pjx_replace)
         wrap_context_methods(cls)
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+        cls._pjx_children_target = _resolve_children_field(cls)
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -276,6 +276,22 @@ _BUILTIN_TAG_NAMES = frozenset(
 )
 
 
+def _ambiguous_children_error(tag_name: str, component_class: type) -> ValueError:
+    from .base import PjxSlot
+
+    slots = [
+        name
+        for name, field in component_class.model_fields.items()
+        if any(isinstance(m, PjxSlot) for m in field.metadata)
+    ]
+    return ValueError(
+        f"<{tag_name}> has multiple slot fields ({', '.join(slots)}) and no "
+        f"'content' field, so the target for nested children is ambiguous. "
+        f"Mark the intended field with PjxSlot(children=True) (or the Children "
+        f"alias)."
+    )
+
+
 def _missing_template_error(tag_name: str) -> FileNotFoundError:
     if tag_name in _BUILTIN_TAG_NAMES:
         return FileNotFoundError(
@@ -341,7 +357,10 @@ def render_tag_node(
 
         updates: dict[str, Any] = dict(attrs_without_id)
         if rendered_children:
-            updates[type(existing_instance)._pjx_children_field] = rendered_children
+            target = type(existing_instance)._pjx_children_target
+            if target is None:
+                raise _ambiguous_children_error(node.name, type(existing_instance))
+            updates[target] = rendered_children
         if updates:
             updated_instance = existing_instance.model_copy()
             validator = type(existing_instance).__pydantic_validator__
@@ -375,14 +394,17 @@ def render_tag_node(
     component_class = Registry.get_class(node.name)
     if component_class is not None:
         init_kwargs: dict[str, Any] = dict(attrs_without_id)
-        children_field = component_class._pjx_children_field
-        if rendered_children and children_field in init_kwargs:
-            raise ValueError(
-                f"<{node.name}> received both children and the "
-                f"'{children_field}' attribute; supply one"
-            )
-        if rendered_children or children_field not in init_kwargs:
-            init_kwargs[children_field] = rendered_children
+        children_field = component_class._pjx_children_target
+        if rendered_children and children_field is None:
+            raise _ambiguous_children_error(node.name, component_class)
+        if children_field is not None:
+            if rendered_children and children_field in init_kwargs:
+                raise ValueError(
+                    f"<{node.name}> received both children and the "
+                    f"'{children_field}' attribute; supply one"
+                )
+            if rendered_children or children_field not in init_kwargs:
+                init_kwargs[children_field] = rendered_children
         component = component_class(id=component_id, **init_kwargs)
     else:
         if template_path is None:

--- a/tests/unit/test_children_resolution.py
+++ b/tests/unit/test_children_resolution.py
@@ -1,0 +1,84 @@
+"""Per-class resolution of the children target (_pjx_children_target)."""
+
+from typing import Annotated, ClassVar
+
+import pytest
+
+from pyjinhx import BaseComponent, Children, Slot
+from pyjinhx.base import PjxSlot, _is_slot_field
+
+
+def test_sole_slot_field_is_inferred_as_target():
+    class SearchFieldRes(BaseComponent):
+        filters: Annotated[str | BaseComponent | None, PjxSlot()] = None
+
+    assert SearchFieldRes._pjx_children_target == "filters"
+    assert _is_slot_field(SearchFieldRes, "filters") is True
+
+
+def test_content_field_beats_sole_other_slot():
+    class CardRes(BaseComponent):
+        content: str = ""
+        footer: Slot = ""
+
+    assert CardRes._pjx_children_target == "content"
+
+
+def test_flag_beats_content_field():
+    class PanelRes(BaseComponent):
+        content: str = ""
+        body: Children = ""
+
+    assert PanelRes._pjx_children_target == "body"
+
+
+def test_multiple_unflagged_slots_no_content_is_ambiguous():
+    class MenuRes(BaseComponent):
+        trigger: Slot = ""
+        items: Annotated[str | BaseComponent, PjxSlot()] = ""
+
+    assert MenuRes._pjx_children_target is None
+
+
+def test_no_slots_defaults_to_content():
+    class PlainRes(BaseComponent):
+        label: str = ""
+
+    assert PlainRes._pjx_children_target == "content"
+
+
+def test_two_children_flags_raise_at_definition():
+    with pytest.raises(ValueError, match="multiple fields flagged"):
+
+        class BadRes(BaseComponent):
+            a: Children = ""
+            b: Children = ""
+
+
+def test_override_conflicting_with_flag_raises_at_definition():
+    with pytest.raises(ValueError, match="conflicts with"):
+
+        class Bad2Res(BaseComponent):
+            _pjx_children_field: ClassVar[str] = "x"
+            x: str = ""
+            y: Children = ""
+
+
+def test_explicit_override_wins():
+    class BoxedRes(BaseComponent):
+        _pjx_children_field: ClassVar[str] = "kids"
+        kids: str = ""
+
+    assert BoxedRes._pjx_children_target == "kids"
+    assert _is_slot_field(BoxedRes, "kids") is True
+
+
+def test_subclass_inherits_override_via_mro():
+    class Boxed2Res(BaseComponent):
+        _pjx_children_field: ClassVar[str] = "kids"
+        kids: str = ""
+
+    class SubBoxedRes(Boxed2Res):
+        extra: str = ""
+
+    assert SubBoxedRes._pjx_children_target == "kids"

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -2,6 +2,7 @@ import pyjinhx
 from pyjinhx import (
     AssetMode,
     BaseComponent,
+    Children,  # noqa: F401
     MutationKey,
     PjxContext,
     PjxKey,
@@ -19,6 +20,7 @@ from pyjinhx import (
 PUBLIC_API = {
     "BaseComponent",
     "Slot",
+    "Children",
     "component",
     "ReactiveComponent",
     "Renderer",

--- a/tests/unit/test_slot_type.py
+++ b/tests/unit/test_slot_type.py
@@ -61,3 +61,18 @@ def test_undeclared_children_field_becomes_markup_in_context(tmp_path):
     assert "content" not in type(inst).model_fields  # sanity: it's an extra
     built = inst._build_template_context()
     assert isinstance(built["content"], Markup)
+
+
+def test_pjxslot_children_flag_defaults_false_and_opts_in():
+    assert PjxSlot().children is False
+    assert PjxSlot(children=True).children is True
+
+
+def test_children_alias_carries_flagged_marker():
+    from typing import get_args
+    from pyjinhx import Children
+
+    # Children == Annotated[str | BaseComponent, PjxSlot(children=True)]
+    markers = [m for m in get_args(Children) if isinstance(m, PjxSlot)]
+    assert len(markers) == 1
+    assert markers[0].children is True

--- a/tests/unit/test_tag_children_field.py
+++ b/tests/unit/test_tag_children_field.py
@@ -2,8 +2,10 @@
 
 import pytest
 from jinja2 import Environment, FileSystemLoader
+from typing import Annotated
 
-from pyjinhx import BaseComponent, Renderer
+from pyjinhx import BaseComponent, Children, Renderer, Slot
+from pyjinhx.base import PjxSlot
 from pyjinhx.builtins import PJXModal, PJXTooltip, PJXTooltipContent, PJXTooltipTrigger  # noqa: F401  (importing registers the tags)
 
 
@@ -93,3 +95,89 @@ def test_modal_both_children_and_content_attr_raises(tmp_path):
 
     with pytest.raises(ValueError, match="both children and the 'content' attribute"):
         renderer.render('<PJXModal id="m2" content="x">y</PJXModal>')
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Route children via _pjx_children_target
+# ---------------------------------------------------------------------------
+
+
+def test_sole_slot_children_land_in_inferred_field(tmp_path):
+    class SearchFieldTag(BaseComponent):
+        filters: Annotated[str | BaseComponent | None, PjxSlot()] = None
+
+    (tmp_path / "search_field_tag.html").write_text(
+        '<div id="{{ id }}"><span class="filters">{{ filters }}</span></div>'
+    )
+    renderer = Renderer(Environment(loader=FileSystemLoader(str(tmp_path))))
+
+    rendered = renderer.render('<SearchFieldTag id="sf"><i>x</i></SearchFieldTag>')
+
+    assert '<span class="filters"><i>x</i></span>' in rendered
+
+
+def test_children_alias_field_receives_children(tmp_path):
+    class PanelTag(BaseComponent):
+        head: Slot = ""
+        body: Children = ""
+
+    (tmp_path / "panel_tag.html").write_text(
+        '<div>{{ head }}|<section>{{ body }}</section></div>'
+    )
+    renderer = Renderer(Environment(loader=FileSystemLoader(str(tmp_path))))
+
+    rendered = renderer.render('<PanelTag id="p"><b>kid</b></PanelTag>')
+
+    assert '<section><b>kid</b></section>' in rendered
+
+
+def test_ambiguous_component_with_children_raises_clear_error(tmp_path):
+    class MenuTag(BaseComponent):
+        trigger: Slot = ""
+        items: Annotated[str | BaseComponent, PjxSlot()] = ""
+
+    (tmp_path / "menu_tag.html").write_text('<div>{{ trigger }}{{ items }}</div>')
+    renderer = Renderer(Environment(loader=FileSystemLoader(str(tmp_path))))
+
+    with pytest.raises(ValueError) as exc:
+        renderer.render('<MenuTag id="m"><b>kid</b></MenuTag>')
+    msg = str(exc.value)
+    assert "MenuTag" in msg
+    assert "trigger" in msg and "items" in msg
+    assert "children=True" in msg
+
+
+def test_ambiguous_existing_instance_with_children_raises_clear_error(tmp_path):
+    """The existing-instance re-render branch (tags.py:334) must also raise for
+    an ambiguous (None-target) component when children are nested."""
+
+    class Menu3Tag(BaseComponent):
+        trigger: Slot = ""
+        items: Annotated[str | BaseComponent, PjxSlot()] = ""
+
+    (tmp_path / "menu3_tag.html").write_text('<div>{{ trigger }}{{ items }}</div>')
+    Renderer.set_default_environment(str(tmp_path))
+    renderer = Renderer.get_default_renderer()
+
+    Menu3Tag(id="reg1")  # pre-register an instance so the existing-instance path fires
+    with pytest.raises(ValueError) as exc:
+        renderer.render('<Menu3Tag id="reg1"><b>kid</b></Menu3Tag>')
+    assert "Menu3Tag" in str(exc.value)
+
+
+def test_ambiguous_component_props_only_does_not_crash(tmp_path):
+    """Regression: props-only construction of an ambiguous (None-target)
+    component must not run init_kwargs[None] = "" (TypeError: keywords must be
+    strings). This guard stays green before AND after the reader switch — its
+    value is catching a regression once tags.py reads the None-valued target."""
+
+    class Menu2Tag(BaseComponent):
+        trigger: Slot = ""
+        items: Annotated[str | BaseComponent, PjxSlot()] = ""
+
+    (tmp_path / "menu2_tag.html").write_text('<div>{{ trigger }}{{ items }}</div>')
+    renderer = Renderer(Environment(loader=FileSystemLoader(str(tmp_path))))
+
+    rendered = renderer.render('<Menu2Tag id="m2" trigger="go"/>')
+
+    assert "go" in rendered

--- a/tests/unit/test_tag_children_field.py
+++ b/tests/unit/test_tag_children_field.py
@@ -181,3 +181,19 @@ def test_ambiguous_component_props_only_does_not_crash(tmp_path):
     rendered = renderer.render('<Menu2Tag id="m2" trigger="go"/>')
 
     assert "go" in rendered
+
+
+def test_subclass_of_override_component_routes_children_to_inherited_field(tmp_path):
+    class BoxedTag(BaseComponent):
+        _pjx_children_field = "kids"
+        kids: str = ""
+
+    class SubBoxedTag(BoxedTag):
+        extra: str = ""
+
+    (tmp_path / "sub_boxed_tag.html").write_text('<div id="{{ id }}">{{ kids }}</div>')
+    renderer = Renderer(Environment(loader=FileSystemLoader(str(tmp_path))))
+
+    rendered = renderer.render('<SubBoxedTag id="sb">inherited</SubBoxedTag>')
+
+    assert '<div id="sb">inherited</div>' in rendered


### PR DESCRIPTION
## Summary

Closes #194. Infers a component's nested-children target from its `PjxSlot()` fields, so authors no longer need the `_pjx_children_field` ClassVar override in the common case.

Before, routing tag children into a non-`content` slot required a leaky private override:

```python
class SearchField(BaseComponent):
    _pjx_children_field = "filters"            # redundant — the slot is already declared below
    filters: Annotated[str | BaseComponent | None, PjxSlot()] = None
```

Now the sole `PjxSlot()` field is inferred automatically:

```python
class SearchField(BaseComponent):
    filters: Annotated[str | BaseComponent | None, PjxSlot()] = None   # children land here
```

For multi-slot components, `PjxSlot(children=True)` (or the new `Children` alias) disambiguates locally.

## Approach (alternative C — hybrid)

A new resolved ClassVar `_pjx_children_target: ClassVar[str | None]` is computed once per subclass in `__pydantic_init_subclass__`. The author channel `_pjx_children_field` is untouched (still read via MRO so subclasses inherit overrides). Resolution precedence:

1. Explicit `_pjx_children_field` override (≠ `"content"`, inherited via MRO)
2. The sole `PjxSlot(children=True)`-flagged field (≥2 flagged → eager `ValueError`; override conflicting with a flag → eager `ValueError`)
3. A `content` field → `"content"`
4. The sole `PjxSlot()` field
5. ≥2 slots, none flagged, no `content` → `None` (ambiguous)
6. Default `"content"`

Only `tags.py` routing reads `_pjx_children_target`; nesting children into an ambiguous component raises a clear `ValueError` naming the component, its slot fields, and `children=True`. Props-only construction of an ambiguous component (e.g. `PJXDropdown`) stays crash-free.

## Backward compatibility

- `PJXAlert` (`_pjx_children_field="body"`) and any subclass keep working.
- `PJXDropdown` (two slots) is now ambiguous — it fills slots via props and never nests raw children, so no behavior change in practice; nesting children now errors clearly instead of silently dropping.
- New public export: `Children` alias.

## Testing

- `tests/unit/test_children_resolution.py` (new): 9 per-class resolution tests covering every precedence branch + both eager `ValueError`s.
- `tests/unit/test_tag_children_field.py`: 6 new render tests (inferred-slot landing, `Children` alias, ambiguity error on both fresh-construction and existing-instance branches, props-only no-crash regression guard, subclass-inherits-override).
- `tests/unit/test_slot_type.py`, `test_public_api.py`: additive (`PjxSlot.children` flag, `Children` export).
- Full suite: **1164 passed, 5 skipped**. basedpyright standard mode: **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
