### PR TITLE
test: pin competing-replacer determinism and non-replace collision behaviour

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -344,10 +344,23 @@ class BaseComponent(BaseModel):
 
     __pjx_descriptor__: ClassVar[ClassDescriptor]
 
+    _pjx_replace: ClassVar[bool] = False
+
     id: str = Field(
         default_factory=_auto_id,
         description="The unique ID for this component. Auto-generated when omitted.",
     )
+
+    def __init_subclass__(cls, *, pjx_replace: bool = False, **kwargs: Any) -> None:
+        """Consume the ``pjx_replace`` class kwarg before it reaches
+        ``object.__init_subclass__``, which accepts no keyword arguments.
+
+        Assigned on every subclass, never merely inherited: a subclass of a
+        replacing component is a new class that has not asked to replace
+        anything, and a leaked ``True`` would hand it someone else's tag.
+        """
+        cls._pjx_replace = bool(pjx_replace)
+        super().__init_subclass__(**kwargs)
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:

--- a/pyjinhx2/discovery.py
+++ b/pyjinhx2/discovery.py
@@ -93,22 +93,40 @@ def _qualified_name(cls: type) -> str:
     return f"{cls.__module__}.{cls.__qualname__}"
 
 
+def _wants_replace(cls: type) -> bool:
+    """Whether ``cls`` declared itself the replacement for its tag.
+
+    Read with a default rather than an attribute access so discovery keeps
+    working on any class that resolves a tag, including ones that never went
+    through `BaseComponent`.
+    """
+    return bool(getattr(cls, "_pjx_replace", False))
+
+
 def _resolve_tag_owner(
     tag_name: str, by_tag: Mapping[str, list[type]], warned: set[str]
 ) -> type | None:
     """Which class, if any, claims ``tag_name``.
 
     The single decision point for "who owns this tag", kept apart from the
-    swap mechanism so richer answers (explicit replacement) can change this
-    without touching how the result is published. ``by_tag`` carries every
-    class that resolved to ``tag_name``, not just one, so a collision can be
-    reported in full rather than silently narrowed by the caller. When several
-    classes claim a tag the answer must not depend on the order the caller
-    iterated them in, so candidates are ordered by fully qualified name and the
-    last one alphabetically wins — an arbitrary end of a total order, but the
-    same end on every run. Such a collision is a mistake upstream, so it is
-    warned about; ``warned`` keeps that to one warning per tag per build, since
-    this runs once per walked template and one stem can sit in two
+    swap mechanism so richer answers can change this without touching how the
+    result is published. ``by_tag`` carries every class that resolved to
+    ``tag_name``, not just one, so a collision can be reported in full rather
+    than silently narrowed by the caller.
+
+    Two rules decide a collision. A class declared with ``pjx_replace=True``
+    has said out loud that it means to take the tag over, so it wins and
+    nothing is logged — shadowing a component is a supported move, not a
+    mistake to be reported. Otherwise the collision is unintended, and the
+    answer must still not depend on the order the caller iterated its classes
+    in: candidates are ordered by fully qualified name and the last one
+    alphabetically wins — an arbitrary end of a total order, but the same end
+    on every run — and a warning names the tag and everyone claiming it.
+
+    Several classes all claiming to be the replacement is itself unintended,
+    so those go through the same sort and the same warning, narrowed to the
+    competing replacers. ``warned`` keeps warnings to one per tag per build,
+    since this runs once per walked template and one stem can sit in two
     directories. A tag no class claims is not an error: an orphan template is
     a normal thing to find on disk.
     """
