### PR TITLE
chore: satisfy typecheck and lint gates

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -6,15 +6,22 @@ core is closed: an undeclared kwarg is a ValidationError at construction, and th
 renderer never has to look. Extra-field ergonomics belong on a separate open
 opt-in subclass (L1), not on this class.
 
-Imports pydantic and nothing else. component.py sits below descriptor.py and
-render.py in the import graph and must never reach up into them, nor into
-session.py or reactive/.
+Imports pydantic, plus the one sanctioned edge this issue (#271) adds: importing
+``ClassDescriptor`` from descriptor.py to build and attach it in
+``__pydantic_init_subclass__``. component.py still sits below descriptor.py and
+render.py in the import graph and must never reach into render.py, session.py, or
+reactive/ — the ClassDescriptor import is the sole declared exception, enforced
+statically by tests/pyjinhx2/test_import_graph.py rather than left as a comment
+nobody checks.
 """
 
 import itertools
 import json
 import re
+import sys
 import types
+from collections.abc import Mapping
+from pathlib import Path
 from typing import Annotated, Any, ClassVar, Union, get_args, get_origin
 
 from pydantic import (
@@ -25,6 +32,8 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+
+from pyjinhx2.descriptor import ClassDescriptor
 
 # Process-wide, never per-class: ids must be unique across every subclass, since
 # they end up as HTML ids on the same page. ``count.__next__`` is atomic under
@@ -117,6 +126,98 @@ def _is_json_coercible_annotation(annotation: Any) -> bool:
     if origin in (list, dict):
         return True
     return isinstance(origin, type) and issubclass(origin, BaseModel)
+
+
+def _defining_module_dir(cls: type) -> Path:
+    """Directory of the module that defined ``cls`` — the root every co-located
+    probe starts from (ADR 0007).
+
+    Raises for a class whose module has no file on disk (exec'd, REPL-defined,
+    synthesised). There is genuinely no directory to probe from, so #271 fails
+    at class-definition time rather than inventing one; #272 and #276 inherit
+    this guard when they replace the stubs that call it.
+    """
+    module = sys.modules.get(cls.__module__)
+    file = getattr(module, "__file__", None)
+    if file is None:
+        raise NotImplementedError(
+            f"{cls.__name__} is defined in module {cls.__module__!r}, which has "
+            f"no file on disk; template and asset resolution have no directory "
+            f"to probe from."
+        )
+    return Path(file).parent
+
+
+def _resolve_template_path(cls: type) -> Path:
+    """STUB — #272 (single probe) and #273 (MRO walk) replace this in place.
+
+    Returns the naive co-located path: it does not touch the filesystem and does
+    not walk the MRO. The real ADR 0007 probe is #272's, the per-kind ancestor
+    walk is #273's, and the missing-template message is #277's. Nothing at L0
+    reads this value yet, so a not-yet-probed path cannot mislead anything.
+    """
+    return _defining_module_dir(cls) / f"{cls.__name__}.pjx"
+
+
+def _resolve_slot_fields(cls: type) -> frozenset[str]:
+    """STUB — #275 replaces this in place with real slot-field detection
+    (``_is_slot_field`` over ``model_fields``). Empty until then."""
+    return frozenset()
+
+
+def _resolve_asset_paths(cls: type) -> tuple[tuple[Path, ...], tuple[Path, ...]]:
+    """STUB — #276 replaces this in place with co-located css/js discovery,
+    resolved per-kind up the MRO (ADR 0010). Returns ``(css_paths, js_paths)``
+    as one call because both kinds probe the same directory.
+
+    Calls :func:`_defining_module_dir` for its side effect only: a class with no
+    module file must fail here too, not silently report "no assets".
+    """
+    _defining_module_dir(cls)
+    return ((), ())
+
+
+def _resolve_strict(cls: type[BaseModel]) -> bool:
+    """The ADR 0006 mode, recorded once per class so render.py branches per
+    class instead of per render.
+
+    Not a stub: this is real data available today. Reading the class's own
+    pydantic config means L1's open opt-in subclass flips this to ``False`` with
+    no further wiring.
+    """
+    return cls.model_config.get("extra") == "forbid"
+
+
+def _resolve_provenance(cls: type) -> Mapping[str, type]:
+    """STUB — #274 replaces this in place, mapping each kind (``"template"``,
+    ``"css"``, ``"js"``) to the ancestor class that supplied it. Empty until
+    then; the kinds are #274's to choose, not this stub's to predict."""
+    return {}
+
+
+def _resolve_class_descriptor(cls: type[BaseModel]) -> ClassDescriptor:
+    """Build the one :class:`ClassDescriptor` for ``cls`` (invariant 5).
+
+    The single seam behind which #272-#276 land. They replace the ``_resolve_*``
+    helpers above **in place**; this function's name, signature and its one call
+    site in ``BaseComponent.__pydantic_init_subclass__`` are the contract that
+    does not move. Exceptions from any helper propagate unchanged, so a failure
+    surfaces at the ``class Foo(BaseComponent): ...`` statement exactly like a
+    pydantic model-build error does.
+
+    Returns a whole object. Nothing partially constructs a descriptor or edits
+    one after the fact — that is what ``frozen=True`` is there to enforce, and
+    what lets #278's dev-reload rebuild simply reassign the class attribute.
+    """
+    css_paths, js_paths = _resolve_asset_paths(cls)
+    return ClassDescriptor(
+        template_path=_resolve_template_path(cls),
+        slot_fields=_resolve_slot_fields(cls),
+        css_paths=css_paths,
+        js_paths=js_paths,
+        strict=_resolve_strict(cls),
+        provenance=_resolve_provenance(cls),
+    )
 
 
 class BaseComponent(BaseModel):

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -236,6 +236,14 @@ class BaseComponent(BaseModel):
     # Opt out per component class with ``class Foo(BaseComponent): auto_id = False``.
     auto_id: ClassVar[bool] = True
 
