### PR TITLE
feat: record template provenance on the class descriptor (#274)

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -208,8 +208,16 @@ def _resolve_strict(cls: type[BaseModel]) -> bool:
 
 
 def _resolve_provenance(cls: type) -> Mapping[str, type]:
-    """Resolve provenance (kind → ancestor class) for ``cls``. Stub returns empty dict."""
-    return {}
+    """Which ancestor supplied each resolved kind — ADR 0010's free provenance,
+    for error messages and the dependency graph.
+
+    Template kind only: `css`/`js` keys stay absent until #276 gives assets real
+    resolution, because a stub that resolves nothing has no owner to name. The
+    key is omitted entirely when the walk ended on the unprobed fallback — no
+    file was proven to exist, so no ancestor is named.
+    """
+    _, owner = _walk_template(cls)
+    return {} if owner is None else {"template": owner}
 
 
 def _resolve_class_descriptor(cls: type[BaseModel]) -> ClassDescriptor:

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -221,15 +221,21 @@ def _resolve_provenance(cls: type) -> Mapping[str, type]:
 
 
 def _resolve_class_descriptor(cls: type[BaseModel]) -> ClassDescriptor:
-    """Build the ClassDescriptor for ``cls`` by invoking all resolver helpers."""
+    """Build the ClassDescriptor for ``cls`` by invoking all resolver helpers.
+
+    The template walk runs once here and feeds both ``template_path`` and the
+    template entry of ``provenance``; calling the two single-purpose resolvers
+    separately would probe the same ancestors twice.
+    """
     css_paths, js_paths = _resolve_asset_paths(cls)
+    template_path, template_owner = _walk_template(cls)
     return ClassDescriptor(
-        template_path=_resolve_template_path(cls),
+        template_path=template_path,
         slot_fields=_resolve_slot_fields(cls),
         css_paths=css_paths,
         js_paths=js_paths,
         strict=_resolve_strict(cls),
-        provenance=_resolve_provenance(cls),
+        provenance={} if template_owner is None else {"template": template_owner},
     )
 
 

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -160,6 +160,26 @@ def _resolution_ancestors(cls: type) -> list[type]:
     return ancestors
 
 
+def _walk_template(cls: type) -> tuple[Path, type | None]:
+    """The template MRO walk, run once and reported in full.
+
+    Returns ``(path, owner)``: the template ``cls`` renders with, and the
+    ancestor a probe proved owns it — or ``None`` when the answer came from the
+    last ancestor's candidate, which is returned *without* a probe (ADR 0007's
+    budget). An unprobed candidate has no proven owner, so it names none.
+
+    Single source of truth for the walk: `_resolve_template_path` and
+    `_resolve_provenance` both read this one result, so adding provenance costs
+    zero extra `is_file` calls.
+    """
+    ancestors = _resolution_ancestors(cls)
+    for ancestor in ancestors[:-1]:
+        candidate = _template_candidate(ancestor)
+        if candidate.is_file():
+            return candidate, ancestor
+    return _template_candidate(ancestors[-1]), None
+
+
 def _resolve_template_path(cls: type) -> Path:
     """The template ``cls`` renders with: the nearest ancestor's candidate that exists on disk.
 
@@ -168,12 +188,7 @@ def _resolve_template_path(cls: type) -> Path:
     candidate is returned without a probe — it is the answer whether or not the
     file is there.
     """
-    ancestors = _resolution_ancestors(cls)
-    for ancestor in ancestors[:-1]:
-        candidate = _template_candidate(ancestor)
-        if candidate.is_file():
-            return candidate
-    return _template_candidate(ancestors[-1])
+    return _walk_template(cls)[0]
 
 
 def _resolve_slot_fields(cls: type) -> frozenset[str]:

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -15,6 +15,7 @@ from pyjinhx2.component import (
     _resolve_class_descriptor,
     _resolve_strict,
     _resolve_template_path,
+    _walk_template,
 )
 from pyjinhx2.descriptor import ClassDescriptor
 
@@ -511,6 +512,64 @@ class TestTemplateMroWalk:
 
         assert _resolve_template_path(FancyCard) == mro_dir / "card.pjx"
         assert _resolve_template_path(PlainCard) == mro_dir / "card.pjx"
+
+
+class TestWalkTemplate:
+    """The single shared MRO walk both `_resolve_template_path` and
+    `_resolve_provenance` consume: it returns the resolved path *and* the
+    ancestor a probe proved owns it. The final fallback candidate is never
+    probed (ADR 0007), so it can never be named as a winner."""
+
+    def test_reports_the_owning_ancestor_when_a_probe_finds_a_file(self, mro_dir):
+        class Card(BaseComponent):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        Card.__module__ = _MRO_MODULE
+        FancyCard.__module__ = _MRO_MODULE
+        (mro_dir / "fancy_card.pjx").write_text("<div>fancy</div>")
+
+        assert _walk_template(FancyCard) == (mro_dir / "fancy_card.pjx", FancyCard)
+
+    def test_reports_the_nearest_ancestor_with_a_file(self, mro_dir):
+        class Card(BaseComponent):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        class VeryFancyCard(FancyCard):
+            pass
+
+        for klass in (Card, FancyCard, VeryFancyCard):
+            klass.__module__ = _MRO_MODULE
+        (mro_dir / "fancy_card.pjx").write_text("<div>fancy</div>")
+
+        assert _walk_template(VeryFancyCard) == (mro_dir / "fancy_card.pjx", FancyCard)
+
+    def test_reports_no_winner_for_the_unprobed_fallback(self, mro_dir):
+        class Card(BaseComponent):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        Card.__module__ = _MRO_MODULE
+        FancyCard.__module__ = _MRO_MODULE
+
+        assert _walk_template(FancyCard) == (mro_dir / "card.pjx", None)
+
+    def test_a_direct_subclass_has_no_winner_because_nothing_is_probed(self):
+        """`[cls]`'s only ancestor is also the last one, so it is returned
+        unprobed — the walk never learns whether the file is there and so
+        cannot name a winner."""
+
+        class Card(BaseComponent):
+            pass
+
+        assert _walk_template(Card) == (Path(__file__).parent / "card.pjx", None)
 
 
 class TestTemplateWalkProbeBudget:

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -13,6 +13,7 @@ from pyjinhx2.component import (
     _resolution_ancestors,
     _resolve_asset_paths,
     _resolve_class_descriptor,
+    _resolve_provenance,
     _resolve_strict,
     _resolve_template_path,
     _walk_template,
@@ -669,6 +670,178 @@ class TestTemplateWalkStopsAtBaseComponent:
 
         assert BaseComponent not in considered
         assert considered == [FancyCard, Card]
+
+
+class TestResolveProvenance:
+    """ADR 0010: the descriptor records *which ancestor* supplied each kind —
+    free provenance for error messages and the dependency graph. Template kind
+    only; css/js stay absent until #276 gives assets real resolution."""
+
+    def test_an_own_file_names_the_class_itself(self, mro_dir):
+        class Card(BaseComponent):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        Card.__module__ = _MRO_MODULE
+        FancyCard.__module__ = _MRO_MODULE
+        (mro_dir / "card.pjx").write_text("<div>card</div>")
+        (mro_dir / "fancy_card.pjx").write_text("<div>fancy</div>")
+
+        assert _resolve_provenance(FancyCard) == {"template": FancyCard}
+
+    def test_an_inherited_file_names_the_parent(self, mro_dir):
+        """The found ancestor (`Card`) must not be the walk's own terminal
+        candidate, or it would never get probed (see "Key design consequence"
+        above). `Base` supplies the never-probed terminal slot instead."""
+
+        class Base(BaseComponent):
+            pass
+
+        class Card(Base):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        Base.__module__ = _MRO_MODULE
+        Card.__module__ = _MRO_MODULE
+        FancyCard.__module__ = _MRO_MODULE
+        (mro_dir / "card.pjx").write_text("<div>card</div>")
+
+        assert _resolve_provenance(FancyCard) == {"template": Card}
+
+    def test_it_names_the_grandparent_over_a_fileless_parent(self, mro_dir):
+        """Same terminal-slot caveat as above, one generation deeper: `Base`
+        is the unprobed terminal, `Card` is the grandparent whose file a
+        probe actually proves, `FancyCard` is the fileless middle ancestor
+        that gets skipped."""
+
+        class Base(BaseComponent):
+            pass
+
+        class Card(Base):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        class VeryFancyCard(FancyCard):
+            pass
+
+        for klass in (Base, Card, FancyCard, VeryFancyCard):
+            klass.__module__ = _MRO_MODULE
+        (mro_dir / "card.pjx").write_text("<div>card</div>")
+
+        assert _resolve_provenance(VeryFancyCard) == {"template": Card}
+
+    def test_no_template_key_when_no_ancestor_has_a_file(self, mro_dir):
+        """`_resolve_template_path` still answers with the root ancestor's
+        candidate (whether that is an error is #277's call), but that candidate
+        is never probed — there is no ancestor proven to own a file, so naming
+        one would be provenance for a file that does not exist."""
+
+        class Card(BaseComponent):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        Card.__module__ = _MRO_MODULE
+        FancyCard.__module__ = _MRO_MODULE
+
+        provenance = _resolve_provenance(FancyCard)
+
+        assert provenance == {}
+        assert "template" not in provenance
+
+    def test_a_direct_subclass_gets_no_template_key(self):
+        """Consequence of the ADR 0007 budget, stated outright: for `[cls]` the
+        sole candidate is the unprobed fallback, so provenance is empty even
+        when the file happens to exist."""
+
+        class Card(BaseComponent):
+            pass
+
+        assert _resolve_provenance(Card) == {}
+
+    def test_siblings_resolve_independently_to_the_same_parent(self, mro_dir):
+        """Same terminal-slot caveat: `Base` is the unprobed terminal so that
+        `Card`'s file is actually probed and can be named for both siblings."""
+
+        class Base(BaseComponent):
+            pass
+
+        class Card(Base):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        class PlainCard(Card):
+            pass
+
+        for klass in (Base, Card, FancyCard, PlainCard):
+            klass.__module__ = _MRO_MODULE
+        (mro_dir / "card.pjx").write_text("<div>card</div>")
+
+        assert _resolve_provenance(FancyCard) == {"template": Card}
+        assert _resolve_provenance(PlainCard) == {"template": Card}
+
+    def test_base_component_is_never_named(self, mro_dir):
+        """`_resolution_ancestors` truncates before BaseComponent, so it is out
+        of the list before the walk starts — it can never be a provenance value
+        even when nothing else on the chain has a file.
+
+        Uses a real winning ancestor (`Card`, via the `Base` terminal-slot
+        pattern above) rather than checking against an always-empty mapping:
+        `BaseComponent not in {}` would hold trivially and prove nothing."""
+
+        class Base(BaseComponent):
+            pass
+
+        class Card(Base):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        Base.__module__ = _MRO_MODULE
+        Card.__module__ = _MRO_MODULE
+        FancyCard.__module__ = _MRO_MODULE
+        (mro_dir / "card.pjx").write_text("<div>card</div>")
+
+        assert _resolve_provenance(FancyCard) == {"template": Card}
+        assert BaseComponent not in _resolve_provenance(FancyCard).values()
+        assert BaseComponent not in _resolve_provenance(Card).values()
+
+    def test_it_never_records_css_or_js_kinds(self, mro_dir):
+        """Per-kind independence at the resolver level: assets are still #276's
+        stub, so provenance must not invent owners for kinds nothing resolved.
+        Same terminal-slot caveat as the other tests above."""
+
+        class Base(BaseComponent):
+            pass
+
+        class Card(Base):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        Base.__module__ = _MRO_MODULE
+        Card.__module__ = _MRO_MODULE
+        FancyCard.__module__ = _MRO_MODULE
+        (mro_dir / "card.pjx").write_text("<div>card</div>")
+        (mro_dir / "card.css").write_text(".card {}")
+        (mro_dir / "card.js").write_text("//card")
+
+        provenance = _resolve_provenance(FancyCard)
+
+        assert provenance == {"template": Card}
+        assert "css" not in provenance
+        assert "js" not in provenance
 
 
 class TestPerKindIndependence:

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -22,9 +22,16 @@ from pyjinhx2.descriptor import ClassDescriptor
 
 
 class TestResolveClassDescriptor:
-    """The seam #272-#276 land behind: one call, one whole ClassDescriptor."""
+    """The seam #275-#276 land behind: one call, one whole ClassDescriptor."""
 
     def test_returns_a_fully_constructed_descriptor(self):
+        """`provenance` is empty here on purpose, and no longer because #274 is
+        unimplemented: `Card` is a direct subclass, so its sole candidate is the
+        last ancestor's — returned unprobed per ADR 0007 — and no `card.pjx`
+        sits beside this test file anyway. No file was proven to exist, so no
+        ancestor is named. `slot_fields`/`css_paths`/`js_paths` are still the
+        #275/#276 stubs."""
+
         class Card(BaseComponent):
             pass
 

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -844,6 +844,84 @@ class TestResolveProvenance:
         assert "js" not in provenance
 
 
+class TestProvenanceProbeBudget:
+    """ADR 0007's budget survives provenance: at most one `is_file` per
+    ancestor, none for the final fallback, and building a whole descriptor
+    walks once — not once for the path and again for the owner."""
+
+    @staticmethod
+    def _count_is_file(monkeypatch) -> list[Path]:
+        probed: list[Path] = []
+        real_is_file = Path.is_file
+
+        def counting(self, *args, **kwargs):
+            probed.append(self)
+            return real_is_file(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "is_file", counting)
+        return probed
+
+    def test_provenance_alone_probes_exactly_what_the_path_walk_probes(
+        self, mro_dir, monkeypatch
+    ):
+        class Card(BaseComponent):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        class VeryFancyCard(FancyCard):
+            pass
+
+        for klass in (Card, FancyCard, VeryFancyCard):
+            klass.__module__ = _MRO_MODULE
+        (mro_dir / "fancy_card.pjx").write_text("<div>fancy</div>")
+        probed = self._count_is_file(monkeypatch)
+
+        _resolve_provenance(VeryFancyCard)
+
+        assert probed == [mro_dir / "very_fancy_card.pjx", mro_dir / "fancy_card.pjx"]
+
+    def test_building_a_descriptor_walks_only_once(self, mro_dir, monkeypatch):
+        """The path and the owner come out of one shared walk, so a full
+        descriptor build costs the same probes as `_resolve_template_path`
+        alone — no doubling."""
+
+        class Card(BaseComponent):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        class VeryFancyCard(FancyCard):
+            pass
+
+        for klass in (Card, FancyCard, VeryFancyCard):
+            klass.__module__ = _MRO_MODULE
+        (mro_dir / "fancy_card.pjx").write_text("<div>fancy</div>")
+
+        path_only = self._count_is_file(monkeypatch)
+        _resolve_template_path(VeryFancyCard)
+        expected = list(path_only)
+
+        descriptor_probes = self._count_is_file(monkeypatch)
+        descriptor = _resolve_class_descriptor(VeryFancyCard)
+
+        assert descriptor.template_path == mro_dir / "fancy_card.pjx"
+        assert descriptor.provenance == {"template": FancyCard}
+        assert descriptor_probes == expected
+
+    def test_a_direct_subclasss_descriptor_probes_nothing(self, monkeypatch):
+        probed = self._count_is_file(monkeypatch)
+
+        class Card(BaseComponent):
+            pass
+
+        _resolve_class_descriptor(Card)
+
+        assert probed == []
+
+
 class TestPerKindIndependence:
     """ADR 0010: template and assets resolve through separate walks. #273 gave
     template one; css/js keep the stub until #276. If this test starts failing


### PR DESCRIPTION
## Summary
Records template provenance (nearest ancestor with a .pjx file) on the class descriptor. The provenance is a dict with "template" key mapped to the ancestor, or empty dict when no file was proven to exist. Includes performance optimization to build descriptor from a single template walk, plus clarification test for edge case behavior.

## Test Plan
- [x] All existing tests pass
- [x] Ruff linting clean (0.16.0)
- [x] Ruff formatting clean (0.16.0)

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)