### PR TITLE
feat: fill unresolved child refs during render_level

### DIFF
--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -30,7 +30,8 @@ def _passthrough_markup(ref: ChildRef) -> str:
     re-escaped because they arrive from the parse already unescaped.
     """
     attrs = "".join(
-        f' {name}="{html.escape(value, quote=True)}"' for name, value in ref.attrs.items()
+        f' {name}="{html.escape(value, quote=True)}"'
+        for name, value in ref.attrs.items()
     )
     if ref.inner is None:
         return f"<{ref.tag}{attrs}/>"
@@ -98,11 +99,15 @@ def render_level(component: BaseComponent, session: "RenderSession") -> Rendered
         raise ValueError(f"{prefix}{err}") from err
 
     # Return RenderedLevel
-    return RenderedLevel(
+    level = RenderedLevel(
         segments=cast(list[str | ChildRef | RenderedLevel], parser.segments),
         root_span=parser.root_span or (0, 0),
         descriptor=descriptor,
     )
+    # Unregistered tags stop being holes here, one pass per level (ADR 0005);
+    # the ones that do resolve stay ChildRefs for the recursive step.
+    _fill_children(level)
+    return level
 
 
 def render(component: BaseComponent, session: "RenderSession | None" = None) -> str:

--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -5,6 +5,7 @@ Descriptor read → context build → Jinja render → single parse → Rendered
 finished HTML string for a childless component (render, public API).
 """
 
+import html
 from typing import cast
 
 import jinja2
@@ -12,6 +13,27 @@ import jinja2
 from pyjinhx2.component import BaseComponent
 from pyjinhx2.segments import ChildRef, RenderedLevel, VerbatimParser, serialize
 from pyjinhx2.session import RenderSession
+
+
+def _passthrough_markup(ref: ChildRef) -> str:
+    """Markup for a ChildRef whose tag no component class claims.
+
+    An unregistered PascalCase tag is ordinary markup — a web component, or a
+    tag someone meant to ship as-is — so it goes back into the stream instead of
+    raising (architecture-overview: a registry miss is an answer, not an error).
+
+    Reconstructed from the ChildRef's own fields, not echoed: the parse that
+    produced it kept the tag, the attrs and the inner text, and dropped the raw
+    source, so the original quoting style and spacing are not recoverable here.
+    ``inner`` was captured verbatim and is emitted raw; attr values are
+    re-escaped because they arrive from the parse already unescaped.
+    """
+    attrs = "".join(
+        f' {name}="{html.escape(value, quote=True)}"' for name, value in ref.attrs.items()
+    )
+    if ref.inner is None:
+        return f"<{ref.tag}{attrs}/>"
+    return f"<{ref.tag}{attrs}>{ref.inner}</{ref.tag}>"
 
 
 def render_level(component: BaseComponent, session: "RenderSession") -> RenderedLevel:

--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -10,7 +10,8 @@ from typing import cast
 
 import jinja2
 
-from pyjinhx2.component import BaseComponent
+from pyjinhx2.component import BaseComponent, _pascal_to_snake
+from pyjinhx2.discovery import get_class
 from pyjinhx2.segments import ChildRef, RenderedLevel, VerbatimParser, serialize
 from pyjinhx2.session import RenderSession
 
@@ -34,6 +35,20 @@ def _passthrough_markup(ref: ChildRef) -> str:
     if ref.inner is None:
         return f"<{ref.tag}{attrs}/>"
     return f"<{ref.tag}{attrs}>{ref.inner}</{ref.tag}>"
+
+
+def _fill_children(level: RenderedLevel) -> None:
+    """Resolve each ChildRef in ``level`` against the class registry, in place.
+
+    Tags no class claims stop being holes here and go back to being markup.
+    Tags that do resolve are left as ChildRefs for the instantiate-and-recurse
+    step to consume, so this pass only ever decides which holes are real.
+    """
+    for index, segment in enumerate(level.segments):
+        if not isinstance(segment, ChildRef):
+            continue
+        if get_class(_pascal_to_snake(segment.tag)) is None:
+            level.segments[index] = _passthrough_markup(segment)
 
 
 def render_level(component: BaseComponent, session: "RenderSession") -> RenderedLevel:

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -28,8 +28,15 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # scheme that could drift from the one templates are probed with.
     "discovery": frozenset({"pyjinhx2.component"}),
     "markers": frozenset({"pyjinhx2.component"}),
+    # render resolves each ChildRef tag against the published class registry;
+    # an unregistered tag is emitted verbatim, so this is a read-only edge.
     "render": frozenset(
-        {"pyjinhx2.component", "pyjinhx2.segments", "pyjinhx2.session"}
+        {
+            "pyjinhx2.component",
+            "pyjinhx2.discovery",
+            "pyjinhx2.segments",
+            "pyjinhx2.session",
+        }
     ),
     "render_context": frozenset({"pyjinhx2.markers", "pyjinhx2.component"}),
     "root_attrs": frozenset({"pyjinhx2.segments"}),

