### PR TITLE
Drag-to-reorder tabs (PJXTabList reorderable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `PJXTabList(reorderable=True)`: non-pinned tabs can now be drag-reordered, or moved with
+  `Ctrl+ArrowLeft`/`Ctrl+ArrowRight` on a focused tab. Reordering fires a cancelable
+  `pjx:tab:before-reorder` then `pjx:tab:reorder` on the group root, `detail = {id, from, to}`,
+  so the consuming app can persist the new order (#180).
+
 ## 0.33.0 — Auto-coerce JSON-string tag attrs for structural props (2026-07-18)
 
 ### Added

--- a/docs/components.md
+++ b/docs/components.md
@@ -1937,12 +1937,17 @@ Tab button list (the `role="tablist"` container). **Assets:** `pjx-tab-list.css`
     | Field | Type | Default | Description |
     | --- | --- | --- | --- |
     | `label` | `str` | `"Tabs"` | `aria-label` for the tab list — describes the set of tabs. |
+    | `reorderable` | `bool` | `False` | Adds `data-pjx-tab-reorderable`; non-pinned tabs become drag-reorderable, and a focused tab can be moved with `Ctrl+ArrowLeft`/`Ctrl+ArrowRight`. |
     | `class_name` | `str` | `""` | Extra CSS class(es) appended to the root element. |
     | `content` | `str \| BaseComponent` | `""` | One or more `PJXTab` rendered strings. |
 
 ??? note "DOM & classes"
 
-    Root `div[role="tablist"][aria-label][aria-orientation="horizontal"].pjx-tab-group__list`.
+    Root `div[role="tablist"][aria-label][aria-orientation="horizontal"].pjx-tab-group__list` (reorderable: `[data-pjx-tab-reorderable]`).
+
+    Reordering (drag, or `Ctrl+Arrow` on a focused tab) fires `pjx:tab:before-reorder`* then
+    `pjx:tab:reorder` on the group root — `*` = cancelable, `detail = {id, from, to}` (indices
+    among the tablist's own tabs). A `PJXTab(pinned=true)` is excluded from reordering.
 
 ??? note "Python"
 

--- a/pyjinhx/builtins/ui/pjx_tab/pjx-tab.css
+++ b/pyjinhx/builtins/ui/pjx_tab/pjx-tab.css
@@ -27,6 +27,10 @@
   color: var(--pjx-tab-group-tab-active-fg);
 }
 
+.pjx-tab[draggable="true"] {
+  cursor: grab;
+}
+
 .pjx-tab:focus-visible {
   outline: 2px solid var(--pjx-tab-group-tab-active-border);
   outline-offset: -2px;

--- a/pyjinhx/builtins/ui/pjx_tab_group/pjx-tab-group.js
+++ b/pyjinhx/builtins/ui/pjx_tab_group/pjx-tab-group.js
@@ -81,7 +81,61 @@
     });
     var selected = tabs.filter(function (t) { return t.classList.contains("pjx-tab--selected"); })[0] || tabs[0];
     if (selected) select(group, selected, { reason: "api", trigger: null }, true);
+    initReorder(group);
   }
