### PR TITLE
Parametric reactive keys: react to one instance without reloading the rest (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 
 ### Added
 - `reactive_key(key, arg)` builds a per-instance reactive key (`f"{key}:{arg}"`) from a
-  declared `MutationKey` and a keyed component's own load-key. `dirty()`/`@mutates()` now
-  accept it alongside `MutationKey` members. A keyed `ReactiveComponent`'s default
-  `depends_on()` and the OOB dispatch loop both already understand this convention with no
-  override needed, so dirtying one instance's derived key reloads only that mounted
-  instance instead of every instance of that type — the family-wide `MutationKey` dirty
-  still reloads everything, unchanged (#201).
+  declared `MutationKey` and a keyed component's own load-key. `dirty()`/`@mutates()`/
+  `ReactiveResponse()` now accept it alongside `MutationKey` members. A keyed
+  `ReactiveComponent`'s default `depends_on()` and the OOB dispatch loop both already
+  understand this convention with no override needed, so dirtying one instance's derived
+  key reloads only that mounted instance instead of every instance of that type — the
+  family-wide `MutationKey` dirty still reloads everything, unchanged. `ReactiveResponse`
+  also takes a `key=` keyword that derives the per-instance key for you:
+  `ReactiveResponse(ChatKeys.MESSAGE, key=message_id)` (#201).
 
 ## 0.34.0 — Drag-to-reorder tabs (2026-07-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@
   key reloads only that mounted instance instead of every instance of that type — the
   family-wide `MutationKey` dirty still reloads everything, unchanged. `ReactiveResponse`
   also takes a `key=` keyword that derives the per-instance key for you:
-  `ReactiveResponse(ChatKeys.MESSAGE, key=message_id)` (#201).
+  `ReactiveResponse(ChatKeys.MESSAGE, key=message_id)`. `@mutates` takes the same idea as
+  a `key=` *callable*, since it runs at decoration time before any call arguments exist:
+  `@mutates(ChatKeys.MESSAGE, key=lambda message_id: message_id)` derives the key fresh
+  on every call, using the decorated function's own arguments (#201).
 
 ## 0.34.0 — Drag-to-reorder tabs (2026-07-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `reactive_key(key, arg)` builds a per-instance reactive key (`f"{key}:{arg}"`) from a
+  declared `MutationKey` and a keyed component's own load-key. `dirty()`/`@mutates()` now
+  accept it alongside `MutationKey` members. A keyed `ReactiveComponent`'s default
+  `depends_on()` and the OOB dispatch loop both already understand this convention with no
+  override needed, so dirtying one instance's derived key reloads only that mounted
+  instance instead of every instance of that type — the family-wide `MutationKey` dirty
+  still reloads everything, unchanged (#201).
+
 ## 0.34.0 — Drag-to-reorder tabs (2026-07-18)
 
 ### Added

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -288,6 +288,44 @@ after **clear completed**), `oob_swaps` catches `LookupError` from `load(manifes
 and emits a delete OOB swap (`delete:[data-pjx-id='…']`) so stale row regions are removed
 from the DOM without a server error.
 
+### Parametric per-instance keys
+
+A keyed component's `react={...}` still declares the shared "family" key(s) — dirtying
+one reloads and hash-checks *every* mounted instance of that type (unchanged, and still
+useful for "refresh everything"). For the common case of "only this one instance
+changed," `reactive_key()` derives a per-instance key from that same `MutationKey` and
+the instance's own load-key, so only the matching mounted instance is reloaded:
+
+```python
+from pyjinhx import MutationKey, PjxKey, ReactiveComponent, dirty
+from pyjinhx.keys import reactive_key
+from typing import Annotated
+
+class ChatKeys(MutationKey):
+    MESSAGE = "chat.message"
+
+class MessageBubble(ReactiveComponent, react={ChatKeys.MESSAGE}):
+    message_id: Annotated[str, PjxKey()]
+    text: str = ""
+
+    @classmethod
+    def load(cls, message_id: str) -> "MessageBubble":
+        msg = store.get(message_id)
+        return cls(id=f"bubble-{message_id}", message_id=message_id, text=msg.text)
+
+# on settle, after finalizing one message:
+dirty(reactive_key(ChatKeys.MESSAGE, message_id))
+```
+
+`reactive_key(key, arg)` builds the fixed-format string `f"{key}:{arg}"` — the same
+convention `depends_on()`'s default and the OOB dispatch loop both already understand for
+any keyed component, with **no override needed**. Dirtying `ChatKeys.MESSAGE` directly
+still reloads every mounted `MessageBubble`; dirtying `reactive_key(ChatKeys.MESSAGE,
+"42")` reloads only the bubble whose `message_id` is `"42"`.
+
+Avoid declaring a `MutationKey` member whose value itself contains a `:` if you use keyed
+reactive components — it could collide with an auto-derived key from a different member.
+
 ## State keys
 
 Centralize reactive key strings in a `MutationKey` enum so `react=`, `dirtied`, and
@@ -303,9 +341,10 @@ class TodoCounter(ReactiveComponent, react={Keys.TODOS}):
     ...
 ```
 
-Both `react=` and `@mutates` **only accept `MutationKey` members** — passing a bare
-string raises `TypeError` at class-definition time (for `react=`) or at decoration time
-(for `@mutates`).
+`react=` only accepts `MutationKey` members — passing a bare string raises `TypeError`
+at class-definition time. `@mutates` and `dirty()` accept `MutationKey` members or a
+`reactive_key()` value (see [Parametric per-instance keys](#parametric-per-instance-keys)
+below) — a bare string still raises `TypeError` at decoration/call time.
 
 ## Runtime dependencies (`depends_on`)
 
@@ -331,7 +370,11 @@ class AdminPanel(ReactiveComponent, react={Keys.USER, Keys.SETTINGS}):
         return {Keys.SETTINGS}
 ```
 
-`depends_on()` narrows load-cache reverse indexing; `oob_swaps` and `dependency_graph()` always use the static `react` superset, and dev mode warns (or raises) when `depends_on()` returns keys outside it.
+`depends_on()` narrows or widens load-cache reverse indexing (for a keyed component, its
+default already widens to include the per-instance [derived key](#parametric-per-instance-keys)).
+`oob_swaps` matches against the static `react` superset *plus* that same per-instance derived
+key for keyed components; `dependency_graph()` still shows the static superset only. Dev mode
+warns (or raises) when `depends_on()` returns keys outside that widened superset.
 
 ## Mutation tracking (`@mutates`)
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -323,6 +323,11 @@ any keyed component, with **no override needed**. Dirtying `ChatKeys.MESSAGE` di
 still reloads every mounted `MessageBubble`; dirtying `reactive_key(ChatKeys.MESSAGE,
 "42")` reloads only the bubble whose `message_id` is `"42"`.
 
+`ReactiveResponse` takes the same per-instance key as a `key=` keyword instead of calling
+`reactive_key()` yourself — `ReactiveResponse(ChatKeys.MESSAGE, key=message_id)` is
+equivalent to `dirty(reactive_key(ChatKeys.MESSAGE, message_id))`, and applies to every
+positional key passed alongside it.
+
 Avoid declaring a `MutationKey` member whose value itself contains a `:` if you use keyed
 reactive components — it could collide with an auto-derived key from a different member.
 

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -376,6 +376,11 @@ default already widens to include the per-instance [derived key](#parametric-per
 key for keyed components; `dependency_graph()` still shows the static superset only. Dev mode
 warns (or raises) when `depends_on()` returns keys outside that widened superset.
 
+If you override `depends_on()` on a *keyed* component, include the derived key yourself (e.g.
+`return super().depends_on() | {...}`) — `oob_swaps` still matches it independently of your
+override, so omitting it from cache indexing leaves `LoadCache` unaware a per-instance dirty
+should evict that instance's cached `load()` result.
+
 ## Mutation tracking (`@mutates`)
 
 Decorate store mutation methods to invalidate the `load()` cache and accumulate

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -323,10 +323,17 @@ any keyed component, with **no override needed**. Dirtying `ChatKeys.MESSAGE` di
 still reloads every mounted `MessageBubble`; dirtying `reactive_key(ChatKeys.MESSAGE,
 "42")` reloads only the bubble whose `message_id` is `"42"`.
 
-`ReactiveResponse` takes the same per-instance key as a `key=` keyword instead of calling
-`reactive_key()` yourself — `ReactiveResponse(ChatKeys.MESSAGE, key=message_id)` is
-equivalent to `dirty(reactive_key(ChatKeys.MESSAGE, message_id))`, and applies to every
-positional key passed alongside it.
+`ReactiveResponse` and `@mutates` take the same idea as a `key=` keyword instead of
+calling `reactive_key()` yourself:
+
+- `ReactiveResponse(ChatKeys.MESSAGE, key=message_id)` is equivalent to
+  `dirty(reactive_key(ChatKeys.MESSAGE, message_id))` — `key=` is a plain value here,
+  since the caller already has it.
+- `@mutates(ChatKeys.MESSAGE, key=lambda message_id: message_id)` is `key=` as a
+  *callable* instead, since `@mutates` runs at decoration time, before any call
+  arguments exist — see [Mutation tracking](#mutation-tracking-mutates) below.
+
+Both apply to every positional key passed alongside them.
 
 Avoid declaring a `MutationKey` member whose value itself contains a `:` if you use keyed
 reactive components — it could collide with an auto-derived key from a different member.
@@ -404,6 +411,20 @@ def toggle_row(todo_id):
     store.toggle(todo_id)
     return TodoItemRow.render(todo_id)
 ```
+
+This dirties `Keys.TODOS` on every call, so it reloads every mounted `TodoItemRow`
+regardless of which one changed. `key=` derives a [per-instance
+key](#parametric-per-instance-keys) instead — it's called with the wrapped function's
+own arguments, and its return value feeds `reactive_key()` for every key passed to
+`@mutates`:
+
+```python
+@mutates(Keys.TODOS, key=lambda todo_id: todo_id)
+def toggle(todo_id: int) -> Todo:
+    ...
+```
+
+Now only the mounted `TodoItemRow` whose load-key matches `todo_id` reloads.
 
 Use `Registry.request_scope()` on every request when relying on `@mutates` — it
 resets mutation tracking per request.

--- a/pyjinhx/__init__.py
+++ b/pyjinhx/__init__.py
@@ -10,7 +10,7 @@ from pyjinhx.assets import AssetMode
 from pyjinhx.base import BaseComponent, Children, Slot, component
 from pyjinhx.config import PjxSettings, setup
 from pyjinhx.context import PjxContext
-from pyjinhx.keys import MutationKey
+from pyjinhx.keys import MutationKey, reactive_key
 from pyjinhx.mutations import dirty, mutates
 from pyjinhx.reactive import PjxKey, ReactiveComponent
 from pyjinhx.registry import Registry
@@ -31,6 +31,7 @@ __all__ = [
     "mutates",
     "dirty",
     "MutationKey",
+    "reactive_key",
     "PjxKey",
     "PjxContext",
     # Configuration

--- a/pyjinhx/dev.py
+++ b/pyjinhx/dev.py
@@ -59,15 +59,17 @@ def warn_reactive_render_without_client(*, backend: ClientBackend | None) -> Non
 
 
 def validate_depends_on(instance: object) -> None:
-    """Ensure ``depends_on()`` is a subset of the static ``react`` superset."""
+    """Ensure ``depends_on()`` is a subset of the static ``react`` superset
+    (widened by the same per-instance derived keys ``depends_on()`` itself may report)."""
     if not _dev_config.enabled:
         return
-    from .reactive import ReactiveComponent
+    from .reactive import ReactiveComponent, _keyed_derived_keys
 
     if not isinstance(instance, ReactiveComponent):
         return
     component_class = type(instance)
-    superset = set(getattr(component_class, "_pjx_reacts_to", frozenset()))
+    static = frozenset(getattr(component_class, "_pjx_reacts_to", frozenset()))
+    superset = set(static) | _keyed_derived_keys(static, instance._pjx_key)
     runtime = instance.depends_on()
     extra = runtime - superset
     if extra:

--- a/pyjinhx/keys.py
+++ b/pyjinhx/keys.py
@@ -32,3 +32,20 @@ class MutationKey(StrEnum):
     Subclass and declare members; use the members in ``react={...}`` and ``@mutates`` —
     all normalize to their string values.
     """
+
+
+class DynamicReactiveKey(str):
+    """A key produced by ``reactive_key()`` — accepted by ``dirty()``/``@mutates()``
+    alongside ``MutationKey`` members. Not constructed directly."""
+
+
+def reactive_key(key: MutationKey, arg: object) -> DynamicReactiveKey:
+    """
+    Build a per-instance reactive key from a static ``MutationKey`` and an
+    instance's own load-key, e.g. ``reactive_key(ChatKeys.MESSAGE, message_id)``.
+
+    Use the result with ``dirty()``/``@mutates()`` to invalidate/reload only the
+    one mounted instance whose load-key matches ``arg``, instead of every
+    instance reacting to ``key``.
+    """
+    return DynamicReactiveKey(f"{coerce_reactive_key(key)}:{arg}")

--- a/pyjinhx/mutations.py
+++ b/pyjinhx/mutations.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Iterable
 from contextvars import ContextVar
 from typing import Any, ClassVar, TypeVar
 
-from .keys import DynamicReactiveKey, MutationKey, ReactiveKey, coerce_reactive_keys
+from .keys import DynamicReactiveKey, MutationKey, ReactiveKey, coerce_reactive_keys, reactive_key
 from .cache import LoadCache
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -66,13 +66,18 @@ def _require_mutation_keys(keys: tuple[Any, ...], caller: str) -> None:
         )
 
 
-def mutates(*keys: MutationKey) -> Callable[[F], F]:
+def mutates(*keys: MutationKey, key: Callable[..., object] | None = None) -> Callable[[F], F]:
     """
     Decorator for store mutation methods.
 
     Invalidates the load cache for ``keys`` and accumulates them as pending
     dirtied for the next reactive ``render()``. Keys must be ``MutationKey``
     members or ``reactive_key()`` values.
+
+    Pass ``key=`` to derive a per-instance key instead of dirtying ``keys``
+    directly — it's called with the wrapped function's own arguments and its
+    return value feeds ``reactive_key()`` for every key in ``keys``, e.g.
+    ``@mutates(Keys.TODO, key=lambda todo_id: todo_id)``.
     """
     _require_mutation_keys(keys, "@mutates")
 
@@ -80,7 +85,11 @@ def mutates(*keys: MutationKey) -> Callable[[F], F]:
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             result = func(*args, **kwargs)
-            MutationTracker.record(keys)
+            active_keys = keys
+            if key is not None:
+                arg = key(*args, **kwargs)
+                active_keys = tuple(reactive_key(k, arg) for k in keys)
+            MutationTracker.record(active_keys)
             return result
 
         return wrapper  # type: ignore[return-value]

--- a/pyjinhx/mutations.py
+++ b/pyjinhx/mutations.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Iterable
 from contextvars import ContextVar
 from typing import Any, ClassVar, TypeVar
 
-from .keys import MutationKey, ReactiveKey, coerce_reactive_keys
+from .keys import DynamicReactiveKey, MutationKey, ReactiveKey, coerce_reactive_keys
 from .cache import LoadCache
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -56,9 +56,14 @@ class MutationTracker:
 
 
 def _require_mutation_keys(keys: tuple[Any, ...], caller: str) -> None:
-    invalid = sorted(repr(key) for key in keys if not isinstance(key, MutationKey))
+    invalid = sorted(
+        repr(key) for key in keys if not isinstance(key, (MutationKey, DynamicReactiveKey))
+    )
     if invalid:
-        raise TypeError(f"{caller} only accepts MutationKey members; got {', '.join(invalid)}")
+        raise TypeError(
+            f"{caller} only accepts MutationKey members or reactive_key() values; "
+            f"got {', '.join(invalid)}"
+        )
 
 
 def mutates(*keys: MutationKey) -> Callable[[F], F]:
@@ -67,7 +72,7 @@ def mutates(*keys: MutationKey) -> Callable[[F], F]:
 
     Invalidates the load cache for ``keys`` and accumulates them as pending
     dirtied for the next reactive ``render()``. Keys must be ``MutationKey``
-    members.
+    members or ``reactive_key()`` values.
     """
     _require_mutation_keys(keys, "@mutates")
 
@@ -89,7 +94,7 @@ def dirty(*keys: MutationKey) -> None:
 
     Invalidates the load cache for ``keys`` and accumulates them as pending
     dirtied for the next reactive ``render()``. Keys must be ``MutationKey``
-    members.
+    members or ``reactive_key()`` values.
     """
     _require_mutation_keys(keys, "dirty()")
     MutationTracker.record(keys)

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -450,7 +450,8 @@ def oob_swaps(
             load_arg = None
 
         static_keys = set(getattr(component_class, "_pjx_reacts_to", frozenset()))
-        if not (static_keys & dirtied_keys):
+        derived_keys = _keyed_derived_keys(frozenset(static_keys), load_arg) if keyed else set()
+        if not ((static_keys | derived_keys) & dirtied_keys):
             continue
 
         dedup_key = (component_type, load_arg)

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -32,6 +32,15 @@ from .keys import MutationKey, ReactiveKey, coerce_load_key_str, coerce_reactive
 from .mutations import MutationTracker, _require_mutation_keys
 
 
+def _keyed_derived_keys(static_keys: frozenset[str], key: str | None) -> set[str]:
+    """Per-instance reactive keys implied by a keyed component's own load-key,
+    one per declared static key: ``f"{static_key}:{key}"``. Empty when the
+    component isn't keyed (``key`` is ``None``)."""
+    if key is None:
+        return set()
+    return {f"{k}:{key}" for k in static_keys}
+
+
 class PjxKey:
     """Marker for ``Annotated[..., PjxKey()]`` fields stamped as ``data-pjx-load``."""
 
@@ -249,7 +258,8 @@ class ReactiveComponent(BaseComponent):
 
     def depends_on(self) -> set[str]:
         """Reactive state keys this loaded instance currently depends on."""
-        return set(getattr(type(self), "_pjx_reacts_to", frozenset()))
+        static = frozenset(getattr(type(self), "_pjx_reacts_to", frozenset()))
+        return set(static) | _keyed_derived_keys(static, self._pjx_key)
 
     def state_hash(self) -> str:
         """

--- a/pyjinhx/reactive.py
+++ b/pyjinhx/reactive.py
@@ -28,7 +28,7 @@ from .assets import render_missing_assets_oob
 from .cache import LoadCache
 from .client import ClientBackend, LoadedAssets, MountedManifest, current_directives
 from .dev import warn_reactive_render_without_client
-from .keys import MutationKey, ReactiveKey, coerce_load_key_str, coerce_reactive_keys
+from .keys import MutationKey, ReactiveKey, coerce_load_key_str, coerce_reactive_keys, reactive_key
 from .mutations import MutationTracker, _require_mutation_keys
 
 
@@ -567,9 +567,16 @@ class ReactiveResponse(Markup):
 
     Pass mutation keys positionally to dirty them and fan out in one call, e.g.
     ``ReactiveResponse(Keys.TODOS)`` — no separate ``dirty()``/``@mutates`` needed.
+    Pass ``key=`` to dirty a per-instance key instead, e.g.
+    ``ReactiveResponse(Keys.MESSAGE, key=message_id)`` — equivalent to
+    ``dirty(reactive_key(Keys.MESSAGE, message_id))``.
     """
 
-    def __new__(cls, *keys: MutationKey, html: str | Markup = "") -> "ReactiveResponse":
+    def __new__(
+        cls, *keys: MutationKey, key: object | None = None, html: str | Markup = ""
+    ) -> "ReactiveResponse":
+        if key is not None:
+            keys = tuple(reactive_key(k, key) for k in keys)
         _require_mutation_keys(keys, "ReactiveResponse()")
         MutationTracker.record(keys)  # no-op when keys is empty
         if not str(html).strip():

--- a/tests/ui/reactive/counted_row.html
+++ b/tests/ui/reactive/counted_row.html
@@ -1,0 +1,1 @@
+<li class="counted-row">{{ label }}</li>

--- a/tests/ui/reactive/counted_row.py
+++ b/tests/ui/reactive/counted_row.py
@@ -1,0 +1,19 @@
+from typing import Annotated, ClassVar
+
+from pyjinhx import MutationKey, PjxKey, ReactiveComponent
+
+
+class Keys(MutationKey):
+    ROW = "row"
+
+
+class CountedRow(ReactiveComponent, react={Keys.ROW}):
+    load_calls: ClassVar[list[str]] = []
+
+    row_key: Annotated[str, PjxKey()]
+    label: str = ""
+
+    @classmethod
+    def load(cls, key: str) -> "CountedRow":
+        cls.load_calls.append(key)
+        return cls(id=f"row-{key}", row_key=key, label=f"Row {key}")

--- a/tests/unit/test_depends_on.py
+++ b/tests/unit/test_depends_on.py
@@ -97,3 +97,8 @@ def test_depends_on_exceeding_superset_raises_in_strict_dev():
 def test_keyed_component_default_depends_on_includes_derived_key():
     instance = KeyedProbe.load("7")
     assert instance.depends_on() == {"alpha", "alpha:7"}
+
+
+def test_keyed_component_default_depends_on_does_not_trip_strict_dev():
+    enable_reactive_dev(strict=True)
+    KeyedProbe.load("9")  # must not raise — the derived key is expected, not "extra"

--- a/tests/unit/test_depends_on.py
+++ b/tests/unit/test_depends_on.py
@@ -1,8 +1,9 @@
 from pathlib import Path
+from typing import Annotated
 
 import pytest
 
-from pyjinhx import MutationKey, ReactiveComponent, Registry, Renderer
+from pyjinhx import MutationKey, PjxKey, ReactiveComponent, Registry, Renderer
 from pyjinhx.cache import LoadCache
 from pyjinhx.dev import disable_reactive_dev, enable_reactive_dev
 from pyjinhx.reactive import oob_swaps
@@ -24,6 +25,14 @@ class OverBroad(ReactiveComponent, react={_Keys.ALPHA}):
 
     def depends_on(self) -> set[str]:
         return {"alpha", "extra"}
+
+
+class KeyedProbe(ReactiveComponent, react={_Keys.ALPHA}):
+    probe_key: Annotated[str, PjxKey()]
+
+    @classmethod
+    def load(cls, key: str) -> "KeyedProbe":
+        return cls(id=f"probe-{key}", probe_key=key)
 
 
 def setup_function():
@@ -83,3 +92,8 @@ def test_depends_on_exceeding_superset_raises_in_strict_dev():
     enable_reactive_dev(strict=True)
     with pytest.raises(RuntimeError, match="depends_on"):
         OverBroad.load()
+
+
+def test_keyed_component_default_depends_on_includes_derived_key():
+    instance = KeyedProbe.load("7")
+    assert instance.depends_on() == {"alpha", "alpha:7"}

--- a/tests/unit/test_dynamic_reactive_keys.py
+++ b/tests/unit/test_dynamic_reactive_keys.py
@@ -1,0 +1,39 @@
+from pyjinhx.cache import LoadCache
+from pyjinhx.keys import reactive_key
+from pyjinhx.reactive import oob_swaps
+
+from tests.ui.reactive.counted_row import CountedRow, Keys  # noqa: F401
+
+
+def _manifest():
+    return [
+        {"id": "row-1", "type": "CountedRow", "load": "1", "hash": "stale"},
+        {"id": "row-2", "type": "CountedRow", "load": "2", "hash": "stale"},
+        {"id": "row-3", "type": "CountedRow", "load": "3", "hash": "stale"},
+    ]
+
+
+def setup_function():
+    LoadCache.clear()
+    CountedRow.load_calls.clear()
+
+
+def test_static_key_dirty_still_reloads_every_row():
+    out = str(oob_swaps({"row"}, _manifest()))
+    assert sorted(CountedRow.load_calls) == ["1", "2", "3"]
+    for rid in ("row-1", "row-2", "row-3"):
+        assert f"outerHTML:[data-pjx-id='{rid}']" in out
+
+
+def test_dynamic_key_dirty_reloads_only_the_matching_row():
+    out = str(oob_swaps({reactive_key(Keys.ROW, "2")}, _manifest()))
+    assert CountedRow.load_calls == ["2"]
+    assert "outerHTML:[data-pjx-id='row-2']" in out
+    assert "outerHTML:[data-pjx-id='row-1']" not in out
+    assert "outerHTML:[data-pjx-id='row-3']" not in out
+
+
+def test_unrelated_dynamic_key_reloads_nothing():
+    out = str(oob_swaps({reactive_key(Keys.ROW, "999")}, _manifest()))
+    assert CountedRow.load_calls == []
+    assert out == ""

--- a/tests/unit/test_finish_with_oob.py
+++ b/tests/unit/test_finish_with_oob.py
@@ -180,6 +180,47 @@ def test_reactive_response_records_multiple_keys():
     assert MutationTracker.pending() == {"todos", "quota"}
 
 
+def test_reactive_response_key_kwarg_derives_per_instance_key():
+    from pyjinhx.mutations import MutationTracker
+    from pyjinhx.reactive import ReactiveResponse
+    from tests.reactive_test_support import Keys
+
+    ReactiveResponse(Keys.TODOS, key="42")
+    assert MutationTracker.pending() == {"todos:42"}
+
+
+def test_reactive_response_key_kwarg_applies_to_every_key():
+    from pyjinhx import MutationKey
+    from pyjinhx.mutations import MutationTracker
+    from pyjinhx.reactive import ReactiveResponse
+    from tests.reactive_test_support import Keys
+
+    class OtherKeys(MutationKey):
+        QUOTA = "quota"
+
+    ReactiveResponse(Keys.TODOS, OtherKeys.QUOTA, key="42")
+    assert MutationTracker.pending() == {"todos:42", "quota:42"}
+
+
+def test_reactive_response_key_kwarg_reloads_only_the_matching_instance():
+    from pyjinhx.cache import LoadCache
+    from pyjinhx.reactive import ReactiveResponse
+
+    from tests.ui.reactive.counted_row import CountedRow, Keys as RowKeys  # noqa: F401
+
+    LoadCache.clear()
+    CountedRow.load_calls.clear()
+    manifest = [
+        {"id": "row-1", "type": "CountedRow", "load": "1", "hash": "stale"},
+        {"id": "row-2", "type": "CountedRow", "load": "2", "hash": "stale"},
+    ]
+    with reactive_client(manifest):
+        out = str(ReactiveResponse(RowKeys.ROW, key="2"))
+    assert CountedRow.load_calls == ["2"]
+    assert "outerHTML:[data-pjx-id='row-2']" in out
+    assert "outerHTML:[data-pjx-id='row-1']" not in out
+
+
 def test_reactive_response_html_keyword_keeps_primary_and_fans_out():
     from pyjinhx.reactive import ReactiveResponse
 

--- a/tests/unit/test_keys.py
+++ b/tests/unit/test_keys.py
@@ -1,0 +1,26 @@
+from pyjinhx.keys import DynamicReactiveKey, MutationKey, coerce_reactive_key, reactive_key
+
+
+class _Keys(MutationKey):
+    MESSAGE = "chat.message"
+
+
+def test_reactive_key_formats_prefix_and_arg():
+    key = reactive_key(_Keys.MESSAGE, "42")
+    assert key == "chat.message:42"
+
+
+def test_reactive_key_returns_dynamic_reactive_key_instance():
+    key = reactive_key(_Keys.MESSAGE, "42")
+    assert isinstance(key, DynamicReactiveKey)
+    assert isinstance(key, str)
+
+
+def test_reactive_key_coerces_non_string_arg():
+    key = reactive_key(_Keys.MESSAGE, 42)
+    assert key == "chat.message:42"
+
+
+def test_coerce_reactive_key_passes_dynamic_reactive_key_through():
+    key = reactive_key(_Keys.MESSAGE, "42")
+    assert coerce_reactive_key(key) == "chat.message:42"

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -107,6 +107,65 @@ def test_mutates_accepts_reactive_key():
     assert MutationTracker.pending() == {"todos:row-2"}
 
 
+def test_mutates_key_kwarg_derives_from_call_args():
+    MutationTracker.clear()
+
+    @mutates(Keys.TODOS, key=lambda todo_id: todo_id)
+    def toggle(todo_id: str) -> None:
+        pass
+
+    toggle("row-3")
+    assert MutationTracker.pending() == {"todos:row-3"}
+
+
+def test_mutates_key_kwarg_reflects_each_call():
+    MutationTracker.clear()
+
+    @mutates(Keys.TODOS, key=lambda todo_id: todo_id)
+    def toggle(todo_id: str) -> None:
+        pass
+
+    toggle("row-1")
+    assert MutationTracker.pending() == {"todos:row-1"}
+    MutationTracker.clear()
+    toggle("row-2")
+    assert MutationTracker.pending() == {"todos:row-2"}
+
+
+def test_mutates_key_kwarg_applies_to_every_key():
+    MutationTracker.clear()
+
+    @mutates(Keys.TODOS, _ExtraKeys.USERS, key=lambda user_id: user_id)
+    def touch(user_id: str) -> None:
+        pass
+
+    touch("7")
+    assert MutationTracker.pending() == {"todos:7", "users:7"}
+
+
+def test_mutates_key_kwarg_reloads_only_the_matching_instance():
+    from pyjinhx.reactive import oob_swaps
+    from tests.ui.reactive.counted_row import CountedRow, Keys as RowKeys  # noqa: F401
+
+    LoadCache.clear()
+    CountedRow.load_calls.clear()
+    MutationTracker.clear()
+
+    @mutates(RowKeys.ROW, key=lambda row_id: row_id)
+    def toggle_row(row_id: str) -> None:
+        pass
+
+    manifest = [
+        {"id": "row-1", "type": "CountedRow", "load": "1", "hash": "stale"},
+        {"id": "row-2", "type": "CountedRow", "load": "2", "hash": "stale"},
+    ]
+    toggle_row("2")
+    out = str(oob_swaps(MutationTracker.pending(), manifest))
+    assert CountedRow.load_calls == ["2"]
+    assert "outerHTML:[data-pjx-id='row-2']" in out
+    assert "outerHTML:[data-pjx-id='row-1']" not in out
+
+
 def test_dirty_without_args_is_noop():
     MutationTracker.clear()
     dirty()

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -4,6 +4,7 @@ import pytest
 
 from pyjinhx import MutationKey, Registry, Renderer, dirty, mutates
 from pyjinhx.cache import LoadCache
+from pyjinhx.keys import reactive_key
 from pyjinhx.mutations import MutationTracker
 from tests.reactive_test_support import Keys, reactive_client
 from tests.ui.reactive.reactive_clear_button import ReactiveClearButton
@@ -87,6 +88,23 @@ def test_dirty_rejects_bare_strings():
     with pytest.raises(TypeError) as excinfo:
         dirty("todos")  # type: ignore[arg-type]  # deliberately passes a bare string
     assert str(excinfo.value).startswith("dirty()")
+
+
+def test_dirty_accepts_reactive_key():
+    MutationTracker.clear()
+    dirty(reactive_key(Keys.TODOS, "row-1"))
+    assert MutationTracker.pending() == {"todos:row-1"}
+
+
+def test_mutates_accepts_reactive_key():
+    MutationTracker.clear()
+
+    @mutates(reactive_key(Keys.TODOS, "row-2"))
+    def _mutate_one_row() -> None:
+        pass
+
+    _mutate_one_row()
+    assert MutationTracker.pending() == {"todos:row-2"}
 
 
 def test_dirty_without_args_is_noop():

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -14,6 +14,7 @@ from pyjinhx import (
     component,
     dirty,
     mutates,
+    reactive_key,  # noqa: F401
     setup,
 )
 
@@ -29,6 +30,7 @@ PUBLIC_API = {
     "mutates",
     "dirty",
     "MutationKey",
+    "reactive_key",
     "PjxKey",
     "PjxContext",
     "PjxSettings",
@@ -56,7 +58,7 @@ def test_internals_are_not_in_the_public_surface():
     # advanced/internal building blocks must NOT leak into the top-level API
     for name in (
         "CacheScope", "client_script", "oob_swaps", "LoadCache", "InvalidationHub",
-        "InvalidationBackend", "MutationTracker", "Finder", "Parser", "Tag",
+        "InvalidationBackend", "MutationTracker", "DynamicReactiveKey", "Finder", "Parser", "Tag",
         "ClientBackend", "FastAPIClientBackend", "MountedManifest", "TriggerManifest",
         "LoadedAssets", "PJX_MOUNTED_HEADER", "PJX_TRIGGER_HEADER", "PJX_ASSETS_HEADER",
         "configure_pyjinhx", "shutdown_pyjinhx",


### PR DESCRIPTION
## What this fixes

Today, `react={SomeKey}` only lets a reactive component react to a *shared* key — dirtying it reloads and re-renders **every** mounted instance of that type. There's no way to say "only this one row/message changed." For a keyed component (one mounted per row/message/entity), that means any change to *any* instance forces every sibling instance to be reloaded, rendered, and hash-checked too — O(n) work per dirty, even though only one instance's swap actually goes out over the wire.

This PR adds `reactive_key()`: a per-instance reactive key, derived automatically from a component's existing `react={...}` declaration and its own load-key — no new methods to write. Dirtying one instance's derived key now reloads **only** that instance; dirtying the shared key still reloads everyone, unchanged.

## Example (beginner-friendly)

Say you have a keyed `TodoRow` component — one instance mounted per todo item — and today, checking off *one* todo reloads *every* mounted row:

```python
from typing import Annotated
from pyjinhx import MutationKey, PjxKey, ReactiveComponent, dirty
from pyjinhx.keys import reactive_key

class Keys(MutationKey):
    TODO = "todo"

class TodoRow(ReactiveComponent, react={Keys.TODO}):
    todo_id: Annotated[str, PjxKey()]
    done: bool = False

    @classmethod
    def load(cls, todo_id: str) -> "TodoRow":
        todo = store.get(todo_id)
        return cls(id=f"row-{todo_id}", todo_id=todo_id, done=todo.done)

@app.post("/todos/{todo_id}/toggle")
def toggle(todo_id: str):
    store.toggle(todo_id)
    # Before: dirty(Keys.TODO) reloads EVERY mounted TodoRow.
    # After: only the one row whose todo_id matches gets reloaded.
    dirty(reactive_key(Keys.TODO, todo_id))
    return TodoRow.render(todo_id)
```

`reactive_key(Keys.TODO, todo_id)` just builds the string `"todo:<todo_id>"` — the framework already knows to check for that shape on any keyed component reacting to `Keys.TODO`, so there's nothing else to wire up. Dirtying `Keys.TODO` directly (no `reactive_key()`) still works exactly like today and refreshes every row — this is purely additive.

If the route renders no component itself (a `204`, a hand-assembled body) and you'd reach for `ReactiveResponse` instead of `dirty()`, it takes the same per-instance key as a `key=` keyword — no need to import `reactive_key()` yourself:

```python
from pyjinhx.reactive import ReactiveResponse

@app.post("/todos/{todo_id}/toggle")
def toggle(todo_id: str):
    store.toggle(todo_id)
    return ReactiveResponse(Keys.TODO, key=todo_id)  # same effect as dirty(reactive_key(...)) above
```

And if the mutation itself is a `@mutates`-decorated store method rather than an inline `dirty()` call, `key=` works there too — as a **callable**, since `@mutates(...)` runs once at decoration time, before any call arguments exist:

```python
from pyjinhx import mutates

@mutates(Keys.TODO, key=lambda todo_id: todo_id)
def toggle(todo_id: str) -> Todo:
    ...

@app.post("/todos/{todo_id}/toggle")
def toggle_route(todo_id: str):
    toggle(todo_id)  # dirties reactive_key(Keys.TODO, todo_id) fresh on every call
    return TodoRow.render(todo_id)
```

## How it works

- `reactive_key(key, arg) -> DynamicReactiveKey` (new, exported from `pyjinhx`) builds a fixed-format string `f"{key}:{arg}"`. `dirty()`/`@mutates()`/`ReactiveResponse()` now accept this alongside `MutationKey` members — a bare string is still rejected, so the existing typo-safety net holds.
- `ReactiveResponse` also takes a keyword-only `key=` that derives the per-instance key internally (`ReactiveResponse(Keys.TODO, key=todo_id)` is `dirty(reactive_key(Keys.TODO, todo_id))`) — applies to every positional `MutationKey` passed alongside it, so `ReactiveResponse(KeyA, KeyB, key=x)` dirties both `reactive_key(KeyA, x)` and `reactive_key(KeyB, x)`.
- `@mutates` takes `key=` too, but as a *callable* rather than a plain value — it's invoked with the decorated function's own `*args`/`**kwargs` at call time (not decoration time, when the real argument doesn't exist yet), and its return value feeds `reactive_key()` for every key in `@mutates(...)`. Without this, `@mutates` had no way to participate in per-instance dirtying at all — every other entry point (`dirty()`, `ReactiveResponse()`) already had it.
- A keyed `ReactiveComponent`'s **default** `depends_on()` now automatically includes its own derived key, so `LoadCache`'s existing cache-invalidation index (which already calls `depends_on()`) evicts the right cached instance with zero changes to `cache.py`.
- `oob_swaps()`'s dispatch loop now also tests the derived key computed from each mounted instance's own load-key — **before** calling `.load()`. This is the actual perf fix: a per-instance dirty no longer even loads the sibling instances, not just skips their swap.
- `pyjinhx/dev.py`'s strict dev-mode validator was updated to match, so it doesn't false-positive on the new default `depends_on()` behavior.
- If you override `depends_on()` yourself on a keyed component, include the derived key in your override (e.g. `return super().depends_on() | {...}`) — `oob_swaps` matches it independently of your override, so an override that omits it leaves the cache unaware a per-instance dirty should evict that instance. Documented in `docs/reactivity.md`.

Design doc and implementation plan (both brainstormed/reviewed with the user first) are gitignored/local — see `docs/superpowers/specs/2026-07-18-parametric-reactive-keys-design.md` and `docs/superpowers/plans/2026-07-18-parametric-reactive-keys.md` on this branch if you want the full design rationale and task-by-task history.

## Test plan
- [x] `uv run pytest tests/ -q` — 1209 passed, 5 skipped
- [x] Core regression test (`tests/unit/test_dynamic_reactive_keys.py`) proves the O(n)→O(1) claim via a **load-call counter** — not just checking swap HTML — so it actually proves sibling instances were never loaded, not merely that their swap was hash-gated away
- [x] `ReactiveResponse(key=...)` covered end-to-end in `tests/unit/test_finish_with_oob.py` (derives the right key, applies to multiple positional keys, and — via the same load-call-counter technique — reloads only the matching mounted instance)
- [x] `@mutates(key=...)` covered in `tests/unit/test_mutations.py` (derives the right key from call args, re-derives fresh on each call, applies to multiple positional keys, and — same load-call-counter technique — reloads only the matching mounted instance)
- [x] `uv run ruff check .` — clean
- [x] `uv run mkdocs build --strict` — clean

Every task in this branch went through an individual implementer → task-reviewer cycle, plus a final whole-branch review (verdict: ready to merge, no Critical/Important findings). `ReactiveResponse(key=...)` and `@mutates(key=...)` were added afterward at the user's request, each with its own test coverage. Not merging/bumping — flagged for your manual review.

Closes #201