--- a/tests/pyjinhx2/test_render_children.py
+++ b/tests/pyjinhx2/test_render_children.py
@@ -1,9 +1,12 @@
 """Tests for ChildRef registry lookup and unknown-tag passthrough (issue #362)."""
 
+from pathlib import Path
+
 import pytest
 
 from pyjinhx2 import discovery
 from pyjinhx2.component import BaseComponent
+from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.render import _fill_children, _passthrough_markup
 from pyjinhx2.segments import ChildRef, RenderedLevel
 
@@ -103,3 +106,25 @@ def test_unknown_tag_raises_nothing():
     lvl = level(ChildRef(tag="TotallyUnknown", attrs={"a": "b"}, inner=None))
     _fill_children(lvl)
     assert lvl.segments == ['<TotallyUnknown a="b"/>']
+
+
+def test_render_level_passes_unknown_tags_through():
+    from pyjinhx2.render import render, render_level
+    from pyjinhx2.session import RenderSession
+
+    class UnknownHost(BaseComponent):
+        pass
+
+    UnknownHost.__pjx_descriptor__ = ClassDescriptor(
+        template_path=Path("unknown_host.html"),
+        slot_fields=frozenset(),
+        css_paths=(),
+        js_paths=(),
+        strict=True,
+        provenance={"template": UnknownHost},
+    )
+
+    session = RenderSession(template_dir="tests/templates")
+    lvl = render_level(UnknownHost(), session)
+    assert all(isinstance(seg, str) for seg in lvl.segments)
+    assert render(UnknownHost(), session) == '<div><WebThing id="a"/></div>'