+    # The per-class fact sheet (invariant 5), built once by the hook below and
+    # never mutated: #278's dev-reload replaces the whole object. Declared
+    # without a value because Pydantic does not fire __pydantic_init_subclass__
+    # for the class that defines it, so BaseComponent itself has no descriptor —
+    # relied on rather than special-cased. ClassVar keeps it out of model_fields
+    # and out of Pydantic's private-attribute machinery.
+    _pjx_descriptor: ClassVar[ClassDescriptor]
+
     id: str = Field(
         default_factory=_auto_id,
         description="The unique ID for this component. Auto-generated when omitted.",
@@ -243,11 +251,13 @@ class BaseComponent(BaseModel):
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
-        """Reject subclasses that shadow a reserved name (invariant 5: once per
-        class, at definition time — never per instance, never per render).
+        """Reject subclasses that shadow a reserved name, then resolve and
+        attach this class's ClassDescriptor (invariant 5: once per class, at
+        definition time — never per instance, never per render).
 
-        Pydantic calls this after ``model_fields`` is built, so both checks are
-        plain reads of already-computed class facts.
+        Pydantic calls this after ``model_fields`` is built, so the checks are
+        plain reads of already-computed class facts and the descriptor seam sees
+        a fully-built class.
         """
         super().__pydantic_init_subclass__(**kwargs)
         if "auto_id" in cls.model_fields:
@@ -269,6 +279,11 @@ class BaseComponent(BaseModel):
                 f"{id_field.annotation}; id must remain typed str so "
                 f"_validate_id and _require_explicit_id keep their meaning."
             )
+        # One function, one call, one whole-object assignment — the same shape as
+        # v0.x's `cls._pjx_children_target = _resolve_children_field(cls)`.
+        # Anything the seam raises propagates to the `class Foo(BaseComponent)`
+        # statement; nothing here catches or logs it.
+        cls._pjx_descriptor = _resolve_class_descriptor(cls)
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/pyjinhx2/test_component.py
+++ b/tests/pyjinhx2/test_component.py
@@ -427,7 +427,6 @@ class TestReservedNameCollisions:
 
 FORBIDDEN_IMPORTS = (
     "pyjinhx2.render",
-    "pyjinhx2.descriptor",
     "pyjinhx2.session",
     "pyjinhx2.reactive",
     "pyjinhx",
@@ -436,7 +435,11 @@ FORBIDDEN_IMPORTS = (
 
 def test_component_module_does_not_import_above_itself():
     """component.py sits below descriptor/render in the import graph, so it must
