### PR TITLE
chore: satisfy basedpyright narrowing in splice edge-case tests (#258)

### DIFF
--- a/pyjinhx2/segments.py
+++ b/pyjinhx2/segments.py
@@ -379,3 +379,49 @@ class VerbatimParser(HTMLParser):
     def unknown_decl(self, data: str) -> None:
         # `<![CDATA[x]]>` arrives as `CDATA[x]`; the base class would drop it.
         self.segments.append(self._raw_at(RE_RAW_COMMENT) or f"<![{data}]>")
+
+
+def splice(level: RenderedLevel, offset: int, text: str) -> RenderedLevel:
+    """Insert ``text`` into ``level.segments[0]`` at ``offset``, keeping the span true.
+
+    The one generic string-insertion primitive of the segment model — pure
+    slice-and-concatenate, no re-parse (ADR 0002, invariant 1) and no attribute
+    semantics. Building the text to insert (quoting, ordering, which attrs even
+    apply) is the caller's job; ``splice`` only knows a position and a string.
+    That makes it deliberately dumber than v0.x's ``_override_tag``, which
+    search-and-replaced per attribute name over a re-scanned tag.
+
+    ``root_span`` is rewritten so it stays truthful after the insertion: an
+    endpoint at or past ``offset`` moves forward by ``len(text)``, one before it
+    does not. Callers stamp just inside the root tag's closing ``>`` — at
+    ``root_span[1] - 1`` — so in practice ``start`` holds still and ``end`` grows,
+    and a *second* splice reading the updated span lands just inside that same
+    ``>`` again. That is the whole point: the stamp mechanism splices pass-through
+    attrs at render time and fan-out splices ``hx-swap-oob`` at response time —
+    same offset, same primitive, two moments (architecture-overview.md §4). Get
+    this arithmetic wrong and the two silently corrupt each other's insertion
+    point.
+
+    ``segments[0]`` must be a ``str``. When a level's root is itself an unresolved
+    custom tag, ``segments[0]`` is a ``ChildRef``, which no offset can slice; a
+    level being stamped has already rendered its own root, so that combination is
+    a structural-contract violation, not user error — hence a bare ``assert``.
+
+    Nothing here validates ``offset`` against the tag structure or bounds it:
+    ordinary Python slicing semantics apply, and knowing what a sane insertion
+    point is belongs to the caller. Empty ``text`` is a legal no-op. Mutates
+    ``level`` in place (the dataclasses are slotted but not frozen) and returns it
+    so ``render.py`` can chain the stamp step.
+    """
+    root = level.segments[0]
+    assert isinstance(root, str), (
+        f"splice needs a str root segment, got {type(root).__name__}"
+    )
+    level.segments[0] = root[:offset] + text + root[offset:]
+    start, end = level.root_span
+    shift = len(text)
+    level.root_span = (
+        start + shift if offset <= start else start,
+        end + shift if offset <= end else end,
+    )
+    return level

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -689,7 +689,9 @@ class TestSplice:
         )
         assert level.root_span == (0, 48)
         # The span still bounds exactly the root tag, closing `>` included.