--- a/tests/pyjinhx2/test_render_children.py
+++ b/tests/pyjinhx2/test_render_children.py
@@ -1,0 +1,55 @@
+"""Tests for ChildRef registry lookup and unknown-tag passthrough (issue #362)."""
+
+import pytest
+
+from pyjinhx2 import discovery
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.render import _passthrough_markup
+from pyjinhx2.segments import ChildRef, RenderedLevel
+
+
+class PJXButton(BaseComponent):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Each test starts from an empty published mapping."""
+    discovery._registry.mapping = {}
+    yield
+    discovery._registry.mapping = {}
+
+
+def level(*segments):
+    """A RenderedLevel wrapping the given segments, with the rest stubbed out."""
+    return RenderedLevel(segments=list(segments), root_span=(0, 0), descriptor=None)
+
+
+def test_passthrough_self_closing_with_attrs():
+    ref = ChildRef(tag="WebThing", attrs={"id": "a", "data-x": "1"}, inner=None)
+    assert _passthrough_markup(ref) == '<WebThing id="a" data-x="1"/>'
+
+
+def test_passthrough_self_closing_without_attrs_has_no_stray_space():
+    ref = ChildRef(tag="WebThing", attrs={}, inner=None)
+    assert _passthrough_markup(ref) == "<WebThing/>"
+
+
+def test_passthrough_paired_tag_keeps_inner_between_open_and_close():
+    ref = ChildRef(tag="WebThing", attrs={"id": "a"}, inner="<b>hi</b>")
+    assert _passthrough_markup(ref) == '<WebThing id="a"><b>hi</b></WebThing>'
+
+
+def test_passthrough_paired_tag_without_attrs():
+    ref = ChildRef(tag="WebThing", attrs={}, inner="hi")
+    assert _passthrough_markup(ref) == "<WebThing>hi</WebThing>"
+
+
+def test_passthrough_escapes_quotes_in_attr_values():
+    ref = ChildRef(tag="WebThing", attrs={"title": 'say "hi"'}, inner=None)
+    assert _passthrough_markup(ref) == '<WebThing title="say &quot;hi&quot;"/>'
+
+
+def test_passthrough_keeps_boolean_attr_as_empty_value():
+    ref = ChildRef(tag="WebThing", attrs={"disabled": ""}, inner=None)
+    assert _passthrough_markup(ref) == '<WebThing disabled=""/>'

--- a/tests/pyjinhx2/test_render_children.py
+++ b/tests/pyjinhx2/test_render_children.py
@@ -4,7 +4,7 @@ import pytest
 
 from pyjinhx2 import discovery
 from pyjinhx2.component import BaseComponent
-from pyjinhx2.render import _passthrough_markup
+from pyjinhx2.render import _fill_children, _passthrough_markup
 from pyjinhx2.segments import ChildRef, RenderedLevel
 
 
@@ -53,3 +53,53 @@ def test_passthrough_escapes_quotes_in_attr_values():
 def test_passthrough_keeps_boolean_attr_as_empty_value():
     ref = ChildRef(tag="WebThing", attrs={"disabled": ""}, inner=None)
     assert _passthrough_markup(ref) == '<WebThing disabled=""/>'
+
+
+def test_unresolved_tag_becomes_passthrough_string():
+    lvl = level("<div>", ChildRef(tag="WebThing", attrs={}, inner=None), "</div>")
+    _fill_children(lvl)
+    assert lvl.segments == ["<div>", "<WebThing/>", "</div>"]
+
+
+def test_resolved_tag_is_left_as_a_childref():
+    discovery._registry.mapping = {"pjx_button": PJXButton}
+    ref = ChildRef(tag="PJXButton", attrs={"label": "ok"}, inner=None)
+    lvl = level(ref)
+    _fill_children(lvl)
+    assert lvl.segments == [ref]
+    assert isinstance(lvl.segments[0], ChildRef)
+
+
+def test_pascal_tag_is_converted_to_snake_before_lookup():
+    """The registry is keyed snake_case; skipping the conversion would always miss."""
+    discovery._registry.mapping = {"pjx_button": PJXButton}
+    lvl = level(ChildRef(tag="PJXButton", attrs={}, inner=None))
+    _fill_children(lvl)
+    assert isinstance(lvl.segments[0], ChildRef)
+
+
+def test_tag_whose_snake_form_is_unregistered_still_passes_through():
+    discovery._registry.mapping = {"pjx_button": PJXButton}
+    lvl = level(ChildRef(tag="PJXButtons", attrs={}, inner=None))
+    _fill_children(lvl)
+    assert lvl.segments == ["<PJXButtons/>"]
+
+
+def test_mixed_segments_replace_only_the_miss_and_keep_order():
+    discovery._registry.mapping = {"pjx_button": PJXButton}
+    hit = ChildRef(tag="PJXButton", attrs={}, inner=None)
+    lvl = level("<div>", hit, ChildRef(tag="WebThing", attrs={}, inner="x"), "</div>")
+    _fill_children(lvl)
+    assert lvl.segments == ["<div>", hit, "<WebThing>x</WebThing>", "</div>"]
+
+
+def test_level_without_childrefs_is_untouched():
+    lvl = level("<div>", "hello", "</div>")
+    _fill_children(lvl)
+    assert lvl.segments == ["<div>", "hello", "</div>"]
+
+
+def test_unknown_tag_raises_nothing():
+    lvl = level(ChildRef(tag="TotallyUnknown", attrs={"a": "b"}, inner=None))
+    _fill_children(lvl)
+    assert lvl.segments == ['<TotallyUnknown a="b"/>']

--- a/tests/pyjinhx2/test_render_level.py
+++ b/tests/pyjinhx2/test_render_level.py
@@ -2,11 +2,41 @@ from pathlib import Path
 
 import pytest
 
+from pyjinhx2 import discovery
 from pyjinhx2.component import BaseComponent
 from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.render import render_level
 from pyjinhx2.segments import ChildRef, RenderedLevel
 from pyjinhx2.session import RenderSession
+
+
+class _PJXButton(BaseComponent):
+    pass
+
+
+class _PJXCard(BaseComponent):
+    pass
+
+
+class _PJXIcon(BaseComponent):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _registered_child_tags():
+    """Register the PJXButton/PJXCard/PJXIcon tags these tests reference.
+
+    render_level (#362) now resolves ChildRef tags against the registry and
+    passes unregistered ones through as plain markup. These tests assert on
+    ChildRef fields, so their tags must resolve (hit) to stay ChildRefs.
+    """
+    discovery._registry.mapping = {
+        "pjx_button": _PJXButton,
+        "pjx_card": _PJXCard,
+        "pjx_icon": _PJXIcon,
+    }
+    yield
+    discovery._registry.mapping = {}
 
 
 # Test 1: Single div renders → segments[0] is markup, root_span points to <div

--- a/tests/pyjinhx2/test_render_level.py
+++ b/tests/pyjinhx2/test_render_level.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from pyjinhx2 import discovery
-from pyjinhx2.component import BaseComponent
+from pyjinhx2.component import BaseComponent, _pascal_to_snake
 from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.render import render_level
 from pyjinhx2.segments import ChildRef, RenderedLevel
@@ -31,9 +31,8 @@ def _registered_child_tags():
     ChildRef fields, so their tags must resolve (hit) to stay ChildRefs.
     """
     discovery._registry.mapping = {
-        "pjx_button": _PJXButton,
-        "pjx_card": _PJXCard,
-        "pjx_icon": _PJXIcon,
+        _pascal_to_snake(cls.__name__.lstrip("_")): cls
+        for cls in (_PJXButton, _PJXCard, _PJXIcon)
     }
     yield
     discovery._registry.mapping = {}

--- a/tests/templates/unknown_host.html
+++ b/tests/templates/unknown_host.html
@@ -1,0 +1,1 @@
+<div><WebThing id="a"/></div>


### PR DESCRIPTION
## Summary
- Implement ChildRef tag resolution against the component registry during render_level
- Synthesize verbatim markup for unresolved tags  
- Derive stub tag keys via _pascal_to_snake conversion helper
- 4 commits with full test coverage

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)