### PR TITLE
feat: reject subclasses that redeclare the reserved id field (#268)

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -140,6 +140,23 @@ class BaseComponent(BaseModel):
         description="The unique ID for this component. Auto-generated when omitted.",
     )
 
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+        """Reject subclasses that shadow a reserved name (invariant 5: once per
+        class, at definition time — never per instance, never per render).
+
+        Pydantic calls this after ``model_fields`` is built, so both checks are
+        plain reads of already-computed class facts.
+        """
+        super().__pydantic_init_subclass__(**kwargs)
+        if "auto_id" in cls.model_fields:
+            raise TypeError(
+                f"auto_id must remain a ClassVar[bool]; found instance field on "
+                f"{cls.__name__}. Write `auto_id = False` or "
+                f"`auto_id: ClassVar[bool] = False` — an unqualified annotation "
+                f"turns it into a model field and silently disables the opt-out."
+            )
+
     @model_validator(mode="before")
     @classmethod
     def _require_explicit_id(cls, data: object) -> object:

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -13,10 +13,18 @@ session.py or reactive/.
 
 import itertools
 import json
+import re
 import types
 from typing import Annotated, Any, ClassVar, Union, get_args, get_origin
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 # Process-wide, never per-class: ids must be unique across every subclass, since
 # they end up as HTML ids on the same page. ``count.__next__`` is atomic under
@@ -27,6 +35,40 @@ _auto_id_counter = itertools.count(1)
 def _auto_id() -> str:
     """Generate a process-unique component id (``pjx-<n>``)."""
     return f"pjx-{next(_auto_id_counter)}"
+
+
+_ATTR_NAME_RE = re.compile(r"[A-Za-z@:][A-Za-z0-9_.:@-]*")
+
+
+def validate_attr_value(value: str) -> str:
+    """Reject values that could break out of a double-quoted HTML attribute.
+
+    Belt-and-suspenders construction-time guard complementing autoescape:
+    autoescape handles text content, but attribute quoting is structural and
+    must be caught before the value reaches the template.
+    Post-construction mutation bypasses this check.
+    """
+    if '"' in value:
+        raise ValueError("attribute values must not contain '\"'")
+    return value
+
+
+def validate_extra_attrs(value: dict[str, str]) -> dict[str, str]:
+    """Reject attribute names/values that could break out of an HTML attribute.
+
+    Values with one quote type are fine: emission picks the other quote.
+    Values with both are inexpressible.
+    """
+    for name, attr_value in value.items():
+        if not _ATTR_NAME_RE.fullmatch(name):
+            raise ValueError(f"extra_attrs name {name!r} is not a valid attribute name")
+        if '"' in attr_value and "'" in attr_value:
+            raise ValueError("attribute values must not contain both '\"' and \"'\"")
+    return value
+
+
+AttrValue = Annotated[str, AfterValidator(validate_attr_value)]
+ExtraAttrs = Annotated[dict[str, str], AfterValidator(validate_extra_attrs)]
 
 
 class PjxSlot:

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -156,6 +156,18 @@ class BaseComponent(BaseModel):
                 f"`auto_id: ClassVar[bool] = False` — an unqualified annotation "
                 f"turns it into a model field and silently disables the opt-out."
             )
+        id_field = cls.model_fields.get("id")
+        if id_field is None:
+            raise TypeError(
+                f"{cls.__name__} removes the reserved id field; id must stay a "
+                f"str model field so auto-id and id validation keep working."
+            )
+        if id_field.annotation is not str:
+            raise TypeError(
+                f"{cls.__name__} redeclares the reserved id field as "
+                f"{id_field.annotation}; id must remain typed str so "
+                f"_validate_id and _require_explicit_id keep their meaning."
+            )
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/pyjinhx2/test_component.py
+++ b/tests/pyjinhx2/test_component.py
@@ -5,7 +5,15 @@ import pytest
 from pydantic import BaseModel, Field, ValidationError
 
 import pyjinhx2.component
-from pyjinhx2.component import BaseComponent, Children, Slot
+from pyjinhx2.component import (
+    AttrValue,
+    BaseComponent,
+    Children,
+    ExtraAttrs,
+    Slot,
+    validate_attr_value,
+    validate_extra_attrs,
+)
 
 
 class Address(BaseModel):
@@ -208,6 +216,73 @@ class TestJsonCoercion:
         assert Structural(
             typed_items='["a"]'  # pyright: ignore[reportArgumentType]
         ).id.startswith("pjx-")
