### PR TITLE
test: multi-segment compositions and EOF-truncation exclusion (#260)

### DIFF
--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -803,3 +803,62 @@ class TestSerialize:
         parent = make_level(segments=["<div>", child, "</div>"])
         with pytest.raises(AssertionError, match="ChildRef"):
             serialize(parent)
+
+
+class TestRoundTripThroughSerialize:
+    """The composed pipeline: parse -> RenderedLevel -> serialize -> same string.
+
+    Invariant 1 (architecture-overview.md §1, ADR 0002): pyjinhx never re-parses
+    its own output, so a level's segments must carry the source text losslessly
+    all the way to the single join. TestVerbatimParser.round_trip proves the cut
+    is lossless at the parser boundary and TestSerialize proves the join is
+    lossless over hand-built levels; this class is the only place a real string
+    travels the whole way through both.
+
+    Domain is markup *without* custom tags: no fixture here holds a PascalCase
+    tag, so nothing is cut into a ChildRef and every segment stays a str.
+    Adversarial markup is #261; root_span correctness is #262.
+    """
+
+    @staticmethod
+    def round_trip(markup: str) -> str:
+        parser = VerbatimParser()
+        parser.feed(markup)
+        parser.close()
+        # No fixture in this class contains a PascalCase tag, so #254's cutting
+        # never fires and every segment is raw source text. enforce_single_root
+        # is deliberately not called: several fixtures are zero-root (plain text)
+        # or multi-root by design, and lossless passthrough is orthogonal to
+        # single-root validation (#257 owns that).
+        assert all(isinstance(segment, str) for segment in parser.segments), (
+            "fixtures for this class must be custom-tag-free; "
+            "a ChildRef appeared, so something got cut"
+        )
+        segments: list[str | ChildRef | RenderedLevel] = list(parser.segments)
+        level = RenderedLevel(
+            segments=segments,
+            # serialize never reads root_span (segments.py:448); a rootless
+            # fixture parses to None, so substitute a harmless span rather than
+            # widening RenderedLevel's type. #262 owns root_span's real value.
+            root_span=parser.root_span or (0, 0),
+            descriptor=None,
+        )
+        return serialize(level)
+
+    @pytest.mark.parametrize(
+        "markup",
+        [
+            "<div><p>hi</p></div>",
+            '<img src="x.png"/>',
+            "<input disabled value=bare data-x='single' data-y=\"double\">",
+            "<!-- note -->",
+            "<!DOCTYPE html>",
+            "<div><p>hi</div>",
+            "</span>hi",
+            "<3 and 2 < 4",
+            "plain text, no markup at all",
+            "",
+        ],
+    )
+    def test_round_trips_core_markup(self, markup: str):
+        assert self.round_trip(markup) == markup

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -862,3 +862,48 @@ class TestRoundTripThroughSerialize:
     )
     def test_round_trips_core_markup(self, markup: str):
         assert self.round_trip(markup) == markup
+
+    @pytest.mark.parametrize(
+        "markup",
+        [
+            "<DIV>hi</DIV>",
+            "<div>\n<p>a</p>\n</DIV>",
+            "</DIV >",
+            "<p>x</p >",
+            "<div\n  id='a'\n  class='b'\n>x</div>",
+        ],
+    )
+    def test_round_trips_casing_and_intra_tag_whitespace(self, markup: str):
+        assert self.round_trip(markup) == markup
+
+    @pytest.mark.parametrize(
+        "markup",
+        [
+            "a &amp; b &#65; c",
+            "&nbsp;&lt;div&gt;",
+            "<p>&unknown;</p>",
+            "text with & bare ampersand",
+            "<a href=/x?q=1&y=2>link</a>",
+            "<p title='a&amp;b'>t</p>",
+        ],
+    )
+    def test_round_trips_entities_undecoded_through_the_join(self, markup: str):
+        # convert_charrefs=False at the parser plus a verbatim join means no
+        # decode/re-encode boundary exists anywhere in the pipeline.
+        assert self.round_trip(markup) == markup
+
+    @pytest.mark.parametrize(
+        "markup",
+        [
+            '<script>if (a < b && c) { x("q"); }</script>',
+            '<style>a[href="x"] > b { content: "&"; }</style>',
+            "<script>var s = '</p>';</script>",
+            "<SCRIPT>A < B</SCRIPT>",
+            "<![CDATA[x]]>",
+            "<![if IE]>a<![endif]>",
+            "<!--[if IE]>x<![endif]-->",
+            "<?php echo 1 ?>",
+        ],
+    )
+    def test_round_trips_cdata_marked_sections_and_pis(self, markup: str):
+        assert self.round_trip(markup) == markup

--- a/tests/pyjinhx2/test_segments.py
+++ b/tests/pyjinhx2/test_segments.py
@@ -907,3 +907,31 @@ class TestRoundTripThroughSerialize:
     )
     def test_round_trips_cdata_marked_sections_and_pis(self, markup: str):
         assert self.round_trip(markup) == markup
+
+    @pytest.mark.parametrize(
+        "markup",
+        [
+            '<div class="card">\n  <h2>Hi</h2>\n  <p>a &amp; b</p>\n</div>',
+            "  <div>  <span> x </span>  </div>  ",
+            "<ul><li>a<li>b</ul>",
+            "<div><!-- c --><br><hr/>t</div>",
+            "<my-el data-x>hi</my-el>",
+            "\n\n\t  \n",
+        ],
+    )
+    def test_round_trips_multi_segment_compositions(self, markup: str):
+        # Whitespace-heavy, deeply segmented and implicitly-closed markup: the
+        # cases where a lossy join would show up as collapsed or reordered text.
+        assert self.round_trip(markup) == markup
+
+    @pytest.mark.parametrize(
+        "markup",
+        ["<div", "<!-- unclosed"],
+    )
+    def test_markup_truncated_at_eof_is_a_documented_non_round_trip(self, markup: str):
+        # Pinned counter-example, not a gap: HTMLParser.close() drops or
+        # completes a construct cut off mid-source, so these cannot round-trip
+        # (VerbatimParser docstring, segments.py:166-169). Jinja never emits
+        # such output. Asserting the inequality here keeps the class's positive
+        # claim honest and makes the day this behaviour changes visible.
+        assert self.round_trip(markup) != markup


### PR DESCRIPTION
## Summary
- Added comprehensive test coverage for parse → serialize round-trips of core markup
- Added tests for casing, entities, and CDATA families round-trip behavior
- Added tests for multi-segment compositions and EOF-truncation exclusion

These tests strengthen the serialization/deserialization pipeline validation.

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)