### PR TITLE
feat(v2): RenderedLevel dataclass — segment model seed

### DIFF
--- a/docs/superpowers/rebuild/implementation-overview.md
+++ b/docs/superpowers/rebuild/implementation-overview.md
@@ -25,7 +25,7 @@ One test asserts the import graph. Cheap, catches spine violations forever.
 ## Folder / file structure
 
 ```text
-src/pyjinhx2/
+pyjinhx2/
 ├── __init__.py          public API, curated exports
 ├── component.py         BaseComponent (strict), OpenComponent, Slot, children inference
 ├── descriptor.py        ClassDescriptor: MRO walk, slot fields, asset paths — frozen at registration

--- a/pyjinhx2/segments.py
+++ b/pyjinhx2/segments.py
@@ -18,4 +18,6 @@ class RenderedLevel:
 
     segments: list["str | RenderedLevel"]
     root_span: tuple[int, int]
-    descriptor: object  # ClassDescriptor once #246 lands; typed loosely to stay import-pure
+    descriptor: (
+        object  # ClassDescriptor once #246 lands; typed loosely to stay import-pure
+    )

--- a/pyjinhx2/segments.py
+++ b/pyjinhx2/segments.py
@@ -1,0 +1,21 @@
+"""Segment model: the types every other v2 module trusts (ADR 0002).
+
+Import-pure — stdlib only. Nothing in pyjinhx2 may be imported here.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class RenderedLevel:
+    """One component's rendered output: its own markup cut into ordered segments.
+
+    Children enter ``segments`` as whole RenderedLevel objects, never as text.
+    ``root_span`` is the (start, end) offset of the root tag inside ``segments[0]``,
+    recorded by the parse that produced the cut — later attr stamping is a splice
+    at that offset, never a re-parse.
+    """
+
+    segments: list["str | RenderedLevel"]
+    root_span: tuple[int, int]
+    descriptor: object  # ClassDescriptor once #246 lands; typed loosely to stay import-pure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/paulomtts/pyjinhx"
 
+[tool.hatch.build.targets.wheel]
+# Auto-discovery only picks the name-matching `pyjinhx/`; `pyjinhx2/` (the v2
+# rebuild, ADR 0011) must be listed or wheels ship without it.
+packages = ["pyjinhx", "pyjinhx2"]
+
 [tool.pytest.ini_options]
 markers = [
     "pjx_runtime: enable pjx.js auto-injection in tests (disabled by default via conftest)",
@@ -37,6 +42,7 @@ markers = [
 ]
 
 [tool.pyright]
+typeCheckingMode = "standard"
 # `docs/` holds the mkdocs demo registry (`demos/`) and `hooks.py`, which the
 # gallery tests add to sys.path at runtime. Put it on the type-checker's import
 # roots so those imports resolve in the editor.

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -4,7 +4,6 @@ import inspect
 
 import pytest
 
-
 import pyjinhx2.segments
 from pyjinhx2.segments import RenderedLevel
 
@@ -44,7 +43,7 @@ class TestRenderedLevel:
     def test_slots_reject_undeclared_attributes(self):
         level = make_level()
         with pytest.raises(AttributeError):
-            setattr(level, "markup", "nope")
+            level.markup = "nope"  # pyright: ignore[reportAttributeAccessIssue]
 
     def test_is_a_slotted_dataclass(self):
         fields = {f.name for f in dataclasses.fields(RenderedLevel)}

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -58,6 +58,7 @@ def test_segments_module_is_import_pure():
         if isinstance(node, ast.Import):
             names = [alias.name for alias in node.names]
         elif isinstance(node, ast.ImportFrom):
+            assert node.level == 0, "segments.py must not use relative imports"
             names = [node.module or ""]
         else:
             continue

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -1,0 +1,65 @@
+import ast
+import dataclasses
+import inspect
+
+import pytest
+
+
+import pyjinhx2.segments
+from pyjinhx2.segments import RenderedLevel
+
+
+def make_level(
+    segments: "list[str | RenderedLevel] | None" = None,
+    root_span: tuple[int, int] = (0, 5),
+    descriptor: object = None,
+) -> "RenderedLevel":
+    if segments is None:
+        segments = ["<div>hi</div>"]
+    return RenderedLevel(segments=segments, root_span=root_span, descriptor=descriptor)
+
+
+class TestRenderedLevel:
+    def test_holds_its_three_fields(self):
+        level = make_level()
+        assert level.segments == ["<div>hi</div>"]
+        assert level.root_span == (0, 5)
+        assert level.descriptor is None
+
+    def test_segments_mutate_in_place(self):
+        child = make_level(segments=["<button>go</button>"])
+        parent = make_level(segments=["<div>", "PLACEHOLDER", "</div>"])
+        parent.segments[1] = child
+        assert parent.segments[1] is child
+
+    def test_nested_levels_are_whole_objects(self):
+        child = make_level()
+        parent = make_level(segments=["<div>", child, "</div>"])
+        assert parent.segments[1] is child
+
+    def test_equality_by_value(self):
+        assert make_level() == make_level()
+        assert make_level() != make_level(root_span=(1, 6))
+
+    def test_slots_reject_undeclared_attributes(self):
+        level = make_level()
+        with pytest.raises(AttributeError):
+            setattr(level, "markup", "nope")
+
+    def test_is_a_slotted_dataclass(self):
+        fields = {f.name for f in dataclasses.fields(RenderedLevel)}
+        assert fields == {"segments", "root_span", "descriptor"}
+        assert not hasattr(make_level(), "__dict__")
+
+
+def test_segments_module_is_import_pure():
+    tree = ast.parse(inspect.getsource(pyjinhx2.segments))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names = [node.module or ""]
+        else:
+            continue
+        internal = [n for n in names if n.startswith("pyjinhx")]
+        assert not internal, f"segments.py must not import internal modules: {internal}"


### PR DESCRIPTION
First subtask of the v2 kernel (story #244, milestone L0). Adds `pyjinhx2/segments.py` with the `RenderedLevel` dataclass per ADR 0002 / architecture-overview §5.

- `RenderedLevel(segments, root_span, descriptor)` — mutable, slotted; union is `str | RenderedLevel` until #251 adds `ChildRef`; `descriptor` loosely typed until #246 lands `ClassDescriptor`.
- Import-purity test (AST-based, catches `import`/`from`/relative forms — mutation-verified).
- `[tool.hatch.build.targets.wheel] packages` — auto-discovery only picked `pyjinhx/`; wheels now ship `pyjinhx2/` (verified via `uv build`).
- Pin `typeCheckingMode = "standard"` (matches editor convention).
- Doc fix: implementation-overview folder block `src/pyjinhx2/` → `pyjinhx2/` (repo is flat layout).

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)