### PR TITLE
feat(v2): JSON-string attr coercion for list/dict/BaseModel fields

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -12,7 +12,9 @@ session.py or reactive/.
 """
 
 import itertools
-from typing import Annotated, ClassVar
+import json
+import types
+from typing import Annotated, Any, ClassVar, Union, get_args, get_origin
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -58,6 +60,23 @@ def _is_slot_field(cls: type, field_name: str) -> bool:
     return field is not None and any(isinstance(m, PjxSlot) for m in field.metadata)
 
 
+def _is_json_coercible_annotation(annotation: Any) -> bool:
+    """A field is a JSON-coercion candidate if, once ``None`` is stripped from
+    a ``T | None`` union, exactly one type remains and it's ``list``, ``dict``,
+    or a ``BaseModel`` subclass. Unions that keep ``str`` (e.g. ``str | list``,
+    and ``Slot``/``Children``) are left alone — a JSON-looking string there is
+    ambiguous, and for a slot it is almost certainly literal markup."""
+    if get_origin(annotation) in (Union, types.UnionType):
+        args = [a for a in get_args(annotation) if a is not type(None)]
+        if len(args) != 1:
+            return False
+        annotation = args[0]
+    origin = get_origin(annotation) or annotation
+    if origin in (list, dict):
+        return True
+    return isinstance(origin, type) and issubclass(origin, BaseModel)
+
+
 class BaseComponent(BaseModel):
     """Base for all components: declared fields only, undeclared kwargs rejected.
 
@@ -89,6 +108,36 @@ class BaseComponent(BaseModel):
         if isinstance(data, dict) and data.get("id"):
             return data
         raise ValueError(f"{cls.__name__} sets auto_id = False, so id is required")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_json_string_attrs(cls, data: object) -> object:
+        """A tag attribute always arrives as a string (Jinja renders the tag
+        before it's parsed). For a field typed ``list``/``dict``/a ``BaseModel``,
+        a JSON-looking string (``{...}``/``[...]``) is parsed before Pydantic
+        sees it, so ``<Child sources="{{ sources | tojson }}"/>`` just works
+        instead of every such component hand-rolling the same ``BeforeValidator``.
+
+        Declared fields only: this never reads or writes ``model_extra``, so the
+        strict core keeps its promise that undeclared keys are never walked."""
+        if not isinstance(data, dict):
+            return data
+        for name, field in cls.model_fields.items():
+            value = data.get(name)
+            if not isinstance(value, str):
+                continue
+            text = value.strip()
+            if not text or text[0] not in "{[":
+                continue
+            if not _is_json_coercible_annotation(field.annotation):
+                continue
+            try:
+                data[name] = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"{cls.__name__}.{name}: invalid JSON attribute value"
+                ) from exc
+        return data
 
     @field_validator("id", mode="before")
     @classmethod

--- a/tests/pyjinhx2/test_component.py
+++ b/tests/pyjinhx2/test_component.py
@@ -179,6 +179,36 @@ class TestJsonCoercion:
             Structural(meta="")  # pyright: ignore[reportArgumentType]
         assert "invalid JSON attribute value" not in str(excinfo.value)
 
