### PR TITLE
fix: drawer slide-out reverses on close (side <-> center)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.36.1 — Drawer close animation fix (2026-07-19)
+
+### Fixed
+- `PJXDrawer`: close animation now slides the box back toward the side it opened from
+  (mirroring the open animation in reverse), instead of leaving it pinned at center while
+  only the backdrop/root faded out.
+
 ## 0.36.0 — Image/content carousel (2026-07-19)
 
 ### Added

--- a/pyjinhx/builtins/ui/pjx_drawer/pjx-drawer.css
+++ b/pyjinhx/builtins/ui/pjx_drawer/pjx-drawer.css
@@ -97,6 +97,15 @@
   animation: pjx-drawer-slide-bottom-in 200ms ease forwards;
 }
 
+.pjx-drawer--closing.pjx-drawer--left .pjx-drawer__box,
+.pjx-drawer--closing.pjx-drawer--right .pjx-drawer__box {
+  animation: pjx-drawer-slide-side-out 150ms ease forwards;
+}
+
+.pjx-drawer--closing.pjx-drawer--bottom .pjx-drawer__box {
+  animation: pjx-drawer-slide-bottom-out 150ms ease forwards;
+}
+
 @keyframes pjx-drawer-backdrop-in {
   from { opacity: 0; }
   to { opacity: 1; }
@@ -127,6 +136,16 @@
   to { transform: translateY(0); }
 }
 
+@keyframes pjx-drawer-slide-side-out {
+  from { transform: translateX(0); }
+  to { transform: translateX(var(--pjx-drawer-slide-from, 100%)); }
+}
+
+@keyframes pjx-drawer-slide-bottom-out {
+  from { transform: translateY(0); }
+  to { transform: translateY(100%); }
+}
+
 .pjx-drawer--left .pjx-drawer__box {
   --pjx-drawer-slide-from: -100%;
 }
@@ -142,7 +161,10 @@
   .pjx-drawer.pjx-drawer--closing::backdrop,
   .pjx-drawer--left .pjx-drawer__box,
   .pjx-drawer--right .pjx-drawer__box,
-  .pjx-drawer--bottom .pjx-drawer__box {
+  .pjx-drawer--bottom .pjx-drawer__box,
+  .pjx-drawer--closing.pjx-drawer--left .pjx-drawer__box,
+  .pjx-drawer--closing.pjx-drawer--right .pjx-drawer__box,
+  .pjx-drawer--closing.pjx-drawer--bottom .pjx-drawer__box {
     animation-duration: 0.01ms !important;
   }
 }


### PR DESCRIPTION
## Summary
- Open animation already slid side->center (`translateX(--pjx-drawer-slide-from)` -> `0`).
- Close only faded opacity on the dialog root; box stayed pinned at center until removed.
- Added `pjx-drawer-slide-side-out` / `pjx-drawer-slide-bottom-out` keyframes under `.pjx-drawer--closing`, mirroring open in reverse (center->side), reusing the same `--pjx-drawer-slide-from` var.
- Extended `prefers-reduced-motion` override to cover the new closing selectors.

## Test plan
- [x] `uv run pytest -q -k drawer` (45 passed)
- [ ] Manual: open/close left, right, bottom drawers in docs demo, confirm box slides toward its side on close