### PR TITLE
test(v2): pin Slot field validation under the strict core

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -33,6 +33,20 @@ class PjxSlot:
         self.children = children
 
 
+def _is_slot_field(cls: type, field_name: str) -> bool:
+    """True when ``field_name`` is a raw-HTML slot on ``cls``.
+
+    A field qualifies either by being the model's designated children field, or
+    by carrying a :class:`PjxSlot` marker in its ``Annotated`` metadata. Unknown
+    field names are not slots.
+    """
+    if field_name == getattr(cls, "_pjx_children_field", None):
+        return True
+    fields = getattr(cls, "model_fields", {})
+    field = fields.get(field_name)
+    return field is not None and any(isinstance(m, PjxSlot) for m in field.metadata)
+
+
 class BaseComponent(BaseModel):
     """Base for all components: declared fields only, undeclared kwargs rejected.
 

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -11,6 +11,8 @@ render.py in the import graph and must never reach up into them, nor into
 session.py or reactive/.
 """
 
+from typing import Annotated
+
 from pydantic import BaseModel, ConfigDict
 
 
@@ -40,3 +42,11 @@ class BaseComponent(BaseModel):
     """
 
     model_config = ConfigDict(extra="forbid")
+
+
+# Defined after BaseComponent so the union member resolves at definition time.
+# The full ``str | BaseComponent`` union is kept at L0 even though only the
+# ``str`` half gets behavior here, so the type does not change under callers
+# when L1 lands opaque component nodes (ADR 0003).
+Slot = Annotated[str | BaseComponent, PjxSlot()]
+Children = Annotated[str | BaseComponent, PjxSlot(children=True)]

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -14,6 +14,23 @@ session.py or reactive/.
 from pydantic import BaseModel, ConfigDict
 
 
+class PjxSlot:
+    """Marker (in a field's ``Annotated`` metadata) for a raw-HTML slot field —
+    its string value is emitted unescaped (invariant 6, the autoescape exemption).
+    Use via the ``Slot`` alias.
+
+    ``children=True`` additionally flags the field as the target for a
+    PascalCase tag's nested children (use via the ``Children`` alias).
+
+    Purely descriptive at this layer: nothing here escapes, wraps or renders.
+    The render-time half (Markup-wrapping strings, opaque component nodes) is
+    L1 work and lives above component.py in the import graph.
+    """
+
+    def __init__(self, children: bool = False) -> None:
+        self.children = children
+
+
 class BaseComponent(BaseModel):
     """Base for all components: declared fields only, undeclared kwargs rejected.
 

--- a/tests/pyjinhx2/test_slot_type_v2.py
+++ b/tests/pyjinhx2/test_slot_type_v2.py
@@ -1,0 +1,12 @@
+from pyjinhx2.component import PjxSlot
+
+
+class TestPjxSlotMarker:
+    def test_children_flag_defaults_to_false(self):
+        assert PjxSlot().children is False
+
+    def test_children_flag_opts_in(self):
+        assert PjxSlot(children=True).children is True
+
+    def test_marker_instances_are_distinct_objects(self):
+        assert PjxSlot() is not PjxSlot()

--- a/tests/pyjinhx2/test_slot_type_v2.py
+++ b/tests/pyjinhx2/test_slot_type_v2.py
@@ -10,3 +10,31 @@ class TestPjxSlotMarker:
 
     def test_marker_instances_are_distinct_objects(self):
         assert PjxSlot() is not PjxSlot()
+
+
+class TestSlotAliases:
+    def test_slot_alias_carries_an_unflagged_marker(self):
+        from typing import get_args
+
+        from pyjinhx2.component import Slot
+
+        markers = [m for m in get_args(Slot) if isinstance(m, PjxSlot)]
+        assert len(markers) == 1
+        assert markers[0].children is False
+
+    def test_children_alias_carries_a_flagged_marker(self):
+        from typing import get_args
+
+        from pyjinhx2.component import Children
+
+        markers = [m for m in get_args(Children) if isinstance(m, PjxSlot)]
+        assert len(markers) == 1
+        assert markers[0].children is True
+
+    def test_slot_alias_underlying_type_is_the_str_component_union(self):
+        from typing import get_args
+
+        from pyjinhx2.component import BaseComponent, Slot
+
+        underlying = get_args(Slot)[0]
+        assert set(get_args(underlying)) == {str, BaseComponent}

--- a/tests/pyjinhx2/test_slot_type_v2.py
+++ b/tests/pyjinhx2/test_slot_type_v2.py
@@ -1,4 +1,6 @@
-from pyjinhx2.component import PjxSlot
+from typing import Annotated, ClassVar
+
+from pyjinhx2.component import BaseComponent, Children, PjxSlot, Slot, _is_slot_field
 
 
 class TestPjxSlotMarker:
@@ -38,3 +40,49 @@ class TestSlotAliases:
 
         underlying = get_args(Slot)[0]
         assert set(get_args(underlying)) == {str, BaseComponent}
+
+
+class _Demo(BaseComponent):
+    label: str = ""  # plain scalar, no marker
+    count: int = 0  # plain scalar, no marker
+    body: Slot = ""  # explicit slot
+    inner: Children = ""  # children-flagged slot
+    nullable_slot: Annotated[str | BaseComponent | None, PjxSlot()] = None
+
+
+class _DesignatedChildren(BaseComponent):
+    # Must carry an explicit `ClassVar` annotation here. `BaseComponent` does not
+    # declare `_pjx_children_field` as a ClassVar (that's L1's job, out of scope
+    # for #264 per the note above), so an unannotated `_pjx_children_field = "kids"`
+    # gets treated as a private *model* attribute by Pydantic — `Demo._pjx_children_field`
+    # then returns a `ModelPrivateAttr` object at the class level, not the plain
+    # string "kids", and the `==` check in `_is_slot_field` silently returns False.
+    # The explicit `ClassVar[str]` annotation on this subclass sidesteps that
+    # without touching `BaseComponent` itself. Verified: without it, this test fails.
+    _pjx_children_field: ClassVar[str] = "kids"
+    kids: str = ""  # designated children field, no PjxSlot metadata
+
+
+class TestIsSlotField:
+    def test_true_for_explicit_slot_field(self):
+        assert _is_slot_field(_Demo, "body") is True
+
+    def test_true_for_children_alias_field(self):
+        assert _is_slot_field(_Demo, "inner") is True
+
+    def test_true_for_designated_children_field_without_marker(self):
+        assert _is_slot_field(_DesignatedChildren, "kids") is True
+
+    def test_false_for_plain_str_field(self):
+        assert _is_slot_field(_Demo, "label") is False
+
+    def test_false_for_plain_int_field(self):
+        assert _is_slot_field(_Demo, "count") is False
+
+    def test_false_for_unknown_field_name(self):
+        assert _is_slot_field(_Demo, "not_a_field") is False
+
+    def test_true_for_nullable_slot_with_outer_annotation(self):
+        # `Slot | None` drops PjxSlot at the field level, so the marker must sit
+        # on the OUTER Annotated. This asserts the outer form keeps working.
+        assert _is_slot_field(_Demo, "nullable_slot") is True

--- a/tests/pyjinhx2/test_slot_type_v2.py
+++ b/tests/pyjinhx2/test_slot_type_v2.py
@@ -1,5 +1,8 @@
 from typing import Annotated, ClassVar
 
+import pytest
+from pydantic import ValidationError
+
 from pyjinhx2.component import BaseComponent, Children, PjxSlot, Slot, _is_slot_field
 
 
@@ -86,3 +89,43 @@ class TestIsSlotField:
         # `Slot | None` drops PjxSlot at the field level, so the marker must sit
         # on the OUTER Annotated. This asserts the outer form keeps working.
         assert _is_slot_field(_Demo, "nullable_slot") is True
+
+
+class _Leaf(BaseComponent):
+    text: str = ""
+
+
+class TestSlotFieldValidation:
+    def test_accepts_a_plain_string(self):
+        demo = _Demo(body="<b>bold</b>")
+        assert demo.body == "<b>bold</b>"
+        assert isinstance(demo.body, str)
+
+    def test_does_not_escape_or_wrap_the_string_at_construction(self):
+        # L0 is marker-only: no Markup, no escaping, no side effects. The
+        # value round-trips byte-for-byte as the plain str that was passed in.
+        raw = "<script>alert(1)</script>"
+        assert _Demo(body=raw).body == raw
+        assert type(_Demo(body=raw).body) is str
+
+    def test_accepts_a_basecomponent_instance(self):
+        # Type-level acceptance only; render-time behavior is L1 (ADR 0003).
+        leaf = _Leaf(text="hi")
+        assert _Demo(body=leaf).body is leaf
+
+    def test_rejects_an_int(self):
+        with pytest.raises(ValidationError):
+            _Demo(body=1)  # pyright: ignore[reportArgumentType]
+
+    def test_rejects_a_list(self):
+        with pytest.raises(ValidationError):
+            _Demo(body=["a"])  # pyright: ignore[reportArgumentType]
+
+    def test_slot_field_does_not_weaken_extra_forbid(self):
+        assert _Demo.model_config.get("extra") == "forbid"
+        with pytest.raises(ValidationError):
+            _Demo(body="x", undeclared="y")  # pyright: ignore[reportCallIssue]
+
+    def test_slot_field_default_applies(self):
+        assert _Demo().body == ""
+        assert _Demo().inner == ""


### PR DESCRIPTION
## Summary
Implements Slot support for the pyjinhx v2 strict core with field validation and type aliases.

**What:** Adds PjxSlot marker, Slot/Children type aliases, and _is_slot_field detection for the strict core component system.

**Why:** Enables raw HTML slot injection in typed components while maintaining strict field validation under the v2 core.

- test(v2): pin Slot field validation under the strict core
- feat(v2): add _is_slot_field slot detection helper
- feat(v2): add Slot and Children type aliases
- feat(v2): add PjxSlot raw-HTML slot marker to component.py

Tests added: 131 lines covering Slot field validation scenarios.

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)