### PR TITLE
fix: rebuild _missing_template_error to match the plan's pinned design

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -185,30 +185,27 @@ def _walk_template(cls: type) -> tuple[Path, type | None]:
     return _template_candidate(ancestors[-1]), None
 
 
-def _missing_template_error(cls: type) -> FileNotFoundError:
-    """The error for a class whose template file exists nowhere up its MRO.
+def _missing_template_error(cls: type) -> LookupError:
+    """The error for a component whose template is nowhere on disk.
 
-    Lists one candidate per ancestor, nearest first, so a subclass author sees
-    every path that was tried instead of only the fallback the walk ended on.
+    Returns the exception rather than raising it: the resolvers deliberately
+    answer with an unprobed candidate path, and only the caller that tries to
+    load that file knows the answer was wrong. The message lists every class
+    the template could have come from next to the exact path it would have
+    been read from, nearest first, so the fix is either creating one of those
+    files or renaming the one that is misspelled.
 
-    Returned rather than raised so the raise site stays with the caller that
-    checked the file is absent; this function only formats, and reuses the
-    walk's own result instead of probing the filesystem again.
+    Pure path arithmetic — no probes. Building this message costs nothing
+    beyond what `_template_candidate` already does for each ancestor.
     """
-    ancestors = _resolution_ancestors(cls)
-    resolved, _ = _walk_template(cls)
-    if len(ancestors) == 1:
-        return FileNotFoundError(
-            f"No template found for {cls.__name__}. Expected a file at {resolved}."
-        )
-    candidates = [_template_candidate(ancestor) for ancestor in ancestors[:-1]]
-    candidates.append(resolved)
-    listing = "\n".join(
-        f"  {ancestor.__name__} -> {candidate}"
-        for ancestor, candidate in zip(ancestors, candidates, strict=True)
+    probed = "\n".join(
+        f"  {ancestor.__name__} -> {_template_candidate(ancestor)}"
+        for ancestor in _resolution_ancestors(cls)
     )
-    return FileNotFoundError(
-        f"No template found for {cls.__name__}. Checked, nearest ancestor first:\n{listing}"
+    return LookupError(
+        f"{cls.__name__} has no template: no class it inherits from has a .pjx "
+        f"file beside the module that defines it, so there is nothing to "
+        f"render.\nPaths probed, nearest first:\n{probed}"
     )
 
 

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -188,12 +188,27 @@ def _walk_template(cls: type) -> tuple[Path, type | None]:
 def _missing_template_error(cls: type) -> FileNotFoundError:
     """The error for a class whose template file exists nowhere up its MRO.
 
+    Lists one candidate per ancestor, nearest first, so a subclass author sees
+    every path that was tried instead of only the fallback the walk ended on.
+
     Returned rather than raised so the raise site stays with the caller that
-    checked the file is absent; this function only formats.
+    checked the file is absent; this function only formats, and reuses the
+    walk's own result instead of probing the filesystem again.
     """
+    ancestors = _resolution_ancestors(cls)
     resolved, _ = _walk_template(cls)
+    if len(ancestors) == 1:
+        return FileNotFoundError(
+            f"No template found for {cls.__name__}. Expected a file at {resolved}."
+        )
+    candidates = [_template_candidate(ancestor) for ancestor in ancestors[:-1]]
+    candidates.append(resolved)
+    listing = "\n".join(
+        f"  {ancestor.__name__} -> {candidate}"
+        for ancestor, candidate in zip(ancestors, candidates, strict=True)
+    )
     return FileNotFoundError(
-        f"No template found for {cls.__name__}. Expected a file at {resolved}."
+        f"No template found for {cls.__name__}. Checked, nearest ancestor first:\n{listing}"
     )
 
 

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -185,6 +185,18 @@ def _walk_template(cls: type) -> tuple[Path, type | None]:
     return _template_candidate(ancestors[-1]), None
 
 
+def _missing_template_error(cls: type) -> FileNotFoundError:
+    """The error for a class whose template file exists nowhere up its MRO.
+
+    Returned rather than raised so the raise site stays with the caller that
+    checked the file is absent; this function only formats.
+    """
+    resolved, _ = _walk_template(cls)
+    return FileNotFoundError(
+        f"No template found for {cls.__name__}. Expected a file at {resolved}."
+    )
+
+
 def _walk_asset(cls: type, kind: str) -> tuple[Path | None, type | None]:
     """The MRO walk for one asset kind, run once and reported in full.
 

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -1566,3 +1566,69 @@ class TestMissingTemplateError:
         assert f"FancyCard -> {mro_dir / 'fancy_card.pjx'}" in message
         assert f"Card -> {mro_dir / 'card.pjx'}" in message
         assert "FancyCard" in message.splitlines()[0]