-        assert level.segments[0][level.root_span[0] : level.root_span[1]] == (
+        markup = level.segments[0]
+        assert isinstance(markup, str)
+        assert markup[level.root_span[0] : level.root_span[1]] == (
             '<div class="card" data-x="1" hx-swap-oob="true">'
         )
 
@@ -704,9 +706,11 @@ class TestSplice:
         text = ' data-emoji="\U0001f389é"'
         assert len(text) == 16  # code points, not the 20 bytes of its UTF-8 form
         splice(level, 17, text)
-        assert level.segments[0] == '<div class="card" data-emoji="\U0001f389é">hi</div>'
+        markup = level.segments[0]
+        assert isinstance(markup, str)
+        assert markup == '<div class="card" data-emoji="\U0001f389é">hi</div>'
         assert level.root_span == (0, 34)
-        assert len(level.segments[0]) == 42
+        assert len(markup) == 42
 
     @pytest.mark.parametrize(
         ("offset", "text", "expected_markup", "expected_span"),
@@ -720,7 +724,9 @@ class TestSplice:
         self, offset, text, expected_markup, expected_span
     ):
         level = make_level(segments=['<div class="card">hi</div>'], root_span=(0, 18))
-        assert offset in (0, len(level.segments[0]))
+        markup = level.segments[0]
+        assert isinstance(markup, str)
+        assert offset in (0, len(markup))
         splice(level, offset, text)
         assert level.segments[0] == expected_markup
         assert level.root_span == expected_span

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -11,6 +11,7 @@ from pyjinhx2.segments import (
     RenderedLevel,
     VerbatimParser,
     contains_custom_tag,
+    splice,
 )
 
 
@@ -658,3 +659,36 @@ class TestEnforceSingleRoot:
         # Invariant 3 / ADR 0002: single-root violations raise unconditionally.
         source = inspect.getsource(pyjinhx2.segments)
         assert "except" not in source
+
+
+class TestSplice:
+    def test_inserts_text_at_offset(self):
+        level = make_level(segments=['<div class="card">hi</div>'], root_span=(0, 18))
+        splice(level, 17, ' data-x="1"')
+        assert level.segments[0] == '<div class="card" data-x="1">hi</div>'
+
+    def test_root_span_end_shifts_by_inserted_length(self):
+        level = make_level(segments=['<div class="card">hi</div>'], root_span=(0, 18))
+        splice(level, level.root_span[1] - 1, ' data-x="1"')
+        assert level.root_span == (0, 29)
+
+    def test_returns_the_same_level_for_chaining(self):
+        level = make_level(segments=['<div class="card">hi</div>'], root_span=(0, 18))
+        assert splice(level, 17, ' data-x="1"') is level
+
+    def test_second_splice_after_first_lands_correctly(self):
+        # First splice = #247's root-attr stamp at render time.
+        level = make_level(segments=['<div class="card">hi</div>'], root_span=(0, 18))
+        splice(level, level.root_span[1] - 1, ' data-x="1"')
+        # Second splice = L3's OOB fan-out at response time, using the span the
+        # first call left behind.
+        splice(level, level.root_span[1] - 1, ' hx-swap-oob="true"')
+        assert (
+            level.segments[0]
+            == '<div class="card" data-x="1" hx-swap-oob="true">hi</div>'
+        )
+        assert level.root_span == (0, 48)
+        # The span still bounds exactly the root tag, closing `>` included.
+        assert level.segments[0][level.root_span[0] : level.root_span[1]] == (
+            '<div class="card" data-x="1" hx-swap-oob="true">'
+        )

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -692,3 +692,45 @@ class TestSplice:
         assert level.segments[0][level.root_span[0] : level.root_span[1]] == (
             '<div class="card" data-x="1" hx-swap-oob="true">'
         )
+
+    def test_empty_text_is_a_no_op(self):
+        level = make_level(segments=['<div class="card">hi</div>'], root_span=(0, 18))
+        splice(level, 17, "")
+        assert level.segments[0] == '<div class="card">hi</div>'
+        assert level.root_span == (0, 18)
+
+    def test_unicode_text_offsets_are_character_based(self):
+        level = make_level(segments=['<div class="card">hi</div>'], root_span=(0, 18))
+        text = ' data-emoji="\U0001f389é"'
+        assert len(text) == 16  # code points, not the 20 bytes of its UTF-8 form
+        splice(level, 17, text)
+        assert level.segments[0] == '<div class="card" data-emoji="\U0001f389é">hi</div>'
+        assert level.root_span == (0, 34)
+        assert len(level.segments[0]) == 42
+
+    @pytest.mark.parametrize(
+        ("offset", "text", "expected_markup", "expected_span"),
+        [
+            (0, "X", 'X<div class="card">hi</div>', (1, 19)),
+            (26, "Y", '<div class="card">hi</div>Y', (0, 18)),
+        ],
+        ids=["prepend", "append"],
+    )
+    def test_insert_at_start_and_at_end(
+        self, offset, text, expected_markup, expected_span
+    ):
+        level = make_level(segments=['<div class="card">hi</div>'], root_span=(0, 18))
+        assert offset in (0, len(level.segments[0]))
+        splice(level, offset, text)
+        assert level.segments[0] == expected_markup
+        assert level.root_span == expected_span
+
+    @pytest.mark.parametrize(
+        "root",
+        [make_child_ref(), make_level()],
+        ids=["child-ref", "nested-level"],
+    )
+    def test_raises_when_root_segment_is_not_a_str(self, root):
+        level = make_level(segments=[root, "</div>"], root_span=(0, 18))
+        with pytest.raises(AssertionError):
+            splice(level, 17, ' data-x="1"')


### PR DESCRIPTION
## Summary
- Add `splice` primitive for segment string insertion operations
- Implement comprehensive edge-case tests for splice functionality (empty text, unicode, bounds checking, non-str root)
- Satisfy basedpyright type narrowing requirements in test assertions

**Test count:** 3 commits with new splice feature and comprehensive test coverage

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)