-    not reach up into them (nor into session.py, reactive/, or v0.x pyjinhx)."""
+    not reach up into them (nor into session.py, reactive/, or v0.x pyjinhx) —
+    except the one sanctioned edge #271 adds: importing ``ClassDescriptor`` from
+    descriptor.py to build and attach it in ``__pydantic_init_subclass__``.
+    tests/pyjinhx2/test_import_graph.py is the whole-package view that enforces
+    component.py is the *only* module allowed that edge."""
     tree = ast.parse(inspect.getsource(pyjinhx2.component))
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -53,7 +53,7 @@ class TestResolveStrict:
 
     def test_false_when_a_subclass_reopens_extras(self):
         class Open(BaseComponent):
-            model_config = {"extra": "allow"}
+            model_config = {"extra": "allow"}  # noqa: RUF012 — pydantic's own ConfigDict pattern
 
         assert _resolve_strict(Open) is False
 
@@ -130,7 +130,9 @@ class TestDescriptorAttachedAtClassDefinition:
             pass
 
         assert Card._pjx_descriptor is not Banner._pjx_descriptor
-        assert Card._pjx_descriptor.template_path != Banner._pjx_descriptor.template_path
+        assert (
+            Card._pjx_descriptor.template_path != Banner._pjx_descriptor.template_path
+        )
 
     def test_a_subclass_of_a_subclass_gets_its_own_descriptor(self):
         class Card(BaseComponent):
@@ -154,13 +156,13 @@ class TestHookOrdering:
         with pytest.raises(TypeError, match="auto_id must remain a ClassVar"):
 
             class Bad(BaseComponent):
-                auto_id: bool = True
+                auto_id: bool = True  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def test_redeclaring_id_with_a_non_str_type_still_raises(self):
         with pytest.raises(TypeError, match="redeclares the reserved id field"):
 
             class Bad(BaseComponent):
