### PR TITLE
feat(v2): port contains_custom_tag PascalCase prepass to segments

### DIFF
--- a/pyjinhx2/segments.py
+++ b/pyjinhx2/segments.py
@@ -3,6 +3,7 @@
 Import-pure — stdlib only. Nothing in pyjinhx2 may be imported here.
 """
 
+import re
 from dataclasses import dataclass
 
 
@@ -41,3 +42,22 @@ class RenderedLevel:
     descriptor: (
         object  # ClassDescriptor once #246 lands; typed loosely to stay import-pure
     )
+
+
+RE_PASCAL_CASE_TAG_NAME = re.compile(r"^[A-Z](?=[A-Za-z0-9]*[a-z])[A-Za-z0-9]*$")
+RE_TAG_OPENER = re.compile(r"<\s*([A-Za-z][A-Za-z0-9]*)")
+
+
+def contains_custom_tag(markup: str) -> bool:
+    """Cheap check: does ``markup`` contain any PascalCase-tag-looking substring?
+
+    The gate in front of the single parse (ADR 0005): output with no component
+    tag in it never pays for a parser feed. Regex-only and O(n) — it must
+    never itself parse.
+    """
+    if "<" not in markup:
+        return False
+    for match in RE_TAG_OPENER.finditer(markup):
+        if RE_PASCAL_CASE_TAG_NAME.match(match.group(1)):
+            return True
+    return False

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -5,7 +5,12 @@ import inspect
 import pytest
 
 import pyjinhx2.segments
-from pyjinhx2.segments import ChildRef, RenderedLevel
+from pyjinhx2.segments import (
+    RE_PASCAL_CASE_TAG_NAME,
+    ChildRef,
+    RenderedLevel,
+    contains_custom_tag,
+)
 
 
 def make_level(
@@ -113,3 +118,36 @@ def test_segments_module_is_import_pure():
             continue
         internal = [n for n in names if n.startswith("pyjinhx")]
         assert not internal, f"segments.py must not import internal modules: {internal}"
+
+
+class TestContainsCustomTag:
+    @pytest.mark.parametrize(
+        ("markup", "expected"),
+        [
+            ("", False),
+            ("just some plain text, no angle brackets", False),
+            ("<div>hi</div>", False),
+            ("<my-el>hi</my-el>", False),
+            ("<ABC>hi</ABC>", False),
+            ("<3 and 2 < 4", False),
+            ('<PJXButton label="Go">', True),
+            ('<div><PJXIcon name="gear"/></div>', True),
+            ('<PJXIcon name="gear"/>', True),
+            ("< PJXButton>", True),
+            ("<div>text</div><PJXButton>Go</PJXButton>", True),
+        ],
+    )
+    def test_detects_pascal_case_tags(self, markup: str, expected: bool):
+        assert contains_custom_tag(markup) is expected
+
+    def test_pascal_case_regex_matches_bare_tag_names(self):
+        assert RE_PASCAL_CASE_TAG_NAME.match("PJXButton")
+        assert RE_PASCAL_CASE_TAG_NAME.match("Button2")
+        assert not RE_PASCAL_CASE_TAG_NAME.match("PJX")
+        assert not RE_PASCAL_CASE_TAG_NAME.match("div")
+        assert not RE_PASCAL_CASE_TAG_NAME.match("My-El")
+
+    def test_does_not_instantiate_a_parser(self):
+        source = inspect.getsource(contains_custom_tag)
+        assert "HTMLParser" not in source
+        assert "html.parser" not in source


### PR DESCRIPTION
## Summary
- Adds `RE_PASCAL_CASE_TAG_NAME` and `contains_custom_tag()` to `pyjinhx2/segments.py`
- Ported verbatim in semantics from `pyjinhx/tags.py:546-557`
- Per ADR 0005, this gate lets leaf component output skip the single `html.parser` feed entirely
- Regex-only, O(n), no parser instantiation, no caller wiring yet

## Testing
- Added 3 comprehensive test functions to validate PascalCase tag detection logic

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)