### PR TITLE
refactor(pyjinhx2): register descriptors via rebuild_class_descriptor

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -348,7 +348,7 @@ class BaseComponent(BaseModel):
                 f"{id_field.annotation}; id must remain typed str so "
                 f"_validate_id and _require_explicit_id keep their meaning."
             )
-        cls._pjx_descriptor = _resolve_class_descriptor(cls)
+        rebuild_class_descriptor(cls)
 
     @model_validator(mode="before")
     @classmethod

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -297,6 +297,20 @@ def _resolve_class_descriptor(cls: type[BaseModel]) -> ClassDescriptor:
     )
 
 
+def rebuild_class_descriptor(cls: type[BaseModel]) -> None:
+    """Recompute ``cls``'s ClassDescriptor from scratch and swap it in.
+
+    The one place a descriptor is recomputed after registration. Because the
+    descriptor is frozen, refreshing it means building a new one and rebinding
+    the class attribute — nothing is ever edited in place, so a render holding
+    the old object keeps a coherent view of the class it started with.
+
+    Callable only: dev-reload machinery decides *when* to invalidate, and this
+    watches nothing.
+    """
+    cls._pjx_descriptor = _resolve_class_descriptor(cls)  # pyright: ignore[reportAttributeAccessIssue]
+
+
 class BaseComponent(BaseModel):
     """Base for all components: strict field validation with auto-id support."""
 

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -23,6 +23,7 @@ from pyjinhx2.component import (
     _resolve_template_path,
     _template_candidate,
     _walk_template,
+    rebuild_class_descriptor,
 )
 from pyjinhx2.descriptor import ClassDescriptor
 
@@ -370,6 +371,145 @@ class TestDevReloadReassignmentSmokeTest:
 
         assert Card._pjx_descriptor is replacement
         assert Card._pjx_descriptor is not original
