### PR TITLE
feat: run load() for tag-mounted reactive components (#196)

### DIFF
--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -122,6 +122,21 @@ from pyjinhx.client import client_script
 </body>
 ```
 
+## Mounting a reactive component by tag
+
+A reactive component placed as a bare PascalCase tag runs `load()` automatically
+on cold render, so state that can't ride scalar tag attributes (e.g. a nested
+child built in `load()`) is populated:
+
+```html
+<SidebarShell/>            <!-- type-singleton: runs load() -->
+<UserCard user_id="42"/>   <!-- keyed: runs load("42"), id "user-card-42" -->
+```
+
+Remaining scalar attrs override the loaded values (`<UserCard user_id="42"
+highlight="on"/>`). The pre-load-into-the-registry pattern still works and takes
+precedence, but is no longer required for the common case.
+
 The runtime attaches these headers to htmx requests:
 
 | Header | Purpose |

--- a/pyjinhx/assets.py
+++ b/pyjinhx/assets.py
@@ -74,6 +74,9 @@ class RenderSession:
             currently on the render stack, used to break cross-reference
             cycles (a same-type-and-id reference renders empty and logs a
             warning).
+        reactive_mount_ids: data-pjx-ids assigned to reactive components
+            auto-mounted by tag in this render pass, used to detect id
+            collisions between mounts.
     """
 
     assets: list[CollectedAsset] = field(default_factory=list)
@@ -82,6 +85,7 @@ class RenderSession:
     styles: list[str] = field(default_factory=list)
     runtime_injected: bool = False
     rendering: set[tuple[str, str]] = field(default_factory=set)
+    reactive_mount_ids: set[str] = field(default_factory=set)
 
     def manifest(self, *, resolver: AssetUrlResolver) -> AssetManifest:
         stylesheets: list[str] = []

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -319,7 +319,18 @@ def _mount_reactive_instance(
     The keyed id (``f"{kebab}-{key}"``) is produced by ``LoadCache`` inside
     ``load()``; an explicit ``id`` attr overrides it.
     """
-    instance = component_class.load()
+    keyed = getattr(component_class, "_pjx_keyed", False)
+    load_field = getattr(component_class, "_pjx_load_field", None)
+
+    if keyed:
+        if load_field is None or load_field not in attrs_without_id:
+            raise ValueError(
+                f"<{tag_name}> is instance-keyed; mounting it as a tag requires "
+                f"the key attr '{load_field}=...'."
+            )
+        instance = component_class.load(attrs_without_id[load_field])
+    else:
+        instance = component_class.load()
 
     if explicit_id:
         instance.id = explicit_id

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -335,6 +335,13 @@ def _mount_reactive_instance(
     if explicit_id:
         instance.id = explicit_id
 
+    if instance.id in session.reactive_mount_ids:
+        raise ValueError(
+            f"<{tag_name}> mount resolved to data-pjx-id '{instance.id}', which is "
+            f"already used in this render; give one an explicit id."
+        )
+    session.reactive_mount_ids.add(instance.id)
+
     overrides = {
         field_name: value
         for field_name, value in attrs_without_id.items()

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -470,6 +470,7 @@ def render_tag_node(
             )
 
     if is_reactive:
+        assert component_class is not None  # is_reactive implies a registered ReactiveComponent
         component = _mount_reactive_instance(
             component_class,
             attrs_without_id,
@@ -479,6 +480,7 @@ def render_tag_node(
             tag_name=node.name,
         )
     elif component_class is not None:
+        assert component_id is not None  # non-reactive path always has a concrete id (explicit or auto)
         init_kwargs: dict[str, Any] = dict(attrs_without_id)
         children_field = component_class._pjx_children_target
         if rendered_children and children_field is None:
@@ -493,6 +495,7 @@ def render_tag_node(
                 init_kwargs[children_field] = rendered_children
         component = component_class(id=component_id, **init_kwargs)
     else:
+        assert component_id is not None  # non-reactive path always has a concrete id (explicit or auto)
         if template_path is None:
             raise _missing_template_error(node.name)
         from .base import BaseComponent

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -335,6 +335,22 @@ def _mount_reactive_instance(
     if explicit_id:
         instance.id = explicit_id
 
+    overrides = {
+        field_name: value
+        for field_name, value in attrs_without_id.items()
+        if field_name != load_field
+    }
+    children_field = component_class._pjx_children_target
+    if rendered_children:
+        if children_field is None:
+            raise _ambiguous_children_error(tag_name, component_class)
+        overrides[children_field] = rendered_children
+    if overrides:
+        instance = instance.model_copy()
+        validator = component_class.__pydantic_validator__
+        for field_name, value in overrides.items():
+            validator.validate_assignment(instance, field_name, value)
+
     Registry.get_instances()[
         Registry.make_key(tag_name, instance.id)
     ] = instance

--- a/pyjinhx/tags.py
+++ b/pyjinhx/tags.py
@@ -305,6 +305,31 @@ def _missing_template_error(tag_name: str) -> FileNotFoundError:
     )
 
 
+def _mount_reactive_instance(
+    component_class: type,
+    attrs_without_id: dict[str, Any],
+    *,
+    explicit_id: str | None,
+    rendered_children: str,
+    session: RenderSession,
+    tag_name: str,
+) -> Any:
+    """Build a reactive instance for a tag mount by running ``load()``.
+
+    The keyed id (``f"{kebab}-{key}"``) is produced by ``LoadCache`` inside
+    ``load()``; an explicit ``id`` attr overrides it.
+    """
+    instance = component_class.load()
+
+    if explicit_id:
+        instance.id = explicit_id
+
+    Registry.get_instances()[
+        Registry.make_key(tag_name, instance.id)
+    ] = instance
+    return instance
+
+
 def render_tag_node(
     renderer: Renderer,
     node: Tag | str,
@@ -327,72 +352,99 @@ def render_tag_node(
         for child in node.children
     ).strip()
 
-    component_id = node.attrs.get("id")
-    if not component_id:
-        if not renderer._auto_id:
-            raise ValueError(
-                f'Missing required "id" for <{node.name}> and auto_id=False'
-            )
-        from .base import _auto_id
-
-        component_id = _auto_id()
-
+    explicit_id = node.attrs.get("id")
     attrs_without_id = {k: v for k, v in node.attrs.items() if k != "id"}
 
-    registry_key = Registry.make_key(node.name, component_id)
-    existing_instance = Registry.get_instances().get(registry_key)
     template_path: str | None = None
     try:
         template_path = renderer._find_template_for_tag(node.name)
     except FileNotFoundError:
         pass
 
-    if existing_instance is not None:
-        instance_class_name = type(existing_instance).__name__
-        if instance_class_name != node.name:
-            raise TypeError(
-                f"Tag <{node.name}> references instance '{component_id}' "
-                f"which is of type {instance_class_name}"
-            )
-
-        updates: dict[str, Any] = dict(attrs_without_id)
-        if rendered_children:
-            target = type(existing_instance)._pjx_children_target
-            if target is None:
-                raise _ambiguous_children_error(node.name, type(existing_instance))
-            updates[target] = rendered_children
-        if updates:
-            updated_instance = existing_instance.model_copy()
-            validator = type(existing_instance).__pydantic_validator__
-            for field_name, field_value in updates.items():
-                validator.validate_assignment(updated_instance, field_name, field_value)
-            existing_instance = updated_instance
-            Registry.get_instances()[registry_key] = existing_instance
-
-        return str(
-            existing_instance._render(
-                base_context=base_context,
-                _renderer=renderer,
-                _session=session,
-                _template_path=template_path,
-                emit_assets=emit_assets,
-            )
-        )
-
+    # Resolve the class up front so we can tell a reactive tag from a plain one
+    # before assigning its id. Autodiscovery and {#def#} model-building are
+    # idempotent and deduplicated, so running them here is safe.
     if not Registry.has_class(node.name):
         ComponentAutodiscover.try_for_tag(node.name, template_path)
-
     if not Registry.has_class(node.name) and template_path is not None:
         from .props_header import build_component_model
 
         with open(template_path, encoding="utf-8") as template_file:
             build_component_model(node.name, template_file.read())
-        # build_component_model auto-registers the generated class via
-        # BaseComponent.__init_subclass__; if there's no header it returns None
-        # and we fall through to the bare-BaseComponent path below.
 
     component_class = Registry.get_class(node.name)
-    if component_class is not None:
+
+    from .reactive import ReactiveComponent
+
+    is_reactive = component_class is not None and issubclass(
+        component_class, ReactiveComponent
+    )
+
+    # A reactive tag derives its id from load() (or an explicit id attr), never a
+    # random auto_id. Non-reactive tags keep the existing id rules.
+    if explicit_id:
+        component_id: str | None = explicit_id
+    elif is_reactive:
+        component_id = None
+    elif renderer._auto_id:
+        from .base import _auto_id
+
+        component_id = _auto_id()
+    else:
+        raise ValueError(
+            f'Missing required "id" for <{node.name}> and auto_id=False'
+        )
+
+    # Reuse an already-registered instance when we have a concrete id to look up.
+    # Bare reactive tags skip this and go straight to load(), whose LoadCache
+    # already dedupes per request.
+    if component_id is not None:
+        registry_key = Registry.make_key(node.name, component_id)
+        existing_instance = Registry.get_instances().get(registry_key)
+        if existing_instance is not None:
+            instance_class_name = type(existing_instance).__name__
+            if instance_class_name != node.name:
+                raise TypeError(
+                    f"Tag <{node.name}> references instance '{component_id}' "
+                    f"which is of type {instance_class_name}"
+                )
+
+            updates: dict[str, Any] = dict(attrs_without_id)
+            if rendered_children:
+                target = type(existing_instance)._pjx_children_target
+                if target is None:
+                    raise _ambiguous_children_error(node.name, type(existing_instance))
+                updates[target] = rendered_children
+            if updates:
+                updated_instance = existing_instance.model_copy()
+                validator = type(existing_instance).__pydantic_validator__
+                for field_name, field_value in updates.items():
+                    validator.validate_assignment(
+                        updated_instance, field_name, field_value
+                    )
+                existing_instance = updated_instance
+                Registry.get_instances()[registry_key] = existing_instance
+
+            return str(
+                existing_instance._render(
+                    base_context=base_context,
+                    _renderer=renderer,
+                    _session=session,
+                    _template_path=template_path,
+                    emit_assets=emit_assets,
+                )
+            )
+
+    if is_reactive:
+        component = _mount_reactive_instance(
+            component_class,
+            attrs_without_id,
+            explicit_id=explicit_id,
+            rendered_children=rendered_children,
+            session=session,
+            tag_name=node.name,
+        )
+    elif component_class is not None:
         init_kwargs: dict[str, Any] = dict(attrs_without_id)
         children_field = component_class._pjx_children_target
         if rendered_children and children_field is None:

--- a/tests/unit/test_tag_mount_reactive_load.py
+++ b/tests/unit/test_tag_mount_reactive_load.py
@@ -89,3 +89,46 @@ def test_keyed_reactive_tag_missing_key_attr_raises():
         with Registry.request_scope():
             with pytest.raises(ValueError, match="instance-keyed"):
                 _renderer(temp_dir).render("<WidgetCard/>")
+
+
+def test_scalar_attr_overrides_load_result():
+    """A non-key scalar attr overrides the loaded value via validated assignment."""
+
+    class PanelShell(ReactiveComponent, react={Keys.SHELL}):
+        highlight: str = "off"
+
+        @classmethod
+        def load(cls) -> "PanelShell":
+            return cls(highlight="off")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "panel_shell.html"), "w") as f:
+            f.write("<div id='{{ id }}'>{{ highlight }}</div>")
+        with Registry.request_scope():
+            rendered = str(
+                _renderer(temp_dir).render('<PanelShell highlight="on"/>')
+            )
+
+    assert ">on<" in rendered  # tag attr won over load()'s "off"
+
+
+def test_children_override_loaded_target_field():
+    """Tag children override the _pjx_children_target field after load()."""
+
+    class CardShell(ReactiveComponent, react={Keys.SHELL}):
+        content: str = ""
+
+        @classmethod
+        def load(cls) -> "CardShell":
+            return cls(content="loaded")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "card_shell.html"), "w") as f:
+            f.write("<section id='{{ id }}'>{{ content }}</section>")
+        with Registry.request_scope():
+            rendered = str(
+                _renderer(temp_dir).render("<CardShell>from-children</CardShell>")
+            )
+
+    assert "from-children" in rendered
+    assert "loaded" not in rendered

--- a/tests/unit/test_tag_mount_reactive_load.py
+++ b/tests/unit/test_tag_mount_reactive_load.py
@@ -1,0 +1,49 @@
+import os
+import tempfile
+
+from typing import Annotated
+
+from jinja2 import Environment, FileSystemLoader
+
+from pyjinhx import BaseComponent, MutationKey, ReactiveComponent
+from pyjinhx.registry import Registry
+from pyjinhx.renderer import Renderer
+
+
+class Keys(MutationKey):
+    SHELL = "shell"
+
+
+def _renderer(temp_dir: str) -> Renderer:
+    env = Environment(loader=FileSystemLoader(temp_dir))
+    return Renderer(env, auto_id=True)
+
+
+def test_singleton_reactive_tag_runs_load():
+    """A bare reactive tag runs load(), populating a non-scalar field."""
+
+    class Inner(BaseComponent):
+        # Point load_template_for_component at the loader root so it can find
+        # inner.html in the temp dir (the class lives in tests/unit/, which
+        # Jinja2's FileSystemLoader cannot traverse to via ".." path segments).
+        _pjx_template = "inner"
+        text: str = ""
+
+    class SidebarShell(ReactiveComponent, react={Keys.SHELL}):
+        org_host: BaseComponent | None = None  # non-scalar; cannot ride a tag attr
+
+        @classmethod
+        def load(cls) -> "SidebarShell":
+            return cls(org_host=Inner(id="org", text="acme"))
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "sidebar_shell.html"), "w") as f:
+            f.write("<aside id='{{ id }}'>{{ org_host }}</aside>")
+        with open(os.path.join(temp_dir, "inner.html"), "w") as f:
+            f.write("<div id='{{ id }}'>{{ text }}</div>")
+
+        with Registry.request_scope():
+            rendered = str(_renderer(temp_dir).render("<SidebarShell/>"))
+
+    assert "acme" in rendered  # load() ran; org_host rendered
+    assert 'data-pjx-id="sidebar-shell"' in rendered

--- a/tests/unit/test_tag_mount_reactive_load.py
+++ b/tests/unit/test_tag_mount_reactive_load.py
@@ -176,3 +176,116 @@ def test_distinct_keyed_mounts_coexist():
 
     assert 'data-pjx-id="cell-card-1"' in rendered
     assert 'data-pjx-id="cell-card-2"' in rendered
+
+
+def test_preloaded_instance_is_reused_without_reloading():
+    """REUSE precedence: a route pre-load means the tag does NOT re-run load()."""
+    calls = {"n": 0}
+
+    class PreShell(ReactiveComponent, react={Keys.SHELL}):
+        label: str = ""
+
+        @classmethod
+        def load(cls) -> "PreShell":
+            calls["n"] += 1
+            return cls(label=f"load-{calls['n']}")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "pre_shell.html"), "w") as f:
+            f.write("<div id='{{ id }}'>{{ label }}</div>")
+        with Registry.request_scope():
+            PreShell.load()  # pre-load: seeds the registry under "pre-shell"
+            assert calls["n"] == 1
+            rendered = str(
+                _renderer(temp_dir).render('<PreShell id="pre-shell"/>')
+            )
+
+    assert "load-1" in rendered
+    assert calls["n"] == 1  # tag reused the pre-loaded instance, no second load
+
+
+def test_same_singleton_tag_loads_once_via_cache():
+    """LoadCache: the same singleton mounted twice triggers one real load()."""
+    calls = {"n": 0}
+
+    class CacheShell(ReactiveComponent, react={Keys.SHELL}):
+        label: str = ""
+
+        @classmethod
+        def load(cls) -> "CacheShell":
+            calls["n"] += 1
+            return cls(label="x")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "cache_shell.html"), "w") as f:
+            f.write("<div id='{{ id }}'>{{ label }}</div>")
+        with open(os.path.join(temp_dir, "wrap.html"), "w") as f:
+            # Two mounts: first bare (auto id), second explicit id to avoid collision.
+            f.write('<div id="{{ id }}"><CacheShell/><CacheShell id="cache-2"/></div>')
+        with Registry.request_scope():
+            str(_renderer(temp_dir).render('<Wrap id="wrap"/>'))
+
+    assert calls["n"] == 1  # LoadCache deduped the second load
+
+
+def test_nested_reactive_child_auto_loads():
+    """A reactive tag nested inside another component auto-loads too."""
+
+    class NestChild(ReactiveComponent, react={Keys.SHELL}):
+        msg: str = ""
+
+        @classmethod
+        def load(cls) -> "NestChild":
+            return cls(msg="nested-loaded")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "nest_child.html"), "w") as f:
+            f.write("<span id='{{ id }}'>{{ msg }}</span>")
+        with open(os.path.join(temp_dir, "host.html"), "w") as f:
+            f.write("<div id='{{ id }}'><NestChild/></div>")
+        with Registry.request_scope():
+            rendered = str(_renderer(temp_dir).render('<Host id="host"/>'))
+
+    assert "nested-loaded" in rendered
+
+
+def test_non_reactive_tag_path_unchanged():
+    """A plain BaseComponent tag still constructs from attrs (no load())."""
+
+    class NonReactivePlain(BaseComponent):
+        text: str = ""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "non_reactive_plain.html"), "w") as f:
+            f.write("<div id='{{ id }}'>{{ text }}</div>")
+        with Registry.request_scope():
+            rendered = str(
+                _renderer(temp_dir).render('<NonReactivePlain id="p" text="hi"/>')
+            )
+
+    assert ">hi<" in rendered
+
+
+def test_keyed_tag_key_excluded_non_key_attr_overridden():
+    """Keyed path: key field is excluded from overrides; a non-key attr IS applied."""
+    from pyjinhx import PjxKey
+
+    class WidgetX(ReactiveComponent, react={Keys.SHELL}):
+        widget_id: Annotated[str, PjxKey()]
+        tone: str = "muted"
+
+        @classmethod
+        def load(cls, key: str) -> "WidgetX":
+            return cls(widget_id=str(key), tone="muted")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "widget_x.html"), "w") as f:
+            f.write("<div id='{{ id }}'>{{ tone }}</div>")
+        with Registry.request_scope():
+            rendered = str(
+                _renderer(temp_dir).render('<WidgetX widget_id="k1" tone="loud"/>')
+            )
+
+    assert "loud" in rendered          # non-key attr override applied
+    assert "muted" not in rendered     # loaded default was replaced
+    assert 'data-pjx-load="k1"' in rendered  # key is preserved in output

--- a/tests/unit/test_tag_mount_reactive_load.py
+++ b/tests/unit/test_tag_mount_reactive_load.py
@@ -109,7 +109,8 @@ def test_scalar_attr_overrides_load_result():
                 _renderer(temp_dir).render('<PanelShell highlight="on"/>')
             )
 
-    assert ">on<" in rendered  # tag attr won over load()'s "off"
+    assert ">on<" in rendered   # tag attr won over load()'s "off"
+    assert ">off<" not in rendered  # loaded default was replaced
 
 
 def test_children_override_loaded_target_field():

--- a/tests/unit/test_tag_mount_reactive_load.py
+++ b/tests/unit/test_tag_mount_reactive_load.py
@@ -132,3 +132,47 @@ def test_children_override_loaded_target_field():
 
     assert "from-children" in rendered
     assert "loaded" not in rendered
+
+
+def test_duplicate_keyed_mount_id_raises():
+    """Two keyed mounts deriving the same id raise a clear collision error."""
+    from pyjinhx import PjxKey
+    import pytest
+
+    class RowCard(ReactiveComponent, react={Keys.SHELL}):
+        row_id: Annotated[str, PjxKey()]
+
+        @classmethod
+        def load(cls, key: str) -> "RowCard":
+            return cls(row_id=str(key))
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "row_card.html"), "w") as f:
+            f.write("<div id='{{ id }}'></div>")
+        with open(os.path.join(temp_dir, "page.html"), "w") as f:
+            f.write('<div id="{{ id }}"><RowCard row_id="1"/><RowCard row_id="1"/></div>')
+        with Registry.request_scope():
+            with pytest.raises(ValueError, match="already used in this render"):
+                _renderer(temp_dir).render('<Page id="page"/>')
+
+
+def test_distinct_keyed_mounts_coexist():
+    from pyjinhx import PjxKey
+
+    class CellCard(ReactiveComponent, react={Keys.SHELL}):
+        cell_id: Annotated[str, PjxKey()]
+
+        @classmethod
+        def load(cls, key: str) -> "CellCard":
+            return cls(cell_id=str(key))
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "cell_card.html"), "w") as f:
+            f.write("<div id='{{ id }}'>{{ cell_id }}</div>")
+        with open(os.path.join(temp_dir, "grid.html"), "w") as f:
+            f.write('<div id="{{ id }}"><CellCard cell_id="1"/><CellCard cell_id="2"/></div>')
+        with Registry.request_scope():
+            rendered = str(_renderer(temp_dir).render('<Grid id="grid"/>'))
+
+    assert 'data-pjx-id="cell-card-1"' in rendered
+    assert 'data-pjx-id="cell-card-2"' in rendered

--- a/tests/unit/test_tag_mount_reactive_load.py
+++ b/tests/unit/test_tag_mount_reactive_load.py
@@ -47,3 +47,45 @@ def test_singleton_reactive_tag_runs_load():
 
     assert "acme" in rendered  # load() ran; org_host rendered
     assert 'data-pjx-id="sidebar-shell"' in rendered
+
+
+def test_keyed_reactive_tag_loads_from_key_attr():
+    """A keyed tag passes its PjxKey-named attr to load() and derives kebab-key id."""
+    from pyjinhx import PjxKey
+
+    class UserCard(ReactiveComponent, react={Keys.SHELL}):
+        user_id: Annotated[str, PjxKey()]
+        name: str = ""
+
+        @classmethod
+        def load(cls, key: str) -> "UserCard":
+            return cls(user_id=str(key), name=f"user {key}")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "user_card.html"), "w") as f:
+            f.write("<div id='{{ id }}'>{{ name }}</div>")
+        with Registry.request_scope():
+            rendered = str(_renderer(temp_dir).render('<UserCard user_id="42"/>'))
+
+    assert "user 42" in rendered
+    assert 'data-pjx-id="user-card-42"' in rendered
+    assert 'data-pjx-load="42"' in rendered
+
+
+def test_keyed_reactive_tag_missing_key_attr_raises():
+    from pyjinhx import PjxKey
+    import pytest
+
+    class WidgetCard(ReactiveComponent, react={Keys.SHELL}):
+        widget_id: Annotated[str, PjxKey()]
+
+        @classmethod
+        def load(cls, key: str) -> "WidgetCard":
+            return cls(widget_id=str(key))
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with open(os.path.join(temp_dir, "widget_card.html"), "w") as f:
+            f.write("<div id='{{ id }}'></div>")
+        with Registry.request_scope():
+            with pytest.raises(ValueError, match="instance-keyed"):
+                _renderer(temp_dir).render("<WidgetCard/>")


### PR DESCRIPTION
## Summary

Tag-mounted reactive components now run `load()` on cold render (closes #196).

Previously, a reactive component placed as a bare PascalCase tag (`<SidebarShell/>`) was expanded by `render_tag_node` **without ever calling `load()`** — so state that can't ride scalar tag attrs (e.g. a field holding a nested child built in `load()`) rendered empty unless the route pre-loaded the instance into the registry. This branch makes the tag path run `load()` automatically.

## What changed

`render_tag_node` (`pyjinhx/tags.py`) now resolves the component class up front, detects reactive components, skips the random `auto_id` for them, and routes them to a new `_mount_reactive_instance` helper that:

- runs `load()` — **singleton**: no args; **keyed**: passes the `PjxKey`-named attr's value (`<UserCard user_id="42"/>` → `load("42")`);
- honors an explicit `id` override (the keyed `kebab-key` id comes for free from `LoadCache` inside `load()`);
- applies remaining scalar attrs as validated overrides **on top of** `load()` (mirrors the REUSE branch);
- enforces per-render-pass `data-pjx-id` uniqueness via a new `RenderSession.reactive_mount_ids` set.

The REUSE branch is untouched, so the existing route-pre-load pattern still works and **takes precedence** — fully backward compatible (a pre-loaded instance is never double-loaded).

```html
<SidebarShell/>                      <!-- singleton: runs load() -->
<UserCard user_id="42"/>             <!-- keyed: load("42"), id "user-card-42" -->
<UserCard user_id="42" tone="loud"/> <!-- scalar attr overrides loaded value -->
```

## Testing

- New `tests/unit/test_tag_mount_reactive_load.py` (13 tests): singleton/keyed load, attrs/children override, keyed+override, id-uniqueness collision, and regression guards — pre-load reuse (asserts `load()` runs exactly once), LoadCache single-load, nested reactive child, non-reactive tag unchanged.
- Full suite: **1176 passed, 5 skipped**. basedpyright (standard): no new errors; `tags.py` type-clean.

## Notes

- Mounting the *same singleton bare twice* in one page now raises the per-pass id-collision error by design (give one an explicit `id`).
- A follow-up could extract the shared `validate_assignment` override loop between the helper and the REUSE branch once both paths stabilize; kept inline here per the repo's "undo over-abstraction" preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
