### PR TITLE
test(#272): guard fileless-module propagation and zero-probe behavior

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -128,6 +128,20 @@ def _is_json_coercible_annotation(annotation: Any) -> bool:
     return isinstance(origin, type) and issubclass(origin, BaseModel)
 
 
+# ADR 0007's filename convention, applied to the class name to get the single
+# candidate filename. Consecutive capitals are one acronym (PJXButton ->
+# pjx_button), so components named after acronyms get the filename an author
+# would have written by hand. Same regex as v0.x's
+# pyjinhx/utils.py:pascal_case_to_snake_case, restated here because component.py
+# may not import the legacy package (see this module's docstring).
+_PASCAL_BOUNDARY_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+
+
+def _pascal_to_snake(name: str) -> str:
+    """Convert a PascalCase/CamelCase identifier to snake_case."""
+    return _PASCAL_BOUNDARY_RE.sub("_", name).lower()
+
+
 def _defining_module_dir(cls: type) -> Path:
     """Directory of the module that defined ``cls`` — the root every co-located
     probe starts from (ADR 0007).

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -163,14 +163,21 @@ def _defining_module_dir(cls: type) -> Path:
 
 
 def _resolve_template_path(cls: type) -> Path:
-    """STUB — #272 (single probe) and #273 (MRO walk) replace this in place.
+    """The single ADR 0007 template candidate for ``cls``: snake_case of the
+    class name plus ``.pjx``, in the directory of the module that defined it.
 
-    Returns the naive co-located path: it does not touch the filesystem and does
-    not walk the MRO. The real ADR 0007 probe is #272's, the per-kind ancestor
-    walk is #273's, and the missing-template message is #277's. Nothing at L0
-    reads this value yet, so a not-yet-probed path cannot mislead anything.
+    One candidate, not v0.x's six (three extensions x two case conventions) —
+    which is why v2 needs none of ``Finder``'s per-tag probe caches.
+
+    Deliberately does not touch the filesystem: this computes *where* the
+    template goes, and #277 owns turning "no file there" into a user-facing
+    error, after #273's MRO walk has had its chance to find one on an ancestor.
+    Returning the path unconditionally keeps those two concerns out of here.
+
+    ``_defining_module_dir``'s ``NotImplementedError`` for a fileless module
+    propagates unchanged — a class with no directory has no template path.
     """
-    return _defining_module_dir(cls) / f"{cls.__name__}.pjx"
+    return _defining_module_dir(cls) / f"{_pascal_to_snake(cls.__name__)}.pjx"
 
 
 def _resolve_slot_fields(cls: type) -> frozenset[str]:

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -332,3 +332,38 @@ class TestResolveTemplatePath:
 
         assert not path.exists()
         assert path == Path(__file__).parent / "no_such_template_anywhere.pjx"
+
+    def test_a_fileless_module_still_raises_not_implemented(self):
+        """Regression guard: #272 must not catch or reword #271's guard."""
+        module = types.ModuleType("pyjinhx2_test_fileless_template_module")
+        sys.modules["pyjinhx2_test_fileless_template_module"] = module
+        try:
+
+            class Card(BaseComponent):
+                pass
+
+            Card.__module__ = "pyjinhx2_test_fileless_template_module"
+            with pytest.raises(NotImplementedError, match="no file on disk"):
+                _resolve_template_path(Card)
+        finally:
+            del sys.modules["pyjinhx2_test_fileless_template_module"]
+
+    def test_it_never_touches_the_filesystem(self, monkeypatch):
+        """ADR 0007 allows at most one probe; #272 needs zero, because it does
+        not validate existence. Counting Path.exists calls pins that down so a
+        later 'helpful' existence check has to be a deliberate change."""
+        calls: list[Path] = []
+        real_exists = Path.exists
+
+        def counting(self, *args, **kwargs):
+            calls.append(self)
+            return real_exists(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "exists", counting)
+
+        class Card(BaseComponent):
+            pass
+
+        _resolve_template_path(Card)
+
+        assert calls == []

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -8,6 +8,7 @@ import pyjinhx2.component
 from pyjinhx2.component import (
     BaseComponent,
     _defining_module_dir,
+    _pascal_to_snake,
     _resolve_class_descriptor,
     _resolve_strict,
 )
@@ -250,3 +251,26 @@ class TestDevReloadReassignmentSmokeTest:
 
         assert Card._pjx_descriptor is replacement
         assert Card._pjx_descriptor is not original
+
+
+class TestPascalToSnake:
+    """The ADR 0007 filename convention: acronym-aware PascalCase -> snake_case,
+    matching v0.x's pyjinhx/utils.py:pascal_case_to_snake_case exactly, but
+    reimplemented locally because pyjinhx2 must not import the legacy package."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("Card", "card"),
+            ("ScrollSentinel", "scroll_sentinel"),
+            ("PJXButton", "pjx_button"),
+            ("HTMLParser", "html_parser"),
+            ("PJX", "pjx"),
+            ("TabPanelPJX", "tab_panel_pjx"),
+            ("Grid2Col", "grid2_col"),
+            ("A", "a"),
+            ("already_snake", "already_snake"),
+        ],
+    )
+    def test_converts_pascal_case_to_snake_case(self, name, expected):
+        assert _pascal_to_snake(name) == expected

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -11,6 +11,7 @@ from pyjinhx2.component import (
     _pascal_to_snake,
     _resolve_class_descriptor,
     _resolve_strict,
+    _resolve_template_path,
 )
 from pyjinhx2.descriptor import ClassDescriptor
 
@@ -25,7 +26,7 @@ class TestResolveClassDescriptor:
         descriptor = _resolve_class_descriptor(Card)
 
         assert isinstance(descriptor, ClassDescriptor)
-        assert descriptor.template_path == Path(__file__).parent / "Card.pjx"
+        assert descriptor.template_path == Path(__file__).parent / "card.pjx"
         assert descriptor.slot_fields == frozenset()
         assert descriptor.css_paths == ()
         assert descriptor.js_paths == ()
@@ -274,3 +275,60 @@ class TestPascalToSnake:
     )
     def test_converts_pascal_case_to_snake_case(self, name, expected):
         assert _pascal_to_snake(name) == expected
+
+
+class TestResolveTemplatePath:
+    """ADR 0007: one candidate — snake_case(class name) + `.pjx`, in the
+    defining module's own directory. No MRO walk (#273), no existence check
+    (#277 owns the missing-template error)."""
+
+    def test_returns_snake_case_pjx_beside_the_defining_module(self):
+        class Card(BaseComponent):
+            pass
+
+        assert _resolve_template_path(Card) == Path(__file__).parent / "card.pjx"
+
+    def test_multi_word_class_names_are_snake_cased(self):
+        class ScrollSentinel(BaseComponent):
+            pass
+
+        assert (
+            _resolve_template_path(ScrollSentinel)
+            == Path(__file__).parent / "scroll_sentinel.pjx"
+        )
+
+    def test_acronym_leading_class_names_are_snake_cased(self):
+        class PJXButton(BaseComponent):
+            pass
+
+        assert (
+            _resolve_template_path(PJXButton)
+            == Path(__file__).parent / "pjx_button.pjx"
+        )
+
+    def test_the_directory_is_exactly_the_defining_module_dir(self):
+        class Card(BaseComponent):
+            pass
+
+        assert _resolve_template_path(Card).parent == _defining_module_dir(Card)
+
+    def test_the_only_extension_attempted_is_pjx(self):
+        class Card(BaseComponent):
+            pass
+
+        path = _resolve_template_path(Card)
+
+        assert path.suffix == ".pjx"
+        assert path.name == "card.pjx"
+
+    def test_the_path_is_returned_even_when_no_file_exists(self):
+        """This subtask computes the path; it does not validate existence.
+        Turning 'file absent' into an error is #277's job."""
+
+        class NoSuchTemplateAnywhere(BaseComponent):
+            pass
+
+        path = _resolve_template_path(NoSuchTemplateAnywhere)
+
+        assert not path.exists()
+        assert path == Path(__file__).parent / "no_such_template_anywhere.pjx"


### PR DESCRIPTION
## Summary
- Implement ADR 0007 for template path resolution as snake_case(class).pjx
- Add acronym-aware `_pascal_to_snake` helper for proper filename generation
- Guard fileless-module propagation and zero-probe behavior with comprehensive tests

## Test plan
- All existing tests pass
- New tests verify template path resolution and fileless-module edge cases
- Ruff linting and formatting checks pass

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)