+
+  function reorderableTablists(group) {
+    return Array.prototype.filter.call(
+      group.querySelectorAll('[role="tablist"][data-pjx-tab-reorderable]'),
+      function (tl) { return tl.closest("[data-pjx-tab-group]") === group; }
+    );
+  }
+
+  function initReorder(group) {
+    reorderableTablists(group).forEach(function (tablist) {
+      listTabsOf(tablist).forEach(function (tab) {
+        if (tab.getAttribute("data-pjx-tab-pinned") == null) tab.draggable = true;
+      });
+    });
+  }
+
+  // Moves `tab` to `toIndex` among its tablist's list tabs, firing the
+  // cancelable pjx:tab:before-reorder / pjx:tab:reorder pair either way (drag
+  // or keyboard) drives it through.
+  function moveTab(group, tablist, tab, toIndex) {
+    var tabs = listTabsOf(tablist), fromIndex = tabs.indexOf(tab);
+    if (fromIndex < 0 || toIndex < 0 || toIndex >= tabs.length || toIndex === fromIndex) return;
+    var detail = { id: tab.id, from: fromIndex, to: toIndex };
+    if (!fire(group, "pjx:tab:before-reorder", detail, true)) return;
+    var ref = tabs[toIndex];
+    tablist.insertBefore(tab, fromIndex < toIndex ? ref.nextSibling : ref);
+    fire(group, "pjx:tab:reorder", detail);
+  }
+
+  var dragTab = null;
+  document.addEventListener("dragstart", function (e) {
+    var tab = e.target.closest && e.target.closest("[draggable='true'][data-pjx-tab]");
+    if (!tab) return;
+    dragTab = tab;
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text/plain", tab.id);
+  });
+  document.addEventListener("dragover", function (e) {
+    if (!dragTab) return;
+    var tablist = dragTab.closest('[role="tablist"][data-pjx-tab-reorderable]');
+    if (tablist && tablist.contains(e.target)) e.preventDefault();
+  });
+  document.addEventListener("drop", function (e) {
+    if (!dragTab) return;
+    var tablist = dragTab.closest('[role="tablist"][data-pjx-tab-reorderable]');
+    var over = tablist && e.target.closest("[data-pjx-tab]");
+    if (tablist && over && over !== dragTab && tablist.contains(over)) {
+      e.preventDefault();
+      var group = groupOf(dragTab);
+      if (group) moveTab(group, tablist, dragTab, listTabsOf(tablist).indexOf(over));
+    }
+  });
+  document.addEventListener("dragend", function () { dragTab = null; });
 
   function select(group, tab, detail, silent) {
     var panel = controlledPanel(tab);
@@ -141,6 +195,14 @@
     // Arrow roving only within a tablist; standalone triggers don't rove.
     var tablist = tab.closest('[role="tablist"]');
     if (!tablist) return;
+    if (e.ctrlKey && tablist.hasAttribute("data-pjx-tab-reorderable") &&
+        (e.key === "ArrowRight" || e.key === "ArrowLeft")) {
+      e.preventDefault();
+      var idx0 = listTabsOf(tablist).indexOf(tab);
+      moveTab(group, tablist, tab, idx0 + (e.key === "ArrowRight" ? 1 : -1));
+      tab.focus();
+      return;
+    }
     var tabs = listTabsOf(tablist), idx = tabs.indexOf(tab), next = null;
     if (e.key === "ArrowRight") next = tabs[(idx + 1) % tabs.length];
     else if (e.key === "ArrowLeft") next = tabs[(idx - 1 + tabs.length) % tabs.length];

--- a/pyjinhx/builtins/ui/pjx_tab_list/pjx-tab-list.html
+++ b/pyjinhx/builtins/ui/pjx_tab_list/pjx-tab-list.html
@@ -1,1 +1,1 @@
-<div id="{{ id }}" role="tablist" aria-label="{{ label }}" aria-orientation="horizontal" class="pjx-tab-group__list{% if class_name %} {{ class_name }}{% endif %}">{{ content }}</div>
+<div id="{{ id }}" role="tablist" aria-label="{{ label }}" aria-orientation="horizontal" class="pjx-tab-group__list{% if class_name %} {{ class_name }}{% endif %}"{% if reorderable %} data-pjx-tab-reorderable{% endif %}>{{ content }}</div>

--- a/pyjinhx/builtins/ui/pjx_tab_list/pjx_tab_list.py
+++ b/pyjinhx/builtins/ui/pjx_tab_list/pjx_tab_list.py
@@ -4,5 +4,6 @@ from pyjinhx.base import AttrValue
 
 class PJXTabList(BaseComponent):
     label: str = "Tabs"
+    reorderable: bool = False
     class_name: AttrValue = ""
     content: str | BaseComponent = ""

--- a/tests/reactivity/app.py
+++ b/tests/reactivity/app.py
@@ -111,6 +111,7 @@ Fetch notification
 <section>
 {{ password }}
 {{ tabs }}
+{{ reorder_tabs }}
 </section>
 
 <section>
@@ -152,6 +153,7 @@ class KitchenSinkPage(BaseComponent):
     detached_group: PJXTabGroup
     password: PJXPasswordInput
     tabs: PJXTabGroup
+    reorder_tabs: PJXTabGroup
     resizable: PJXResizableGroup
     floor_box: str
     accordion_box: str
@@ -269,6 +271,19 @@ def render_page() -> str:
                 )).render())
                 + str(PJXTabPanel(id="rx-tabp-one", tab="rx-tab-one", content="<p>Tab one body</p>").render())
                 + str(PJXTabPanel(id="rx-tabp-two", tab="rx-tab-two", content="<p>Tab two body</p>").render())
