### PR TITLE
feat(pyjinhx2): auto_id = False opt-out requiring an explicit id (#265)

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -11,9 +11,20 @@ render.py in the import graph and must never reach up into them, nor into
 session.py or reactive/.
 """
 
+import itertools
 from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# Process-wide, never per-class: ids must be unique across every subclass, since
+# they end up as HTML ids on the same page. ``count.__next__`` is atomic under
+# the GIL, so concurrent construction needs no extra locking.
+_auto_id_counter = itertools.count(1)
+
+
+def _auto_id() -> str:
+    """Generate a process-unique component id (``pjx-<n>``)."""
+    return f"pjx-{next(_auto_id_counter)}"
 
 
 class PjxSlot:
@@ -50,12 +61,25 @@ def _is_slot_field(cls: type, field_name: str) -> bool:
 class BaseComponent(BaseModel):
     """Base for all components: declared fields only, undeclared kwargs rejected.
 
-    Deliberately empty otherwise. Auto-ids, Slot, attribute coercion and
-    quote-safety are separate concerns and land as their own changes; nothing
-    here runs a side effect at construction time (ADR 0004/0009).
+    Deliberately minimal otherwise. Slot, attribute coercion and quote-safety are
+    separate concerns and land as their own changes. The auto-id counter is the
+    single chartered construction-time side effect (ADR 0004/0009); nothing else
+    here runs one.
     """
 
     model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(
+        default_factory=_auto_id,
+        description="The unique ID for this component. Auto-generated when omitted.",
+    )
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def _validate_id(cls, value: object) -> str:
+        if not value:
+            return _auto_id()
+        return str(value)
 
 
 # Defined after BaseComponent so the union member resolves at definition time.

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -12,9 +12,9 @@ session.py or reactive/.
 """
 
 import itertools
-from typing import Annotated
+from typing import Annotated, ClassVar
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Process-wide, never per-class: ids must be unique across every subclass, since
 # they end up as HTML ids on the same page. ``count.__next__`` is atomic under
@@ -69,10 +69,26 @@ class BaseComponent(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    # Construction-time control, not model data: a ClassVar is invisible to
+    # model_fields, so it never collides with extra="forbid" or serialization.
+    # Opt out per component class with ``class Foo(BaseComponent): auto_id = False``.
+    auto_id: ClassVar[bool] = True
+
     id: str = Field(
         default_factory=_auto_id,
         description="The unique ID for this component. Auto-generated when omitted.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _require_explicit_id(cls, data: object) -> object:
+        """Runs before field defaults, so it is the only hook that can see an
+        omitted ``id`` and stop ``default_factory`` from silently filling it."""
+        if cls.auto_id:
+            return data
+        if isinstance(data, dict) and data.get("id"):
+            return data
+        raise ValueError(f"{cls.__name__} sets auto_id = False, so id is required")
 
     @field_validator("id", mode="before")
     @classmethod

--- a/tests/pyjinhx2/test_component.py
+++ b/tests/pyjinhx2/test_component.py
@@ -23,6 +23,10 @@ class Panel(BaseComponent):
     title: str = ""
 
 
+class Named(BaseComponent):
+    auto_id = False
+
+
 class TestStrictConfig:
     def test_forbids_extra_fields(self):
         assert BaseComponent.model_config.get("extra") == "forbid"
@@ -83,6 +87,27 @@ class TestAutoId:
 
     def test_none_id_falls_back_to_auto_id(self):
         assert Card(name="a", id=None).id.startswith("pjx-")  # pyright: ignore[reportArgumentType]
+
+
+class TestAutoIdOptOut:
+    def test_auto_id_false_without_explicit_id_raises(self):
+        with pytest.raises(ValidationError):
+            Named()
+
+    def test_auto_id_false_with_falsy_id_raises(self):
+        with pytest.raises(ValidationError):
+            Named(id="")
+
+    def test_auto_id_false_with_explicit_id_succeeds(self):
+        assert Named(id="x").id == "x"
+
+    def test_auto_id_defaults_to_on(self):
+        assert BaseComponent.auto_id is True
+        assert Card(name="a").id.startswith("pjx-")
+
+    def test_auto_id_is_not_a_model_field(self):
+        assert "auto_id" not in BaseComponent.model_fields
+        assert "auto_id" not in Named.model_fields
 
 
 FORBIDDEN_IMPORTS = (

--- a/tests/pyjinhx2/test_component.py
+++ b/tests/pyjinhx2/test_component.py
@@ -19,12 +19,16 @@ class Card(BaseComponent):
     address: Address | None = None
 
 
+class Panel(BaseComponent):
+    title: str = ""
+
+
 class TestStrictConfig:
     def test_forbids_extra_fields(self):
         assert BaseComponent.model_config.get("extra") == "forbid"
 
-    def test_declares_no_fields_of_its_own(self):
-        assert BaseComponent.model_fields == {}
+    def test_declares_only_the_id_field(self):
+        assert set(BaseComponent.model_fields) == {"id"}
 
     def test_bare_base_instantiates(self):
         assert BaseComponent() is not None
@@ -55,6 +59,30 @@ class TestSubclassing:
     def test_still_validates_declared_field_types(self):
         with pytest.raises(ValidationError):
             Card(name="x", count="not-an-int")  # pyright: ignore[reportArgumentType]
+
+
+class TestAutoId:
+    def test_omitting_id_auto_generates_pjx_prefixed_id(self):
+        first = Card(name="a")
+        second = Card(name="b")
+        assert first.id.startswith("pjx-")
+        assert second.id.startswith("pjx-")
+        assert first.id != second.id
+
+    def test_auto_generated_ids_are_monotonic_and_unique_across_subclasses(self):
+        ids = [Card(name="a").id, Panel().id, Card(name="b").id, Panel().id]
+        suffixes = [int(component_id.removeprefix("pjx-")) for component_id in ids]
+        assert suffixes == sorted(suffixes)
+        assert len(set(suffixes)) == len(suffixes)
+
+    def test_explicit_id_is_used_as_given(self):
+        assert Card(name="a", id="custom-id").id == "custom-id"
+
+    def test_empty_string_id_falls_back_to_auto_id(self):
+        assert Card(name="a", id="").id.startswith("pjx-")
+
+    def test_none_id_falls_back_to_auto_id(self):
+        assert Card(name="a", id=None).id.startswith("pjx-")  # pyright: ignore[reportArgumentType]
 
 
 FORBIDDEN_IMPORTS = (


### PR DESCRIPTION
## Summary
- Implements auto_id opt-out mechanism requiring explicit id when disabled
- Adds configuration control for auto-generated component ID behavior

## Changes
Adds `auto_id` parameter to BaseComponent to control ID generation. When `auto_id=False`, components must provide an explicit `id` parameter, preventing silent auto-ID allocation.

Test additions: +57 lines with comprehensive coverage of auto_id behavior and validation.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)