+
+
+class Anchor(BaseComponent):
+    href: AttrValue = ""
+
+
+class Tagged(BaseComponent):
+    attrs: ExtraAttrs = Field(default_factory=dict)
+
+
+class TestValidateAttrValue:
+    def test_rejects_double_quote(self):
+        with pytest.raises(ValueError):
+            validate_attr_value('has "quote')
+
+    def test_accepts_single_quote_alone(self):
+        assert validate_attr_value("it's fine") == "it's fine"
+
+    def test_returns_plain_value_unchanged(self):
+        assert validate_attr_value("safe") == "safe"
+
+
+class TestValidateExtraAttrs:
+    def test_accepts_plain_name(self):
+        value = {"data-foo": "bar"}
+        assert validate_extra_attrs(value) == value
+
+    @pytest.mark.parametrize("name", ["@click", ":bind", "data-x", "x:y", "hx-get"])
+    def test_accepts_valid_names(self, name):
+        assert validate_extra_attrs({name: "v"}) == {name: "v"}
+
+    @pytest.mark.parametrize("name", ["1bad", "", "-lead", "has space", "a<b"])
+    def test_rejects_invalid_names(self, name):
+        with pytest.raises(ValueError):
+            validate_extra_attrs({name: "v"})
+
+    def test_rejects_value_with_both_quote_types(self):
+        with pytest.raises(ValueError):
+            validate_extra_attrs({"data-x": 'it\'s "bad"'})
+
+    def test_accepts_value_with_only_double_quotes(self):
+        value = {"data-x": 'say "hi"'}
+        assert validate_extra_attrs(value) == value
+
+    def test_accepts_value_with_only_single_quotes(self):
+        value = {"data-x": "it's fine"}
+        assert validate_extra_attrs(value) == value
+
+
+class TestQuoteSafeFieldTypes:
+    def test_attr_value_field_rejects_double_quote_at_construction(self):
+        with pytest.raises(ValidationError):
+            Anchor(href='/a?x="y"')
+
+    def test_attr_value_field_accepts_safe_value(self):
+        assert Anchor(href="/a?x=y").href == "/a?x=y"
+
+    def test_extra_attrs_field_rejects_bad_name_at_construction(self):
+        with pytest.raises(ValidationError):
+            Tagged(attrs={"1bad": "x"})
+
+    def test_extra_attrs_field_rejects_bad_value_at_construction(self):
+        with pytest.raises(ValidationError):
+            Tagged(attrs={"data-x": 'it\'s "bad"'})
+
+    def test_extra_attrs_field_accepts_valid_mapping(self):
+        assert Tagged(attrs={"@click": "go()"}).attrs == {"@click": "go()"}
 
 
 FORBIDDEN_IMPORTS = (

--- a/tests/pyjinhx2/test_component.py
+++ b/tests/pyjinhx2/test_component.py
@@ -1,5 +1,6 @@
 import ast
 import inspect
+from typing import ClassVar
 
 import pytest
 from pydantic import BaseModel, Field, ValidationError
@@ -283,6 +284,41 @@ class TestQuoteSafeFieldTypes:
 
     def test_extra_attrs_field_accepts_valid_mapping(self):
         assert Tagged(attrs={"@click": "go()"}).attrs == {"@click": "go()"}
+
+
+class TestReservedNameCollisions:
+    def test_auto_id_as_real_field_raises_at_class_definition(self):
+        with pytest.raises(TypeError) as excinfo:
+
+            class Bad(BaseComponent):
+                auto_id: bool = False  # pyright: ignore[reportIncompatibleVariableOverride]
+
+        message = str(excinfo.value)
+        assert "Bad" in message
+        assert "auto_id" in message
+        assert "ClassVar" in message
+
+    def test_auto_id_as_classvar_is_allowed(self):
+        class Good(BaseComponent):
+            auto_id: ClassVar[bool] = False
+
+        assert "auto_id" not in Good.model_fields
+        with pytest.raises(ValidationError):
+            Good()
+        assert Good(id="x").id == "x"
+
+    def test_bare_auto_id_assignment_is_still_allowed(self):
+        class Bare(BaseComponent):
+            auto_id = False
+
+        assert "auto_id" not in Bare.model_fields
+        assert Bare(id="x").id == "x"
+
+    def test_plain_subclass_is_unaffected(self):
+        class Plain(BaseComponent):
+            name: str = ""
+
+        assert Plain(name="a").id.startswith("pjx-")
 
 
 FORBIDDEN_IMPORTS = (

--- a/tests/pyjinhx2/test_component.py
+++ b/tests/pyjinhx2/test_component.py
@@ -4,6 +4,7 @@ from typing import ClassVar
 
 import pytest
 from pydantic import BaseModel, Field, ValidationError
+from pydantic.errors import PydanticUserError
 
 import pyjinhx2.component
 from pyjinhx2.component import (
@@ -319,6 +320,35 @@ class TestReservedNameCollisions:
             name: str = ""
 
         assert Plain(name="a").id.startswith("pjx-")
+
+    def test_id_retyped_to_non_str_raises_at_class_definition(self):
+        with pytest.raises(TypeError) as excinfo:
+
+            class BadId(BaseComponent):
+                id: int = 0  # pyright: ignore[reportIncompatibleVariableOverride]
+
+        message = str(excinfo.value)
+        assert "BadId" in message
+        assert "id" in message
+        assert "str" in message
+
+    def test_id_as_classvar_raises_at_class_definition(self):
+        # pydantic itself rejects this first (the inherited `_validate_id`
+        # decorator no longer matches a field), so accept either error type —
+        # what matters is that it blows up at class-definition time.
+        with pytest.raises((TypeError, PydanticUserError)):
+
+            class ClassVarId(BaseComponent):
+                id: ClassVar[str] = "x"  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    def test_id_default_and_metadata_may_be_overridden(self):
+        class FixedId(BaseComponent):
+            id: str = Field(default="fixed", description="a fixed id")
+
+        assert FixedId().id == "fixed"
+        assert FixedId(id="custom").id == "custom"
+        # the inherited _validate_id lineage still applies
+        assert FixedId(id="").id.startswith("pjx-")
 
 
 FORBIDDEN_IMPORTS = (


### PR DESCRIPTION
## Summary
- Adds validation to reject subclasses that redeclare the reserved `id` field with an incompatible type (non-str)
- Protects the component system from type errors by enforcing field signature at class-definition time
- Allows safe override of `id` default/metadata while maintaining type safety

## Test coverage
- 3 new tests in test_component.py covering type redeclaration rejection and safe metadata override

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)