### PR TITLE
fix: defer remove_on_close removal until in-flight htmx requests settle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.32.1 — Defer remove_on_close removal until htmx requests settle (2026-07-04)
+
+### Fixed
+- A submit button carrying `data-pjx-close` inside a `remove_on_close` modal or
+  drawer raced its own htmx request against the dialog's removal. When the
+  response arrived after removal, htmx dispatched its `HX-Trigger` events (e.g.
+  `pjx:toast`) on the now-detached requesting element — where they can't bubble
+  to `PJXToastHost`'s window listener — and the response's OOB swaps were
+  dropped with them, with zero client-side errors. `close()` in `pjx-modal.js`
+  and `pjx-drawer.js` now defers the actual `remove()` until no descendant
+  carries the `htmx-request` class; the dialog is already closed at that point,
+  so the deferral is invisible (#198).
+
+## 0.32.0 — Tag-mounted reactive components run load() on cold render (2026-06-29)
+
+### Added
+- A reactive component placed as a bare PascalCase tag is now hydrated
+  automatically — no route pre-load required. `<SidebarShell/>` runs `load()`;
+  keyed components like `<UserCard user_id="42"/>` run `load("42")`, with
+  remaining scalar attrs overriding the loaded values. The pre-load-into-the-
+  registry pattern still works and takes precedence. Mounting the same
+  singleton bare twice on one page now raises a per-render id-collision error
+  by design (#196).
+
 ## 0.31.0 — Infer children slot from PjxSlot field (2026-06-27)
 
 ### Added

--- a/pyjinhx/builtins/ui/pjx_drawer/pjx-drawer.js
+++ b/pyjinhx/builtins/ui/pjx_drawer/pjx-drawer.js
@@ -20,6 +20,24 @@
         return true;
     }
 
+    // Same deferral as pjx-modal.js: never remove the dialog while an htmx
+    // request from inside it is in flight — HX-Trigger events dispatch on the
+    // requester and OOB swaps ride the same response; a detached requester
+    // silently drops both. The dialog is already close()d, so this is invisible.
+    function removeWhenSettled(el) {
+        function attempt() {
+            if (el.querySelector('.htmx-request')) return false;
+            el.remove();
+            return true;
+        }
+        if (attempt()) return;
+        el.addEventListener('htmx:afterRequest', function onAfter() {
+            setTimeout(function () {
+                if (attempt()) el.removeEventListener('htmx:afterRequest', onAfter);
+            }, 0);
+        });
+    }
+
     function close(id, reason, trigger) {
         const drawer = document.getElementById(id);
         if (!drawer || !drawer.open) return false;
@@ -36,7 +54,7 @@
             drawer.classList.remove('pjx-drawer--closing');
             drawer.close();
             fire(drawer, 'pjx:drawer:close', detail);
-            if (drawer.hasAttribute('data-pjx-remove-on-close')) drawer.remove();
+            if (drawer.hasAttribute('data-pjx-remove-on-close')) removeWhenSettled(drawer);
         }
         function onAnimationEnd(e) {
             if (e.target !== drawer) return; // ignore bubbled descendant animations

--- a/pyjinhx/builtins/ui/pjx_modal/pjx-modal.js
+++ b/pyjinhx/builtins/ui/pjx_modal/pjx-modal.js
@@ -20,6 +20,25 @@
         return true;
     }
 
+    // Removing a dialog while an htmx request fired from inside it is still in
+    // flight would detach the requesting element — HX-Trigger events dispatch on
+    // the requester (a detached node's events can't bubble to window listeners
+    // like PJXToastHost's) and the response's OOB swaps are dropped with them.
+    // The dialog is already close()d, so deferring removal is invisible.
+    function removeWhenSettled(el) {
+        function attempt() {
+            if (el.querySelector('.htmx-request')) return false;
+            el.remove();
+            return true;
+        }
+        if (attempt()) return;
+        el.addEventListener('htmx:afterRequest', function onAfter() {
+            setTimeout(function () {
+                if (attempt()) el.removeEventListener('htmx:afterRequest', onAfter);
+            }, 0);
+        });
+    }
+
     function close(id, reason, trigger) {
         const modal = document.getElementById(id);
         if (!modal || !modal.open) return false;
@@ -36,7 +55,7 @@
             modal.classList.remove('pjx-modal--closing');
             modal.close();
             fire(modal, 'pjx:modal:close', detail);
-            if (modal.hasAttribute('data-pjx-remove-on-close')) modal.remove();
+            if (modal.hasAttribute('data-pjx-remove-on-close')) removeWhenSettled(modal);
         }
         function onAnimationEnd(e) {
             if (e.target !== modal) return; // ignore bubbled descendant animations

--- a/tests/reactivity/app.py
+++ b/tests/reactivity/app.py
@@ -50,6 +50,8 @@ _PAGE_TEMPLATE = """
 <section>
 {{ modal }}
 <button type="button" id="modal-open-btn" data-pjx-open="rx-modal">Open modal</button>
+{{ remove_modal }}
+<button type="button" id="remove-modal-open-btn" data-pjx-open="rx-remove-modal">Open remove-on-close modal</button>
 </section>
 
 <section>
@@ -124,6 +126,7 @@ Fetch notification
 
 class KitchenSinkPage(BaseComponent):
     modal: PJXModal
+    remove_modal: PJXModal
     drawer: PJXDrawer
     popover_a: PJXPopover
     popover_b: PJXPopover
@@ -167,6 +170,18 @@ def render_page() -> str:
                 str(PJXModalHeader(id="rx-modal-h", title="Demo modal").render())
                 + str(PJXModalBody(id="rx-modal-b", content="Modal body.").render())
             ),
+        ),
+        remove_modal=PJXModal(
+            id="rx-remove-modal",
+            remove_on_close=True,
+            content=str(PJXModalBody(
+                id="rx-remove-modal-b",
+                content=(
+                    '<form id="rx-remove-form" hx-post="/actions/slow-save" hx-swap="none">'
+                    '<button type="submit" id="rx-remove-submit" data-pjx-close>Send</button>'
+                    "</form>"
+                ),
+            ).render()),
         ),
         drawer=PJXDrawer(
             id="rx-drawer",
@@ -309,6 +324,15 @@ def create_app() -> FastAPI:
     @app.post("/actions/save")
     def save() -> Response:
         headers = {"HX-Trigger": json.dumps({"pjx:toast": {"message": "Saved!", "level": "success"}})}
+        return Response(status_code=200, headers=headers)
+
+    @app.post("/actions/slow-save")
+    def slow_save() -> Response:
+        # Slower than the modal-close animation/fallback (~250ms), so the
+        # response lands after a remove_on_close dialog would have removed
+        # itself — the race the deferred-removal fix covers.
+        time.sleep(0.6)
+        headers = {"HX-Trigger": json.dumps({"pjx:toast": {"message": "Slow saved!", "level": "success"}})}
         return Response(status_code=200, headers=headers)
 
     @app.get("/slow-content", response_class=HTMLResponse)

--- a/tests/reactivity/test_modal.py
+++ b/tests/reactivity/test_modal.py
@@ -47,6 +47,24 @@ def test_api_round_trip_returns_booleans(sink_page):
     assert sink_page.evaluate("pjx.modal.close('rx-modal')") is False  # already closed
 
 
+def test_remove_on_close_defers_removal_until_request_settles(sink_page):
+    """A submit that both fires an htmx request and closes a remove_on_close
+    modal must still deliver the response: HX-Trigger events dispatch on the
+    requesting element, so the dialog defers its removal until the in-flight
+    request settles (a detached requester's events can't bubble to window).
+    Regression test for the slow-response race — on the old immediate-removal
+    behavior the toast below never arrives."""
+    sink_page.click("#remove-modal-open-btn")
+    modal = sink_page.locator("#rx-remove-modal")
+    expect(modal).to_be_visible()
+
+    sink_page.click("#rx-remove-submit")
+    toast = sink_page.locator("#rx-toasts .pjx-toast")
+    expect(toast.locator(".pjx-toast__message")).to_have_text("Slow saved!", timeout=5000)
+    # And the dialog still honors remove_on_close once the request settles.
+    expect(sink_page.locator("#rx-remove-modal")).to_have_count(0)
+
+
 def test_drawer_opens_and_closes_via_data_attributes(sink_page):
     drawer = sink_page.locator("#rx-drawer")
     expect(drawer).not_to_be_visible()


### PR DESCRIPTION
Closes #198.

## Problem

A submit button carrying `data-pjx-close` inside a `remove_on_close` modal/drawer races its own htmx request against the dialog's removal (`animationend` or the 250ms fallback). When the response arrives after removal, htmx dispatches the `HX-Trigger` events (e.g. `pjx:toast`) on the now-detached requesting element — a detached node's events cannot bubble to the window listener `PJXToastHost` uses — and the response's OOB swaps are dropped with them. Fast local responses always won the race, which is why this only surfaced as flaky toast failures on slow CI runners, with zero client-side errors.

## Fix

`close()` in `pjx-modal.js` and `pjx-drawer.js` now defers the actual `remove()` until no descendant carries the `htmx-request` class, waiting on `htmx:afterRequest` (plus a `setTimeout(0)` so htmx finishes processing the response) when one does. The dialog is already `close()`d at that point, so the deferral is invisible to the user.

## Test

The regression test drives the exact race — a 600ms route behind a `remove_on_close` modal's submit — and fails on the previous immediate-removal behavior. Full suite: 1177 passed, 5 skipped.

Also backfills the missing 0.32.0 CHANGELOG entry and adds the 0.32.1 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)