+
+
+class TestRebuildClassDescriptor:
+    """The single post-registration recomputation point (invariant 5). It swaps
+    a whole new descriptor in; it watches nothing and triggers nothing itself."""
+
+    def test_an_unchanged_class_rebuilds_to_an_equal_descriptor(self):
+        class Card(BaseComponent):
+            pass
+
+        original = Card._pjx_descriptor
+
+        rebuild_class_descriptor(Card)
+
+        assert Card._pjx_descriptor == original
+
+    def test_the_rebuilt_descriptor_is_a_new_object(self):
+        """Frozen dataclass: the only way to rebuild is build-then-swap, so an
+        equal descriptor must still be a different object."""
+
+        class Card(BaseComponent):
+            pass
+
+        original = Card._pjx_descriptor
+
+        rebuild_class_descriptor(Card)
+
+        assert Card._pjx_descriptor is not original
+
+    def test_the_previous_descriptor_is_left_untouched(self):
+        class Card(BaseComponent):
+            pass
+
+        original = Card._pjx_descriptor
+        snapshot = (
+            original.template_path,
+            original.slot_fields,
+            original.css_paths,
+            original.js_paths,
+            original.strict,
+            dict(original.provenance),
+        )
+
+        rebuild_class_descriptor(Card)
+
+        assert (
+            original.template_path,
+            original.slot_fields,
+            original.css_paths,
+            original.js_paths,
+            original.strict,
+            dict(original.provenance),
+        ) == snapshot
+
+    def test_rebuilding_twice_does_not_drift(self):
+        class Card(BaseComponent):
+            pass
+
+        original = Card._pjx_descriptor
+
+        rebuild_class_descriptor(Card)
+        first = Card._pjx_descriptor
+        rebuild_class_descriptor(Card)
+        second = Card._pjx_descriptor
+
+        assert first == original
+        assert second == original
+        assert second is not first
+
+    def test_it_returns_none(self):
+        class Card(BaseComponent):
+            pass
+
+        assert rebuild_class_descriptor(Card) is None
+
+    def test_a_template_that_appeared_on_disk_is_picked_up(self, mro_dir):
+        """Same resolver, fresh inputs: with no file present the walk falls back
+        to the last ancestor's unprobed candidate; once `fancy_card.pjx` exists
+        the nearest ancestor wins and is named in provenance."""
+
+        class Card(BaseComponent):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        Card.__module__ = _MRO_MODULE
+        FancyCard.__module__ = _MRO_MODULE
+
+        rebuild_class_descriptor(FancyCard)
+        before = FancyCard._pjx_descriptor
+
+        (mro_dir / "fancy_card.pjx").write_text("<div></div>", encoding="utf-8")
+        rebuild_class_descriptor(FancyCard)
+        after = FancyCard._pjx_descriptor
+
+        assert before.template_path == mro_dir / "card.pjx"
+        assert before.provenance == {}
+        assert after.template_path == mro_dir / "fancy_card.pjx"
+        assert after.provenance == {"template": FancyCard}
+        assert after != before
+
+    def test_an_asset_that_appeared_on_disk_is_picked_up(self, mro_dir):
+        class Card(BaseComponent):
+            pass
+
+        Card.__module__ = _MRO_MODULE
+
+        rebuild_class_descriptor(Card)
+        assert Card._pjx_descriptor.css_paths == ()
+
+        (mro_dir / "card.css").write_text("a{}", encoding="utf-8")
+        rebuild_class_descriptor(Card)
+
+        assert Card._pjx_descriptor.css_paths == (mro_dir / "card.css",)
+        assert Card._pjx_descriptor.provenance["css"] is Card
+
+    def test_it_delegates_to_the_shared_resolver(self, monkeypatch):
+        """No parallel resolution logic: whatever `_resolve_class_descriptor`
+        returns is exactly what lands on the class."""
+
+        class Card(BaseComponent):
+            pass
+
+        sentinel = ClassDescriptor(
+            template_path=Path("sentinel/card.pjx"),
+            slot_fields=frozenset(),
+            css_paths=(),
+            js_paths=(),
+            strict=True,
+            provenance={},
+        )
+        monkeypatch.setattr(
+            pyjinhx2.component, "_resolve_class_descriptor", lambda cls: sentinel
+        )
+
+        rebuild_class_descriptor(Card)
+
+        assert Card._pjx_descriptor is sentinel
 
 
 class TestPascalToSnake:

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -271,6 +271,24 @@ class TestDescriptorAttachedAtClassDefinition:
 
         assert "_pjx_descriptor" not in Card.model_fields
 
+    def test_registration_goes_through_the_rebuild_entry_point(self, monkeypatch):
+        """One assignment site for `_pjx_descriptor`: registration and
+        dev-reload cannot drift apart because they are the same call."""
+        seen: list[type] = []
+        real = pyjinhx2.component.rebuild_class_descriptor
+
+        def spying(cls):
+            seen.append(cls)
+            real(cls)
+
+        monkeypatch.setattr(pyjinhx2.component, "rebuild_class_descriptor", spying)
+
+        class Card(BaseComponent):
+            pass
+
+        assert seen == [Card]
+        assert isinstance(Card._pjx_descriptor, ClassDescriptor)
+
 
 class TestHookOrdering:
     def test_reserved_auto_id_field_still_raises(self):

--- a/tests/pyjinhx2/test_descriptor.py
+++ b/tests/pyjinhx2/test_descriptor.py
@@ -99,8 +99,10 @@ class TestClassDescriptorIsFrozen:
 
 class TestClassDescriptorEquality:
     def test_equal_field_values_compare_equal(self):
-        # #278 rebuilds by replacing the whole object; equality is how a test
-        # asserts a no-op rebuild produced an equivalent descriptor.
+        # rebuild_class_descriptor replaces the whole object; equality is how a
+        # test asserts a no-op rebuild produced an equivalent descriptor. The
+        # rebuild itself is exercised in test_component_descriptor.py, which may
+        # import component.py — this module may not.
         assert make_descriptor() == make_descriptor()
 
     def test_differing_field_values_compare_unequal(self):


### PR DESCRIPTION
## Summary
Centralizes descriptor registration by having __pydantic_init_subclass__ call rebuild_class_descriptor instead of directly assigning _resolve_class_descriptor's result. This ensures registration and future dev-reload rebuilds share a single assignment site.

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)