### PR TITLE
feat(segments): complete VerbatimParser passthrough

### DIFF
--- a/pyjinhx2/segments.py
+++ b/pyjinhx2/segments.py
@@ -47,6 +47,7 @@ class RenderedLevel:
 
 RE_PASCAL_CASE_TAG_NAME = re.compile(r"^[A-Z](?=[A-Za-z0-9]*[a-z])[A-Za-z0-9]*$")
 RE_TAG_OPENER = re.compile(r"<\s*([A-Za-z][A-Za-z0-9]*)")
+RE_RAW_END_TAG = re.compile(r"</[^>]*>")
 
 
 def contains_custom_tag(markup: str) -> bool:
@@ -90,6 +91,25 @@ class VerbatimParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
         self.segments: list[str] = []
+        self._source = ""
+        self._line_starts: list[int] = [0]
+
+    def feed(self, data: str) -> None:
+        """Parse ``data``. One feed per parser instance — the source is recorded
+        whole so handlers can recover raw text ``HTMLParser`` does not hand back."""
+        self._source = data
+        self._line_starts = [0] + [i + 1 for i, char in enumerate(data) if char == "\n"]
+        super().feed(data)
+
+    def _raw_at(self, pattern: "re.Pattern[str]") -> "str | None":
+        """The source text matching ``pattern`` at the current event's offset.
+
+        ``getpos()`` is line/column, so the line-start index converts it back to
+        an absolute offset into ``_source``.
+        """
+        line, column = self.getpos()
+        match = pattern.match(self._source, self._line_starts[line - 1] + column)
+        return match.group(0) if match else None
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         self.segments.append(self.get_starttag_text() or f"<{tag}>")
@@ -98,7 +118,9 @@ class VerbatimParser(HTMLParser):
         self.segments.append(self.get_starttag_text() or f"<{tag}/>")
 
     def handle_endtag(self, tag: str) -> None:
-        self.segments.append(f"</{tag}>")
+        # HTMLParser lowercases `tag`, which would destroy `</DIV>` and, fatally
+        # for #254, `</PJXButton>`. Recover the source text instead.
+        self.segments.append(self._raw_at(RE_RAW_END_TAG) or f"</{tag}>")
 
     def handle_data(self, data: str) -> None:
         self.segments.append(data)

--- a/pyjinhx2/segments.py
+++ b/pyjinhx2/segments.py
@@ -48,6 +48,7 @@ class RenderedLevel:
 RE_PASCAL_CASE_TAG_NAME = re.compile(r"^[A-Z](?=[A-Za-z0-9]*[a-z])[A-Za-z0-9]*$")
 RE_TAG_OPENER = re.compile(r"<\s*([A-Za-z][A-Za-z0-9]*)")
 RE_RAW_END_TAG = re.compile(r"</[^>]*>")
+RE_RAW_COMMENT = re.compile(r"<!--.*?-->|<!\[.*?\]\]?>", re.DOTALL)
 
 
 def contains_custom_tag(markup: str) -> bool:
@@ -86,6 +87,11 @@ class VerbatimParser(HTMLParser):
 
     Also unlike v0.x, ``close()`` is not overridden and never raises on unclosed
     tags — there is no component stack yet to validate against.
