### PR TITLE
feat: /task subtask pipeline + board-sync hook

### DIFF
--- a/.claude/hooks/board-sync.sh
+++ b/.claude/hooks/board-sync.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Board sync for Project 12. Sole writer of board Status values in the /task pipeline.
+# Fired by a PostToolUse hook on Write|Edit; acts only when the edited file is
+# .claude/board-state.json. Reads {"issue": N, "stage": "..."} from that file,
+# sets the card's Status, then recomputes the parent story's Status as the
+# minimum stage across its sub-issues. It can ONLY set Status field values —
+# it never creates, closes, or deletes anything.
+set -euo pipefail
+
+OWNER="paulomtts"
+REPO="pyjinhx"
+PROJECT_ID="PVT_kwHOBZmM8c4BewiO"
+STATUS_FIELD_ID="PVTSSF_lAHOBZmM8c4BewiOzhZIXw8"
+
+# Stage allowlist, pipeline order. Rank drives the story's min-stage computation.
+STAGES=(backlog spec ready implementing in-review testing done)
+OPTION_IDS=(a4448373 07356194 5d5646cc 20e71636 6554ad50 f397e470 ce6ea6d1)
+OPTION_NAMES=("Backlog" "Spec" "Ready" "In progress" "In review" "Testing" "Done")
+
+# Only react to writes of the state file; every other Write/Edit exits silently.
+INPUT=$(cat)
+FILE_PATH=$(jq -r '.tool_input.file_path // empty' <<<"$INPUT")
+[[ "$FILE_PATH" == */.claude/board-state.json ]] || exit 0
+
+STATE_FILE="$FILE_PATH"
+ISSUE=$(jq -r '.issue // empty' "$STATE_FILE")
+STAGE=$(jq -r '.stage // empty' "$STATE_FILE")
+
+[[ "$ISSUE" =~ ^[0-9]+$ ]] || { echo "board-sync: bad issue '$ISSUE'" >&2; exit 2; }
+RANK=-1
+for i in "${!STAGES[@]}"; do [[ "${STAGES[$i]}" == "$STAGE" ]] && RANK=$i; done
+[[ $RANK -ge 0 ]] || { echo "board-sync: bad stage '$STAGE' (allowed: ${STAGES[*]})" >&2; exit 2; }
+
+item_id_for_issue() { # issue number -> project item id on Project 12
+  gh api graphql -f query='query($n:Int!){repository(owner:"'"$OWNER"'",name:"'"$REPO"'"){issue(number:$n){projectItems(first:10){nodes{id project{id}}}}}}' \
+    -F n="$1" --jq '.data.repository.issue.projectItems.nodes[] | select(.project.id=="'"$PROJECT_ID"'") | .id'
+}
+
+set_status() { # item id, option id
+  gh api graphql -f query='mutation($i:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:"'"$PROJECT_ID"'",itemId:$i,fieldId:"'"$STATUS_FIELD_ID"'",value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
+    -f i="$1" -f o="$2" --jq '.data.updateProjectV2ItemFieldValue.projectV2Item.id' >/dev/null
+}
+
+ITEM_ID=$(item_id_for_issue "$ISSUE")
+[[ -n "$ITEM_ID" ]] || { echo "board-sync: issue #$ISSUE not on project" >&2; exit 2; }
+set_status "$ITEM_ID" "${OPTION_IDS[$RANK]}"
+echo "board-sync: #$ISSUE -> ${OPTION_NAMES[$RANK]}"
+
+# Parent story mirrors the least-advanced of its sub-issues.
+PARENT_JSON=$(gh api graphql -f query='query($n:Int!){repository(owner:"'"$OWNER"'",name:"'"$REPO"'"){issue(number:$n){parent{number subIssues(first:50){nodes{projectItems(first:10){nodes{project{id} fieldValueByName(name:"Status"){... on ProjectV2ItemFieldSingleSelectValue{name}}}}}}}}}}' -F n="$ISSUE")
+PARENT_NUM=$(jq -r '.data.repository.issue.parent.number // empty' <<<"$PARENT_JSON")
+[[ -n "$PARENT_NUM" ]] || exit 0
+
+MIN_RANK=$((${#STAGES[@]} - 1))
+while read -r name; do
+  for i in "${!OPTION_NAMES[@]}"; do
+    [[ "${OPTION_NAMES[$i]}" == "$name" && $i -lt $MIN_RANK ]] && MIN_RANK=$i
+  done
+done < <(jq -r '.data.repository.issue.parent.subIssues.nodes[].projectItems.nodes[] | select(.project.id=="'"$PROJECT_ID"'") | .fieldValueByName.name // "Backlog"' <<<"$PARENT_JSON")
+
+PARENT_ITEM=$(item_id_for_issue "$PARENT_NUM")
+[[ -n "$PARENT_ITEM" ]] || exit 0
+set_status "$PARENT_ITEM" "${OPTION_IDS[$MIN_RANK]}"
+echo "board-sync: story #$PARENT_NUM -> ${OPTION_NAMES[$MIN_RANK]} (min of sub-issues)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/board-sync.sh\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: task
+description: Use when the user says "/task <issue#>" or asks to pick up / work / implement a subtask card from the v2 board — drives one subtask issue end to end through spec, plan, adversarial validation, TDD implementation, review, tests, and PR + merge.
+---
+
+# /task — subtask pipeline
+
+Drives ONE `subtask`-labeled issue from Backlog to Done. Board movement is NOT yours: at each transition you write `.claude/board-state.json` and the board-sync hook (sole holder of board permissions) moves the card and recomputes the parent story. Never call `gh project` mutations yourself.
+
+## Stage writes
+
+At each transition, write exactly this to `$CLAUDE_PROJECT_DIR/.claude/board-state.json` with the Write tool (the hook fires on Write|Edit, not shell redirects):
+
+```json
+{"issue": <N>, "stage": "<stage>"}
+```
+
+Stages, in order: `spec` → `ready` → `implementing` → `in-review` → `testing` → `done`.
+
+## Pipeline
+
+0. **Intake.** `gh issue view <N>` — confirm label `subtask` (a `story` gets refused: point user at its subtasks), read the parent story and its other sub-issues for context. Read the relevant rebuild docs: `docs/superpowers/rebuild/architecture-overview.md`, `implementation-overview.md`, the parent story body, and any ADRs it cites.
+1. **Explore** → *write stage `spec`*. Dispatch an investigator subagent (cavecrew-investigator) over the modules/docs the subtask touches; keep only findings.
+2. **Spec.** Short spec inline or in `docs/superpowers/specs/`: scope, observable behavior, error paths, test list. Scaled to subtask size — most subtasks need half a page.
+3. **Plan.** Use superpowers:writing-plans, scaled down: ordered steps, each with its test.
+4. **Validate** → *write stage `ready`*. Run adversarial-doc-review on spec+plan (kind:spec). Fold survivors back in before proceeding.
+5. **Implement** → *write stage `implementing`*. Worktree (superpowers:using-git-worktrees), then strict TDD — **REQUIRED SUB-SKILL:** superpowers:test-driven-development. Commit granularly.
+6. **Review.** cavecrew-reviewer on the branch diff. Fix real findings; re-run tests.
+7. **Tests.** Full suite + typecheck (`uvx basedpyright`, standard mode). Then test-integrity-gate on the test diff vs merge-base. Gate failures = fix, not argue.
+8. **PR + merge** → *write stage `in-review`*. Push, `gh pr create` (body links the issue: `Closes #<N>`), wait for checks, merge → *write stage `testing`*. Post-merge: run the suite on master.
+9. **Close** → *write stage `done`*. Suite green on master closes the loop; the `Closes #` already closed the issue. Check off the matching roadmap item in `docs/superpowers/rebuild/roadmap.md` if the whole story completed.
+
+## Rules
+
+- One subtask per invocation. Don't drift into sibling subtasks — note follow-ups on their issues instead.
+- Stage writes are mandatory and in order; skipping one leaves the card visibly stuck — that's the design, not a bug to work around.
+- If blocked (spec contradiction, failing gate you can't fix honestly), write the current stage truthfully, comment findings on the issue, and stop.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ docs/superpowers/
 
 # .claude
 .claude/worktrees/
+
+# /task pipeline state (hook-consumed, ephemeral)
+.claude/board-state.json

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@ wheels/
 site/
 
 # Superpowers planning artifacts
-docs/superpowers/
+docs/superpowers/*
+!docs/superpowers/rebuild/
 
 # .claude
 .claude/worktrees/

--- a/docs/superpowers/rebuild/README.md
+++ b/docs/superpowers/rebuild/README.md
@@ -1,0 +1,35 @@
+# pyjinhx v2 rebuild — doc index
+
+The documentation set for rebuilding the pyjinhx engine as `src/pyjinhx2/`, shipping as pyjinhx 1.0. Everything here is local-only (gitignored with the rest of `docs/superpowers/`).
+
+## The set
+
+| Doc | Aim |
+|---|---|
+| [prd.md](./prd.md) | What "done" means: 6 gating goals, non-goals, delivery pipeline, risks. Written once; amended only on genuine scope change. |
+| [adr/](./adr/README.md) | Why it's built this way: one decision per file (0001 pre-rebuild + 0002-0011), context/options/consequences. Immutable — superseded, never edited. New decisions during layer specs get recorded here at decision time. |
+| [architecture-overview.md](./architecture-overview.md) | How it works: hard invariants, the mechanism-interaction map (mermaid), per-layer mechanisms with ship criteria, non-obvious interactions, worked example. *Living* — updated as layers ship; where it and reality disagree, fix the doc. |
+| [feature-port-list.md](./feature-port-list.md) | What ships where: every v0.36 feature with keep/mod/drop verdict and its build layer. The G3 parity checklist; each layer spec must cover its assigned rows. |
+| [implementation-overview.md](./implementation-overview.md) | How it lands as code: architecture style (flat module-per-mechanism + import rule), folder/file structure, render timelines (T0 startup / T1 cold / T2 reactive), load-bearing ordering facts. |
+| [roadmap.md](./roadmap.md) | When and in what order: per-layer deliverables, PR-sized inner steps in dependency order, the two gates, checkboxes + recorded bench numbers. *Living* — check off as things ship. |
+
+Per-layer design docs (RFC role) are not standalone artifacts — the /feature workflow's spec phase (brainstorm + adversarial-doc-review) produces each layer's design just-in-time, saved under `docs/superpowers/specs/`. Decided 2026-07-29.
+
+## How they relate
+
+```text
+  PRD ─────────── what "done" means ──────────┐
+   │                                          │
+   │ constrains                               │ verified against
+   ▼                                          ▼
+  layer specs ── how each layer works ────► implementation
+  (via /feature)                              │
+   │ decisions extracted as                   │ reality feeds back into
+   ▼                                          ▼
+  ADRs ── why it's this way ──────► architecture-overview (living map)
+```
+
+## Background material
+
+- [2026-07-28 rebuild-from-scratch analysis](../reports/2026-07-28-rebuild-from-scratch-analysis.md) — the source research: what v0.36 got right, what a rebuild changes, grounded in perf campaigns #221/#240.
+- Superseded working docs (00-overview, segment-model-walkthrough, feature-layer-map, doc-plan) were merged into the four docs above on 2026-07-29.

--- a/docs/superpowers/rebuild/adr/0001-outerhtml-only-oob-swaps.md
+++ b/docs/superpowers/rebuild/adr/0001-outerhtml-only-oob-swaps.md
@@ -1,0 +1,99 @@
+# ADR 0001: outerHTML-only OOB swaps, no append/prepend modes
+
+**Status:** Reconstructed. This ADR was not written when the reactive engine
+was designed — it was assembled after the fact from a conversation that
+walked through the mechanism and probed why append-mode OOB swaps don't
+exist. Treat the *mechanism* description as verified against source; treat
+the *original intent* framing as inferred, not confirmed by whoever wrote
+the original engine.
+
+## Context
+
+pyjinhx's reactive engine re-renders and swaps components over htmx OOB
+(out-of-band) swaps. On every htmx request, the client scans the DOM for
+mounted reactive components and sends a manifest of `{id, type, load, hash}`
+(the `X-PJX-Mounted` header, read by `pyjinhx/client.py`). The server uses
+that manifest plus a set of "dirtied" keys to decide which mounted instances
+need a fresh render.
+
+Every swap `oob_swaps()` emits is `outerHTML:[data-pjx-id='...']`
+(`pyjinhx/reactive.py:389`) — a full-replacement swap targeted at a specific
+mounted component's root element. There is no append, prepend, or
+`beforeend`-style OOB swap mode.
+
+The question that prompted this ADR: given hash-gating lives on the parent's
+own tag (`state_hash()`, `pyjinhx/reactive.py:264`, computed via
+`model_dump()` minus `state_hash_exclude` — `id` is excluded by default,
+`pyjinhx/reactive.py:208`), appending a child *would* change the parent's
+hash and *would* be detected. So why doesn't append-mode OOB exist?
+
+## Decision
+
+Support exactly one swap mode (`outerHTML`) and push delta-granularity onto
+component composition instead of swap-mode variety.
+
+Two things make append-mode redundant rather than missing:
+
+1. **Rendering is always full-current-state, never a delta.** `.load()` +
+   render always produces the complete current HTML for a component's
+   subtree; there's no code path that renders "only the new item." Hashing
+   on the parent can *detect* that something changed (including an append),
+   but detection isn't the same as being able to *emit* just the appended
+   fragment — the render pipeline has no notion of a diff to emit.
+2. **Fine-grained delta control already exists via nesting.** Any
+   `ReactiveComponent`, at any nesting depth, gets its own `data-pjx-id` /
+   `data-pjx-hash` stamped independently (`reactive_root_attrs()`, called
+   unconditionally in the shared render path — `pyjinhx/renderer.py:333`).
+   Each nested instance is independently reactive and independently
+   participates in `oob_swaps()`'s manifest-driven matching loop
+   (`pyjinhx/reactive.py:404` onward). So a developer who wants
+   per-row/per-item granularity gets it today by mounting a keyed child
+   component per row (`react={...}` + a load-key) — issue #201's
+   `reactive_key()` sharpened this further by letting a *single* mutation
+   target one derived key instead of the whole shared key, without adding a
+   new swap mode.
+
+Introducing genuinely new content (an item that didn't exist in any previous
+manifest) is a **primary swap** concern, not an OOB concern: it's ordinary
+htmx (`hx-swap="beforeend"` or similar) delivering markup that, once
+mounted, contains its own `data-pjx-id`/`data-pjx-hash` and is fully
+OOB-reactive from the *next* request onward. Primary swap introduces;
+OOB tail updates already-mounted siblings. These are complementary
+mechanisms, not competing ones — and once combined with nesting, they cover
+what an append-mode OOB swap would have covered, without a second swap
+format to hash-compare, validate, and keep in sync with `oob_swaps()`'s
+pre-filter/matching logic.
+
+## Consequences
+
+- **No new swap-mode surface area.** `oob_swaps()` only ever needs to reason
+  about one shape of comparison (full-subtree hash vs. full-subtree
+  re-render), which keeps hash-gating simple: one hash per mounted instance,
+  one comparison, one swap format.
+- **The cost is developer discipline, not framework capability.** Getting
+  fine-grained updates requires deliberately breaking a UI into
+  keyed/nested components at the granularity you want to update
+  independently. A monolithic list rendered as one big component will
+  always re-render as one big `outerHTML` swap on any dirty key it reacts
+  to — `reactive_key()` (issue #201) narrows *which* keys trigger that, not
+  *how much* HTML moves when it does.
+- **New content must go through a primary swap**, not `dirty()` /
+  `ReactiveResponse()` alone — those only affect components already present
+  in the client's mounted manifest. This is occasionally surprising: dirtying
+  a key does nothing for content that isn't mounted yet.
+
+## Alternatives considered
+
+- **Append/prepend OOB swap modes.** Rejected implicitly by never being
+  built — would require the render pipeline to produce a delta fragment
+  (not just full current state) and would double the swap-format surface
+  `oob_swaps()` has to support, for a case nesting already covers.
+- **Diffing/patching swaps** (morphdom-style). Same shape of rejection: adds
+  a second rendering mode and a diff engine, for marginal gain over
+  full-subtree `outerHTML` once components are nested at the granularity
+  that actually needs independent updates.
+
+## Related
+
+- [`reactive_key()` / parametric reactive keys](../reactivity.md) — issue
+  #201, sharpens key-level granularity within the existing outerHTML model.

--- a/docs/superpowers/rebuild/adr/0002-segment-list-composition.md
+++ b/docs/superpowers/rebuild/adr/0002-segment-list-composition.md
@@ -1,0 +1,25 @@
+# ADR 0002: Segment-list composition; children opaque by construction
+
+**Status:** Accepted, 2026-07-28. Foundational for the v2 rebuild (layer 0).
+
+## Context
+
+In v0.36, a parent renders children to strings, pastes them into its own output, then re-parses the combined string — once in `expand_custom_tags` and again in `apply_root_attrs` to find the root tag. Every superlinear term found across two perf campaigns (#221, #240) was a consequence: the opacify token machinery (protecting child output from re-parsing), its private-use-area collision bailout, the stamp-on-opacified-markup fix with its `try/except ValueError` full-restart fallback, and a user-visible correctness concession (multi-root templates silently stamp instead of raising). The #240 spec considered single-pass rework and rejected it — correctly, as too risky against shipped opacify/slot/asset invariants. A rebuild has no such invariants to protect.
+
+## Options
+
+1. **Keep bottom-up string composition, design opacify in from day one.** Preserves "slot values are real strings" fully; keeps the structural cost and all downstream machinery, just tidier.
+2. **Hybrid: strings within a level, segments between levels.** Attempts both virtues; every seam between the two representations needs its own proof.
+3. **Segment-list model.** A render level is an ordered list of segments — plain markup strings and opaque child nodes — produced by one parse over the level's own template output. The root-tag span is recorded during that same parse. Children are rendered levels spliced in as whole objects; serialization is one recursive join at the top.
+
+## Decision
+
+Option 3. A component's own template output is parsed exactly once, and that parse simultaneously cuts child-tag positions and records the root span. Children enter the parent as opaque nodes *by construction* — there is no code path through which a parent can see, re-parse, re-escape, or re-expand child markup as text.
+
+## Consequences
+
+- Total parse work per page is O(S) in output size; deep trees scale linearly (PRD G1).
+- Opacify tokens, restore passes, the collision bailout, the second root-attr parse, and the `ValueError` fallback do not exist in v2. Root-attr and OOB stamping become string surgery at a recorded offset.
+- Single-root violations raise again unconditionally — the v0.36 silent-stamp concession is reverted.
+- Slot values are no longer real strings inside `template.render()` — forces ADR 0003.
+- Worked example: [architecture-overview.md §5](../architecture-overview.md).

--- a/docs/superpowers/rebuild/adr/0003-slot-opacity.md
+++ b/docs/superpowers/rebuild/adr/0003-slot-opacity.md
@@ -1,0 +1,25 @@
+# ADR 0003: Slots are opaque — truthiness and interpolation only
+
+**Status:** Accepted, 2026-07-28. Consequence of ADR 0002.
+
+## Context
+
+Under v0.36's string model, a slot value is a genuine string during `template.render()`, so `{{ content|length }}`, `content in x`, and `{{ content|striptags }}` all work — this is precisely why v0.36 opacifies the *output* rather than the *context*, at real complexity cost. Under ADR 0002, child output is an opaque node; a slot holding a component cannot be a plain string without re-flattening structure.
+
+## Options
+
+1. **Opaque + truthiness only.** Templates may test `{% if content %}` and interpolate `{{ content }}`. String filters on component slots raise with a clear error naming the slot and the fix.
+2. **Lazy stringify.** Opaque node implements `__str__`/`__len__`, forcing early child render when inspected. Filters keep working; hidden eager rendering reintroduces string-model complexity into layer 0 and makes render order data-dependent.
+3. **Survey-then-decide.** Defer until slot-filter usage in builtins/docs is measured.
+
+## Decision
+
+Option 1, with option 3's survey folded in as a pre-RFC-1 gate (PRD risk 1): grep builtins and docs for string operations on slot values before layer 1's RFC. If usage turns out widespread, this ADR gets revisited *before* L1 — not discovered after.
+
+String-valued slots (a `Slot` field assigned a plain string) are unaffected — they remain raw-HTML-capable strings. This ADR governs slots holding rendered components.
+
+## Consequences
+
+- Child opacity stays absolute; no hidden render forcing; layer 0 stays simple.
+- `{% if content %}`, `{{ content }}` work; `{{ content|length }}` on a component slot raises a targeted error instead of silently misbehaving.
+- Migration note required for any v0.x template using string filters over component slots (expected rare; verified by the survey).

--- a/docs/superpowers/rebuild/adr/0004-drop-peer-cross-reference.md
+++ b/docs/superpowers/rebuild/adr/0004-drop-peer-cross-reference.md
@@ -1,0 +1,25 @@
+# ADR 0004: Peer cross-reference dropped entirely
+
+**Status:** Accepted, 2026-07-28.
+
+## Context
+
+v0.x lets a template reference a registered sibling by bare name — a name-miss in Jinja resolves against the request's instance registry. The same design was fixed three times: #72 (eager peer rendering — 32,784 renders for a 5-sibling page), #223 (per-node O(page) registry scans), #240 (O(n²) dict merge, replaced by lazy `_PjxContext.resolve_or_missing`, which itself landed through four regressions: async path, `{% include %}`, globals precedence, derived contexts). It also carries a documented footgun: a reactive component's kebab-default `id` silently shadowed by a same-named field (docs/guide/registry.md). The rebuild analysis leaned "keep, but make it an explicit API" (`{{ pjx.peer('save') }}`).
+
+## Options
+
+1. **Explicit API only** — `pjx.peer('save')` context global; O(1), scoped, no derived-context reasoning. Report's lean.
+2. **Explicit + bare-name fallback** — migration ease, two paths to maintain.
+3. **Drop entirely** — components compose only through nesting and slots.
+
+## Decision
+
+Option 3 — bolder than the report's lean, chosen deliberately. Cross-referencing is composition through a side channel; everything it does is expressible by passing the component (or its id) down the tree. Removing it deletes an entire class of machinery and reasoning rather than shrinking it.
+
+## Consequences
+
+- Deleted outright: `LazyNestedComponentWrapper`, `_PjxContext.resolve_or_missing`, `registry_defaults`/`registry_scanned` session plumbing, incremental registry folding, the shadowing footgun.
+- Zero per-render cross-reference resolution cost — the mechanism behind three of the project's largest perf incidents does not exist in v2.
+- Migration: v0.x templates using bare-name peer references must restructure to pass components explicitly. Breaking; covered by the 1.0 migration guide (PRD G5).
+- The instance registry loses its template-facing role; what remains of it is governed by ADR 0009.
+- The render cycle guard simplifies: cycles can only arise via nesting/`load()` chains.

--- a/docs/superpowers/rebuild/adr/0005-post-render-tag-expansion.md
+++ b/docs/superpowers/rebuild/adr/0005-post-render-tag-expansion.md
@@ -1,0 +1,23 @@
+# ADR 0005: Post-render tag expansion, one parse per level
+
+**Status:** Accepted, 2026-07-28.
+
+## Context
+
+PascalCase tags (`<PJXButton .../>`) must become component renders. v0.36 finds them by feeding rendered output through `html.parser` — validated by the #240 spec as sound: only PascalCase tags are special-cased, everything else passes through verbatim via `get_starttag_text()`, preserving unknown attributes, quoting, and intentional malformed HTML. The alternative — a compile-time Jinja extension turning static tags into call nodes — was rated "big prize, big risk" by the rebuild analysis: the prize was mostly deleting the opacify apparatus, and it fails for *generated* tags (loops emitting `<PJXTableCell>` from data, slot values containing literal tag text), so both paths would be needed.
+
+## Options
+
+1. **Post-render parse per level** — `html.parser` over the level's own output only (ADR 0002 guarantees children are never re-parsed).
+2. **Compile-time extension + runtime fallback** — static tags become call nodes; runtime parse only when output still contains PascalCase. Two expansion paths to keep semantically identical.
+3. **Compile-time only** — generated tags unsupported; loops must call `component()` explicitly. Breaks a real, documented pattern.
+
+## Decision
+
+Option 1. ADR 0002 already claims the compile-time prize (opacify is dead regardless), collapsing the tradeoff: what remains of option 2 is a second expansion path bought for a per-level parse that the #240 spec already ruled inherent. Generated tags work naturally; the `contains_custom_tag` regex prepass carries over to skip parsing leaf output.
+
+## Consequences
+
+- One `html.parser` feed per level, doing double duty (ADR 0002): child-tag cut points and root-span recording in the same pass. Total parse cost O(S) per page.
+- Generated tags and static tags expand through the identical path — no semantic-parity burden.
+- Verbatim pass-through of all non-PascalCase markup is preserved, same as v0.x.

--- a/docs/superpowers/rebuild/adr/0006-strict-core-open-subclass.md
+++ b/docs/superpowers/rebuild/adr/0006-strict-core-open-subclass.md
@@ -1,0 +1,23 @@
+# ADR 0006: Strict Pydantic core, open opt-in subclass
+
+**Status:** Accepted, 2026-07-28.
+
+## Context
+
+v0.x sets `extra="allow"` on `BaseComponent`. It buys stray-attribute pass-through (#75) and classless-component ergonomics (`{#def#}` headers, `component()`), but forces a per-render walk over undeclared keys in `_build_template_context` — hot-path work paid by every component whether or not it uses the feature, and the direct cause of the #240 Task 6 crash (`dictionary changed size during iteration`). The rebuild analysis rated this "no clean answer": strict is faster and safer; open is what two shipped features stand on.
+
+## Options
+
+1. **Open everywhere** — today's model; per-render cost for all.
+2. **Strict everywhere** — fastest; kills stray-attr pass-through and weakens classless components.
+3. **Strict core, open opt-in subclass** — `BaseComponent` strict; a designated open-model base (or `model_config` override) for classless/`{#def#}` components.
+
+## Decision
+
+Option 3. The cost follows the feature: components that need extra-field acceptance opt into it; everything else renders with zero undeclared-key work. Both ergonomic features survive unchanged on the open subclass — `{#def#}`-headed templates and `component()` build on it.
+
+## Consequences
+
+- Strict components skip the undeclared-key walk entirely.
+- Stray-attribute pass-through works only on open-model components; class-based components wanting pass-through declare the subclass. Migration note required (PRD G5).
+- Two base classes to document; the descriptor (overview invariant 5) records which mode a class uses, so the renderer branches once per class, not per render.

--- a/docs/superpowers/rebuild/adr/0007-single-template-convention.md
+++ b/docs/superpowers/rebuild/adr/0007-single-template-convention.md
@@ -1,0 +1,23 @@
+# ADR 0007: One template convention — `.pjx` + snake_case
+
+**Status:** Accepted, 2026-07-28.
+
+## Context
+
+v0.x probes six filename candidates per tag: three extensions (`.pjx`, `.html`, `.jinja`) × two case conventions (snake_case, kebab-case). This produced 10,524 `get_template` calls for 1,754 components (#240 plan, Task 4), fixed with per-tag caches (#225) — a cache that exists only because the probe matrix does. The rebuild analysis called it "a perfect miniature of the whole story": small decision, structural cost, machinery to compensate.
+
+## Options
+
+1. **Keep all six probes** — full naming freedom, keep the cache machinery.
+2. **One extension, one case** — `.pjx` + snake_case; one probe per lookup.
+3. **Drop discovery entirely** — explicit registration; destroys the Tier 1 "drop a template in a folder" experience the docs sell.
+
+## Decision
+
+Option 2. Filesystem discovery is product positioning and stays (docs/guide/usage-tiers.md); the probe matrix is engineering debt and goes. A 1×1 matrix needs no cache. `.pjx` wins over `.html`/`.jinja` because it is already first in v0.x's probe order, is the extension pjx-ls targets, and unambiguously identifies pyjinhx templates.
+
+## Consequences
+
+- One filesystem probe per class per kind (template/css/js), paid once at registration into the descriptor. The per-tag probe caches (#225) and most of `Finder`'s candidate logic do not exist in v2.
+- Migration: v0.x projects with `.html`/`.jinja` templates or kebab-case names rename files. Mechanical (a shell one-liner), covered by the migration guide (PRD G5).
+- MRO resolution (ADR 0010) also shrinks: one candidate per ancestor instead of six.

--- a/docs/superpowers/rebuild/adr/0008-drop-sfc-python-blocks.md
+++ b/docs/superpowers/rebuild/adr/0008-drop-sfc-python-blocks.md
@@ -1,0 +1,24 @@
+# ADR 0008: SFC `{# python #}` blocks dropped
+
+**Status:** Accepted, 2026-07-29.
+
+## Context
+
+v0.x supports single-file components: a `{# python #}` block inside a template holding the component's Python class (pyjinhx PR #128, with LSP support in pjx-ls PR #1). It requires extracting and exec-ing embedded Python at discovery time, and couples template parsing to Python tooling (type-checking, LSP, import semantics for code that lives in a non-`.py` file).
+
+## Options
+
+1. **Port in the initial build** — parity, but exec machinery and LSP coupling land in the critical path.
+2. **Defer post-L4** — keep the option open.
+3. **Drop** — v2 does not have the feature.
+
+## Decision
+
+Option 3 — dropped, not deferred. The component-definition surface already has three well-supported shapes: class + adjacent template, classless `component()`, and `{#def#}`-headed templates. A fourth shape whose main cost is tooling coupling (exec at discovery, special-cased LSP, opaque-to-type-checkers code placement) doesn't pay for itself.
+
+## Consequences
+
+- No exec of template-embedded Python anywhere in v2 discovery.
+- Migration: v0.x SFCs split into a `.py` class + adjacent `.pjx` template — mechanical, covered by the migration guide (PRD G5).
+- pjx-ls's eventual v2 pass (post-1.0) drops its `{# python #}` support for v2 projects.
+- If demand resurfaces, a new ADR reverses this with fresh context; nothing in v2's design forecloses it.

--- a/docs/superpowers/rebuild/adr/0009-minimal-instance-registry.md
+++ b/docs/superpowers/rebuild/adr/0009-minimal-instance-registry.md
@@ -1,0 +1,24 @@
+# ADR 0009: Instance registry minimal, reactivity-only
+
+**Status:** Accepted, 2026-07-29. Depends on ADR 0004.
+
+## Context
+
+v0.x's request-scoped instance registry serves two masters: template-visible peer cross-reference (killed by ADR 0004) and reactivity's bookkeeping. With cross-reference gone, the open question was whether the instance registry survives at all. Reactivity's needs are real: OOB fan-out must resolve a mounted region's `{name, id}` (from the `X-PJX-Mounted` manifest) to something renderable, and hash-gating means a reactive region whose keys were *not* dirtied must be resolvable to its cached render rather than recomputed — the load cache is keyed by `(class, key)` and something must own that mapping per request.
+
+## Options
+
+1. **Drop the instance registry too** — reactivity rebuilds lookup structures ad hoc per request from the manifest; scattered ownership.
+2. **Port it whole** — keeps machinery whose main consumer no longer exists.
+3. **Minimal, reactivity-only** — a request-scoped (ContextVar) map from composite key (`name + id`) to instance/cached render, used exclusively by OOB fan-out and load-cache lookups. Not visible to templates, not consulted during ordinary rendering.
+
+## Decision
+
+Option 3. The registry becomes an implementation detail of layer 3 with its storage in layer 2: one owner for "what is mounted and what did it last render," nothing else. Its exact surface is enumerated before RFC-2 (PRD risk 2) — layer 2 builds only what that enumeration demands.
+
+## Consequences
+
+- Ordinary (non-reactive) rendering never touches the instance registry — zero cost on the common path.
+- Composite keys and `request_scope` ContextVar isolation carry over from v0.x unchanged; both survived the #240 thread-safety audit untouched.
+- Cached-render lookups for not-dirtied reactive regions have a single, named home.
+- The pre-RFC-2 enumeration (swap targeting, manifest membership, hash inputs, cache keying) is the gate; anything it doesn't list doesn't get built.

--- a/docs/superpowers/rebuild/adr/0010-keep-mro-resolution.md
+++ b/docs/superpowers/rebuild/adr/0010-keep-mro-resolution.md
@@ -1,0 +1,30 @@
+# ADR 0010: MRO template/asset resolution kept
+
+**Status:** Accepted, 2026-07-29.
+
+## Context
+
+v0.x resolves a component class with no template of its own by walking its MRO (Python inheritance chain) and using the nearest ancestor's template; template, CSS, and JS resolve independently per kind. This is what makes extending a builtin a three-line class:
+
+```python
+class DangerButton(PJXButton):     # no danger_button.pjx anywhere
+    variant: str = "danger"       # inherits pjx_button.pjx + its JS,
+                                   # may ship only danger_button.css
+```
+
+Without it, every subclass duplicates the parent's template file, which then drifts when the parent's template changes. The cost in v0.x was extra probes through the six-candidate matrix; under ADR 0007 the matrix is 1×1.
+
+## Options
+
+1. **Drop** — subclasses copy templates; simplest finder, drift risk on every extension.
+2. **Keep** — walk MRO at registration, one candidate per ancestor per kind, result frozen into the descriptor.
+
+## Decision
+
+Option 2. The feature is the mechanism behind "extend a builtin without forking its markup," its consumers are real (L4 builtins are designed for subclassing), and under ADR 0007 + the descriptor (overview invariant 5) its entire cost is a handful of filesystem probes paid once at class registration. Zero render-time cost.
+
+## Consequences
+
+- Per-kind independence preserved: a subclass may override CSS while inheriting template and JS.
+- Resolution happens in `__pydantic_init_subclass__` into the frozen descriptor; dev-reload invalidation goes through the descriptor's single invalidation point like everything else.
+- The descriptor records *which ancestor* supplied each kind — free provenance for error messages and the dependency graph.

--- a/docs/superpowers/rebuild/adr/0011-process-decisions.md
+++ b/docs/superpowers/rebuild/adr/0011-process-decisions.md
@@ -1,0 +1,23 @@
+# ADR 0011: Process decisions — packaging, release, deferrals
+
+**Status:** Accepted (packaging/specs 2026-07-28; release/deferrals 2026-07-29). Grouped: low-controversy calls that shape the project rather than the architecture.
+
+## Parallel package, same repo
+
+v2 is built as `src/pyjinhx2/` beside the current code. Shares tests, builtins, and CI; the builtins port validates each layer as it ships; v0.x keeps releasing throughout. Rejected: new repo (loses easy reuse of test suite and builtins during the port), long-lived v2 branch (permanent rebases against an active master).
+
+## Ships as pyjinhx 1.0
+
+At L4 close — parity proven (PRD G3/G4), benchmarks green (G1/G2), migration guide shipped (G5) — the package is renamed and published as pyjinhx 1.0. v0.x freezes to critical fixes. Rejected: separate PyPI package forever (two products to maintain), deciding at L4 (the PRD needs a release vehicle to define "done").
+
+## Layer specs written just-in-time
+
+One RFC per layer, written when that layer starts, adversarially reviewed via /feature before implementation. Rejected: all layer specs up front — build-order layering means lower layers teach upper ones; deep-speccing reactivity before the kernel exists produces fiction.
+
+## Cross-request InvalidationBackend deferred post-1.0
+
+The per-request load cache ports in L3; the Redis/SQLite cross-worker invalidation backends do not gate 1.0. They are additive integrations with stable interfaces, and keeping two external-service integrations off the critical path shortens L3. Consuming apps needing them stay on v0.x until the post-1.0 port.
+
+## Public `Parser`/`Tag` API dropped, no compat shim
+
+v0.x exposes `Parser` and `Tag` for programmatic parse-tree access. v2's equivalent surface is the segment-model types (`RenderedLevel`, `ChildRef`, descriptor), which carry strictly more information (positions, spans, provenance). A shim reproducing the old tree shapes would preserve an API whose underlying model no longer exists. Migration note covers the handful of known uses.

--- a/docs/superpowers/rebuild/adr/README.md
+++ b/docs/superpowers/rebuild/adr/README.md
@@ -1,0 +1,19 @@
+# Rebuild ADRs
+
+Architecture decision records for the pyjinhx 1.0 rebuild. ADR 0001 predates the rebuild (canonical copy at `docs/decisions/`) and remains binding for it (PRD goal G4); it is mirrored here so the set is self-contained.
+
+ADRs are immutable: superseded by a new ADR, never edited. New decisions made during RFCs get recorded here at decision time.
+
+| ADR | Decision |
+|---|---|
+| [0001](./0001-outerhtml-only-oob-swaps.md) | outerHTML-only OOB swaps, no append/prepend modes (pre-rebuild, binding) |
+| [0002](./0002-segment-list-composition.md) | Segment-list composition; children opaque by construction |
+| [0003](./0003-slot-opacity.md) | Slots: opaque + truthiness only |
+| [0004](./0004-drop-peer-cross-reference.md) | Peer cross-reference dropped entirely |
+| [0005](./0005-post-render-tag-expansion.md) | Post-render tag expansion, one parse per level |
+| [0006](./0006-strict-core-open-subclass.md) | Strict Pydantic core, open opt-in subclass |
+| [0007](./0007-single-template-convention.md) | One template convention: `.pjx` + snake_case |
+| [0008](./0008-drop-sfc-python-blocks.md) | SFC `{# python #}` blocks dropped |
+| [0009](./0009-minimal-instance-registry.md) | Instance registry minimal, reactivity-only |
+| [0010](./0010-keep-mro-resolution.md) | MRO template/asset resolution kept |
+| [0011](./0011-process-decisions.md) | Process decisions (packaging, release, deferrals) |

--- a/docs/superpowers/rebuild/architecture-overview.md
+++ b/docs/superpowers/rebuild/architecture-overview.md
@@ -1,0 +1,301 @@
+# Architecture overview — pyjinhx v2
+
+The living map of the rebuild: the hard invariants every layer obeys, one node per mechanism, one edge per real produces/consumes/gates relationship between mechanisms, and a worked example showing the model concretely. Not a module or file map — a mechanism that spans files is one node; a file holding two mechanisms is two. Solid edges are hard data dependencies (consumer cannot run without producer's output), dotted edges are keyed/soft lookups (consumer degrades or skips when the lookup misses), thick edges are ownership (producer is the single writer of that state). Companion to [prd.md](./prd.md) (what "done" means) and [adr/](./adr/) (why it's built this way). Updated as layers ship, so it always describes what exists — where this doc and reality disagree, fix this doc.
+
+> **The short version.** Everything hangs off two spines. The **render spine** (L0→L1): a class's `ClassDescriptor` — frozen at registration, holding template path (MRO-resolved), slot fields, asset paths, strict/open mode — feeds a Jinja render whose output gets exactly one parse, producing an ordered segment list with `ChildRef` holes and a recorded root span. Tag expansion fills holes by recursing; children splice in as opaque nodes; every later actor (root-attr stamp, OOB stamp) is string surgery at a recorded offset, and serialization is one join at the top. The **reactive spine** (L2→L3→client): rendering emits an `on_rendered` hook consumed by `RenderSession` (assets) and the minimal instance registry (mounted reactive instances); the client's `pjx.js` reports what's mounted (`X-PJX-Mounted`) and loaded (`X-PJX-Assets`); on mutation, dirtied keys select cache entries to evict, the instance registry + `LoadCache` resolve what to re-render (cached render if keys untouched), state hashing gates what actually swaps, and OOB swaps go out stamped at their recorded root spans with any missing assets riding along. The two spines touch at exactly three points: the `on_rendered` hook, the root span, and the descriptor.
+
+---
+
+## 1. Hard invariants
+
+Every layer obeys these. A PR that violates one is rejected regardless of what it fixes. They exist to make the efficiency goal structural rather than aspirational.
+
+1. **Structure is never re-derived by re-parsing your own output.** The root-tag span of a component's template output is recorded at the moment that output is produced. There is no second `HTMLParser` pass to find it, no opacify tokens, no marker-collision bailout.
+2. **Child output is opaque by construction.** A rendered child enters its parent as an opaque node in a segment list — never as a substring that the parent might re-parse, re-escape, or re-expand. This single invariant is what makes render cost linear in components rather than quadratic.
+3. **Exactly one root element per component**, enforced at layer 0. Violations raise; there is no silent-stamp fallback (the v0.36 `try/except ValueError` concession does not carry over).
+4. **Process-wide mutable state is either built-then-swapped under a lock, or ContextVar-scoped.** No third category. Deliberate exceptions are classified up front in the mutable-state census (§4), not annotated after an audit.
+5. **Per-class derived facts are computed once, at registration.** Template path, slot fields, asset paths, header status — one descriptor resolved in `__pydantic_init_subclass__`, following the existing `_pjx_children_target` pattern. No per-render recomputation, no scattered cache retrofits (v0.x accumulated seven cache mechanisms across four lifetimes; v2 has one place per-class facts live, which is also the single dev-reload invalidation point).
+6. **Autoescape is on, escape-by-default**, with the Slot exemption as in v0.23+.
+7. **One template convention:** `.pjx` extension, snake_case filenames. One filesystem probe per tag. (v0.x's 3 extensions × 2 cases produced 10,524 `get_template` calls for 1,754 components; the cache that papered over it is unnecessary when the probe matrix is 1×1.)
+8. **A scaling benchmark exists before layer 1 starts.** `scripts/` gets a v2 variant of `bench_render_scaling.py` in layer 0; each layer's done-criteria include recording its number. Not in CI (timing-sensitive), but never absent for 36 versions again.
+
+---
+
+## 2. The map
+
+```mermaid
+graph LR
+    subgraph registration["registration time (once per class)"]
+        Discovery["Autodiscovery<br/>(.pjx + snake_case)"]
+        ClassReg["Class registry<br/>(process-wide)"]
+        Descriptor["ClassDescriptor<br/>(template path via MRO,<br/>slot fields, assets, mode)"]
+    end
+
+    subgraph L0["L0 kernel (per render level)"]
+        Component["Component instance<br/>(strict | open subclass)"]
+        Jinja["Jinja render<br/>(autoescape on)"]
+        Parse["ONE parse<br/>segments + ChildRefs<br/>+ root_span"]
+        Stamp["Root-attr stamp<br/>(offset splice)"]
+        Serialize["Serialize<br/>(one join, top only)"]
+    end
+
+    subgraph L1["L1 composition"]
+        Expand["Tag expansion<br/>(fill ChildRef holes)"]
+        Slots["Slots / children<br/>(opaque nodes)"]
+        DefHeader["{#def#} headers /<br/>component()"]
+    end
+
+    subgraph L2["L2 registry + assets (per request)"]
+        Session["RenderSession<br/>(asset accumulation)"]
+        InstReg["Instance registry<br/>(minimal, reactive only)"]
+    end
+
+    subgraph L3["L3 reactivity"]
+        Load["load() + LoadCache<br/>(keyed (class, key))"]
+        Dirty["@mutates / dirty()<br/>(dirtied keys)"]
+        Hash["State hash"]
+        Fanout["OOB fan-out<br/>+ hash gating"]
+    end
+
+    subgraph client["client (browser)"]
+        Pjx["pjx.js<br/>(manifest headers)"]
+    end
+
+    %% ── registration ─────────────────────────────────────────────
+    Discovery == "registers classes" ==> ClassReg
+    ClassReg -- "class + MRO" --> Descriptor
+    DefHeader == "generates open-model class" ==> ClassReg
+
+    %% ── render spine ─────────────────────────────────────────────
+    Component -- "validated fields" --> Jinja
+    Descriptor -- "template path" --> Jinja
+    Jinja -- "own output string" --> Parse
+    Parse -- "ChildRef holes" --> Expand
+    Expand -. "tag name" .-> ClassReg
+    Expand == "recurse render();<br/>splice opaque node" ==> Component
+    Slots -- "opaque nodes as<br/>field values" --> Jinja
+    Parse -- "root_span" --> Stamp
+    Parse -- "segment tree" --> Serialize
+
+    %% ── the three touch points ───────────────────────────────────
+    Component -. "on_rendered hook" .-> Session
+    Component -. "on_rendered hook<br/>(reactive only)" .-> InstReg
+    Descriptor -- "asset_paths" --> Session
+    Parse -- "root_span" --> Fanout
+
+    %% ── reactive spine ───────────────────────────────────────────
+    Load == "instances +<br/>cached renders" ==> InstReg
+    Dirty -- "evicts by<br/>react={} keys" --> Load
+    Component -- "model_dump()" --> Hash
+    Pjx -- "X-PJX-Mounted<br/>(id, type, load, hash)" --> Fanout
+    InstReg -- "resolve name+id;<br/>cached render if clean" --> Fanout
+    Hash -- "fresh hash vs<br/>manifest hash: gate" --> Fanout
+    Fanout -- "OOB swaps<br/>(stamped at root_span)" --> Pjx
+    Session -. "missing assets<br/>(X-PJX-Assets dedup)" .-> Fanout
+    Fanout -. "swap-in assets" .-> Pjx
+```
+
+Edge semantics, restated for this map: **solid** — the consumer cannot produce its output without this input (`Parse` cannot exist without Jinja's string). **Dotted** — keyed lookup or hook; a miss is a defined, non-error path (`Expand` on an unknown tag passes it through verbatim; a non-reactive component never touches `InstReg`). **Thick** — single-writer ownership (`Discovery` is the only writer of `ClassReg`; `Load` is the only writer of `InstReg` entries; `Expand` is the only caller that splices children).
+
+---
+
+## 3. Mechanisms, by layer
+
+### registration time (ships with L0)
+
+- **Autodiscovery** — walks template dirs for `.pjx` files (snake_case only, ADR 0007); registers classes, generates open-model classes for `{#def#}`-headed templates. Runs at import/startup; the only writer of the class registry. Duplicate-name warning and `pjx_replace` shadowing live here.
+- **Class registry** — process-wide name→class map. Built-then-swapped under lock (invariant 4); read-only at render time.
+- **ClassDescriptor** — the per-class fact sheet, frozen in `__pydantic_init_subclass__` (invariant 5): template path (nearest-ancestor MRO walk per kind, ADR 0010, with provenance), slot-field set, asset paths, strict/open mode (ADR 0006), header status. The single dev-reload invalidation point. Everything downstream *reads* this; nothing recomputes it.
+
+### L0 — kernel
+
+- **Component instance** — strict Pydantic model (open subclass opt-in); validation, JSON-string attr coercion, auto-`pjx-<n>` IDs at construction.
+- **Jinja render** — `template.render(context)` with autoescape on (invariant 6); produces this level's markup only, children still unexpanded tags in the string.
+- **The one parse** — single `html.parser` feed over own output doing triple duty (ADRs 0002/0005): cut segments at PascalCase tags (→ `ChildRef` holes), record the root-tag span, enforce single-root (raise, no fallback). The only parse this level ever gets.
+- **Root-attr stamp** — pass-through attrs, `data-pjx-*`, `hx-swap-oob` all land via one splice at the recorded span. No document parse.
+- **Serialize** — one recursive join over the segment tree, at the top of the outermost render. Each output character produced exactly once.
+
+*Ships when:* a single component renders with validated props; root attrs stamped without a document parse; single-root violations raise; v2 scaling benchmark exists and baseline recorded.
+
+### L1 — composition
+
+- **Tag expansion** — walks `ChildRef` holes in order; resolves tag name against the class registry (unknown tags pass through verbatim); instantiates with coerced attrs; recurses `render()`; splices the result back as an opaque node. The cycle guard (nesting/`load()` chains only, post-ADR 0004) lives here.
+- **Slots / children** — component-valued fields enter templates as opaque nodes: truthiness + interpolation only, string filters raise (ADR 0003). String-valued `Slot` fields remain raw-capable strings.
+- **`{#def#}` / `component()`** — classless surface; builds on the open subclass and discovery. Stale-header warning lives here.
+
+*Ships when:* nested trees render with linear parse cost (benchmark shows it); generated tags work; classless components work; slot semantics tested including the clear-error path for string filters.
+
+### L2 — registry + assets (per request, ContextVar-scoped)
+
+- **RenderSession** — subscribes to `on_rendered`; set-adds each class's `descriptor.asset_paths`; emits deduped INLINE `<style>`/`<script>` (or NONE) at top-level serialize. Also serves `asset_manifest()`, hashed filenames, `all_assets()`.
+- **Instance registry** — minimal (ADR 0009): composite key (`name + id`) → instance/cached render, written only for reactive components, read only by OOB fan-out and cache lookups. Not template-visible (ADR 0004). Reset by `request_scope`.
+
+*Ships when:* a page render produces deduped assets; concurrent requests don't bleed state (tested under a threadpool).
+
+### L3 — reactivity
+
+- **`load()` + LoadCache** — `load()` wrapped at class-definition time; memoized per request under `(class, key)`; reverse-indexed by `react={}` keys. Cross-request scope deferred post-1.0 (ADR 0011).
+- **`@mutates` / `dirty()`** — record dirtied keys (incl. parametric `reactive_key(key, arg)`) in request state; eviction selector for the cache and re-render selector for fan-out.
+- **State hash** — SHA-256 over sorted `model_dump()` (minus exclusions); stamped as `data-pjx-hash` at the root span.
+- **OOB fan-out + gating** — the convergence node. Consumes: client manifest (`X-PJX-Mounted`), dirtied keys, instance registry, LoadCache, fresh hashes. Emits: `outerHTML` OOB swaps (ADR 0001) for dirty+changed regions, delete swaps on `LookupError`, `HX-Reswap: none` when OOB-only, swap-in assets for anything the client hasn't loaded (`X-PJX-Assets` dedup). Nesting dedup is structural: the segment tree already knows containment.
+
+*Ships when:* behavior parity with ADR 0001 and the v0.x reactive test suite; hash gating verified; swap-in assets delivered.
+
+### client (ships with L3)
+
+- **pjx.js** — inlined on cold render (skipped when `X-PJX-Mounted` present); scans DOM for mounted regions, sends manifest headers (`X-PJX-Mounted`/`X-PJX-Assets`/`X-PJX-Trigger`); applies swaps; loading indicators; toast/loader APIs; vendored htmx.
+
+### L4 — builtins
+
+All 60+ components. Pure consumers of everything above — no engine edges of their own, which is the point: if a builtin needs a new edge on this map, that's an engine gap found by the port. Subclassing story rides on MRO resolution (ADR 0010).
+
+*Ships when:* builtin test suite green under v2; published benchmark comparison v0.x vs v2 on the same builtin-heavy page. Closing L4 closes PRD goals G2/G3/G5.
+
+---
+
+## 4. Notes on non-obvious interactions
+
+**The three touch points are the whole coupling between the spines.** The render spine knows nothing about reactivity except that it fires `on_rendered` and records `root_span`; the reactive spine consumes both plus the descriptor. A page with zero reactive components pays: one hook call per component (no-op beyond assets), nothing else.
+
+**Not-dirtied ≠ not-swapped, and the registry is why it's cheap.** On a mutation request, a mounted region whose `react` keys were untouched must still be *considered* (it's in the manifest) but must not be *recomputed*: the instance registry resolves it to its cached render / cached instance, its hash matches the manifest's, gating skips the swap. Three mechanisms (registry, cache, hash) collaborate so the common case — most regions clean — costs lookups, not renders.
+
+**Hash gating and the cache answer different questions.** LoadCache asks "must `load()` re-run?" (answer: only if a `react` key was dirtied). Hash gating asks "did the re-render actually change anything?" (a dirtied key can produce identical output — e.g. a mutation that round-trips to the same state). Both gates must open for bytes to go over the wire.
+
+**Root span is written twice, parsed never.** The stamp mechanism splices pass-through attrs at render time; fan-out splices `hx-swap-oob` at response time. Same offset, same splice primitive, two moments. In v0.36 each of these was a separate document parse.
+
+**Assets flow through two doors.** Cold render: RenderSession → inline tags at serialize. Reactive swap: fan-out compares session accumulation against `X-PJX-Assets` and ships only the delta as OOB fragments. Same accumulator, two emission paths — which is why RenderSession lives in L2 but has a dotted edge into L3.
+
+**Discovery and `{#def#}` are the only writers at import time; everything per-request is ContextVar.** The full mutable-state census (invariant 4): class registry + descriptors (built-then-swap, import/registration time), instance registry + RenderSession + dirtied keys + LoadCache request store (ContextVar, reset by `request_scope`). Nothing else. A mechanism needing mutable state not in this census amends this census first.
+
+**Unknown PascalCase passes through.** `Expand`'s dotted edge to the class registry: a miss is not an error — the tag is emitted verbatim (it may be a web component or intentional markup). Only registered names become renders. This is unchanged from v0.x and load-bearing for the builtins' composed families.
+
+---
+
+## 5. Worked example — the segment model concretely
+
+What "segment list", "opaque child", and "recorded root span" mean in practice. Type names are illustrative; real signatures land with the L0 implementation.
+
+### The types layer 0 owns
+
+```python
+@dataclass
+class RenderedLevel:
+    segments: list[str | ChildRef | RenderedLevel]  # own markup, in order
+    root_span: tuple[int, int]      # where in segments[0] the root tag sits
+    descriptor: ClassDescriptor     # computed once at registration
+
+@dataclass
+class ChildRef:                     # a <PJXButton .../> found during the one parse
+    tag: str
+    attrs: dict[str, str]
+
+@dataclass(frozen=True)
+class ClassDescriptor:              # per-class facts, never recomputed
+    template_path: Path
+    slot_fields: frozenset[str]
+    asset_paths: tuple[Path, ...]
+```
+
+### One parse cuts the output
+
+Template of `Card`:
+
+```html
+<div class="card">
+  <h2>{{ title }}</h2>
+  <PJXButton label="Save"/>
+  <p>{{ note }}</p>
+  <PJXIcon name="gear"/>
+</div>
+```
+
+```text
+Jinja output (one flat string):
+
+  <div class="card">\n  <h2>Hello</h2>\n  <PJXButton label="Save"/>\n  <p>hi</p>\n  <PJXIcon name="gear"/>\n</div>
+  └────────┬────────┘                   └──────────┬───────────┘             └─────────┬─────────┘
+       root tag found                       child tag found                      child tag found
+       (span recorded)                      (cut point)                          (cut point)
+
+Parse cuts at every PascalCase tag. Result — ordered segment list:
+
+  segments = [
+    ①  '<div class="card">\n  <h2>Hello</h2>\n  ',     ← plain markup (str)
+    ②  ChildRef("PJXButton", {label: "Save"}),          ← hole, in order
+    ③  '\n  <p>hi</p>\n  ',                             ← plain markup (str)
+    ④  ChildRef("PJXIcon", {name: "gear"}),             ← hole, in order
+    ⑤  '\n</div>',                                      ← plain markup (str)
+  ]
+  root_span = (0, 18)        ← offsets of <div class="card"> inside segment ①
+```
+
+Segments are sequential and positional in two senses: list order IS document order (joining ①②③④⑤ reproduces the page), and `root_span` is a character offset into segment ① — so stamping attributes later is slice + insert at a known position, never a search.
+
+### Holes fill by recursion; children stay whole objects
+
+```text
+Card level                          PJXButton level (own render, own parse)
+┌──────────────────────────────┐
+│ ① "<div…<h2>Hello</h2>…"     │    ┌───────────────────────────┐
+│ ② ●──────────────────────────┼──► │ ① "<button class=…>Save…" │  ← no children,
+│ ③ "\n  <p>hi</p>\n  "        │    │    root_span=(0,…)        │    list of 1 string
+│ ④ ●──────────────────────────┼─┐  └───────────────────────────┘
+│ ⑤ "\n</div>"                 │ │
+│    root_span=(0,18)          │ │  PJXIcon level
+└──────────────────────────────┘ └► ┌───────────────────────────┐
+                                    │ ① "<svg …>…</svg>"        │
+                                    └───────────────────────────┘
+```
+
+② and ④ are *whole objects* in the parent's list. Card never sees the button's markup as text — so Card cannot accidentally re-parse, re-escape, or re-expand it. That is "opaque by construction" (invariant 2). v0.36 instead pasted button HTML into Card's string and re-parsed the combined string — the source of every superlinear term found across two perf campaigns.
+
+### Stamping is a positional edit; serialization is one join
+
+Card reactive? The stamp lands inside segment ① at `root_span`:
+
+```text
+before:  <div class="card">\n  <h2>…
+after:   <div class="card" data-pjx-key="card-1" hx-swap-oob="outerHTML">\n  <h2>…
+```
+
+No parse, no regex, no token dance — string surgery at an offset recorded when the string was made (invariant 1). Then, depth-first at the very top:
+
+```text
+join(Card) = ① + join(Button) + ③ + join(Icon) + ⑤   — each character produced exactly once
+```
+
+### The engine loop, end to end
+
+Each layer is one function taking lower layers' outputs as plain arguments:
+
+```python
+def render(component, session: RenderSession) -> RenderedLevel:
+    desc = type(component).__pjx_descriptor__          # L0: read, not compute
+
+    level = render_own_template(component, desc)       # L0: Jinja + ONE parse
+    #        └─► RenderedLevel(segments, root_span, desc)
+
+    for i, seg in enumerate(level.segments):           # L1: expand children
+        if isinstance(seg, ChildRef):
+            child = instantiate(seg.tag, seg.attrs)
+            level.segments[i] = render(child, session)  # opaque node. done.
+
+    session.on_rendered(component, desc)               # L2: accumulate assets
+
+    if is_reactive(component):                         # L3: stamp at known span
+        stamp_at(level, level.root_span, oob_attrs(component, desc))
+
+    return level   # serialize() joins the tree once, at the very top
+```
+
+The abstraction stack this code embodies:
+
+```text
+  L3   "edit at offset X"        needs: root_span (a position)
+  L2   "component rendered"      needs: an event + descriptor
+  L1   "fill hole N in order"    needs: segments (positions of holes)
+  L0   "string cut into pieces,  produces: all of the above
+        positions remembered"
+```
+
+Everything above L0 works with *positions L0 remembered*, instead of re-finding them by parsing. That is the whole trick.

--- a/docs/superpowers/rebuild/feature-port-list.md
+++ b/docs/superpowers/rebuild/feature-port-list.md
@@ -1,0 +1,100 @@
+# v2 feature port list
+
+Date: 2026-07-29
+Status: approved. Decided against the full v0.36 inventory (70+ features, agent-swept from docs/guide, CHANGELOG, public API, builtins). This file owns the feature universe: per-feature verdict AND the build layer that ships it. A layer's just-in-time spec must cover every feature assigned to it. Parity checklist for PRD goal G3.
+
+Verdicts: **keep** (ports as-is in behavior), **mod** (ports with changed shape — the change is noted), **drop** (does not exist in v2). Layer "—" = dropped, nothing ships.
+
+## 1. Component definition
+
+| Feature | Verdict | Layer | Notes |
+|---|---|---|---|
+| BaseComponent + Pydantic field validation | keep | L0 | strict core now (ADR 0006) |
+| Classless components via `component()` | keep | L1 | |
+| `{#def#}` prop headers | keep | L1 | built on the open opt-in subclass |
+| Extra/stray fields accepted | mod | L1 | only on the open opt-in subclass, not on strict base |
+| `Slot` type | mod | L1 | string slots stay raw-HTML-capable; component slots are opaque nodes |
+| Children/`content` inference (single `Slot()` / `_pjx_children_target`) | keep | L1 | |
+| Stale-`{#def#}` warning | keep | L1 | |
+| SFC `{# python #}` blocks | **drop** | — | ADR 0008 — not deferred, not ported |
+
+## 2. Composition
+
+| Feature | Verdict | Layer | Notes |
+|---|---|---|---|
+| PascalCase tags | keep | L1 | expansion via segment model, one parse per level (ADRs 0002/0005) |
+| Attribute pass-through to root | keep | L0 | stamped at recorded root span, no parse |
+| JSON-string attr coercion (`list`/`dict`/`BaseModel`) | keep | L0 | at instantiation |
+| Slots | mod | L1 | opaque + truthiness only; string filters raise clear error (ADR 0003) |
+| Direct nesting (instances as field values) | keep | L1 | |
+| Lists & dicts of components | keep | L1 | |
+| NestedComponentWrapper (`{{ field.props.x }}`, `{{ field }}`) | keep | L1 | both work on opaque nodes |
+| Single-root invariant | mod | L0 | stricter — violations raise, no silent-stamp fallback |
+| Auto-generated `pjx-<n>` IDs, `auto_id=False` | keep | L0 | |
+
+## 3. Discovery & registration
+
+| Feature | Verdict | Layer | Notes |
+|---|---|---|---|
+| Class registry | keep | L2 | |
+| Instance registry | mod | L2 | minimal, reactivity-only: maps name+id to instance/cached render for OOB fan-out and not-dirtied cache hits. No template-visible cross-reference (ADRs 0004/0009) |
+| Request scoping (`request_scope`) | keep | L2 | |
+| Composite keys (name + id) | keep | L2 | |
+| Template autodiscovery | mod | L1 | `.pjx` + snake_case only (ADR 0007); `.html`/`.jinja` and kebab probing dropped |
+| MRO template/asset resolution | keep | L0 | nearest-ancestor per kind, frozen into the descriptor at registration (ADR 0010) |
+| Duplicate-class warning | keep | L1 | |
+| `pjx_replace=True` shadowing | keep | L1 | |
+
+## 4. Rendering & context
+
+| Feature | Verdict | Layer | Notes |
+|---|---|---|---|
+| Renderer + Jinja environment | keep | L0 | |
+| Default-environment project-root detection | keep | L0 | |
+| Autoescape on, escape-by-default + Slot exemption | keep | L0 | invariant 6 |
+| Root-attr stamping (override semantics) | mod | L0 | offset splice at recorded span; no document parse |
+| PjxContext injection (`load()` param / `PjxContext.current()`) | keep | L3 | |
+| Render cycle guard | mod | L1 | cross-ref gone, so cycles only via nesting/`load()` chains; simpler guard |
+| Opaque-slot placeholder machinery | **drop** | — | segment model makes it unnecessary (ADR 0002) |
+| Resolution memoization caches | **drop** | — | replaced by the per-class descriptor (invariant 5) |
+| Post-hoc thread-safety patches | **drop** | — | replaced by invariant 4 (built-then-swap or ContextVar) |
+| Registry cross-reference in templates | **drop** | — | ADR 0004 |
+
+## 5. Assets — all keep, ship in L2
+
+Co-located `.js`/`.css` discovery, INLINE/NONE modes, per-session dedup, nested aggregation, `asset_manifest()`, `pjx.js` runtime injection (skip when `X-PJX-Mounted`), hashed filenames + `resolver_with_hash()`, `Finder.all_assets()`, extra `js=[]`/`css=[]` fields. (OOB/head-channel asset *delivery* ships with L3 — it needs fan-out.)
+
+## 6. Reactivity & HTMX — all keep, ship in L3
+
+ADR 0001 parity: ReactiveComponent + `load()`, MutationKey, `@mutates`, `dirty()`, OOB swaps, per-request load cache, instance-keyed components (`PjxKey`), `reactive_key` parametric keys, state hashing + hash gating, delete swaps on `LookupError`, client manifest headers (`X-PJX-Mounted`/`X-PJX-Assets`/`X-PJX-Trigger`), ReactiveResponse, tag-mounted `load()`, loading indicators, `HX-Reswap: none` emission, htmx redirect adaptation. Also L3: `setup()` middleware + PjxSettings, FastAPI integration, reactive dev mode, `dependency_graph()`, unconsumed-mutation check — they only earn their keep once reactivity exists.
+
+| Feature | Verdict | Layer | Notes |
+|---|---|---|---|
+| Nesting dedup of OOB swaps | mod | L3 | segment tree knows containment structurally; v0.x heuristic replaced |
+| Cross-request InvalidationBackend (Redis/SQLite) | defer | post-1.0 | ADR 0011; per-request load cache ships in L3 |
+
+## 7. Builtins — port all, ship in L4
+
+All 60+ components (ADR 0011 context). Families: icons/display (Icon, Badge, Avatar/Stack, Divider, Progress, Spinner, Skeleton, EmptyState), navigation (Breadcrumb, TabGroup/List/Tab/Panel, Paginator), data (Table family), forms (Button, ChipInput, FormField, PasswordInput, SegmentedControl, ToggleSwitch), dialogs/overlays (Modal, Drawer, ConfirmDialog, PromptDialog, Popover families), Dropdown, Accordion family, lazy/loading (LazyLoad, RegionLoader, PageLoader), notifications (Notification, ToastHost), Alert, helpers (Card, Tooltip, Resizable, Carousel families). Already-removed stay dead: PJXPanel, PJXLazyPanel.
+
+## 8. Dev tooling & misc
+
+| Feature | Verdict | Layer | Notes |
+|---|---|---|---|
+| Scaling benchmark | keep | L0 | invariant 8 — exists before L1 |
+| Reactive dev mode (warn/strict) | keep | L3 | |
+| `dependency_graph()` / mermaid formatting | keep | L3 | |
+| Unconsumed-mutation check | keep | L3 | |
+| `setup()` middleware + PjxSettings | keep | L3 | |
+| FastAPI integration | keep | L3 | |
+| Public `Parser`/`Tag` parse-tree API | **drop** | — | v2 exposes segment-model types instead; no compat shim (ADR 0011) |
+| pjx-ls (LSP) | out of scope | post-1.0 | needs a v2 pass eventually; not part of this blueprint |
+
+## Placement rationale
+
+Two judgment calls, decided 2026-07-29:
+
+1. **`{#def#}` headers and classless `component()` sit in L1, not L0.** They depend on discovery and the open opt-in subclass, not on composition itself — but L0's done-criteria stay minimal (one class-based component renders), and discovery ships with L1's tag resolution anyway. L0 stays the smallest shippable kernel.
+2. **`setup()`, FastAPI integration, and dev tooling sit in L3.** They only earn their keep once reactivity exists — before that, nothing needs middleware, client headers, or a dependency graph.
+
+MRO resolution lands in L0 because it lives inside the descriptor computation (per-class, at registration), even though its main consumer is subclassing builtins in L4.

--- a/docs/superpowers/rebuild/implementation-overview.md
+++ b/docs/superpowers/rebuild/implementation-overview.md
@@ -1,0 +1,133 @@
+# Implementation overview — pyjinhx v2
+
+Date: 2026-07-29
+Status: approved. How the mechanisms in [architecture-overview.md](./architecture-overview.md) land as code: the architecture style, the folder/file structure, and the render timelines (what fires, in what order). Input for deriving the implementation roadmap; layer specs refine per-file detail just-in-time.
+
+## Architecture style
+
+Flat module-per-mechanism, subpackages only for cohesive clusters (reactive, client, integrations, builtins). Matches v0.x's proven layout — the rebuild analysis indicted the composition model, never the module structure — and the "small human-looking code" north star: no package-per-layer scaffolding (layer numbers are build order, not domain vocabulary), no hexagonal ports/adapters (single delivery mechanism, single template engine — abstraction layers with one implementation are over-abstraction).
+
+The two spines from the architecture overview become a physical dependency rule — **imports flow down, hooks flow up**:
+
+```text
+reactive/ ──imports──► session, segments, descriptor     (reads root_span, registry, hook)
+session   ──imports──► descriptor                        (asset_paths)
+render    ──imports──► segments, component, discovery
+segments  ──imports──► (nothing internal)                ← the kernel's kernel
+
+FORBIDDEN: anything in the render spine importing reactive/.
+Touch points are the only coupling: render.py fires on_rendered (a plain
+callback list on the session), exposes root_span, reads the descriptor.
+```
+
+One test asserts the import graph. Cheap, catches spine violations forever.
+
+## Folder / file structure
+
+```text
+src/pyjinhx2/
+├── __init__.py          public API, curated exports
+├── component.py         BaseComponent (strict), OpenComponent, Slot, children inference
+├── descriptor.py        ClassDescriptor: MRO walk, slot fields, asset paths — frozen at registration
+├── discovery.py         .pjx walk, class registry (built-then-swap), pjx_replace, dup warning
+├── props_header.py      {#def#} parsing + open-class generation
+├── segments.py          RenderedLevel, ChildRef, the ONE parse, root_span, splice, serialize
+├── render.py            engine loop: render(), ChildRef fill, cycle guard, on_rendered hook
+├── session.py           request_scope, RenderSession, minimal instance registry
+├── assets.py            INLINE/NONE, manifest, hashed filenames, all_assets()
+├── context.py           PjxContext
+├── config.py            setup(), PjxSettings
+├── dev.py               dev mode, dependency_graph()
+├── reactive/
+│   ├── component.py     ReactiveComponent, load(), tag-mounted load
+│   ├── keys.py          MutationKey, reactive_key
+│   ├── mutations.py     @mutates, dirty()
+│   ├── cache.py         LoadCache
+│   ├── fanout.py        state hash, hash gating, OOB fan-out, delete swaps
+│   └── response.py      ReactiveResponse, HX-Reswap, redirect adaptation
+├── client/
+│   ├── pjx.js
+│   └── inject.py        runtime injection, manifest header parsing
+├── integrations/
+│   └── fastapi.py
+└── builtins/            L4, mirrors v0.x layout
+```
+
+Judgment calls: `segments.py` is deliberately import-pure — the type layer everything trusts. The instance registry lives in `session.py`, not `reactive/` — storage is L2, consumer is L3, matching the map. `props_header.py` stays separate from `discovery.py` — parsing vs walking, both feed the registry.
+
+Tests mirror the package: `tests/pyjinhx2/test_<module>.py` per module, `tests/pyjinhx2/reactive/` for the cluster, plus `test_import_graph.py` (the spine rule) and the benchmark under `scripts/`.
+
+## Render timelines
+
+Three timelines: registration (once per process), cold render (per page), reactive request (per mutation). Module-attributed, in firing order.
+
+### T0 — startup (once per process)
+
+```text
+import app
+ 1. discovery.py    walk template dirs (.pjx) ── register classes, {#def#} → generated classes
+ 2. component.py    __pydantic_init_subclass__ fires per class
+ 3. descriptor.py     └─► freeze ClassDescriptor (MRO template walk, slot fields, asset paths, mode)
+ 4. discovery.py    class registry built-then-swapped ── read-only from here on
+```
+
+### T1 — cold render (per request)
+
+```text
+integrations/fastapi.py   request in
+ 1. session.py       request_scope enters ── fresh ContextVars: RenderSession,
+    │                instance registry, dirtied keys, LoadCache store
+ 2. reactive/…       top-level tag-mounted? load() via LoadCache (miss → real load())
+ 3. render.py        render(component, session)          ◄────────────────┐
+    ├─ descriptor.py   read frozen descriptor (no compute)                │
+    ├─ component.py    validated fields → context; slots wrapped opaque   │
+    ├─ Jinja           template.render ── own markup string, autoescape   │
+    ├─ segments.py     THE parse: segments + ChildRefs + root_span;       │
+    │                  single-root enforced (raise)                       │
+    ├─ segments.py     root-attr stamp ── splice at root_span             │
+    ├─ render.py       for each ChildRef, in document order:              │
+    │                    resolve tag (discovery registry; unknown → verbatim)
+    │                    instantiate (JSON coercion, auto-id) ── cycle guard
+    │                    recurse ────────────────────────────────────────┘
+    │                    splice result as opaque node
+    └─ session.py      on_rendered fires:
+                         RenderSession ── set-add descriptor.asset_paths
+                         reactive only ── instance-registry write;
+                                          state hash; data-pjx-id/-hash
+                                          spliced at root_span
+ 4. segments.py      serialize ── ONE recursive join (top level only)
+ 5. client/inject.py pjx.js inlined (cold ⇒ no X-PJX-Mounted header)
+ 6. assets.py        RenderSession → deduped inline <style>/<script>
+ 7. session.py       request_scope exits ── ContextVars reset
+```
+
+### T2 — reactive request (mutation)
+
+```text
+integrations/fastapi.py   request in ── parse X-PJX-Mounted / X-PJX-Assets / X-PJX-Trigger
+ 1. session.py            request_scope enters (fresh state, as T1)
+ 2. app handler runs:
+    ├─ reactive/mutations.py  @mutates / dirty() ── record dirtied keys
+    └─ reactive/cache.py        └─► evict LoadCache entries via react={} reverse index
+ 3. handler returns component | ReactiveResponse
+ 4. render.py             primary render ── T1 steps 3-4 (pjx.js NOT re-injected)
+ 5. reactive/fanout.py    for each manifest entry {id, type, load, hash}:
+    ├─ clean keys?   ── instance registry / LoadCache resolve ── NO re-render, NO load()
+    ├─ dirty keys?   ── load() re-runs (cache was evicted) ── render (T1 steps 3-4)
+    ├─ gone?         ── LookupError ── delete swap
+    ├─ hash gate     ── fresh hash == manifest hash ── swap dropped
+    ├─ nesting dedup ── region inside another survivor ── dropped (segment containment)
+    └─ survivor      ── hx-swap-oob spliced at its root_span
+ 6. reactive/fanout.py    asset delta vs X-PJX-Assets ── OOB asset fragments
+ 7. reactive/response.py  OOB-only? ── HX-Reswap: none
+ 8. client/pjx.js         applies swaps ── updates its mounted map ── next manifest reflects it
+```
+
+## Load-bearing ordering facts
+
+Facts the timelines pin down, which layer specs must not violate:
+
+- **Root-attr stamp precedes child fill.** The parent's first segment is final early; nothing later shifts offsets within a segment, so recorded spans stay valid.
+- **`on_rendered` fires depth-first post-order.** Each component's hook fires after its own subtree completes; children fired their own hooks already, so session state accumulates bottom-up.
+- **Serialize and asset emission happen exactly once, at the top.** No intermediate joins anywhere in the tree.
+- **Fan-out runs after the primary render and must exclude regions the primary response already contains.** Otherwise a region swaps twice (once as primary content, once OOB). v0.x handles this via nesting dedup against the primary; the L3 spec needs an explicit line for it.

--- a/docs/superpowers/rebuild/prd.md
+++ b/docs/superpowers/rebuild/prd.md
@@ -1,0 +1,67 @@
+# PRD — pyjinhx 1.0 (engine rebuild)
+
+Date: 2026-07-29 · Status: approved · Owner: Paulo
+What "done" means for the rebuild. How is the RFCs' job; why is the ADRs'.
+
+## Problem
+
+Two perf campaigns (#221, #240) traced every superlinear render cost to one structural fact: each render level flattens children to a string, then re-derives structure by re-parsing it. Patching produced seven cache mechanisms, opacify token machinery, and one correctness concession (silent root-stamp fallback). The structure cannot be fixed incrementally — the #240 spec rejected single-pass rework as too risky against shipped invariants. Rebuild removes the fact instead of patching around it.
+
+## Users
+
+Primary: existing apps on pyjinhx 0.x (internal). Their migration cost and feature parity gate the release. Public adoption: welcome, not gating.
+
+## Goals — all gating
+
+| # | Goal | Measured by |
+|---|---|---|
+| G1 | Linear render scaling | Bench sweep: ms/component flat as tree grows to 10k components |
+| G2 | Never slower than v0.36 | Same-page benchmark comparison, no regression on any bench case |
+| G3 | Feature parity per port list | Every "keep"/"mod" in [feature-port-list.md](./feature-port-list.md) works; builtin suite green under v2 |
+| G4 | Reactive behavior parity | ADR 0001 semantics preserved; v0.x reactive test suite passes |
+| G5 | Migration is mechanical | Migration guide covers every breaking change; a v0.x app ports without redesign |
+| G6 | Thread-safe by construction | Invariant 4 upheld; concurrent-request tests in CI from L2 |
+
+## Non-goals
+
+- SFC `{# python #}` blocks — dropped, not deferred
+- Template-visible peer cross-reference — dropped (composition via nesting/slots only)
+- String filters on component slots — opaque + truthiness only
+- `.html`/`.jinja` extensions, kebab-case template names — `.pjx` + snake_case only
+- Public `Parser`/`Tag` parse-tree API — segment types instead, no shim
+- Cross-request InvalidationBackend, pjx-ls update — post-1.0
+- New features beyond the port list — parity first, additions after 1.0
+
+## Solution shape
+
+Segment-list composition: a render level is an ordered list of markup segments; children are opaque nodes by construction; the root-tag span is recorded when output is produced. Invariants, mechanism map, and worked example: [architecture-overview.md](./architecture-overview.md).
+
+```text
+v0.36  render child → paste string into parent → RE-PARSE combined string
+                                                  └─ superlinear + opacify machinery
+
+v1.0   render child → opaque node in parent's segment list → join once at top
+                                                  └─ O(S) parse total, no machinery
+```
+
+## Delivery
+
+`src/pyjinhx2/` parallel package, same repo. Five layers, each shippable, each gated by its layer spec and ship criteria ([feature-port-list.md](./feature-port-list.md) assigns every feature to its layer):
+
+```text
+L0 kernel ──► L1 composition ──► L2 registry+assets ──► L3 reactivity ──► L4 builtins
+   │               │                    │                    │                │
+   bench          linear-scaling       concurrency          reactive         parity suite +
+   baseline       proven (G1)          tests (G6)           parity (G4)      G2/G3/G5 close
+```
+
+At L4 close: package renamed, published as **pyjinhx 1.0**, migration guide shipped, v0.x frozen to critical fixes.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Slot opacity breaks real templates (filters on slots) | Grep builtins/docs before the L1 spec (ADR 0003's survey gate); if widespread, revisit before L1, not after |
+| Minimal instance registry misses a reactive need | Enumerate reactivity's registry requirements before the L2 spec (ADR 0009's gate) |
+| Parity gaps surface only at L4 | Builtins are the parity suite by design; L4 is the gate, not a formality |
+| v0.x moves during rebuild | Port list pinned at 0.36.4; new v0.x features triaged into post-1.0 backlog |

--- a/docs/superpowers/rebuild/roadmap.md
+++ b/docs/superpowers/rebuild/roadmap.md
@@ -1,0 +1,97 @@
+# Implementation roadmap — pyjinhx v2
+
+Date: 2026-07-29
+Status: approved, living — check items off as they ship. Derived from [feature-port-list.md](./feature-port-list.md) (what each layer must cover), [implementation-overview.md](./implementation-overview.md) (files + timelines), [architecture-overview.md](./architecture-overview.md) (ship criteria), and the PRD's gating goals. Each layer runs as one /feature cycle (spec → adversarial review → plan → implement → test-integrity gate); inner steps are the intended PR-sized units, in dependency order. A layer's spec may reorder inner steps with reason, but may not weaken its deliverable.
+
+```text
+L0 kernel ──► L1 composition ──► L2 registry+assets ──► L3 reactivity ──► L4 builtins ──► 1.0
+        gate:                gate:
+        slot-filter          instance-registry
+        survey (ADR 0003)    enumeration (ADR 0009)
+```
+
+---
+
+## L0 — kernel · [milestone #1](https://github.com/paulomtts/pyjinhx/milestone/1)
+
+**Deliverable:** `render(Card(title="x"))` returns finished HTML — strict validation, root attrs stamped at the recorded span, single-root violations raise, benchmark exists with baseline recorded. The smallest thing that proves the segment model.
+
+Inner order (each step testable before the next starts):
+
+- [ ] **1. `segments.py`** ([#244](https://github.com/paulomtts/pyjinhx/issues/244)) — `RenderedLevel`, `ChildRef`, the one parse (segment cuts + root_span + single-root), splice, serialize. Import-pure, all pure functions: build and test it against raw strings before any component exists.
+- [ ] **2. `component.py`** ([#245](https://github.com/paulomtts/pyjinhx/issues/245)) — strict `BaseComponent`, `Slot` type, auto-`pjx-<n>` IDs, JSON-string attr coercion. No rendering yet; pure model behavior.
+- [ ] **3. `descriptor.py`** ([#246](https://github.com/paulomtts/pyjinhx/issues/246)) — `ClassDescriptor` frozen in `__pydantic_init_subclass__`: single-probe template resolution (`.pjx` + snake_case), MRO walk per kind with provenance, slot-field set, asset paths, strict/open mode flag.
+- [ ] **4. `render.py` (single level)** ([#247](https://github.com/paulomtts/pyjinhx/issues/247)) — Jinja environment (autoescape on, default-env project-root detection), context build from validated fields, `template.render` → the one parse → root-attr stamp → serialize. T1 steps 3-4 for a childless component.
+- [ ] **5. Guards + bench** ([#248](https://github.com/paulomtts/pyjinhx/issues/248)) — `test_import_graph.py` (spine rule live from day one), `scripts/bench_render_scaling_v2.py`, baseline number recorded in this file.
+
+Baseline: _(record here when step 5 lands)_
+
+**Gate before L1** ([#249](https://github.com/paulomtts/pyjinhx/issues/249))**:** slot-filter survey — grep v0.x builtins + docs for string operations on component-slot values (ADR 0003). Hits → migration notes; widespread → revisit ADR 0003 first.
+
+---
+
+## L1 — composition · [milestone #2](https://github.com/paulomtts/pyjinhx/milestone/2)
+
+**Deliverable:** a builtin-shaped nested page renders — component trees, generated tags, classless components — with the benchmark showing linear scaling (PRD G1 evidence starts here).
+
+- [ ] **1. `discovery.py`** — `.pjx` walk, class registry (built-then-swap), duplicate warning, `pjx_replace`.
+- [ ] **2. ChildRef fill in `render.py`** — resolve tag against registry (unknown → verbatim passthrough), instantiate with coerced attrs, recurse, splice opaque node, cycle guard. This is the step that turns T1's loop real.
+- [ ] **3. Slots & children** — opaque-node semantics (truthiness + interpolation; string filters raise the clear error), children/`content` inference, direct nesting, lists & dicts, `NestedComponentWrapper` (`{{ field.props.x }}` / `{{ field }}`).
+- [ ] **4. Classless surface** — open opt-in subclass, `props_header.py` ({#def#} parse + class generation, stale-header warning), `component()`.
+- [ ] **5. Scaling proof** — bench sweep to 10k components; ms/component flat. Record the number.
+
+Linear-scaling number: _(record here)_
+
+**Gate before L2:** instance-registry enumeration — list exactly what reactivity needs from it (swap targeting, manifest membership, hash inputs, cache keying) per ADR 0009. L2 builds only what's listed.
+
+---
+
+## L2 — registry + assets · [milestone #3](https://github.com/paulomtts/pyjinhx/milestone/3)
+
+**Deliverable:** full static pages with correct deduped assets, safe under concurrent requests (PRD G6 tests land here and stay in CI).
+
+- [ ] **1. `session.py`** — `request_scope` ContextVars (session, instance registry, dirtied-keys store, cache store — all reset on exit), `on_rendered` hook plumbing from `render.py`.
+- [ ] **2. `assets.py`** — accumulation off descriptors, per-session dedup, INLINE/NONE emission at top-level serialize, `asset_manifest()`, hashed filenames + `resolver_with_hash()`, `all_assets()`.
+- [ ] **3. Instance registry (minimal)** — exactly the enumerated surface from the L2 gate; composite keys; written only by reactive paths (stub-consumed until L3).
+- [ ] **4. Concurrency tests** — FastAPI-threadpool-shaped test: parallel renders, no state bleed, no `FileNotFoundError`-class races. The invariant-4 census gets asserted here.
+
+---
+
+## L3 — reactivity · [milestone #4](https://github.com/paulomtts/pyjinhx/milestone/4)
+
+**Deliverable:** reactive behavior parity — a mutation round-trip demo (dirty → evict → fan-out → gated OOB swaps → swap-in assets) plus the ported v0.x reactive test suite green (PRD G4).
+
+- [ ] **1. `reactive/keys.py` + `mutations.py`** — MutationKey, `reactive_key(key, arg)`, `@mutates`, `dirty()`; dirtied-keys request state.
+- [ ] **2. `reactive/cache.py`** — LoadCache: `(class, key)` memoization, `react={}` reverse index, eviction by dirtied keys.
+- [ ] **3. `reactive/component.py`** — ReactiveComponent, `load()` wrap at class-definition time, tag-mounted `load()`, instance-keyed components (`PjxKey`).
+- [ ] **4. State hash + stamping** — SHA-256 over sorted `model_dump()` minus exclusions; `data-pjx-id`/`data-pjx-hash` spliced at root_span via the `on_rendered` reactive branch; instance-registry writes go live.
+- [ ] **5. `reactive/fanout.py`** — manifest walk, clean/dirty resolution (cached render vs re-`load()`), hash gate, structural nesting dedup, primary-region exclusion (the T2 ordering fact), delete swaps on `LookupError`, `hx-swap-oob` splice.
+- [ ] **6. `reactive/response.py`** — ReactiveResponse, `HX-Reswap: none`, htmx redirect adaptation.
+- [ ] **7. `client/`** — port `pjx.js` (manifest scan, swap apply, loading indicators, toast/loader APIs, vendored htmx), `inject.py` cold-render injection + header parsing.
+- [ ] **8. Wiring** — `config.py` (`setup()`, PjxSettings), `integrations/fastapi.py`, `context.py` (PjxContext), `dev.py` (dev mode, `dependency_graph()`, unconsumed-mutation check).
+- [ ] **9. Parity suite** — port the v0.x reactive test suite; green = layer done.
+
+---
+
+## L4 — builtins · [milestone #5](https://github.com/paulomtts/pyjinhx/milestone/5)
+
+**Deliverable:** 1.0 readiness — all builtins green under v2, benchmark comparison v0.36 vs v2 published (PRD G2), migration guide shipped (G5), package renamed and released as pyjinhx 1.0.
+
+Port order — dependency- and risk-sorted, tests ported alongside each family:
+
+- [ ] **1. Display primitives** — Icon, Badge, Avatar/Stack, Divider, Progress, Spinner, Skeleton, EmptyState. Simplest; smoke-tests L1's classless + slot semantics in volume.
+- [ ] **2. Forms** — Button, ChipInput, FormField, PasswordInput, SegmentedControl, ToggleSwitch.
+- [ ] **3. Composed shells** — Card, Modal, Drawer, Accordion, Tabs, Popover, Tooltip, Dropdown, Breadcrumb families. Heaviest users of slots/children composition and MRO subclassing.
+- [ ] **4. Data + HTMX-heavy** — Table family, Paginator, LazyLoad (+ infinite-scroll sentinel), RegionLoader, PageLoader. Exercises reactivity + loading indicators hard.
+- [ ] **5. JS-heavy tail** — Notification, ToastHost, Alert, Carousel, Resizable families.
+- [ ] **6. Release train** — bench comparison on the builtin-heavy page (G2: never slower), migration guide written from the port list's mods/drops (G5), rename `pyjinhx2` → `pyjinhx`, publish 1.0, freeze v0.x to critical fixes.
+
+Bench comparison: _(record here)_
+
+---
+
+## Post-1.0 backlog
+
+- Cross-request InvalidationBackend port (Redis/SQLite) — ADR 0011.
+- pjx-ls v2 pass (drops `{# python #}` support per ADR 0008).
+- v0.x features shipped after 0.36.4, triaged from the PRD's pinned-baseline risk.


### PR DESCRIPTION
Project-local workflow + hook pair for working the v2 board.

- `.claude/skills/task/SKILL.md` — /task <issue#>: explore → spec → plan → adversarial validation → TDD implement → review → tests → PR + merge, one subtask per invocation.
- `.claude/hooks/board-sync.sh` — sole writer of board Status. Fired by PostToolUse on Write|Edit, acts only on `.claude/board-state.json`, validates issue+stage against an allowlist, moves the card, mirrors the parent story to min(sub-issue stages). No model invocation, no background sessions, cannot create/close/delete anything.
- `.claude/settings.json` — hook registration.
- `.gitignore` — ignores the ephemeral state file.

Tested live: path filtering, bad-stage rejection, real move #250 → Spec (story recompute correct) and revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)