### PR TITLE
Auto-coerce JSON-string tag attrs for structural (list/dict/model) props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- A tag attribute typed `list`/`dict`/a nested `BaseModel` (or one of those unioned with `None`)
+  now auto-parses a JSON-looking string value (`{...}`/`[...]`) before Pydantic validates it, so
+  `<Child sources="{{ sources | tojson }}"/>` just works instead of every component hand-rolling
+  the same `BeforeValidator`. Fields typed as a union with `str` (e.g. `str | list`, `Slot`) are
+  left untouched — a JSON-looking string there is ambiguous (#187).
+
 ## 0.32.4 — Accessibility baseline pass (2026-07-18)
 
 ### Fixed

--- a/docs/guide/tags.md
+++ b/docs/guide/tags.md
@@ -41,6 +41,27 @@ on the root element of that component with **override semantics** — an inline 
 replaces any same-named attribute the template hardcodes, including `class` and `style`.
 See [Creating Components](components.md#attribute-pass-through) for the full rules.
 
+### Passing lists and dicts
+
+A tag attribute is always a plain string — the template is fully rendered before the tag is
+parsed out of it. For a field typed `list`, `dict`, or a nested `BaseModel`, a JSON-looking
+attribute value (starts with `{` or `[`) is parsed automatically before Pydantic sees it, so a
+structured prop just works with `| tojson`:
+
+```python
+class Sources(BaseComponent):
+    items: list = Field(default_factory=list)
+```
+
+```html
+<Sources items='{{ items | tojson }}'/>
+```
+
+Use single quotes around the attribute — `tojson` is HTML-safe but leaves `"` unescaped. This
+coercion only fires when the field's annotation is unambiguous (`list`, `dict`, a `BaseModel`
+subclass, or one of those unioned with `None`); a field typed `str | list` is left as a literal
+string, since a JSON-looking string there is ambiguous.
+
 ## The `content` Variable
 
 Inner content of a tag becomes the `{{ content }}` template variable:

--- a/pyjinhx/base.py
+++ b/pyjinhx/base.py
@@ -1,11 +1,12 @@
 import itertools
+import json
 import logging
 import re
 from functools import cached_property
-from typing import Annotated, Any, ClassVar, Optional
+from typing import Annotated, Any, ClassVar, Optional, Union, get_args, get_origin
 
 from markupsafe import Markup
-from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .context import wrap_context_methods
 from .registry import Registry
@@ -133,6 +134,22 @@ def _wrap_slot_value(value: Any) -> Any:
     if isinstance(value, dict):
         return {key: _wrap_slot_value(item) for key, item in value.items()}
     return value
+
+
+def _is_json_coercible_annotation(annotation: Any) -> bool:
+    """A field is a JSON-coercion candidate if, once ``None`` is stripped from
+    a ``T | None`` union, exactly one type remains and it's ``list``, ``dict``,
+    or a ``BaseModel`` subclass. Unions with ``str`` (e.g. ``str | list``,
+    ``Slot``) are left alone — a JSON-looking string there is ambiguous."""
+    if get_origin(annotation) is Union:
+        args = [a for a in get_args(annotation) if a is not type(None)]
+        if len(args) != 1:
+            return False
+        annotation = args[0]
+    origin = get_origin(annotation) or annotation
+    if origin in (list, dict):
+        return True
+    return isinstance(origin, type) and issubclass(origin, BaseModel)
 
 
 def collect_extra_attrs(component: "BaseComponent") -> dict[str, str]:
@@ -264,6 +281,31 @@ class BaseComponent(BaseModel):
         if not v:
             return _auto_id()
         return str(v)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_json_string_attrs(cls, data: Any) -> Any:
+        """A tag attribute always arrives as a string (Jinja renders the tag
+        before it's parsed). For a field typed ``list``/``dict``/a ``BaseModel``,
+        a JSON-looking string (``{...}``/``[...]``) is parsed before Pydantic
+        sees it, so ``<Child sources="{{ sources | tojson }}"/>`` just works
+        instead of every such component hand-rolling the same ``BeforeValidator``."""
+        if not isinstance(data, dict):
+            return data
+        for name, field in cls.model_fields.items():
+            value = data.get(name)
+            if not isinstance(value, str):
+                continue
+            text = value.strip()
+            if not text or text[0] not in "{[":
+                continue
+            if not _is_json_coercible_annotation(field.annotation):
+                continue
+            try:
+                data[name] = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{cls.__name__}.{name}: invalid JSON attribute value") from exc
+        return data
 
     def __init_subclass__(cls, pjx_replace: bool = False, **kwargs: Any) -> None:
         """

--- a/tests/unit/test_tag_coercion.py
+++ b/tests/unit/test_tag_coercion.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 from jinja2 import Environment, FileSystemLoader
-from pydantic import ValidationError
+from pydantic import Field, ValidationError
 
 from pyjinhx import BaseComponent, Renderer
 
@@ -13,6 +13,48 @@ class CoercionProbe(BaseComponent):
 
 
 PROBE_TEMPLATE = '<span id="{{ id }}">{{ count }}|{{ enabled }}</span>'
+
+
+class StructuralProbe(BaseComponent):
+    sources: list = Field(default_factory=list)
+    meta: dict = Field(default_factory=dict)
+    label: str | list = ""
+
+
+STRUCTURAL_PROBE_TEMPLATE = '<span id="{{ id }}">{{ sources }}|{{ meta }}|{{ label }}</span>'
+
+
+def test_json_string_attr_coerces_to_list(tmp_path):
+    (tmp_path / "structural_probe.html").write_text(STRUCTURAL_PROBE_TEMPLATE)
+    env = Environment(loader=FileSystemLoader(str(tmp_path)))
+    renderer = Renderer(env)
+    html = renderer.render(
+        '<StructuralProbe id="s1" sources=\'[{"id": "a"}]\'/>'
+    )
+    assert "[{&#39;id&#39;: &#39;a&#39;}]" in html or "[{'id': 'a'}]" in html
+
+
+def test_json_string_attr_coerces_to_dict(tmp_path):
+    (tmp_path / "structural_probe.html").write_text(STRUCTURAL_PROBE_TEMPLATE)
+    env = Environment(loader=FileSystemLoader(str(tmp_path)))
+    renderer = Renderer(env)
+    html = renderer.render('<StructuralProbe id="s2" meta=\'{"k": "v"}\'/>')
+    assert "'k': 'v'" in html
+
+
+def test_invalid_json_raises_clear_error():
+    with pytest.raises(ValidationError):
+        StructuralProbe(sources="[not json")
+
+
+def test_union_with_str_is_not_coerced():
+    probe = StructuralProbe(label="[1, 2, 3]")
+    assert probe.label == "[1, 2, 3]"
+
+
+def test_non_json_looking_string_left_alone():
+    with pytest.raises(ValidationError):
+        StructuralProbe(sources="plain text")
 
 
 def test_tag_attrs_coerce_to_int_and_bool(tmp_path):


### PR DESCRIPTION
## Summary
Closes #187 with option A from the issue's own analysis (smallest change, type-directed, no new API):

- `BaseComponent` gains a `model_validator(mode="before")` that, for a field typed `list`/`dict`/a nested `BaseModel` (optionally unioned with `None`), auto-parses a JSON-looking string value (starts with `{`/`[`) before Pydantic validates it.
- Fields unioned with `str` (e.g. `str | list`, `Slot` which is `str | BaseComponent`) are deliberately left untouched — a JSON-looking string there is ambiguous, per the issue's own tradeoff analysis.
- Malformed JSON raises a clear `ValidationError` naming the field, instead of the silent char-iteration failure mode described in the issue.
- Existing hand-rolled per-field `BeforeValidator`s (`PJXBreadcrumb.items`, `PJXTabGroup.tabs`, `PJXAvatar`) are unaffected — they only act on `isinstance(value, str)`, and by the time they run the generic pass has already turned the string into the same shape they'd have parsed themselves.

Consumers still need `| tojson` at the call site (`<Child sources="{{ sources | tojson }}"/>`) — this removes the per-component validator boilerplate, not the serialization step, which the issue itself flagged as the realistic scope for this option.

## Test plan
- [x] `uv run pytest tests/` — 1186 passed, 5 skipped
- [x] New tests in `tests/unit/test_tag_coercion.py`: list/dict coercion end-to-end through a real tag render, invalid JSON raises, `str | list` union is left alone, non-JSON-looking string still fails validation naturally
- [x] `uv run ruff check .` — clean
- [x] `uv run mkdocs build --strict` — clean
Closes #187