+
+    def test_it_probes_nothing_beyond_the_walk_itself(self, mro_dir, monkeypatch):
+        """The formatter adds zero filesystem cost: the only `is_file` calls are
+        the walk's own, one per ancestor except the unprobed fallback. A future
+        'let me double-check each path' edit has to be deliberate.
+
+        Classes are defined and re-pointed at `mro_dir` *before* the spy is
+        installed: `__pydantic_init_subclass__` itself walks template and
+        asset candidates at class-definition time (against whatever module the
+        class has *then*), and installing the spy first would let those
+        registration-time probes (against the test file's own directory, since
+        `__module__` isn't reassigned yet) leak into the counts below — the
+        same reason `TestTemplateWalkProbeBudget` defines its classes first."""
+
+        class Grandparent(BaseComponent):
+            pass
+
+        class Parent(Grandparent):
+            pass
+
+        class Child(Parent):
+            pass
+
+        for klass in (Grandparent, Parent, Child):
+            klass.__module__ = _MRO_MODULE
+
+        is_file_calls: list[Path] = []
+        exists_calls: list[Path] = []
+        real_is_file = Path.is_file
+        real_exists = Path.exists
+
+        def counting_is_file(self: Path, *args, **kwargs):
+            is_file_calls.append(self)
+            return real_is_file(self, *args, **kwargs)
+
+        def counting_exists(self: Path, *args, **kwargs):
+            exists_calls.append(self)
+            return real_exists(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "is_file", counting_is_file)
+        monkeypatch.setattr(Path, "exists", counting_exists)
+
+        _missing_template_error(Child)
+
+        assert is_file_calls == [mro_dir / "child.pjx", mro_dir / "parent.pjx"]
+        assert exists_calls == []
+
+    def test_the_resolvers_still_succeed_for_a_template_less_class(self, mro_dir):
+        """The error exists as a value only. Registration and resolution must
+        keep answering with the unprobed fallback for a class with no file, so
+        no resolver has quietly started raising it."""
+
+        class Card(BaseComponent):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        Card.__module__ = _MRO_MODULE
+        FancyCard.__module__ = _MRO_MODULE
+
+        rebuild_class_descriptor(FancyCard)
+
+        assert _resolve_template_path(FancyCard) == mro_dir / "card.pjx"
+        assert _resolve_provenance(FancyCard) == {}
+        assert FancyCard._pjx_descriptor.template_path == mro_dir / "card.pjx"

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -1526,3 +1526,43 @@ class TestMissingTemplateError:
 
         assert "Card" in message
         assert str(Path(__file__).parent / "card.pjx") in message