-                id: int = 0
+                id: int = 0  # pyright: ignore[reportIncompatibleVariableOverride]
 
     def test_the_seam_does_not_run_when_reserved_name_validation_fails(
         self, monkeypatch
@@ -177,7 +179,7 @@ class TestHookOrdering:
         with pytest.raises(TypeError):
 
             class Bad(BaseComponent):
-                auto_id: bool = True
+                auto_id: bool = True  # pyright: ignore[reportIncompatibleVariableOverride]
 
         assert calls == []
 
@@ -213,11 +215,11 @@ class TestSeamFailurePropagates:
 
     def test_a_class_defined_in_a_fileless_module_fails_at_definition_time(self):
         module = types.ModuleType("pyjinhx2_test_fileless_defining_module")
-        module.BaseComponent = BaseComponent
+        module.BaseComponent = BaseComponent  # pyright: ignore[reportAttributeAccessIssue]
         sys.modules["pyjinhx2_test_fileless_defining_module"] = module
         try:
             with pytest.raises(NotImplementedError, match="no file on disk"):
-                exec(
+                exec(  # noqa: S102 — only way to define a class in a fileless module
                     "class Card(BaseComponent):\n    pass\n",
                     module.__dict__,
                 )

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import pyjinhx2.component
 from pyjinhx2.component import (
     BaseComponent,
     _defining_module_dir,
@@ -80,3 +81,170 @@ class TestDefiningModuleDir:
                 _defining_module_dir(Card)
         finally:
             del sys.modules["pyjinhx2_test_fileless_module"]
+
+
+class TestDescriptorAttachedAtClassDefinition:
+    def test_a_subclass_gets_a_class_descriptor(self):
+        class Card(BaseComponent):
+            pass
+
+        assert isinstance(Card._pjx_descriptor, ClassDescriptor)
+
+    def test_base_component_itself_has_no_descriptor(self):
+        """Pydantic does not fire __pydantic_init_subclass__ for the class that
+        defines it. Relied on, not special-cased."""
+        assert "_pjx_descriptor" not in vars(BaseComponent)
+
+    def test_the_seam_is_called_exactly_once_per_class_definition(self, monkeypatch):
+        calls: list[type] = []
+        real = pyjinhx2.component._resolve_class_descriptor
+
+        def counting(cls):
+            calls.append(cls)
+            return real(cls)
+
+        monkeypatch.setattr(pyjinhx2.component, "_resolve_class_descriptor", counting)
+
+        class Card(BaseComponent):
+            pass
+
+        Card()
+        Card()
+
+        assert calls == [Card]
+
+    def test_the_descriptor_is_the_same_object_across_instantiations(self):
+        class Card(BaseComponent):
+            pass
+
+        first, second = Card(), Card()
+
+        assert first._pjx_descriptor is second._pjx_descriptor
+        assert first._pjx_descriptor is Card._pjx_descriptor
+
+    def test_sibling_subclasses_get_distinct_descriptors(self):
+        class Card(BaseComponent):
+            pass
+
+        class Banner(BaseComponent):
+            pass
+
+        assert Card._pjx_descriptor is not Banner._pjx_descriptor
+        assert Card._pjx_descriptor.template_path != Banner._pjx_descriptor.template_path
+
+    def test_a_subclass_of_a_subclass_gets_its_own_descriptor(self):
+        class Card(BaseComponent):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        assert FancyCard._pjx_descriptor is not Card._pjx_descriptor
+        assert "_pjx_descriptor" in vars(FancyCard)
+
+    def test_the_descriptor_is_not_a_model_field(self):
+        class Card(BaseComponent):
+            pass
+
+        assert "_pjx_descriptor" not in Card.model_fields
+
+
+class TestHookOrdering:
+    def test_reserved_auto_id_field_still_raises(self):
+        with pytest.raises(TypeError, match="auto_id must remain a ClassVar"):
+
+            class Bad(BaseComponent):
+                auto_id: bool = True
+
+    def test_redeclaring_id_with_a_non_str_type_still_raises(self):
+        with pytest.raises(TypeError, match="redeclares the reserved id field"):
+
+            class Bad(BaseComponent):
+                id: int = 0
+
+    def test_the_seam_does_not_run_when_reserved_name_validation_fails(
+        self, monkeypatch
+    ):
+        """The attach step comes after the reserved-name checks, so a rejected
+        class never reaches the resolver."""
+        calls: list[type] = []
+        monkeypatch.setattr(
+            pyjinhx2.component,
+            "_resolve_class_descriptor",
+            lambda cls: calls.append(cls),
+        )
+
+        with pytest.raises(TypeError):
+
+            class Bad(BaseComponent):
+                auto_id: bool = True
+
+        assert calls == []
+
+    def test_the_seam_runs_after_super_has_built_model_fields(self, monkeypatch):
+        """super().__pydantic_init_subclass__(**kwargs) is still called first:
+        by the time the seam sees the class, pydantic has finished building it."""
+        seen: list[frozenset[str]] = []
+        real = pyjinhx2.component._resolve_class_descriptor
+
+        def spying(cls):
+            seen.append(frozenset(cls.model_fields))
+            return real(cls)
+
+        monkeypatch.setattr(pyjinhx2.component, "_resolve_class_descriptor", spying)
+
+        class Card(BaseComponent):
+            title: str = ""
+
+        assert seen == [frozenset({"id", "title"})]
+
+
+class TestSeamFailurePropagates:
+    def test_a_raising_seam_aborts_the_class_statement(self, monkeypatch):
+        def boom(cls):
+            raise NotImplementedError("resolver not implemented yet")
+
+        monkeypatch.setattr(pyjinhx2.component, "_resolve_class_descriptor", boom)
+
+        with pytest.raises(NotImplementedError, match="resolver not implemented yet"):
+
+            class Card(BaseComponent):
+                pass
+
+    def test_a_class_defined_in_a_fileless_module_fails_at_definition_time(self):
+        module = types.ModuleType("pyjinhx2_test_fileless_defining_module")
+        module.BaseComponent = BaseComponent
+        sys.modules["pyjinhx2_test_fileless_defining_module"] = module
+        try:
+            with pytest.raises(NotImplementedError, match="no file on disk"):
+                exec(
+                    "class Card(BaseComponent):\n    pass\n",
+                    module.__dict__,
+                )
+        finally:
+            del sys.modules["pyjinhx2_test_fileless_defining_module"]
+
+
+class TestDevReloadReassignmentSmokeTest:
+    def test_the_attribute_can_be_replaced_wholesale(self):
+        """#278's dev-reload rebuild replaces the whole descriptor object. The
+        ClassDescriptor is frozen; the class attribute pointing at it is not, so
+        this needs no unlock beyond a plain attribute set."""
+
+        class Card(BaseComponent):
+            pass
+
+        original = Card._pjx_descriptor
+        replacement = ClassDescriptor(
+            template_path=Path("rebuilt/card.pjx"),
+            slot_fields=frozenset({"body"}),
+            css_paths=(Path("rebuilt/card.css"),),
+            js_paths=(),
+            strict=True,
+            provenance={"template": Card},
+        )
+
+        Card._pjx_descriptor = replacement
+
+        assert Card._pjx_descriptor is replacement
+        assert Card._pjx_descriptor is not original

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -1,0 +1,82 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from pyjinhx2.component import (
+    BaseComponent,
+    _defining_module_dir,
+    _resolve_class_descriptor,
+    _resolve_strict,
+)
+from pyjinhx2.descriptor import ClassDescriptor
+
+
+class TestResolveClassDescriptor:
+    """The seam #272-#276 land behind: one call, one whole ClassDescriptor."""
+
+    def test_returns_a_fully_constructed_descriptor(self):
+        class Card(BaseComponent):
+            pass
+
+        descriptor = _resolve_class_descriptor(Card)
+
+        assert isinstance(descriptor, ClassDescriptor)
+        assert descriptor.template_path == Path(__file__).parent / "Card.pjx"
+        assert descriptor.slot_fields == frozenset()
+        assert descriptor.css_paths == ()
+        assert descriptor.js_paths == ()
+        assert descriptor.strict is True
+        assert descriptor.provenance == {}
+
+    def test_each_call_builds_a_new_object(self):
+        """The seam itself is pure and uncached; the caching is the hook's job
+        (one call per class definition), which Task 2 covers."""
+
+        class Card(BaseComponent):
+            pass
+
+        assert _resolve_class_descriptor(Card) is not _resolve_class_descriptor(Card)
+
+
+class TestResolveStrict:
+    """strict is real data today, not a stub: it reads the ADR 0006 mode off
+    the class's own pydantic config, so L1's open subclass flips it for free."""
+
+    def test_true_for_the_closed_core(self):
+        class Card(BaseComponent):
+            pass
+
+        assert _resolve_strict(Card) is True
+
+    def test_false_when_a_subclass_reopens_extras(self):
+        class Open(BaseComponent):
+            model_config = {"extra": "allow"}
+
+        assert _resolve_strict(Open) is False
+
+
+class TestDefiningModuleDir:
+    def test_returns_the_directory_of_the_defining_module(self):
+        class Card(BaseComponent):
+            pass
+
+        assert _defining_module_dir(Card) == Path(__file__).parent
+
+    def test_raises_not_implemented_when_the_module_has_no_file(self):
+        """A class with no module on disk has no directory to probe from. #271
+        fails loudly here rather than inventing a path; #272/#276 inherit the
+        guard when they replace the stubs."""
+        module = types.ModuleType("pyjinhx2_test_fileless_module")
+        sys.modules["pyjinhx2_test_fileless_module"] = module
+        try:
+
+            class Card(BaseComponent):
+                pass
+
+            Card.__module__ = "pyjinhx2_test_fileless_module"
+            with pytest.raises(NotImplementedError, match="no file on disk"):
+                _defining_module_dir(Card)
+        finally:
+            del sys.modules["pyjinhx2_test_fileless_module"]

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -1,0 +1,85 @@
+"""The declared import direction for pyjinhx2, enforced statically.
+
+component.py sits below descriptor.py and render.py and must never reach up into
+them for anything but the one sanctioned edge: the ClassDescriptor it builds and
+attaches in __pydantic_init_subclass__ (#271). descriptor.py and segments.py are
+import-pure — stdlib only. Per-module purity is also asserted in
+test_descriptor.py and test_segments.py; this file is the whole-package view, so
+a new module cannot quietly add an edge nobody declared.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "pyjinhx2"
+
+# Every internal edge pyjinhx2 is allowed to have, module -> modules it may
+# import. A module absent from a value list may not be imported by that key.
+# Add an entry here deliberately when a new edge is designed, never to make a
+# failing test go green.
+ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
+    "__init__": frozenset(),
+    "component": frozenset({"pyjinhx2.descriptor"}),
+    "descriptor": frozenset(),
+    "segments": frozenset(),
+}
+
+
+def module_paths() -> list[Path]:
+    return sorted(PACKAGE_ROOT.glob("*.py"))
+
+
+def internal_imports(path: Path) -> set[str]:
+    """Every ``pyjinhx2.*`` module name imported by ``path``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            assert node.level == 0, (
+                f"{path.name} must use absolute imports, not relative ones"
+            )
+            names = [node.module or ""]
+        else:
+            continue
+        found.update(n for n in names if n == "pyjinhx2" or n.startswith("pyjinhx2."))
+    return found
+
+
+def test_every_module_is_covered_by_the_declared_edge_table():
+    """A new module must declare its edges here before it can be imported
+    anywhere — otherwise the table silently stops being a whole-package view."""
+    on_disk = {path.stem for path in module_paths()}
+    assert on_disk == set(ALLOWED_INTERNAL_IMPORTS)
+
+
+@pytest.mark.parametrize("path", module_paths(), ids=lambda p: p.stem)
+def test_module_imports_only_declared_internal_modules(path: Path):
+    allowed = ALLOWED_INTERNAL_IMPORTS[path.stem]
+    unexpected = internal_imports(path) - allowed
+    assert not unexpected, (
+        f"{path.name} imports undeclared internal modules: {sorted(unexpected)}"
+    )
+
+
+def test_descriptor_imports_nothing_from_pyjinhx2():
+    assert internal_imports(PACKAGE_ROOT / "descriptor.py") == set()
+
+
+def test_segments_imports_nothing_from_pyjinhx2():
+    assert internal_imports(PACKAGE_ROOT / "segments.py") == set()
+
+
+def test_component_is_the_only_importer_of_class_descriptor():
+    """The wiring seam (#271) is the one sanctioned reach upward. Anything else
+    importing ClassDescriptor means the fact sheet is being rebuilt somewhere it
+    should be read from the class instead."""
+    importers = {
+        path.stem
+        for path in module_paths()
+        if "pyjinhx2.descriptor" in internal_imports(path)
+    }
+    assert importers == {"component"}


### PR DESCRIPTION
## Summary

- Adds pyright and ruff ignore comments to satisfy strict type checking and linting rules
- Implements ClassDescriptor pattern with static import graph enforcement
- Covers: reserved-name test fixtures, dynamic-module BaseComponent assignment, model_config dict override, and exec() in fileless module contexts

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)