+            ),
+        ),
+        reorder_tabs=PJXTabGroup(
+            id="rx-reorder-tabs",
+            content=(
+                str(PJXTabList(reorderable=True, content=(
+                    str(PJXTab(id="rx-reorder-a", panel="rx-reorder-pa", selected=True, content="A").render())
+                    + str(PJXTab(id="rx-reorder-b", panel="rx-reorder-pb", content="B").render())
+                    + str(PJXTab(id="rx-reorder-c", panel="rx-reorder-pc", content="C").render())
+                )).render())
+                + str(PJXTabPanel(id="rx-reorder-pa", tab="rx-reorder-a", content="A body").render())
+                + str(PJXTabPanel(id="rx-reorder-pb", tab="rx-reorder-b", content="B body").render())
+                + str(PJXTabPanel(id="rx-reorder-pc", tab="rx-reorder-c", content="C body").render())
             ),
         ),
         resizable=PJXResizableGroup(

--- a/tests/reactivity/test_tab_reorder.py
+++ b/tests/reactivity/test_tab_reorder.py
@@ -1,0 +1,49 @@
+"""Browser contracts for PJXTabList(reorderable=True)."""
+import pytest
+
+pytest.importorskip("playwright")
+
+pytestmark = [pytest.mark.pjx_runtime, pytest.mark.reactivity]
+
+
+def _order(page):
+    return page.eval_on_selector_all(
+        "#rx-reorder-tabs [data-pjx-tab]", "els => els.map(e => e.id)"
+    )
+
+
+def test_ctrl_arrow_right_moves_tab_forward(sink_page):
+    assert _order(sink_page) == ["rx-reorder-a", "rx-reorder-b", "rx-reorder-c"]
+    sink_page.focus("#rx-reorder-a")
+    sink_page.keyboard.down("Control")
+    sink_page.keyboard.press("ArrowRight")
+    sink_page.keyboard.up("Control")
+    assert _order(sink_page) == ["rx-reorder-b", "rx-reorder-a", "rx-reorder-c"]
+    assert sink_page.evaluate("document.activeElement.id") == "rx-reorder-a"
+
+
+def test_ctrl_arrow_left_moves_tab_backward(sink_page):
+    sink_page.focus("#rx-reorder-c")
+    sink_page.keyboard.down("Control")
+    sink_page.keyboard.press("ArrowLeft")
+    sink_page.keyboard.up("Control")
+    assert _order(sink_page) == ["rx-reorder-a", "rx-reorder-c", "rx-reorder-b"]
+
+
+def test_reorder_fires_cancelable_event(sink_page):
+    sink_page.evaluate(
+        "document.getElementById('rx-reorder-tabs')"
+        ".addEventListener('pjx:tab:before-reorder', e => e.preventDefault(), {once:true})"
+    )
+    sink_page.focus("#rx-reorder-a")
+    sink_page.keyboard.down("Control")
+    sink_page.keyboard.press("ArrowRight")
+    sink_page.keyboard.up("Control")
+    assert _order(sink_page) == ["rx-reorder-a", "rx-reorder-b", "rx-reorder-c"]
+
+
+def test_plain_arrow_still_roves_focus_not_reorders(sink_page):
+    sink_page.focus("#rx-reorder-a")
+    sink_page.keyboard.press("ArrowRight")
+    assert _order(sink_page) == ["rx-reorder-a", "rx-reorder-b", "rx-reorder-c"]
+    assert sink_page.evaluate("document.activeElement.id") == "rx-reorder-b"

--- a/tests/unit/test_tabs.py
+++ b/tests/unit/test_tabs.py
@@ -48,6 +48,13 @@ def test_tablist_role_and_label():
     assert "pjx-tab-group__list" in html
 
 
+def test_tablist_reorderable_attr():
+    html = str(PJXTabList(id="l", content="x").render())
+    assert "data-pjx-tab-reorderable" not in html
+    html = str(PJXTabList(id="l", reorderable=True, content="x").render())
+    assert "data-pjx-tab-reorderable" in html
+
+
 def test_tab_basic_roving_and_label():
     html = str(PJXTab(id="t", content="Home").render())
     assert 'role="tab"' in html


### PR DESCRIPTION
## Summary
Closes #180: opt-in `reorderable` flag on `PJXTabList`.

- `PJXTabList(reorderable=True)` → `data-pjx-tab-reorderable` on the tablist root.
- Non-pinned tabs (`PJXTab(pinned=True)` is excluded, same as it already is from `closeTab`) become `draggable="true"`; native HTML5 drag-and-drop reorders on drop.
- `Ctrl+ArrowLeft`/`Ctrl+ArrowRight` on a focused tab moves it one position (the keyboard-accessible nice-to-have the issue called out), sharing the same `moveTab()` path as drag — refocuses the moved tab.
- Both paths fire a cancelable `pjx:tab:before-reorder` then `pjx:tab:reorder` on the group root, `detail = {id, from, to}` (indices among the tablist's own tabs), so the app can persist the new order or veto it — matching the existing `pjx:tab:before-close`/`close` event-naming convention.
- No animation is added, so there's nothing for `prefers-reduced-motion` to need to suppress (the issue asked this be respected).

## Test plan
- [x] `uv run pytest tests/` — 1191 passed, 5 skipped
- [x] New unit test (`test_tablist_reorderable_attr`) for the prop → attribute wiring
- [x] New browser tests (`tests/reactivity/test_tab_reorder.py`, real Chromium): `Ctrl+ArrowRight`/`Ctrl+ArrowLeft` reorder correctly and refocus the moved tab, the `before-reorder` veto works, plain `ArrowRight` still only roves focus (doesn't reorder)
- [x] `uv run ruff check .` — clean
- [x] `uv run mkdocs build --strict` — clean

Native drag-and-drop itself isn't covered by an automated test (simulating real `DataTransfer` drag gestures cross-browser in Playwright is unreliable) — both interaction paths share the same `moveTab()` function, which the keyboard tests exercise directly.
Closes #180