### PR TITLE
test: drop redundant str() around composed .render() calls

### DIFF
--- a/tests/integration/app.py
+++ b/tests/integration/app.py
@@ -216,8 +216,8 @@ def _gallery_inner_html() -> str:
         modal=PJXModal(
             id="g-modal",
             content=(
-                str(PJXModalHeader(id="g-modal-h", title="Demo modal").render())
-                + str(PJXModalBody(id="g-modal-b", content="Modal body content from the gallery.").render())
+                PJXModalHeader(id="g-modal-h", title="Demo modal").render()
+                + PJXModalBody(id="g-modal-b", content="Modal body content from the gallery.").render()
             ),
         ),
         notification=PJXNotification(
@@ -229,8 +229,8 @@ def _gallery_inner_html() -> str:
         popover=PJXPopover(
             id="g-pop",
             content=(
-                str(PJXPopoverTrigger(id="g-pop-t", content="Open popover").render())
-                + str(PJXPopoverPanel(id="g-pop-p", content="Popover details appear on click.").render())
+                PJXPopoverTrigger(id="g-pop-t", content="Open popover").render()
+                + PJXPopoverPanel(id="g-pop-p", content="Popover details appear on click.").render()
             ),
         ),
         region_loader=PJXRegionLoader(id="g-overlay"),
@@ -238,8 +238,8 @@ def _gallery_inner_html() -> str:
             id="g-tip",
             placement="top",
             content=(
-                str(PJXTooltipTrigger(id="g-tip-tr", content="Focus or hover").render())
-                + str(PJXTooltipContent(id="g-tip-tc", content="Tooltip copy").render())
+                PJXTooltipTrigger(id="g-tip-tr", content="Focus or hover").render()
+                + PJXTooltipContent(id="g-tip-tc", content="Tooltip copy").render()
             ),
         ),
         alert=PJXAlert(
@@ -257,8 +257,8 @@ def _gallery_inner_html() -> str:
             id="g-drawer",
             side="right",
             content=(
-                str(PJXDrawerHeader(id="g-drawer-h", title="Drawer").render())
-                + str(PJXDrawerBody(id="g-drawer-b", content="Side panel content.").render())
+                PJXDrawerHeader(id="g-drawer-h", title="Drawer").render()
+                + PJXDrawerBody(id="g-drawer-b", content="Side panel content.").render()
             ),
         ),
         progress_determinate=PJXProgress(
@@ -304,12 +304,12 @@ def _gallery_inner_html() -> str:
         tab_group=PJXTabGroup(
             id="g-tabs",
             content=(
-                str(PJXTabList(content=(
-                    str(PJXTab(id="g-tabs-t0", panel="g-tabs-p0", selected=True, content="Overview").render())
-                    + str(PJXTab(id="g-tabs-t1", panel="g-tabs-p1", content="Details").render())
+                (PJXTabList(content=(
+                    PJXTab(id="g-tabs-t0", panel="g-tabs-p0", selected=True, content="Overview").render()
+                    + PJXTab(id="g-tabs-t1", panel="g-tabs-p1", content="Details").render()
                 )).render())
-                + str(PJXTabPanel(id="g-tabs-p0", tab="g-tabs-t0", content="<p>First panel content.</p>").render())
-                + str(PJXTabPanel(id="g-tabs-p1", tab="g-tabs-t1", content="<p>Second panel content.</p>").render())
+                + PJXTabPanel(id="g-tabs-p0", tab="g-tabs-t0", content="<p>First panel content.</p>").render()
+                + PJXTabPanel(id="g-tabs-p1", tab="g-tabs-t1", content="<p>Second panel content.</p>").render()
             ),
         ),
         panel_trigger_alpha=PJXTab(
@@ -323,11 +323,11 @@ def _gallery_inner_html() -> str:
         panel_host=PJXTabGroup(
             id="g-panel",
             content=(
-                str(PJXTabPanel(
+                (PJXTabPanel(
                     id="g-panel-panel-alpha",
                     content="<p>Panel alpha (default). Beta is hidden but still connected to SSE.</p>",
                 ).render())
-                + str(PJXTabPanel(
+                + (PJXTabPanel(
                     id="g-panel-panel-beta",
                     content=(
                         '<div id="g-panel-sse-live" hx-ext="sse" sse-connect="/sse/panel-demo" '

--- a/tests/reactivity/app.py
+++ b/tests/reactivity/app.py
@@ -166,8 +166,8 @@ def _popover(prefix: str, label: str) -> PJXPopover:
     return PJXPopover(
         id=prefix,
         content=(
-            str(PJXPopoverTrigger(id=f"{prefix}-t", content=label).render())
-            + str(PJXPopoverPanel(id=f"{prefix}-p", content=f"{label} panel content").render())
+            PJXPopoverTrigger(id=f"{prefix}-t", content=label).render()
+            + PJXPopoverPanel(id=f"{prefix}-p", content=f"{label} panel content").render()
         ),
     )
 
@@ -178,14 +178,14 @@ def render_page() -> str:
         modal=PJXModal(
             id="rx-modal",
             content=(
-                str(PJXModalHeader(id="rx-modal-h", title="Demo modal").render())
-                + str(PJXModalBody(id="rx-modal-b", content="Modal body.").render())
+                PJXModalHeader(id="rx-modal-h", title="Demo modal").render()
+                + PJXModalBody(id="rx-modal-b", content="Modal body.").render()
             ),
         ),
         remove_modal=PJXModal(
             id="rx-remove-modal",
             remove_on_close=True,
-            content=str(PJXModalBody(
+            content=(PJXModalBody(
                 id="rx-remove-modal-b",
                 content=(
                     '<form id="rx-remove-form" hx-post="/actions/slow-save" hx-swap="none">'
@@ -198,8 +198,8 @@ def render_page() -> str:
             id="rx-drawer",
             side="right",
             content=(
-                str(PJXDrawerHeader(id="rx-drawer-h", title="Demo drawer").render())
-                + str(PJXDrawerBody(id="rx-drawer-b", content="Drawer body.").render())
+                PJXDrawerHeader(id="rx-drawer-h", title="Demo drawer").render()
+                + PJXDrawerBody(id="rx-drawer-b", content="Drawer body.").render()
             ),
         ),
         popover_a=_popover("rx-pop-a", "Open A"),
@@ -234,10 +234,10 @@ def render_page() -> str:
         panel=PJXTabGroup(
             id="rx-panel",
             content=(
-                str(PJXTabPanel(id="rx-panel-panel-a", content="<p>Panel A body</p>").render())
-                + str(PJXTabPanel(
+                PJXTabPanel(id="rx-panel-panel-a", content="<p>Panel A body</p>").render()
+                + (PJXTabPanel(
                     id="rx-panel-panel-b",
-                    content=str(PJXLazyLoad(
+                    content=(PJXLazyLoad(
                         id="rx-lazy",
                         when="reveal",
                         url="/fragments/lazy",
@@ -257,57 +257,57 @@ def render_page() -> str:
         detached_group=PJXTabGroup(
             id="rx-detached-group",
             content=(
-                str(PJXTabPanel(id="rx-detached-p0", content="<p>Detached body 0</p>").render())
-                + str(PJXTabPanel(id="rx-detached-p1", content="<p>Detached body 1</p>").render())
+                PJXTabPanel(id="rx-detached-p0", content="<p>Detached body 0</p>").render()
+                + PJXTabPanel(id="rx-detached-p1", content="<p>Detached body 1</p>").render()
             ),
         ),
         password=PJXPasswordInput(id="rx-pw"),
         tabs=PJXTabGroup(
             id="rx-tabs",
             content=(
-                str(PJXTabList(content=(
-                    str(PJXTab(id="rx-tab-one", panel="rx-tabp-one", selected=True, content="One").render())
-                    + str(PJXTab(id="rx-tab-two", panel="rx-tabp-two", closeable=True, content="Two").render())
+                (PJXTabList(content=(
+                    PJXTab(id="rx-tab-one", panel="rx-tabp-one", selected=True, content="One").render()
+                    + PJXTab(id="rx-tab-two", panel="rx-tabp-two", closeable=True, content="Two").render()
                 )).render())
-                + str(PJXTabPanel(id="rx-tabp-one", tab="rx-tab-one", content="<p>Tab one body</p>").render())
-                + str(PJXTabPanel(id="rx-tabp-two", tab="rx-tab-two", content="<p>Tab two body</p>").render())
+                + PJXTabPanel(id="rx-tabp-one", tab="rx-tab-one", content="<p>Tab one body</p>").render()
+                + PJXTabPanel(id="rx-tabp-two", tab="rx-tab-two", content="<p>Tab two body</p>").render()
             ),
         ),
         reorder_tabs=PJXTabGroup(
             id="rx-reorder-tabs",
             content=(
-                str(PJXTabList(reorderable=True, content=(
-                    str(PJXTab(id="rx-reorder-a", panel="rx-reorder-pa", selected=True, content="A").render())
-                    + str(PJXTab(id="rx-reorder-b", panel="rx-reorder-pb", content="B").render())
-                    + str(PJXTab(id="rx-reorder-c", panel="rx-reorder-pc", content="C").render())
+                (PJXTabList(reorderable=True, content=(
+                    PJXTab(id="rx-reorder-a", panel="rx-reorder-pa", selected=True, content="A").render()
+                    + PJXTab(id="rx-reorder-b", panel="rx-reorder-pb", content="B").render()
+                    + PJXTab(id="rx-reorder-c", panel="rx-reorder-pc", content="C").render()
                 )).render())
-                + str(PJXTabPanel(id="rx-reorder-pa", tab="rx-reorder-a", content="A body").render())
-                + str(PJXTabPanel(id="rx-reorder-pb", tab="rx-reorder-b", content="B body").render())
-                + str(PJXTabPanel(id="rx-reorder-pc", tab="rx-reorder-c", content="C body").render())
+                + PJXTabPanel(id="rx-reorder-pa", tab="rx-reorder-a", content="A body").render()
+                + PJXTabPanel(id="rx-reorder-pb", tab="rx-reorder-b", content="B body").render()
+                + PJXTabPanel(id="rx-reorder-pc", tab="rx-reorder-c", content="C body").render()
             ),
         ),
         resizable=PJXResizableGroup(
             id="rx-resize-group",
             direction="row",
             content=(
-                str(PJXResizablePanel(id="rx-resize-left", size=50, min=20, content="<div>left</div>").render())
-                + str(PJXResizableHandle(id="rx-resize-handle").render())
-                + str(PJXResizablePanel(id="rx-resize-right", size=50, content="<div>right</div>").render())
+                PJXResizablePanel(id="rx-resize-left", size=50, min=20, content="<div>left</div>").render()
+                + PJXResizableHandle(id="rx-resize-handle").render()
+                + PJXResizablePanel(id="rx-resize-right", size=50, content="<div>right</div>").render()
             ),
         ),
-        floor_box=str(PJXResizableGroup(id="rx-floor-group", direction="column", content=(
-            str(PJXResizablePanel(id="rx-floor-top", size=60, content="<div>top</div>").render())
-            + str(PJXResizableHandle(id="rx-floor-handle").render())
-            + str(PJXResizablePanel(id="rx-floor-bottom", size=40, min="content", content='<div id="rx-floor-strip" style="height:36px;flex-shrink:0">strip</div><div>body</div>').render())
+        floor_box=(PJXResizableGroup(id="rx-floor-group", direction="column", content=(
+            PJXResizablePanel(id="rx-floor-top", size=60, content="<div>top</div>").render()
+            + PJXResizableHandle(id="rx-floor-handle").render()
+            + PJXResizablePanel(id="rx-floor-bottom", size=40, min="content", content='<div id="rx-floor-strip" style="height:36px;flex-shrink:0">strip</div><div>body</div>').render()
         )).render()),
-        accordion_box=str(PJXAccordionGroup(id="rx-accordion-group", content=(
-            str(PJXAccordion(id="rx-accordion-open", open=False, content=(
-                str(PJXAccordionTrigger(id="rx-accordion-trigger-open", content="Open item").render())
-                + str(PJXAccordionContent(content="Open item body").render())
+        accordion_box=(PJXAccordionGroup(id="rx-accordion-group", content=(
+            (PJXAccordion(id="rx-accordion-open", open=False, content=(
+                PJXAccordionTrigger(id="rx-accordion-trigger-open", content="Open item").render()
+                + PJXAccordionContent(content="Open item body").render()
             )).render())
-            + str(PJXAccordion(id="rx-accordion-disabled", open=False, content=(
-                str(PJXAccordionTrigger(id="rx-accordion-trigger-disabled", disabled=True, content="Disabled item").render())
-                + str(PJXAccordionContent(content="Disabled item body").render())
+            + (PJXAccordion(id="rx-accordion-disabled", open=False, content=(
+                PJXAccordionTrigger(id="rx-accordion-trigger-disabled", disabled=True, content="Disabled item").render()
+                + PJXAccordionContent(content="Disabled item body").render()
             )).render())
         )).render()),
     )
@@ -345,7 +345,7 @@ def create_app() -> FastAPI:
 
     @app.get("/fragments/notification", response_class=HTMLResponse)
     def notification_fragment() -> str:
-        return str(
+        return (
             PJXNotification(
                 id="rx-note-frag",
                 content="Fragment note",

--- a/tests/unit/test_golden_builtins.py
+++ b/tests/unit/test_golden_builtins.py
@@ -24,26 +24,26 @@ CASES = [
     ("avatar_stack", lambda: b.PJXAvatarStack(id="g", avatars=[b.PJXAvatar(id="g-a", initials="AB")], extra_count=2)),
     ("badge_default", lambda: b.PJXBadge(id="g", label="New")),
     ("breadcrumb", lambda: b.PJXBreadcrumb(id="g", items=[("Home", "/"), ("Here", None)])),
-    ("card_full", lambda: b.PJXCard(id="g", content=str(b.PJXCardHeader(id="g-h", title="T").render()) + str(b.PJXCardBody(id="g-b", content="B").render()) + str(b.PJXCardFooter(id="g-f", content="F").render()))),
+    ("card_full", lambda: b.PJXCard(id="g", content=b.PJXCardHeader(id="g-h", title="T").render() + b.PJXCardBody(id="g-b", content="B").render() + b.PJXCardFooter(id="g-f", content="F").render())),
     ("card_header_title", lambda: b.PJXCardHeader(id="g", title="Title")),
     ("card_header_content", lambda: b.PJXCardHeader(id="g", content="<span>Rich</span>")),
     ("card_body", lambda: b.PJXCardBody(id="g", content="<p>body</p>")),
     ("card_footer", lambda: b.PJXCardFooter(id="g", content="Footer")),
     ("carousel_multi", lambda: b.PJXCarousel(id="g", content=(
-        str(b.PJXCarouselSlide(id="g-s0", content="<img src='/a.png'>").render())
-        + str(b.PJXCarouselSlide(id="g-s1", label="Second photo", content="<img src='/b.png'>").render())
+        b.PJXCarouselSlide(id="g-s0", content="<img src='/a.png'>").render()
+        + b.PJXCarouselSlide(id="g-s1", label="Second photo", content="<img src='/b.png'>").render()
     ))),
-    ("carousel_single", lambda: b.PJXCarousel(id="g", content=str(b.PJXCarouselSlide(id="g-s0", content="<img src='/a.png'>").render()))),
+    ("carousel_single", lambda: b.PJXCarousel(id="g", content=b.PJXCarouselSlide(id="g-s0", content="<img src='/a.png'>").render())),
     ("carousel_empty", lambda: b.PJXCarousel(id="g")),
-    ("carousel_autoplay", lambda: b.PJXCarousel(id="g", autoplay=True, interval_ms=3000, content=str(b.PJXCarouselSlide(id="g-s0", content="<img src='/a.png'>").render()))),
-    ("carousel_no_loop", lambda: b.PJXCarousel(id="g", loop=False, content=str(b.PJXCarouselSlide(id="g-s0", content="<img src='/a.png'>").render()))),
+    ("carousel_autoplay", lambda: b.PJXCarousel(id="g", autoplay=True, interval_ms=3000, content=b.PJXCarouselSlide(id="g-s0", content="<img src='/a.png'>").render())),
+    ("carousel_no_loop", lambda: b.PJXCarousel(id="g", loop=False, content=b.PJXCarouselSlide(id="g-s0", content="<img src='/a.png'>").render())),
     ("carousel_slide", lambda: b.PJXCarouselSlide(id="g", label="Bridge at sunset", content="<img src='/photo.jpg'>")),
     ("confirm_dialog", lambda: b.PJXConfirmDialog(id="g")),
     ("divider_labeled", lambda: b.PJXDivider(id="g", label="or")),
     ("drawer", lambda: b.PJXDrawer(id="g", side="left", content=(
-        str(b.PJXDrawerHeader(id="g-h", title="Menu").render())
-        + str(b.PJXDrawerBody(id="g-b", content="Links").render())
-        + str(b.PJXDrawerFooter(id="g-f", content="v1.0").render())
+        b.PJXDrawerHeader(id="g-h", title="Menu").render()
+        + b.PJXDrawerBody(id="g-b", content="Links").render()
+        + b.PJXDrawerFooter(id="g-f", content="v1.0").render()
     ))),
     ("drawer_header_title", lambda: b.PJXDrawerHeader(id="g", title="Settings")),
     ("drawer_header_content", lambda: b.PJXDrawerHeader(id="g", content="<strong>Custom</strong>")),
@@ -54,7 +54,7 @@ CASES = [
     ("lazy_load", lambda: b.PJXLazyLoad(id="g", url="/load")),
     ("lazy_load_tr", lambda: b.PJXLazyLoad(id="g", url="/rows?cursor=20", tag="tr", content='<td colspan="3">Loading…</td>')),
     ("region_loader", lambda: b.PJXRegionLoader(id="g")),
-    ("modal_shell", lambda: b.PJXModal(id="g", content=str(b.PJXModalHeader(id="g-h", title="T").render()) + str(b.PJXModalBody(id="g-b", content="B").render()) + str(b.PJXModalFooter(id="g-f", content="F").render()))),
+    ("modal_shell", lambda: b.PJXModal(id="g", content=b.PJXModalHeader(id="g-h", title="T").render() + b.PJXModalBody(id="g-b", content="B").render() + b.PJXModalFooter(id="g-f", content="F").render())),
     ("modal_header", lambda: b.PJXModalHeader(id="g", title="T")),
     ("modal_header_content", lambda: b.PJXModalHeader(id="g", content="<b>Custom</b>")),
     ("modal_body", lambda: b.PJXModalBody(id="g", content="Body text")),
@@ -62,19 +62,19 @@ CASES = [
     ("notification", lambda: b.PJXNotification(id="g", content="Hi", corner="bottom-right", timeout=0)),
     ("page_loader", lambda: b.PJXPageLoader(id="g")),
     ("popover_compound", lambda: b.PJXPopover(id="g", content=(
-        str(b.PJXPopoverTrigger(id="g-t", content="Open", role="menu").render())
-        + str(b.PJXPopoverPanel(id="g-p", content="Items", role="menu").render())
+        b.PJXPopoverTrigger(id="g-t", content="Open", role="menu").render()
+        + b.PJXPopoverPanel(id="g-p", content="Items", role="menu").render()
     ))),
     ("progress_determinate", lambda: b.PJXProgress(id="g", value=40, label="Upload")),
     ("progress_indeterminate", lambda: b.PJXProgress(id="g")),
     ("prompt_dialog", lambda: b.PJXPromptDialog(id="g", input_label="Name")),
     ("skeleton_text", lambda: b.PJXSkeleton(id="g", lines=2)),
     ("spinner", lambda: b.PJXSpinner(id="g")),
-    ("tab_group", lambda: b.PJXTabGroup(id="g", content=str(b.PJXTabList(id="g-l", content=str(b.PJXTab(id="g-t0", panel="g-p0", selected=True, content="A").render()) + str(b.PJXTab(id="g-t1", panel="g-p1", closeable=True, content="B").render())).render()) + str(b.PJXTabPanel(id="g-p0", tab="g-t0", content="<p>First</p>").render()) + str(b.PJXTabPanel(id="g-p1", tab="g-t1", content="<p>Second</p>").render()))),
+    ("tab_group", lambda: b.PJXTabGroup(id="g", content=b.PJXTabList(id="g-l", content=b.PJXTab(id="g-t0", panel="g-p0", selected=True, content="A").render() + b.PJXTab(id="g-t1", panel="g-p1", closeable=True, content="B").render()).render() + b.PJXTabPanel(id="g-p0", tab="g-t0", content="<p>First</p>").render() + b.PJXTabPanel(id="g-p1", tab="g-t1", content="<p>Second</p>").render())),
     ("tab", lambda: b.PJXTab(id="g", panel="p", icon="file", closeable=True, content="Tab")),
     ("tab_panel", lambda: b.PJXTabPanel(id="g", tab="t", content="body")),
     ("toast_host", lambda: b.PJXToastHost(id="g")),
-    ("tooltip", lambda: b.PJXTooltip(id="g", content=str(b.PJXTooltipTrigger(id="g-t", content="?").render()) + str(b.PJXTooltipContent(id="g-c", content="Help").render()))),
+    ("tooltip", lambda: b.PJXTooltip(id="g", content=b.PJXTooltipTrigger(id="g-t", content="?").render() + b.PJXTooltipContent(id="g-c", content="Help").render())),
     ("tooltip_trigger", lambda: b.PJXTooltipTrigger(id="g", content="Hover me")),
     ("tooltip_content", lambda: b.PJXTooltipContent(id="g", content="Helpful text")),
     ("chip_input", lambda: b.PJXChipInput(id="g", name="tags", values=["alpha", "beta"])),
@@ -86,26 +86,26 @@ CASES = [
     ("icon_labeled", lambda: b.PJXIcon(id="g", name="search", label="Search", size=20)),
     ("button_default", lambda: b.PJXButton(id="g", content="Save")),
     ("button_loading", lambda: b.PJXButton(id="g", content="Save", loading=True, variant="primary")),
-    ("accordion_open", lambda: b.PJXAccordion(id="g", content=str(b.PJXAccordionTrigger(id="g-t", content="Today").render()) + str(b.PJXAccordionContent(id="g-c", content="<p>x</p>").render()))),
-    ("accordion_grouped_closed", lambda: b.PJXAccordion(id="g", open=False, group="nav", content=str(b.PJXAccordionTrigger(id="g-t", content="Older").render()) + str(b.PJXAccordionContent(id="g-c", content="<p>y</p>").render()))),
+    ("accordion_open", lambda: b.PJXAccordion(id="g", content=b.PJXAccordionTrigger(id="g-t", content="Today").render() + b.PJXAccordionContent(id="g-c", content="<p>x</p>").render())),
+    ("accordion_grouped_closed", lambda: b.PJXAccordion(id="g", open=False, group="nav", content=b.PJXAccordionTrigger(id="g-t", content="Older").render() + b.PJXAccordionContent(id="g-c", content="<p>y</p>").render())),
     ("accordion_trigger", lambda: b.PJXAccordionTrigger(id="g", content="Section")),
     ("accordion_content", lambda: b.PJXAccordionContent(id="g", content="<p>body</p>")),
-    ("accordion_group_multi", lambda: b.PJXAccordionGroup(id="g", content=str(b.PJXAccordion(id="g-a", content=str(b.PJXAccordionTrigger(id="g-at", content="A").render()) + str(b.PJXAccordionContent(id="g-ac", content="<p>x</p>").render())).render()) + str(b.PJXAccordion(id="g-b", open=False, content=str(b.PJXAccordionTrigger(id="g-bt", content="B").render()) + str(b.PJXAccordionContent(id="g-bc", content="<p>y</p>").render())).render()))),
-    ("accordion_group_exclusive", lambda: b.PJXAccordionGroup(id="g", mode="exclusive", gap="0.5rem", content=str(b.PJXAccordion(id="g-a", content=str(b.PJXAccordionTrigger(id="g-at", content="A").render()) + str(b.PJXAccordionContent(id="g-ac", content="<p>x</p>").render())).render()) + str(b.PJXAccordion(id="g-b", open=False, content=str(b.PJXAccordionTrigger(id="g-bt", content="B").render()) + str(b.PJXAccordionContent(id="g-bc", content="<p>y</p>").render())).render()))),
-    ("accordion_group_default_open_first", lambda: b.PJXAccordionGroup(id="g", default_open="first", content=str(b.PJXAccordion(id="g-a", open=False, content=str(b.PJXAccordionTrigger(id="g-at", content="A").render()) + str(b.PJXAccordionContent(id="g-ac", content="<p>x</p>").render())).render()) + str(b.PJXAccordion(id="g-b", open=False, content=str(b.PJXAccordionTrigger(id="g-bt", content="B").render()) + str(b.PJXAccordionContent(id="g-bc", content="<p>y</p>").render())).render()))),
-    ("resizable_group", lambda: b.PJXResizableGroup(id="g", content=str(b.PJXResizablePanel(id="g-l", size=40, min=20, content="L").render()) + str(b.PJXResizableHandle(id="g-h").render()) + str(b.PJXResizablePanel(id="g-r", size=60, content="R").render()))),
+    ("accordion_group_multi", lambda: b.PJXAccordionGroup(id="g", content=b.PJXAccordion(id="g-a", content=b.PJXAccordionTrigger(id="g-at", content="A").render() + b.PJXAccordionContent(id="g-ac", content="<p>x</p>").render()).render() + b.PJXAccordion(id="g-b", open=False, content=b.PJXAccordionTrigger(id="g-bt", content="B").render() + b.PJXAccordionContent(id="g-bc", content="<p>y</p>").render()).render())),
+    ("accordion_group_exclusive", lambda: b.PJXAccordionGroup(id="g", mode="exclusive", gap="0.5rem", content=b.PJXAccordion(id="g-a", content=b.PJXAccordionTrigger(id="g-at", content="A").render() + b.PJXAccordionContent(id="g-ac", content="<p>x</p>").render()).render() + b.PJXAccordion(id="g-b", open=False, content=b.PJXAccordionTrigger(id="g-bt", content="B").render() + b.PJXAccordionContent(id="g-bc", content="<p>y</p>").render()).render())),
+    ("accordion_group_default_open_first", lambda: b.PJXAccordionGroup(id="g", default_open="first", content=b.PJXAccordion(id="g-a", open=False, content=b.PJXAccordionTrigger(id="g-at", content="A").render() + b.PJXAccordionContent(id="g-ac", content="<p>x</p>").render()).render() + b.PJXAccordion(id="g-b", open=False, content=b.PJXAccordionTrigger(id="g-bt", content="B").render() + b.PJXAccordionContent(id="g-bc", content="<p>y</p>").render()).render())),
+    ("resizable_group", lambda: b.PJXResizableGroup(id="g", content=b.PJXResizablePanel(id="g-l", size=40, min=20, content="L").render() + b.PJXResizableHandle(id="g-h").render() + b.PJXResizablePanel(id="g-r", size=60, content="R").render())),
     ("resizable_panel", lambda: b.PJXResizablePanel(id="g", size=30, min=10, content="body")),
     ("resizable_panel_px", lambda: b.PJXResizablePanel(id="g", size=40, min="120px", max="400px", content="body")),
     ("resizable_panel_content", lambda: b.PJXResizablePanel(id="g", size=40, min="content", content="body")),
     ("resizable_handle", lambda: b.PJXResizableHandle(id="g", label="Resize")),
     ("table", lambda: b.PJXTable(id="g", caption="Users", striped=True, bordered="horizontal", content=(
-        str(b.PJXTableHead(id="g-h", content=str(b.PJXTableRow(id="g-hr", content=(
-            str(b.PJXTableHeaderCell(id="g-hc0", content="Name").render())
-            + str(b.PJXTableHeaderCell(id="g-hc1", content="Role").render())
+        (b.PJXTableHead(id="g-h", content=(b.PJXTableRow(id="g-hr", content=(
+            b.PJXTableHeaderCell(id="g-hc0", content="Name").render()
+            + b.PJXTableHeaderCell(id="g-hc1", content="Role").render()
         )).render())).render())
-        + str(b.PJXTableBody(id="g-b", content=str(b.PJXTableRow(id="g-r", content=(
-            str(b.PJXTableCell(id="g-c0", content="Ada").render())
-            + str(b.PJXTableCell(id="g-c1", content="Eng").render())
+        + (b.PJXTableBody(id="g-b", content=(b.PJXTableRow(id="g-r", content=(
+            b.PJXTableCell(id="g-c0", content="Ada").render()
+            + b.PJXTableCell(id="g-c1", content="Eng").render()
         )).render())).render())
     ))),
     ("table_head", lambda: b.PJXTableHead(id="g", content="<tr></tr>")),
@@ -114,7 +114,7 @@ CASES = [
     ("table_header_cell", lambda: b.PJXTableHeaderCell(id="g", content="Name")),
     ("table_header_cell_sortable", lambda: b.PJXTableHeaderCell(id="g", sortable=True, sort="asc", content="Name")),
     ("table_cell", lambda: b.PJXTableCell(id="g", content="x")),
-    ("table_row_selectable", lambda: b.PJXTableRow(id="g", selectable=True, value="42", content=str(b.PJXTableCell(id="g-c", content="Ada").render()))),
+    ("table_row_selectable", lambda: b.PJXTableRow(id="g", selectable=True, value="42", content=b.PJXTableCell(id="g-c", content="Ada").render())),
     ("paginator_windowed_htmx", lambda: b.PJXPaginator(id="g", page=5, total_pages=20, url="/items?page={page}", target="#list", first_last=True)),
     ("paginator_all_pages", lambda: b.PJXPaginator(id="g", page=2, total_pages=5, url="/items?page={page}")),
     ("paginator_single_page", lambda: b.PJXPaginator(id="g", page=1, total_pages=1, url="/items?page={page}")),


### PR DESCRIPTION
## What this fixes

Closes #209.

`str(SomeComponent(...).render())` fed into another component's field strips `render()`'s `Markup` "already safe" flag for no benefit — `Markup` concatenates (`+`) and composes fine on its own. Currently harmless (every occurrence lands on a `Slot` field, which `_wrap_slot_value` unconditionally re-wraps back into `Markup`), but the pattern is unsafe if copied onto a non-`Slot` field — autoescape (on by default since v0.23.0) would then double-escape it.

## Scope decision

~512 occurrences of `str(...render())` exist across tests/docs. Audited and split into two buckets:

- **Composition sites** (~55-60, this PR): `str(X.render())` passed as a kwarg/argument into another component's field. This is the actual pattern the issue is about. Fixed in `tests/unit/test_golden_builtins.py`, `tests/integration/app.py`, `tests/reactivity/app.py`.
- **Test-assertion/parsing sites** (~440-450, left untouched): `html = str(x.render())` followed by `assert "..." in html`, or returned from a test helper for the same purpose. `str()` is doing legitimate work there — not the risky pattern, and touching ~450 sites for zero behavior change would be pure churn.

No defensive coercion added to `BaseComponent` for non-`Slot` fields, per the issue's second (optional) ask — nothing today is actually broken (`_wrap_slot_value` already covers every real case), so adding runtime machinery for a hypothetical future misuse isn't warranted. Removing the bad pattern from the code that models it is the fix.

## Test plan
- [x] `uv run pytest tests/ -q` — 1232 passed, 5 skipped (golden snapshots byte-identical, confirming no rendering behavior changed)
- [x] `uv run ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)