### PR TITLE
perf: cache builtin from_string templates (fixes #237)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.36.2
+current_version = 0.36.3
 commit = True
 tag = True
 message = Bump version: {current_version} → {new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.36.3 — Builtin component template caching (2026-07-27)
+
+### Fixed
+- Builtin components (all `PJX*` classes under `pyjinhx.builtins`, e.g. icon, badge, button,
+  popover, table) were recompiled (Jinja lex/parse/codegen) from their template file on every
+  single render, since their template files live outside the app's loader root and always
+  missed the normal `environment.get_template()` cache. Now cached per builtin template file
+  after the first render, ~50% render CPU reduction on component-dense pages (#237).
+
 ## 0.36.2 — Render pipeline performance sweep (2026-07-28)
 
 ### Fixed

--- a/pyjinhx/renderer.py
+++ b/pyjinhx/renderer.py
@@ -112,9 +112,14 @@ def load_template_for_component(
             component_dir = Finder.get_class_directory(klass)
             for filename in tag_name_to_template_filenames(klass.__name__):
                 candidate_path = os.path.join(component_dir, filename)
+                cached_template = renderer._builtin_template_cache.get(candidate_path)
+                if cached_template is not None:
+                    return cached_template
                 if os.path.isfile(candidate_path):
                     with open(candidate_path, encoding="utf-8") as template_file:
-                        return environment.from_string(template_file.read())
+                        template = environment.from_string(template_file.read())
+                    renderer._builtin_template_cache[candidate_path] = template
+                    return template
 
     raise TemplateNotFound(", ".join(attempted) if attempted else "unknown")
 
@@ -431,6 +436,7 @@ class Renderer:
         self._js_mode = js_mode if js_mode is not None else Renderer._default_js_mode
         self._css_mode = css_mode if css_mode is not None else Renderer._default_css_mode
         self._template_finder_cache: dict[str, Finder] = {}
+        self._builtin_template_cache: dict[str, Template] = {}
 
     @property
     def environment(self) -> Environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyjinhx"
-version = "0.36.2"
+version = "0.36.3"
 description = "UI components for Python using Pydantic and Jinja2 templates"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
Builtin components (all `PJX*` classes under `pyjinhx.builtins` — icon, badge, button, popover, table, etc.) were being recompiled from scratch (Jinja lex/parse/codegen) on *every single render*, accounting for roughly 50% of render CPU on component-dense pages.

## Root Cause
`load_template_for_component` in `pyjinhx/renderer.py` falls back to `environment.from_string(file_content)` for any `BaseComponent` subclass under `pyjinhx.builtins`, because those template files live in the installed package directory, outside the app's Jinja loader root. That means `environment.get_template()` — which Jinja caches internally — always misses for builtins, and every render re-parses the same static template file from scratch. Instrumentation confirmed all 63 builtin component classes hit this exact fallback branch, and none go through the `template_source=`/`get_template` cached paths.

## Fix
- Added `Renderer._builtin_template_cache: dict[str, Template]`, keyed by the candidate template file's absolute path.
- In the builtins fallback branch of `load_template_for_component`, check/populate that cache before falling back to `environment.from_string`.
- Scoped narrowly: does **not** touch the `template_source is not None` early-return branch, which can carry per-instance dynamic content baked into the source string (a blanket cache there previously broke element identity across re-renders in a consuming app). This fix only caches static builtin template *file content*, which is fixed per class for the life of the process.

## Testing
- Instrumentation confirmed 62/63 renderable builtins (`PJXPaginator` needs a valid `url` kwarg to construct) return the identical cached `Template` object on a second render — i.e. the cache is stable and hit on every subsequent render.
- Full test suite: 1251 passed, 5 skipped, both before and after the change.

## Version Bump
`0.36.2` → `0.36.3`

Fixes #237