### PR TITLE
feat: serialize() recursive depth-first join of a segment tree (#259)

### DIFF
--- a/pyjinhx2/segments.py
+++ b/pyjinhx2/segments.py
@@ -425,3 +425,37 @@ def splice(level: RenderedLevel, offset: int, text: str) -> RenderedLevel:
         end + shift if offset <= end else end,
     )
     return level
+
+
+def serialize(level: RenderedLevel) -> str:
+    """Join a segment tree back into one string — depth-first, in order.
+
+    The read-side counterpart to ``splice``: where ``splice`` writes into a
+    single segment, this walks the whole tree once and produces the output.
+    It is *the* join — called once, at the top of the outermost render, so each
+    output character is produced exactly once (architecture-overview.md §3/§5).
+    Levels do not join themselves as they finish; joining early would mean a
+    parent holds its child as text, and every enclosing level would then copy
+    that text again on its way up.
+
+    A nested ``RenderedLevel`` recurses rather than being flattened or re-read:
+    a child is opaque by construction (ADR 0002, invariant 2), so its segments
+    are its own business and only its serialized text enters the parent's output
+    stream. Nothing here parses, scans or rewrites the text it passes through
+    (invariant 1) — ``str`` segments go out verbatim, byte for byte as the single
+    parse cut them.
+
+    ``root_span`` is not read, and neither are ``ChildRef.attrs`` or ``inner``.
+    A live ``ChildRef`` reaching this function means L1 tag expansion never
+    turned that hole into a rendered child, which is a structural-contract
+    violation in the caller rather than user error — hence a bare ``assert``,
+    same posture as ``splice``'s ``str``-root check. Empty ``segments`` is a
+    legal no-op and serializes to ``""``.
+    """
+    parts: list[str] = []
+    for seg in level.segments:
+        assert isinstance(seg, (str, RenderedLevel)), (
+            f"serialize needs str or RenderedLevel segments, got {type(seg).__name__}"
+        )
+        parts.append(seg if isinstance(seg, str) else serialize(seg))
+    return "".join(parts)

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -11,6 +11,7 @@ from pyjinhx2.segments import (
     RenderedLevel,
     VerbatimParser,
     contains_custom_tag,
+    serialize,
     splice,
 )
 
@@ -740,3 +741,65 @@ class TestSplice:
         level = make_level(segments=[root, "</div>"], root_span=(0, 18))
         with pytest.raises(AssertionError):
             splice(level, 17, ' data-x="1"')
+
+
+class TestSerialize:
+    def test_joins_flat_string_segments_in_order(self):
+        level = make_level(segments=["<div>", "hi", "</div>"])
+        assert serialize(level) == "<div>hi</div>"
+
+    def test_returns_a_str(self):
+        level = make_level(segments=["<div>", "hi", "</div>"])
+        assert type(serialize(level)) is str
+
+    def test_single_string_segment_passes_through_verbatim(self):
+        level = make_level(segments=['<div class="card">hi &amp; bye</div>'])
+        assert serialize(level) == '<div class="card">hi &amp; bye</div>'
+
+    def test_nested_level_is_spliced_in_at_its_position(self):
+        child = make_level(segments=["<button>go</button>"])
+        parent = make_level(segments=["<div>", child, "</div>"])
+        assert serialize(parent) == "<div><button>go</button></div>"
+
+    def test_only_a_nested_level_serializes_to_that_child(self):
+        child = make_level(segments=["<button>go</button>"])
+        parent = make_level(segments=[child])
+        assert serialize(parent) == "<button>go</button>"
+
+    def test_recurses_depth_two_and_deeper(self):
+        grandchild = make_level(segments=["<i>", "deep", "</i>"])
+        child = make_level(segments=["<span>", grandchild, "</span>"])
+        parent = make_level(segments=["<div>", child, "</div>"])
+        assert serialize(parent) == "<div><span><i>deep</i></span></div>"
+
+    def test_multiple_sibling_levels_keep_their_order(self):
+        first = make_level(segments=["<b>1</b>"])
+        second = make_level(segments=["<b>2</b>"])
+        parent = make_level(segments=["<div>", first, "|", second, "</div>"])
+        assert serialize(parent) == "<div><b>1</b>|<b>2</b></div>"
+
+    def test_empty_segments_serialize_to_empty_string(self):
+        assert serialize(make_level(segments=[])) == ""
+
+    def test_empty_nested_level_contributes_nothing(self):
+        child = make_level(segments=[])
+        parent = make_level(segments=["<div>", child, "</div>"])
+        assert serialize(parent) == "<div></div>"
+
+    def test_ignores_root_span(self):
+        # serialize never reads root_span; a nonsense span changes nothing.
+        level = make_level(segments=["<div>hi</div>"], root_span=(99, 999))
+        assert serialize(level) == "<div>hi</div>"
+
+    def test_raises_when_a_segment_is_a_live_child_ref(self):
+        # Mirrors TestSplice.test_raises_when_root_segment_is_not_a_str:
+        # an L1-expanded tree has no live ChildRef left by join time.
+        level = make_level(segments=["<div>", make_child_ref(), "</div>"])
+        with pytest.raises(AssertionError, match="ChildRef"):
+            serialize(level)
+
+    def test_raises_when_a_nested_level_holds_a_live_child_ref(self):
+        child = make_level(segments=[make_child_ref()])
+        parent = make_level(segments=["<div>", child, "</div>"])
+        with pytest.raises(AssertionError, match="ChildRef"):
+            serialize(parent)


### PR DESCRIPTION
## Summary

Adds `serialize(level: RenderedLevel) -> str` to pyjinhx2/segments.py, the read-side counterpart to `splice`: the single recursive depth-first join over a segment tree. String segments pass through verbatim, nested RenderedLevel segments recurse, and a live ChildRef trips an assert as a structural-contract violation, mirroring splice's behavior. Pure `"".join(...)` — no regex, no HTMLParser, no re-scan.

## Test Coverage

New TestSerialize class with 8 test cases covering:
- Flat joins
- Nested levels (depth 3)
- Sibling order
- Empty segments
- root_span being ignored
- str return type
- Both ChildRef assert paths

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)