### PR TITLE
Vendor ellipsis/ellipsis-vertical icons for overflow menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Vendored Lucide's `ellipsis`/`ellipsis-vertical` icons into `PJXIcon`'s icon
+  set, for `…`/kebab overflow-menu triggers (e.g. a `PJXDropdown` actions
+  trigger) (#200).
+
 ## 0.32.2 — Add pin/pin-off icons to PJXIcon set (2026-07-18)
 
 ### Added

--- a/pyjinhx/builtins/ui/pjx_icon/_icons.py
+++ b/pyjinhx/builtins/ui/pjx_icon/_icons.py
@@ -132,6 +132,8 @@ ICONS: dict[str, str] = {
     'power': '<path d="M12 2v10" /> <path d="M18.4 6.6a9 9 0 1 1-12.77.04" />',
     'building': '<path d="M12 10h.01" /> <path d="M12 14h.01" /> <path d="M12 6h.01" /> <path d="M16 10h.01" /> <path d="M16 14h.01" /> <path d="M16 6h.01" /> <path d="M8 10h.01" /> <path d="M8 14h.01" /> <path d="M8 6h.01" /> <path d="M9 22v-3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v3" /> <rect x="4" y="2" width="16" height="20" rx="2" />',
     'brain': '<path d="M12 18V5" /> <path d="M15 13a4.17 4.17 0 0 1-3-4 4.17 4.17 0 0 1-3 4" /> <path d="M17.598 6.5A3 3 0 1 0 12 5a3 3 0 1 0-5.598 1.5" /> <path d="M17.997 5.125a4 4 0 0 1 2.526 5.77" /> <path d="M18 18a4 4 0 0 0 2-7.464" /> <path d="M19.967 17.483A4 4 0 1 1 12 18a4 4 0 1 1-7.967-.517" /> <path d="M6 18a4 4 0 0 1-2-7.464" /> <path d="M6.003 5.125a4 4 0 0 0-2.526 5.77" />',
+    'ellipsis': '<circle cx="12" cy="12" r="1" /> <circle cx="19" cy="12" r="1" /> <circle cx="5" cy="12" r="1" />',
+    'ellipsis-vertical': '<circle cx="12" cy="12" r="1" /> <circle cx="12" cy="5" r="1" /> <circle cx="12" cy="19" r="1" />',
 }
 
 ICON_NAMES: tuple[str, ...] = tuple(ICONS)

--- a/scripts/vendor_lucide_icons.py
+++ b/scripts/vendor_lucide_icons.py
@@ -18,7 +18,7 @@ CURATED: tuple[str, ...] = (
     "chevron-right", "chevron-left", "chevron-up", "chevron-down",
     "chevrons-left", "chevrons-right", "chevrons-up-down",
     "arrow-right", "arrow-left", "arrow-up", "arrow-down", "arrow-up-right",
-    "corner-down-right", "menu", "more-horizontal", "more-vertical",
+    "corner-down-right", "menu",
     "panel-left", "panel-right", "sidebar", "external-link",
     "maximize", "minimize", "expand",
     # actions / editing
@@ -53,6 +53,8 @@ CURATED: tuple[str, ...] = (
     "building", "brain",
     # issue-204: pin/unpin toggle
     "pin", "pin-off",
+    # issue-200: overflow/kebab menu trigger
+    "ellipsis", "ellipsis-vertical",
 )
 
 INNER_RE = re.compile(r"<svg[^>]*>(.*)</svg>", re.DOTALL)

--- a/tests/unit/test_icon_data.py
+++ b/tests/unit/test_icon_data.py
@@ -34,3 +34,12 @@ def test_issue_204_pin_icons_present():
         inner = ICONS[name]
         assert inner, f"icon {name!r} has empty inner markup"
         assert "<svg" not in inner, f"icon {name!r}: must be inner markup only, not a full <svg>"
+
+
+def test_issue_200_ellipsis_icons_present():
+    """ellipsis/ellipsis-vertical were missing from the vendored set (issue #200)."""
+    for name in ("ellipsis", "ellipsis-vertical"):
+        assert name in ICONS, f"icon {name!r} missing from ICONS"
+        inner = ICONS[name]
+        assert inner, f"icon {name!r} has empty inner markup"
+        assert "<svg" not in inner, f"icon {name!r}: must be inner markup only, not a full <svg>"


### PR DESCRIPTION
## Summary
- Adds `ellipsis` (horizontal `…`) and `ellipsis-vertical` (`⋮`) to the vendored Lucide icon set, closing #200.
- Cleans up the vendor script's curated list: `more-horizontal`/`more-vertical` were listed but never actually present in `_icons.py` (dead entries from a prior run), replaced with the current canonical Lucide names.

## Test plan
- [x] `uv run pytest tests/unit/test_icon_data.py -q` — 6 passed
Closes #200