+
+    Known limitation: markup truncated mid-construct at EOF (``"<div"``,
+    ``"<!-- unclosed"``) does not round-trip — ``HTMLParser`` drops or completes
+    the fragment on ``close()``. Jinja never emits such output, and the
+    exhaustive round-trip and adversarial suites are #260/#261.
     """
 
     def __init__(self) -> None:
@@ -135,10 +141,16 @@ class VerbatimParser(HTMLParser):
         self.segments.append(f"&#{name};")
 
     def handle_comment(self, data: str) -> None:
-        self.segments.append(f"<!--{data}-->")
+        # HTMLParser routes marked sections like `<![if IE]>` here too, having
+        # already rewritten them into comment form, so recover the source text.
+        self.segments.append(self._raw_at(RE_RAW_COMMENT) or f"<!--{data}-->")
 
     def handle_decl(self, decl: str) -> None:
         self.segments.append(f"<!{decl}>")
 
     def handle_pi(self, data: str) -> None:
         self.segments.append(f"<?{data}>")
+
+    def unknown_decl(self, data: str) -> None:
+        # `<![CDATA[x]]>` arrives as `CDATA[x]`; the base class would drop it.
+        self.segments.append(self._raw_at(RE_RAW_COMMENT) or f"<![{data}]>")

--- a/pyjinhx2/segments.py
+++ b/pyjinhx2/segments.py
@@ -5,6 +5,7 @@ Import-pure — stdlib only. Nothing in pyjinhx2 may be imported here.
 
 import re
 from dataclasses import dataclass
+from html.parser import HTMLParser
 
 
 @dataclass(slots=True)
@@ -61,3 +62,52 @@ def contains_custom_tag(markup: str) -> bool:
         if RE_PASCAL_CASE_TAG_NAME.match(match.group(1)):
             return True
     return False
+
+
+class VerbatimParser(HTMLParser):
+    """The one parse (ADR 0005), in its lossless form: markup in, same markup out.
+
+    Every event handler appends the *raw source text* for that event to a flat
+    ``segments`` list, so ``"".join(parser.segments)`` reproduces the input
+    exactly — attribute quoting, attribute order, unknown and boolean attrs,
+    odd casing and intentionally malformed HTML all survive untouched. There is
+    no tag tree and no stack: cutting at PascalCase tags (#254), recording
+    ``root_span`` (#255), capturing paired-tag ``inner`` (#256) and enforcing a
+    single root (#257) all layer onto this harness later.
+
+    Deliberate deviation from v0.x's ``pyjinhx/tags.py`` ``Parser``: ``handle_data``
+    does **not** re-escape with ``markupsafe.escape``. That dependency is
+    unavailable here (this module is import-pure, stdlib only) and unnecessary —
+    v2 parses markup Jinja already rendered with autoescape on, not a decode /
+    re-encode boundary, so escaping would double-encode. For the same reason
+    ``<script>``/``<style>`` bodies need no special case: ``HTMLParser`` already
+    delivers CDATA content undecoded, and passthrough never touches it.
+
+    Also unlike v0.x, ``close()`` is not overridden and never raises on unclosed
+    tags — there is no component stack yet to validate against.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.segments: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.segments.append(self.get_starttag_text() or f"<{tag}>")
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.segments.append(self.get_starttag_text() or f"<{tag}/>")
+
+    def handle_endtag(self, tag: str) -> None:
+        self.segments.append(f"</{tag}>")
+
+    def handle_data(self, data: str) -> None:
+        self.segments.append(data)
+
+    def handle_comment(self, data: str) -> None:
+        self.segments.append(f"<!--{data}-->")
+
+    def handle_decl(self, decl: str) -> None:
+        self.segments.append(f"<!{decl}>")
+
+    def handle_pi(self, data: str) -> None:
+        self.segments.append(f"<?{data}>")

--- a/pyjinhx2/segments.py
+++ b/pyjinhx2/segments.py
@@ -89,7 +89,10 @@ class VerbatimParser(HTMLParser):
     """
 
     def __init__(self) -> None:
-        super().__init__()
+        # convert_charrefs would decode `&amp;` into `&` inside handle_data,
+        # silently unescaping markup Jinja escaped on purpose. Keep refs intact
+        # and reconstruct them below.
+        super().__init__(convert_charrefs=False)
         self.segments: list[str] = []
         self._source = ""
         self._line_starts: list[int] = [0]
@@ -124,6 +127,12 @@ class VerbatimParser(HTMLParser):
 
     def handle_data(self, data: str) -> None:
         self.segments.append(data)
+
+    def handle_entityref(self, name: str) -> None:
+        self.segments.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        self.segments.append(f"&#{name};")
 
     def handle_comment(self, data: str) -> None:
         self.segments.append(f"<!--{data}-->")

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -200,3 +200,33 @@ class TestVerbatimParser:
     )
     def test_round_trips_end_tag_casing_and_spacing(self, markup: str):
         assert self.round_trip(markup) == markup
+
+    @pytest.mark.parametrize(
+        "markup",
+        [
+            "a &amp; b &#65; c",
+            "&nbsp;&lt;div&gt;",
+            "<p>&unknown;</p>",
+            "text with & bare ampersand",
+            "<a href=/x?q=1&y=2>link</a>",
+            "<p title='a&amp;b'>t</p>",
+        ],
+    )
+    def test_round_trips_entities_without_decoding(self, markup: str):
+        assert self.round_trip(markup) == markup
+
+    @pytest.mark.parametrize(
+        "markup",
+        [
+            '<script>if (a < b && c) { x("q"); }</script>',
+            '<style>a[href="x"] > b { content: "&"; }</style>',
+            "<script>var s = '</p>';</script>",
+            "<SCRIPT>A < B</SCRIPT>",
+        ],
+    )
+    def test_cdata_bodies_are_never_re_escaped(self, markup: str):
+        # Regression guard for the deliberate deviation from pyjinhx/tags.py:127:
+        # v0.x re-escapes handle_data with markupsafe.escape and needs a CDATA
+        # exemption to stop `&&` becoming `&amp;&amp;`. v2 escapes nothing, so
+        # JS/CSS bodies survive by construction.
+        assert self.round_trip(markup) == markup

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -230,3 +230,36 @@ class TestVerbatimParser:
         # exemption to stop `&&` becoming `&amp;&amp;`. v2 escapes nothing, so
         # JS/CSS bodies survive by construction.
         assert self.round_trip(markup) == markup
+
+    @pytest.mark.parametrize(
+        "markup",
+        [
+            "<![CDATA[x]]>",
+            "<![if IE]>a<![endif]>",
+            "<!--[if IE]>x<![endif]-->",
+            "<?php echo 1 ?>",
+        ],
+    )
+    def test_round_trips_marked_sections_and_processing_instructions(self, markup: str):
+        assert self.round_trip(markup) == markup
+
+    @pytest.mark.parametrize(
+        "markup",
+        [
+            "<PJXAccordion><PJXIcon name='gear'/>",
+            "<PJXButton>go",
+            "<div><PJXButton>go</div>",
+        ],
+    )
+    def test_unclosed_component_tags_do_not_raise(self, markup: str):
+        # Deliberate difference from v0.x pyjinhx/tags.py, whose Parser.close()
+        # raises ValueError on an unclosed component stack. There is no stack
+        # here; enforcement arrives with #254/#257.
+        assert self.round_trip(markup) == markup
+
+    def test_pascal_case_tags_get_no_special_treatment(self):
+        parser = VerbatimParser()
+        parser.feed('<div><PJXButton label="Go">text</PJXButton></div>')
+        parser.close()
+        assert all(isinstance(segment, str) for segment in parser.segments)
+        assert '<PJXButton label="Go">' in parser.segments

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -9,6 +9,7 @@ from pyjinhx2.segments import (
     RE_PASCAL_CASE_TAG_NAME,
     ChildRef,
     RenderedLevel,
+    VerbatimParser,
     contains_custom_tag,
 )
 
@@ -151,3 +152,37 @@ class TestContainsCustomTag:
         source = inspect.getsource(contains_custom_tag)
         assert "HTMLParser" not in source
         assert "html.parser" not in source
+
+
+class TestVerbatimParser:
+    @staticmethod
+    def round_trip(markup: str) -> str:
+        parser = VerbatimParser()
+        parser.feed(markup)
+        parser.close()
+        return "".join(parser.segments)
+
+    @pytest.mark.parametrize(
+        "markup",
+        [
+            "<div><p>hi</p></div>",
+            '<img src="x.png"/>',
+            "<input disabled value=bare data-x='single' data-y=\"double\">",
+            "<!-- note -->",
+            "<!DOCTYPE html>",
+            "<div><p>hi</div>",
+            "</span>hi",
+            "<3 and 2 < 4",
+            '<PJXIcon name="gear"/>',
+            "plain text, no markup at all",
+            "",
+        ],
+    )
+    def test_round_trips_verbatim(self, markup: str):
+        assert self.round_trip(markup) == markup
+
+    def test_segments_is_a_flat_list_of_strings(self):
+        parser = VerbatimParser()
+        parser.feed("<div>hi</div>")
+        parser.close()
+        assert parser.segments == ["<div>", "hi", "</div>"]

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -186,3 +186,17 @@ class TestVerbatimParser:
         parser.feed("<div>hi</div>")
         parser.close()
         assert parser.segments == ["<div>", "hi", "</div>"]
+
+    @pytest.mark.parametrize(
+        "markup",
+        [
+            "<DIV>hi</DIV>",
+            '<PJXButton label="Go">text</PJXButton>',
+            "<div>\n<p>a</p>\n</DIV>",
+            "</DIV >",
+            "<p>x</p >",
+            "<PJXButton\n  label='Go'\n>t</PJXButton>",
+        ],
+    )
+    def test_round_trips_end_tag_casing_and_spacing(self, markup: str):
+        assert self.round_trip(markup) == markup


### PR DESCRIPTION
## Summary

- Completes VerbatimParser implementation to enable lossless template parsing
- Adds entity reference preservation and raw end-tag text handling
- Ensures segment core handlers maintain verbatim output semantics

## Test Coverage

- 8 new test cases covering VerbatimParser passthrough behavior

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)