### PR TITLE
Theme-aware PJXRegionLoader backdrop and spinner track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
   set, for `…`/kebab overflow-menu triggers (e.g. a `PJXDropdown` actions
   trigger) (#200).
 
+### Fixed
+- `PJXRegionLoader`'s overlay backdrop and spinner track were hardcoded dark
+  (`rgb(0 0 0 / 0.55)` / `rgb(255 255 255 / 0.1)`), reading like an error scrim
+  on light surfaces and requiring every light-theme consumer to override both
+  tokens by hand. Both now derive from `--text` via `color-mix`, matching the
+  pattern every other builtin already uses (`PJXSkeleton`, `PJXDropdown`,
+  etc.), so the overlay auto-adapts to the app's theme with no override
+  needed (#179).
+
 ## 0.32.2 — Add pin/pin-off icons to PJXIcon set (2026-07-18)
 
 ### Added

--- a/docs/components.md
+++ b/docs/components.md
@@ -2229,13 +2229,13 @@ In-place loading veil over a positioned ancestor. **Assets:** `pjx-region-loader
 
     | Token | Default |
     | --- | --- |
-    | `--pjx-region-loader-bg` | `rgb(0 0 0 / 0.55)` |
+    | `--pjx-region-loader-bg` | `color-mix(in srgb, var(--text) 55%, transparent)` |
     | `--pjx-region-loader-backdrop` | `blur(2px)` |
     | `--pjx-region-loader-z` | `100` |
     | `--pjx-region-loader-spinner-size` | `2.5rem` |
     | `--pjx-region-loader-spinner-width` | `3px` |
     | `--pjx-region-loader-spinner-color` | `var(--brand)` |
-    | `--pjx-region-loader-spinner-track` | `rgb(255 255 255 / 0.1)` |
+    | `--pjx-region-loader-spinner-track` | `color-mix(in srgb, var(--text) 12%, transparent)` |
 
 ??? note "DOM & classes"
 

--- a/pyjinhx/builtins/ui/pjx_region_loader/pjx-region-loader.css
+++ b/pyjinhx/builtins/ui/pjx_region_loader/pjx-region-loader.css
@@ -1,12 +1,12 @@
 /* ── PJXRegionLoader tokens ──────────────────────────────────── */
 :where(:root) {
-  --pjx-region-loader-bg:            rgb(0 0 0 / 0.55);
+  --pjx-region-loader-bg:            color-mix(in srgb, var(--text) 55%, transparent);
   --pjx-region-loader-backdrop:      blur(2px);
   --pjx-region-loader-z:             100;
   --pjx-region-loader-spinner-size:  2.5rem;
   --pjx-region-loader-spinner-width: 3px;
   --pjx-region-loader-spinner-color: var(--brand);
-  --pjx-region-loader-spinner-track: rgb(255 255 255 / 0.1);
+  --pjx-region-loader-spinner-track: color-mix(in srgb, var(--text) 12%, transparent);
 }
 
 /* ── Overlay ────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Fixes #179: `PJXRegionLoader`'s backdrop/spinner-track were hardcoded dark colors that clashed on light surfaces.
- Both tokens now derive from `--text` via `color-mix`, matching the convention every other builtin already follows (`PJXSkeleton`, `PJXDropdown`, `PJXAlert`, ...), so the overlay auto-adapts to whatever theme the app sets — no manual override needed.

## Test plan
- [x] `uv run pytest tests/unit/test_loading_family.py tests/unit/test_golden_builtins.py tests/reactivity/test_loaders.py -q` — 86 passed
Closes #179