+    def test_real_values_pass_through_untouched(self):
+        address = Address(city="Porto")
+        component = Structural(
+            sources=[1, 2], meta={"a": 1}, typed_items=["x"], address=address
+        )
+        assert component.sources == [1, 2]
+        assert component.meta == {"a": 1}
+        assert component.typed_items == ["x"]
+        assert component.address == address
+
+    def test_non_dict_input_is_passed_through(self):
+        assert Structural.model_validate(Structural(typed_items=["a"])).typed_items == [
+            "a"
+        ]
+
+    def test_coercion_does_not_disturb_auto_id_opt_out(self):
+        with pytest.raises(ValidationError):
+            StrictStructural(sources='["a"]')  # pyright: ignore[reportArgumentType]
+        component = StrictStructural(
+            id="fixed",
+            sources='["a"]',  # pyright: ignore[reportArgumentType]
+        )
+        assert component.id == "fixed"
+        assert component.sources == ["a"]
+
+    def test_coercion_does_not_disturb_auto_id_generation(self):
+        assert Structural(
+            typed_items='["a"]'  # pyright: ignore[reportArgumentType]
+        ).id.startswith("pjx-")
+
 
 FORBIDDEN_IMPORTS = (
     "pyjinhx2.render",

--- a/tests/pyjinhx2/test_component.py
+++ b/tests/pyjinhx2/test_component.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic import BaseModel, Field, ValidationError
 
 import pyjinhx2.component
-from pyjinhx2.component import BaseComponent, Slot
+from pyjinhx2.component import BaseComponent, Children, Slot
 
 
 class Address(BaseModel):
@@ -149,6 +149,18 @@ class TestJsonCoercion:
         assert Structural(
             maybe_items='["a"]'  # pyright: ignore[reportArgumentType]
         ).maybe_items == ["a"]
+
+    def test_union_with_str_is_not_coerced(self):
+        assert Structural(label="[1, 2, 3]").label == "[1, 2, 3]"
+
+    def test_slot_field_is_never_coerced(self):
+        assert Slotted(body='{"not": "json-here"}').body == '{"not": "json-here"}'
+
+    def test_children_slot_field_is_never_coerced(self):
+        class WithChildren(BaseComponent):
+            content: Children = ""
+
+        assert WithChildren(content="[1, 2]").content == "[1, 2]"
 
 
 FORBIDDEN_IMPORTS = (

--- a/tests/pyjinhx2/test_component.py
+++ b/tests/pyjinhx2/test_component.py
@@ -162,6 +162,23 @@ class TestJsonCoercion:
 
         assert WithChildren(content="[1, 2]").content == "[1, 2]"
 
+    def test_invalid_json_raises_validation_error_naming_class_and_field(self):
+        with pytest.raises(ValidationError) as excinfo:
+            Structural(sources="[not json")  # pyright: ignore[reportArgumentType]
+        message = str(excinfo.value)
+        assert "Structural" in message
+        assert "sources" in message
+
+    def test_non_json_looking_string_is_left_for_pydantic_to_reject(self):
+        with pytest.raises(ValidationError) as excinfo:
+            Structural(sources="plain text")  # pyright: ignore[reportArgumentType]
+        assert "invalid JSON attribute value" not in str(excinfo.value)
+
+    def test_empty_string_is_left_for_pydantic_to_reject(self):
+        with pytest.raises(ValidationError) as excinfo:
+            Structural(meta="")  # pyright: ignore[reportArgumentType]
+        assert "invalid JSON attribute value" not in str(excinfo.value)
+
 
 FORBIDDEN_IMPORTS = (
     "pyjinhx2.render",

--- a/tests/pyjinhx2/test_component.py
+++ b/tests/pyjinhx2/test_component.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic import BaseModel, Field, ValidationError
 
 import pyjinhx2.component
-from pyjinhx2.component import BaseComponent
+from pyjinhx2.component import BaseComponent, Slot
 
 
 class Address(BaseModel):
@@ -25,6 +25,25 @@ class Panel(BaseComponent):
 
 class Named(BaseComponent):
     auto_id = False
+
+
+class Structural(BaseComponent):
+    sources: list = Field(default_factory=list)
+    meta: dict = Field(default_factory=dict)
+    typed_items: list[str] = Field(default_factory=list)
+    typed_map: dict[str, int] = Field(default_factory=dict)
+    address: Address | None = None
+    maybe_items: list[str] | None = None
+    label: str | list = ""
+
+
+class Slotted(BaseComponent):
+    body: Slot = ""
+
+
+class StrictStructural(BaseComponent):
+    auto_id = False
+    sources: list = Field(default_factory=list)
 
 
 class TestStrictConfig:
@@ -108,6 +127,28 @@ class TestAutoIdOptOut:
     def test_auto_id_is_not_a_model_field(self):
         assert "auto_id" not in BaseComponent.model_fields
         assert "auto_id" not in Named.model_fields
+
+
+class TestJsonCoercion:
+    def test_json_string_coerces_to_list(self):
+        assert Structural(
+            typed_items='["a", "b"]'  # pyright: ignore[reportArgumentType]
+        ).typed_items == ["a", "b"]
+
+    def test_json_string_coerces_to_dict(self):
+        assert Structural(
+            typed_map='{"a": 1}'  # pyright: ignore[reportArgumentType]
+        ).typed_map == {"a": 1}
+
+    def test_json_object_string_coerces_to_base_model_field(self):
+        assert Structural(
+            address='{"city": "Lisbon"}'  # pyright: ignore[reportArgumentType]
+        ).address == Address(city="Lisbon")
+
+    def test_optional_annotation_still_coerces(self):
+        assert Structural(
+            maybe_items='["a"]'  # pyright: ignore[reportArgumentType]
+        ).maybe_items == ["a"]
 
 
 FORBIDDEN_IMPORTS = (


### PR DESCRIPTION
## Summary
- Implements JSON-string attribute coercion for list, dict, and BaseModel fields in pyjinhx2
- Adds comprehensive test coverage for JSON coercion edge cases
- Guards against invalid JSON, string unions, and Slot/Children coercion
- Covers no-op passthrough and validator declaration order

## Test count
4 commits: 1 feature + 3 test commits

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)