+
+    def test_a_chain_lists_every_ancestors_candidate_nearest_first(self, mro_dir):
+        class Grandparent(BaseComponent):
+            pass
+
+        class Parent(Grandparent):
+            pass
+
+        class Child(Parent):
+            pass
+
+        for klass in (Grandparent, Parent, Child):
+            klass.__module__ = _MRO_MODULE
+
+        message = str(_missing_template_error(Child))
+
+        assert str(mro_dir / "child.pjx") in message
+        assert str(mro_dir / "parent.pjx") in message
+        assert str(mro_dir / "grandparent.pjx") in message
+        assert message.index("child.pjx") < message.index("parent.pjx")
+        assert message.index("parent.pjx") < message.index("grandparent.pjx")
+
+    def test_each_listed_line_pairs_an_ancestor_name_with_its_path(self, mro_dir):
+        """The point of the message: a subclass author can read off which class
+        was expected to own which file, not just that something is missing."""
+
+        class Card(BaseComponent):
+            pass
+
+        class FancyCard(Card):
+            pass
+
+        Card.__module__ = _MRO_MODULE
+        FancyCard.__module__ = _MRO_MODULE
+
+        message = str(_missing_template_error(FancyCard))
+
+        assert f"FancyCard -> {mro_dir / 'fancy_card.pjx'}" in message
+        assert f"Card -> {mro_dir / 'card.pjx'}" in message
+        assert "FancyCard" in message.splitlines()[0]

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -13,6 +13,7 @@ from pyjinhx2.component import (
     Slot,
     _asset_candidate,
     _defining_module_dir,
+    _missing_template_error,
     _pascal_to_snake,
     _resolution_ancestors,
     _resolve_asset_paths,
@@ -1502,3 +1503,26 @@ class TestPerKindIndependence:
 
         assert _resolve_template_path(FancyCard) == mro_dir / "fancy_card.pjx"
         assert _resolve_asset_paths(FancyCard)[0] == (mro_dir / "card.css",)
+
+
+class TestMissingTemplateError:
+    """The diagnostic a caller raises when no ancestor has a template file.
+    Returned, not raised: the raise site belongs to the renderer, matching
+    `pyjinhx.tags._missing_template_error`."""
+
+    def test_it_returns_a_file_not_found_error_instead_of_raising(self):
+        class Card(BaseComponent):
+            pass
+
+        error = _missing_template_error(Card)
+
+        assert isinstance(error, FileNotFoundError)
+
+    def test_a_bare_class_message_names_the_class_and_its_one_candidate(self):
+        class Card(BaseComponent):
+            pass
+
+        message = str(_missing_template_error(Card))
+
+        assert "Card" in message
+        assert str(Path(__file__).parent / "card.pjx") in message

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -1507,16 +1507,15 @@ class TestPerKindIndependence:
 
 class TestMissingTemplateError:
     """The diagnostic a caller raises when no ancestor has a template file.
-    Returned, not raised: the raise site belongs to the renderer, matching
-    `pyjinhx.tags._missing_template_error`."""
+    Returned, not raised: the raise site belongs to the renderer."""
 
-    def test_it_returns_a_file_not_found_error_instead_of_raising(self):
+    def test_it_returns_a_lookup_error_instead_of_raising(self):
         class Card(BaseComponent):
             pass
 
         error = _missing_template_error(Card)
 
-        assert isinstance(error, FileNotFoundError)
+        assert isinstance(error, LookupError)
 
     def test_a_bare_class_message_names_the_class_and_its_one_candidate(self):
         class Card(BaseComponent):
@@ -1567,17 +1566,33 @@ class TestMissingTemplateError:
         assert f"Card -> {mro_dir / 'card.pjx'}" in message
         assert "FancyCard" in message.splitlines()[0]
 
-    def test_it_probes_nothing_beyond_the_walk_itself(self, mro_dir, monkeypatch):
-        """The formatter adds zero filesystem cost: the only `is_file` calls are
-        the walk's own, one per ancestor except the unprobed fallback. A future
-        'let me double-check each path' edit has to be deliberate.
+    def test_the_message_states_plainly_that_no_ancestor_has_a_file(self):
+        class Card(BaseComponent):
+            pass
+
+        message = str(_missing_template_error(Card))
+
+        assert "no class it inherits from has a .pjx file" in message
+
+    def test_the_message_labels_the_probed_paths(self):
+        class Card(BaseComponent):
+            pass
+
+        message = str(_missing_template_error(Card))
+
+        assert "Paths probed, nearest first:" in message
+
+    def test_it_performs_no_filesystem_probes(self, mro_dir, monkeypatch):
+        """The builder is pure path arithmetic: the walk that already answered
+        `_resolve_template_path` spent the filesystem budget (ADR 0007); this
+        formatter must not spend any more, not even for the last ancestor.
 
         Classes are defined and re-pointed at `mro_dir` *before* the spy is
         installed: `__pydantic_init_subclass__` itself walks template and
         asset candidates at class-definition time (against whatever module the
         class has *then*), and installing the spy first would let those
         registration-time probes (against the test file's own directory, since
-        `__module__` isn't reassigned yet) leak into the counts below — the
+        `__module__` isn't reassigned yet) leak into the assertion below — the
         same reason `TestTemplateWalkProbeBudget` defines its classes first."""
 
         class Grandparent(BaseComponent):
@@ -1592,26 +1607,23 @@ class TestMissingTemplateError:
         for klass in (Grandparent, Parent, Child):
             klass.__module__ = _MRO_MODULE
 
-        is_file_calls: list[Path] = []
-        exists_calls: list[Path] = []
+        probed: list[Path] = []
         real_is_file = Path.is_file
         real_exists = Path.exists
 
         def counting_is_file(self: Path, *args, **kwargs):
-            is_file_calls.append(self)
+            probed.append(self)
             return real_is_file(self, *args, **kwargs)
 
         def counting_exists(self: Path, *args, **kwargs):
-            exists_calls.append(self)
+            probed.append(self)
             return real_exists(self, *args, **kwargs)
 
         monkeypatch.setattr(Path, "is_file", counting_is_file)
         monkeypatch.setattr(Path, "exists", counting_exists)
 
-        _missing_template_error(Child)
-
-        assert is_file_calls == [mro_dir / "child.pjx", mro_dir / "parent.pjx"]
-        assert exists_calls == []
+        assert isinstance(_missing_template_error(Child), LookupError)
+        assert probed == []
 
     def test_the_resolvers_still_succeed_for_a_template_less_class(self, mro_dir):
         """The error exists as a value only. Registration and resolution must


### PR DESCRIPTION
## Summary

Replace the stale worktree run's implementation with the one the plan actually specifies: LookupError (not FileNotFoundError), the plan's literal wording ("Paths probed, nearest first:" / "no class it inherits from has a .pjx file"), and a uniform per-ancestor listing with no single-ancestor special case.

Also drops the _walk_template call: the plan's hard constraint is that this helper never touches the filesystem, but _walk_template performs real Path.is_file() probes. The rewrite builds every candidate straight from _resolution_ancestors + _template_candidate, both pure, so the zero-probe invariant actually holds instead of being asserted backwards.

Closes #277

Test count: 1121 tests across 202 test files passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)