### PR TITLE
docs: apply root_span semantics + segments[0]/ChildRef caveats to VerbatimParser docstring

### DIFF
--- a/pyjinhx2/segments.py
+++ b/pyjinhx2/segments.py
@@ -82,9 +82,31 @@ class VerbatimParser(HTMLParser):
     ``segments`` list, so ``"".join(parser.segments)`` reproduces the input
     exactly — attribute quoting, attribute order, unknown and boolean attrs,
     odd casing and intentionally malformed HTML all survive untouched. There is
-    no tag tree. Top-level PascalCase tags are cut out (#254, below); recording
-    ``root_span`` (#255), capturing paired-tag ``inner`` (#256) and enforcing a
-    single root (#257) all layer onto this harness later.
+    no tag tree. Top-level PascalCase tags are cut out (#254, below) and the
+    first tag event's raw span is recorded as ``root_span`` (#255, below);
+    capturing paired-tag ``inner`` (#256) and enforcing a single root (#257)
+    still layer onto this harness later.
+
+    ``root_span`` (#255) is the ``(start, end)`` offset of the very first tag
+    event into the *original source string*, not an index into ``segments``.
+    ``_record_root_span`` fires from both ``handle_starttag`` and
+    ``handle_startendtag`` before any cutting happens, and is a no-op after the
+    first call, so the outermost tag always wins even when a top-level custom
+    tag wraps other tags (``test_root_span_records_the_outer_tag_not_a_nested_one``).
+    ``end`` lands exactly one character past that tag's closing ``>`` — for a
+    plain tag (``<div class="card">``) and for a top-level self-closing or
+    paired custom tag alike (``<PJXButton label="Go">``) — enough for #258's
+    attribute splice to slice and re-stitch at those offsets without a
+    re-parse.
+
+    Despite the ``RenderedLevel`` docstring's shorthand ("the offset of the
+    root tag inside ``segments[0]``"), ``root_span`` is never an offset *into*
+    ``segments[0]`` — it is an offset into the raw source text, recorded before
+    ``segments[0]`` even exists in the self-closing top-level case. When the
+    root is itself a cut custom tag, ``segments[0]`` is a ``ChildRef`` object,
+    not a string, so it cannot be sliced by any offset at all; ``root_span``
+    must always be read against the original markup passed to the parser,
+    never against ``segments[0]`` directly.
 
     Cutting (#254) covers **self-closing** top-level component tags only: they
     become ``ChildRef(tag, attrs, inner=None)`` at their exact position, so

--- a/pyjinhx2/segments.py
+++ b/pyjinhx2/segments.py
@@ -165,8 +165,22 @@ class VerbatimParser(HTMLParser):
         match = pattern.match(self._source, self._line_starts[line - 1] + column)
         return match.group(0) if match else None
 
+    def _record_root_span(self, raw: str) -> None:
+        """Record the first tag event's raw text span; a no-op after that.
+
+        Same ``getpos()`` → ``_line_starts`` conversion as ``_raw_at``. ``raw`` is
+        whatever ``get_starttag_text()`` returned, so ``end`` lands just past the
+        tag's closing ``>`` — the offsets #258's splice stamps attributes at.
+        """
+        if self.root_span is not None:
+            return
+        line, column = self.getpos()
+        start = self._line_starts[line - 1] + column
+        self.root_span = (start, start + len(raw))
+
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         raw = self.get_starttag_text() or f"<{tag}>"
+        self._record_root_span(raw)
         name = self._custom_tag_name(raw)
         if name is not None:
             self._custom_stack.append((name, len(self.segments)))
@@ -175,6 +189,7 @@ class VerbatimParser(HTMLParser):
 
     def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         raw = self.get_starttag_text() or f"<{tag}/>"
+        self._record_root_span(raw)
         name = self._custom_tag_name(raw)
         if name is not None and not self._custom_stack:
             self.segments.append(

--- a/pyjinhx2/segments.py
+++ b/pyjinhx2/segments.py
@@ -130,6 +130,10 @@ class VerbatimParser(HTMLParser):
         # and reconstruct them below.
         super().__init__(convert_charrefs=False)
         self.segments: list[str | ChildRef] = []
+        # The (start, end) absolute offsets of the first tag event's raw opening-tag
+        # text; None until that event fires. See the class docstring. Recording only
+        # — no root validation happens here (#257 owns that).
+        self.root_span: tuple[int, int] | None = None
         self._source = ""
         self._line_starts: list[int] = [0]
         # One entry per currently-open PascalCase tag: (original-cased name, index

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -297,7 +297,9 @@ class TestVerbatimParser:
         )
         parser = self.parsed(markup)
         assert parser.root_span == (0, 18)
-        start, end = parser.root_span
+        span = parser.root_span
+        assert span is not None
+        start, end = span
         assert markup[start:end] == '<div class="card">'
 
     def test_root_span_covers_a_cut_top_level_self_closing_tag(self):
@@ -317,7 +319,9 @@ class TestVerbatimParser:
     def test_root_span_covers_only_the_opening_tag_of_a_paired_custom_tag(self):
         markup = '<PJXButton label="Go">text</PJXButton>'
         parser = self.parsed(markup)
-        start, end = parser.root_span
+        span = parser.root_span
+        assert span is not None
+        start, end = span
         assert (start, end) == (0, len('<PJXButton label="Go">'))
         assert markup[start:end] == '<PJXButton label="Go">'
 
@@ -325,14 +329,18 @@ class TestVerbatimParser:
         # Multi-root rejection is #257's; #255 just must not get confused by it.
         markup = '<PJXButton label="Go"/> and <PJXIcon name="gear"/>'
         parser = self.parsed(markup)
-        start, end = parser.root_span
+        span = parser.root_span
+        assert span is not None
+        start, end = span
         assert markup[start:end] == '<PJXButton label="Go"/>'
         assert (start, end) == (0, 23)
 
     def test_root_span_records_the_outer_tag_not_a_nested_one(self):
         markup = "<PJXAccordion><PJXIcon name='gear'/></PJXAccordion>"
         parser = self.parsed(markup)
-        start, end = parser.root_span
+        span = parser.root_span
+        assert span is not None
+        start, end = span
         assert markup[start:end] == "<PJXAccordion>"
         assert (start, end) == (0, len("<PJXAccordion>"))
 
@@ -343,7 +351,9 @@ class TestVerbatimParser:
     def test_root_span_end_is_start_plus_raw_length_for_irregular_tag_text(self):
         markup = "<PJXButton\n  label='Go'\n>t</PJXButton>"
         parser = self.parsed(markup)
-        start, end = parser.root_span
+        span = parser.root_span
+        assert span is not None
+        start, end = span
         raw = "<PJXButton\n  label='Go'\n>"
         assert markup[start:end] == raw
         assert end - start == len(raw)
@@ -353,7 +363,9 @@ class TestVerbatimParser:
         # tag on a later line still slices back to its own raw text.
         markup = "\n\n  <div class='card'>hi</div>"
         parser = self.parsed(markup)
-        start, end = parser.root_span
+        span = parser.root_span
+        assert span is not None
+        start, end = span
         assert markup[start:end] == "<div class='card'>"
 
     def test_top_level_self_closing_tag_becomes_a_child_ref(self):

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -274,6 +274,19 @@ class TestVerbatimParser:
         parser.close()
         return parser.segments
 
+    @staticmethod
+    def parsed(markup: str) -> "VerbatimParser":
+        parser = VerbatimParser()
+        parser.feed(markup)
+        parser.close()
+        return parser
+
+    def test_root_span_starts_none_and_stays_none_without_a_root(self):
+        assert VerbatimParser().root_span is None
+        assert self.parsed("plain text, no markup at all").root_span is None
+        assert self.parsed("").root_span is None
+        assert self.parsed("&amp; just an entity").root_span is None
+
     def test_top_level_self_closing_tag_becomes_a_child_ref(self):
         assert self.parse('<div><PJXIcon name="gear"/></div>') == [
             "<div>",

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -321,6 +321,41 @@ class TestVerbatimParser:
         assert (start, end) == (0, len('<PJXButton label="Go">'))
         assert markup[start:end] == '<PJXButton label="Go">'
 
+    def test_root_span_records_only_the_first_of_several_top_level_siblings(self):
+        # Multi-root rejection is #257's; #255 just must not get confused by it.
+        markup = '<PJXButton label="Go"/> and <PJXIcon name="gear"/>'
+        parser = self.parsed(markup)
+        start, end = parser.root_span
+        assert markup[start:end] == '<PJXButton label="Go"/>'
+        assert (start, end) == (0, 23)
+
+    def test_root_span_records_the_outer_tag_not_a_nested_one(self):
+        markup = "<PJXAccordion><PJXIcon name='gear'/></PJXAccordion>"
+        parser = self.parsed(markup)
+        start, end = parser.root_span
+        assert markup[start:end] == "<PJXAccordion>"
+        assert (start, end) == (0, len("<PJXAccordion>"))
+
+    def test_root_span_ignores_tag_name_casing(self):
+        # Unlike _custom_tag_name, span capture makes no PascalCase distinction.
+        assert self.parsed("<DIV>hi</DIV>").root_span == (0, len("<DIV>"))
+
+    def test_root_span_end_is_start_plus_raw_length_for_irregular_tag_text(self):
+        markup = "<PJXButton\n  label='Go'\n>t</PJXButton>"
+        parser = self.parsed(markup)
+        start, end = parser.root_span
+        raw = "<PJXButton\n  label='Go'\n>"
+        assert markup[start:end] == raw
+        assert end - start == len(raw)
+
+    def test_root_span_is_absolute_across_leading_newlines(self):
+        # Offsets are into the whole fed source, resolved through _line_starts, so a
+        # tag on a later line still slices back to its own raw text.
+        markup = "\n\n  <div class='card'>hi</div>"
+        parser = self.parsed(markup)
+        start, end = parser.root_span
+        assert markup[start:end] == "<div class='card'>"
+
     def test_top_level_self_closing_tag_becomes_a_child_ref(self):
         assert self.parse('<div><PJXIcon name="gear"/></div>') == [
             "<div>",

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -287,6 +287,40 @@ class TestVerbatimParser:
         assert self.parsed("").root_span is None
         assert self.parsed("&amp; just an entity").root_span is None
 
+    def test_root_span_covers_a_plain_opening_tag(self):
+        assert self.parsed("<div><p>hi</p></div>").root_span == (0, len("<div>"))
+
+    def test_root_span_matches_the_architecture_overview_example(self):
+        markup = (
+            '<div class="card">\n  <h2>Hello</h2>\n  <PJXButton label="Save"/>\n'
+            '  <p>hi</p>\n  <PJXIcon name="gear"/>\n</div>'
+        )
+        parser = self.parsed(markup)
+        assert parser.root_span == (0, 18)
+        start, end = parser.root_span
+        assert markup[start:end] == '<div class="card">'
+
+    def test_root_span_covers_a_cut_top_level_self_closing_tag(self):
+        markup = '<PJXIcon name="gear"/>'
+        parser = self.parsed(markup)
+        # The cut into a ChildRef (#254) and the span capture (#255) are orthogonal:
+        # both come off the same raw tag text.
+        assert parser.segments == [
+            ChildRef(tag="PJXIcon", attrs={"name": "gear"}, inner=None)
+        ]
+        assert parser.root_span == (0, len(markup))
+
+    def test_root_span_covers_a_plain_self_closing_tag(self):
+        markup = '<img src="x.png"/>'
+        assert self.parsed(markup).root_span == (0, len(markup))
+
+    def test_root_span_covers_only_the_opening_tag_of_a_paired_custom_tag(self):
+        markup = '<PJXButton label="Go">text</PJXButton>'
+        parser = self.parsed(markup)
+        start, end = parser.root_span
+        assert (start, end) == (0, len('<PJXButton label="Go">'))
+        assert markup[start:end] == '<PJXButton label="Go">'
+
     def test_top_level_self_closing_tag_becomes_a_child_ref(self):
         assert self.parse('<div><PJXIcon name="gear"/></div>') == [
             "<div>",


### PR DESCRIPTION
## Summary

- Record `root_span` in VerbatimParser's single pass through source
- Add test coverage for `root_span` defaults and first-tag-wins offset semantics
- Document `root_span` semantics and the critical caveat: it's an offset into the source string, never an index into `segments[0]` (which may itself be a ChildRef)
- Update VerbatimParser docstring to reflect actual behavior and caveats

## Test coverage

Added 94 lines to tests/pyjinhx2/test_segments.py covering root_span semantics, offset behavior, and segment edge cases.

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)