@@ -117,7 +135,11 @@ def _resolve_tag_owner(
         return None
     if len(candidates) == 1:
         return candidates[0]
-    ordered = sorted(candidates, key=_qualified_name)
+    replacers = [cls for cls in candidates if _wants_replace(cls)]
+    if len(replacers) == 1:
+        return replacers[0]
+    contenders = replacers or candidates
+    ordered = sorted(contenders, key=_qualified_name)
     winner = ordered[-1]
     if tag_name not in warned:
         warned.add(tag_name)

--- a/tests/pyjinhx2/test_replace.py
+++ b/tests/pyjinhx2/test_replace.py
@@ -1,0 +1,61 @@
+"""Tests for the pjx_replace override: the class kwarg and how discovery
+resolves a tag when one of the colliding classes opts in as the replacement."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from pyjinhx2 import discovery
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.discovery import build_registry, get_class
+
+DISCOVERY_DIR = Path(__file__).parent.parent / "templates" / "discovery"
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Each test starts from an empty published mapping."""
+    discovery._registry.mapping = {}
+    yield
+    discovery._registry.mapping = {}
+
+
+def test_plain_component_does_not_want_replace():
+    class PlainThing(BaseComponent):
+        pass
+
+    assert PlainThing._pjx_replace is False
+
+
+def test_component_declaring_the_kwarg_wants_replace():
+    class ReplacingThing(BaseComponent, pjx_replace=True):
+        pass
+
+    assert ReplacingThing._pjx_replace is True
+
+
+def test_replace_false_is_accepted_explicitly():
+    class NotReplacingThing(BaseComponent, pjx_replace=False):
+        pass
+
+    assert NotReplacingThing._pjx_replace is False
+
+
+def test_replace_flag_does_not_leak_to_subclasses():
+    class ReplacingBase(BaseComponent, pjx_replace=True):
+        pass
+
+    class QuietChild(ReplacingBase):
+        pass
+
+    assert ReplacingBase._pjx_replace is True
+    assert QuietChild._pjx_replace is False
+
+
+def test_replace_kwarg_does_not_become_a_model_field():
+    class FlaggedThing(BaseComponent, pjx_replace=True):
+        pass
+
+    assert "pjx_replace" not in FlaggedThing.model_fields
+    assert "_pjx_replace" not in FlaggedThing.model_fields

--- a/tests/pyjinhx2/test_replace.py
+++ b/tests/pyjinhx2/test_replace.py
@@ -107,3 +107,58 @@ def test_replace_with_no_collision_is_a_no_op(caplog):
 
     assert caplog.records == []
     assert get_class("nested_widget") is NestedWidget
+
+
+def test_two_competing_replacers_resolve_deterministically(caplog):
+    class AaaAlphaCard(BaseComponent, pjx_replace=True):
+        pass
+
+    class BbbAlphaCard(BaseComponent, pjx_replace=True):
+        pass
+
+    AaaAlphaCard.__name__ = "AlphaCard"
+    BbbAlphaCard.__name__ = "AlphaCard"
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        build_registry(DISCOVERY_DIR, [AaaAlphaCard, BbbAlphaCard])
+    first = get_class("alpha_card")
+    assert len(caplog.records) == 1
+    assert "alpha_card" in caplog.records[0].getMessage()
+    caplog.clear()
+
+    # `pyjinhx2` already sits at the default WARNING level (verified: a
+    # `logger.warning` call is captured by caplog whether or not it runs
+    # inside an `at_level` block), so the second build's own warning would
+    # also land in caplog.records if not cleared above — clear first, then
+    # this call only needs to prove the winner is order-independent.
+    build_registry(DISCOVERY_DIR, [BbbAlphaCard, AaaAlphaCard])
+    second = get_class("alpha_card")
+
+    assert first is second is BbbAlphaCard
+
+
+def test_non_replace_collision_still_warns_and_sorts(caplog):
+    class AaaAlphaCard(BaseComponent):
+        pass
+
+    class BbbAlphaCard(BaseComponent):
+        pass
+
+    AaaAlphaCard.__name__ = "AlphaCard"
+    BbbAlphaCard.__name__ = "AlphaCard"
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        build_registry(DISCOVERY_DIR, [BbbAlphaCard, AaaAlphaCard])
+
+    assert get_class("alpha_card") is BbbAlphaCard
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.WARNING
+
+
+def test_replace_adds_no_module_level_mutable_state():
+    mutable = [
+        name
+        for name, value in vars(discovery).items()
+        if isinstance(value, (dict, list, set)) and not name.startswith("__")
+    ]
+    assert mutable == []

--- a/tests/pyjinhx2/test_replace.py
+++ b/tests/pyjinhx2/test_replace.py
@@ -59,3 +59,51 @@ def test_replace_kwarg_does_not_become_a_model_field():
 
     assert "pjx_replace" not in FlaggedThing.model_fields
     assert "_pjx_replace" not in FlaggedThing.model_fields
+
+
+def test_explicit_replace_wins_the_tag():
+    class AlphaCard(BaseComponent):
+        pass
+
+    class ZzzOriginalAlphaCard(BaseComponent):
+        pass
+
+    ZzzOriginalAlphaCard.__name__ = "AlphaCard"
+
+    build_registry(DISCOVERY_DIR, [AlphaCard, ZzzOriginalAlphaCard])
+    assert get_class("alpha_card") is ZzzOriginalAlphaCard
+
+    class ReplacingAlphaCard(BaseComponent, pjx_replace=True):
+        pass
+
+    ReplacingAlphaCard.__name__ = "AlphaCard"
+
+    build_registry(DISCOVERY_DIR, [AlphaCard, ZzzOriginalAlphaCard, ReplacingAlphaCard])
+    assert get_class("alpha_card") is ReplacingAlphaCard
+
+
+def test_explicit_replace_does_not_warn(caplog):
+    class AlphaCard(BaseComponent):
+        pass
+
+    class ReplacingAlphaCard(BaseComponent, pjx_replace=True):
+        pass
+
+    ReplacingAlphaCard.__name__ = "AlphaCard"
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        build_registry(DISCOVERY_DIR, [AlphaCard, ReplacingAlphaCard])
+
+    assert caplog.records == []
+    assert get_class("alpha_card") is ReplacingAlphaCard
+
+
+def test_replace_with_no_collision_is_a_no_op(caplog):
+    class NestedWidget(BaseComponent, pjx_replace=True):
+        pass
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        build_registry(DISCOVERY_DIR, [NestedWidget])
+
+    assert caplog.records == []
+    assert get_class("nested_widget") is NestedWidget


### PR DESCRIPTION
## Summary
- Pin determinism for competing-replacer in component registry
- Test non-replace collision behavior to ensure proper component resolution
- Validate pjx_replace class precedence without duplicate warnings

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)