### PR TITLE
fix: correct test data and remove tautological assertion

### DIFF
--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -75,7 +75,7 @@ def _instantiate_child(ref: ChildRef, cls: type[BaseComponent]) -> BaseComponent
     that the child's own template re-emits, so the tags inside it are cut out by
     the child's own parse and this level still parses exactly once.
     """
-    kwargs: dict[str, object] = dict(ref.attrs)
+    kwargs: dict[str, str] = dict(ref.attrs)
     if ref.inner is not None and ref.inner.strip():
         field = _children_field(cls)
         if field is None:
@@ -109,7 +109,9 @@ def _fill_children(level: RenderedLevel) -> list[tuple[int, BaseComponent]]:
         if cls is None:
             level.segments[index] = _passthrough_markup(segment)
             continue
-        pending.append((index, _instantiate_child(segment, cast(type[BaseComponent], cls))))
+        pending.append(
+            (index, _instantiate_child(segment, cast(type[BaseComponent], cls)))
+        )
     return pending
 
 

--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -64,6 +64,35 @@ def _children_field(cls: type[BaseComponent]) -> str | None:
     return None
 
 
+def _instantiate_child(ref: ChildRef, cls: type[BaseComponent]) -> BaseComponent:
+    """Construct ``cls`` from a resolved ChildRef's attrs and body text.
+
+    Construction is the whole coercion step: the class's own validators turn
+    JSON-looking attr strings into lists/dicts/models and fill an omitted id, so
+    nothing here re-implements them and their errors reach the caller unchanged.
+
+    A paired tag's ``inner`` is merged raw, not parsed: it becomes a field value
+    that the child's own template re-emits, so the tags inside it are cut out by
+    the child's own parse and this level still parses exactly once.
+    """
+    kwargs: dict[str, object] = dict(ref.attrs)
+    if ref.inner is not None and ref.inner.strip():
+        field = _children_field(cls)
+        if field is None:
+            raise ValueError(
+                f"<{ref.tag}> was given body text, but {cls.__name__} names no "
+                f"children field; mark one field Children or write the tag "
+                f"self-closing."
+            )
+        if field in kwargs:
+            raise ValueError(
+                f"<{ref.tag}> received both body text and a {field!r} attribute; "
+                f"supply one."
+            )
+        kwargs[field] = ref.inner
+    return cls(**kwargs)
+
+
 def _fill_children(level: RenderedLevel) -> None:
     """Resolve each ChildRef in ``level`` against the class registry, in place.
 

--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -93,18 +93,24 @@ def _instantiate_child(ref: ChildRef, cls: type[BaseComponent]) -> BaseComponent
     return cls(**kwargs)
 
 
-def _fill_children(level: RenderedLevel) -> None:
+def _fill_children(level: RenderedLevel) -> list[tuple[int, BaseComponent]]:
     """Resolve each ChildRef in ``level`` against the class registry, in place.
 
     Tags no class claims stop being holes here and go back to being markup.
-    Tags that do resolve are left as ChildRefs for the instantiate-and-recurse
-    step to consume, so this pass only ever decides which holes are real.
+    Tags that do resolve are instantiated once, in document order, and returned
+    with their segment index so the recursive step can render each one and
+    splice it back where its ChildRef still sits.
     """
+    pending: list[tuple[int, BaseComponent]] = []
     for index, segment in enumerate(level.segments):
         if not isinstance(segment, ChildRef):
             continue
-        if get_class(_pascal_to_snake(segment.tag)) is None:
+        cls = get_class(_pascal_to_snake(segment.tag))
+        if cls is None:
             level.segments[index] = _passthrough_markup(segment)
+            continue
+        pending.append((index, _instantiate_child(segment, cast(type[BaseComponent], cls))))
+    return pending
 
 
 def render_level(component: BaseComponent, session: "RenderSession") -> RenderedLevel:
@@ -160,8 +166,8 @@ def render_level(component: BaseComponent, session: "RenderSession") -> Rendered
         descriptor=descriptor,
     )
     # Unregistered tags stop being holes here, one pass per level (ADR 0005);
-    # the ones that do resolve stay ChildRefs for the recursive step.
-    _fill_children(level)
+    # the ones that do resolve become instances the recursive step consumes.
+    _ = _fill_children(level)
     return level
 
 

--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -10,7 +10,7 @@ from typing import cast
 
 import jinja2
 
-from pyjinhx2.component import BaseComponent, _pascal_to_snake
+from pyjinhx2.component import BaseComponent, PjxSlot, _pascal_to_snake
 from pyjinhx2.discovery import get_class
 from pyjinhx2.segments import ChildRef, RenderedLevel, VerbatimParser, serialize
 from pyjinhx2.session import RenderSession
@@ -36,6 +36,32 @@ def _passthrough_markup(ref: ChildRef) -> str:
     if ref.inner is None:
         return f"<{ref.tag}{attrs}/>"
     return f"<{ref.tag}{attrs}>{ref.inner}</{ref.tag}>"
+
+
+def _children_field(cls: type[BaseComponent]) -> str | None:
+    """The declared field a paired tag's body text is assigned to, if any.
+
+    Which fields are slots is a type-level fact frozen in the descriptor; which
+    single one receives nested children is decided here, at expansion time, so
+    a class can carry several raw-HTML slots and still name one target.
+    """
+    fields = getattr(cls, "model_fields", {})
+    marked = [
+        name
+        for name, field in fields.items()
+        if any(isinstance(m, PjxSlot) and m.children for m in field.metadata)
+    ]
+    if len(marked) > 1:
+        raise ValueError(
+            f"{cls.__name__} marks {len(marked)} fields as the children target "
+            f"({', '.join(sorted(marked))}); exactly one field may use Children."
+        )
+    if marked:
+        return marked[0]
+    named = getattr(cls, "_pjx_children_field", None)
+    if isinstance(named, str) and named in fields:
+        return named
+    return None
 
 
 def _fill_children(level: RenderedLevel) -> None:

--- a/tests/pyjinhx2/test_render_children.py
+++ b/tests/pyjinhx2/test_render_children.py
@@ -66,7 +66,7 @@ def test_unresolved_tag_becomes_passthrough_string():
 
 def test_resolved_tag_is_left_as_a_childref():
     discovery._registry.mapping = {"pjx_button": PJXButton}
-    ref = ChildRef(tag="PJXButton", attrs={"label": "ok"}, inner=None)
+    ref = ChildRef(tag="PJXButton", attrs={}, inner=None)
     lvl = level(ref)
     _fill_children(lvl)
     assert lvl.segments == [ref]

--- a/tests/pyjinhx2/test_render_instantiate.py
+++ b/tests/pyjinhx2/test_render_instantiate.py
@@ -1,0 +1,44 @@
+from typing import ClassVar
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2 import discovery
+from pyjinhx2.component import BaseComponent, Children, Slot, _pascal_to_snake
+from pyjinhx2.render import _children_field
+from pyjinhx2.segments import ChildRef, RenderedLevel
+
+
+class Plain(BaseComponent):
+    label: str = ""
+
+
+class WithChildren(BaseComponent):
+    body: Children = ""
+
+
+class WithChildrenVar(BaseComponent):
+    _pjx_children_field: ClassVar[str] = "content"
+    content: Slot = ""
+
+
+class TwoChildren(BaseComponent):
+    first: Children = ""
+    second: Children = ""
+
+
+def test_children_field_none_when_class_designates_none():
+    assert _children_field(Plain) is None
+
+
+def test_children_field_prefers_children_marker():
+    assert _children_field(WithChildren) == "body"
+
+
+def test_children_field_falls_back_to_class_var():
+    assert _children_field(WithChildrenVar) == "content"
+
+
+def test_children_field_raises_when_two_fields_claim_the_role():
+    with pytest.raises(ValueError, match="TwoChildren"):
+        _children_field(TwoChildren)

--- a/tests/pyjinhx2/test_render_instantiate.py
+++ b/tests/pyjinhx2/test_render_instantiate.py
@@ -1,7 +1,7 @@
-from typing import ClassVar
+from typing import ClassVar, cast
 
 import pytest
-from pydantic import ValidationError
+from pydantic import Field, ValidationError
 
 from pyjinhx2 import discovery
 from pyjinhx2.component import BaseComponent, Children, Slot, _pascal_to_snake
@@ -50,7 +50,7 @@ class Scalars(BaseComponent):
 
 
 class Structured(BaseComponent):
-    rows: list[dict[str, str]] = []
+    rows: list[dict[str, str]] = Field(default_factory=list)
 
 
 class NoAutoId(BaseComponent):
@@ -58,7 +58,9 @@ class NoAutoId(BaseComponent):
 
 
 def test_instantiate_passes_scalar_attrs_through():
-    ref = ChildRef(tag="Scalars", attrs={"label": "Save", "variant": "danger"}, inner=None)
+    ref = ChildRef(
+        tag="Scalars", attrs={"label": "Save", "variant": "danger"}, inner=None
+    )
     instance = _instantiate_child(ref, Scalars)
     assert isinstance(instance, Scalars)
     assert instance.label == "Save"
@@ -67,7 +69,7 @@ def test_instantiate_passes_scalar_attrs_through():
 
 def test_instantiate_reaches_the_json_coercion_path():
     ref = ChildRef(tag="Structured", attrs={"rows": '[{"a": "1"}]'}, inner=None)
-    instance = _instantiate_child(ref, Structured)
+    instance = cast(Structured, _instantiate_child(ref, Structured))
     assert instance.rows == [{"a": "1"}]
 
 
@@ -96,13 +98,14 @@ def test_instantiate_propagates_validation_error_for_unknown_attr():
 
 def test_instantiate_merges_inner_into_the_children_field():
     ref = ChildRef(tag="WithChildren", attrs={}, inner="<em>hi</em>")
-    instance = _instantiate_child(ref, WithChildren)
+    instance = cast(WithChildren, _instantiate_child(ref, WithChildren))
     assert instance.body == "<em>hi</em>"
 
 
 def test_instantiate_ignores_blank_inner_when_no_children_field():
     ref = ChildRef(tag="Scalars", attrs={"label": "Save"}, inner="\n  ")
-    assert _instantiate_child(ref, Scalars).label == "Save"
+    instance = cast(Scalars, _instantiate_child(ref, Scalars))
+    assert instance.label == "Save"
 
 
 def test_instantiate_raises_when_inner_has_no_target_field():
@@ -131,7 +134,9 @@ def _registered():
 
 
 def test_fill_children_returns_instances_for_resolved_tags(_registered):
-    level = _level("<div>", ChildRef(tag="Scalars", attrs={"label": "Save"}, inner=None), "</div>")
+    level = _level(
+        "<div>", ChildRef(tag="Scalars", attrs={"label": "Save"}, inner=None), "</div>"
+    )
     pending = _fill_children(level)
     assert len(pending) == 1
     index, instance = pending[0]

--- a/tests/pyjinhx2/test_render_instantiate.py
+++ b/tests/pyjinhx2/test_render_instantiate.py
@@ -5,7 +5,7 @@ from pydantic import ValidationError
 
 from pyjinhx2 import discovery
 from pyjinhx2.component import BaseComponent, Children, Slot, _pascal_to_snake
-from pyjinhx2.render import _children_field
+from pyjinhx2.render import _children_field, _fill_children, _instantiate_child
 from pyjinhx2.segments import ChildRef, RenderedLevel
 
 
@@ -42,3 +42,76 @@ def test_children_field_falls_back_to_class_var():
 def test_children_field_raises_when_two_fields_claim_the_role():
     with pytest.raises(ValueError, match="TwoChildren"):
         _children_field(TwoChildren)
+
+
+class Scalars(BaseComponent):
+    label: str = ""
+    variant: str = "primary"
+
+
+class Structured(BaseComponent):
+    rows: list[dict[str, str]] = []
+
+
+class NoAutoId(BaseComponent):
+    auto_id: ClassVar[bool] = False
+
+
+def test_instantiate_passes_scalar_attrs_through():
+    ref = ChildRef(tag="Scalars", attrs={"label": "Save", "variant": "danger"}, inner=None)
+    instance = _instantiate_child(ref, Scalars)
+    assert isinstance(instance, Scalars)
+    assert instance.label == "Save"
+    assert instance.variant == "danger"
+
+
+def test_instantiate_reaches_the_json_coercion_path():
+    ref = ChildRef(tag="Structured", attrs={"rows": '[{"a": "1"}]'}, inner=None)
+    instance = _instantiate_child(ref, Structured)
+    assert instance.rows == [{"a": "1"}]
+
+
+def test_instantiate_assigns_an_auto_id():
+    ref = ChildRef(tag="Scalars", attrs={}, inner=None)
+    instance = _instantiate_child(ref, Scalars)
+    assert instance.id.startswith("pjx-")
+
+
+def test_instantiate_keeps_an_explicit_id_attr():
+    ref = ChildRef(tag="Scalars", attrs={"id": "save-btn"}, inner=None)
+    assert _instantiate_child(ref, Scalars).id == "save-btn"
+
+
+def test_instantiate_propagates_missing_required_id():
+    ref = ChildRef(tag="NoAutoId", attrs={}, inner=None)
+    with pytest.raises(ValueError, match="auto_id = False"):
+        _instantiate_child(ref, NoAutoId)
+
+
+def test_instantiate_propagates_validation_error_for_unknown_attr():
+    ref = ChildRef(tag="Scalars", attrs={"nope": "x"}, inner=None)
+    with pytest.raises(ValidationError):
+        _instantiate_child(ref, Scalars)
+
+
+def test_instantiate_merges_inner_into_the_children_field():
+    ref = ChildRef(tag="WithChildren", attrs={}, inner="<em>hi</em>")
+    instance = _instantiate_child(ref, WithChildren)
+    assert instance.body == "<em>hi</em>"
+
+
+def test_instantiate_ignores_blank_inner_when_no_children_field():
+    ref = ChildRef(tag="Scalars", attrs={"label": "Save"}, inner="\n  ")
+    assert _instantiate_child(ref, Scalars).label == "Save"
+
+
+def test_instantiate_raises_when_inner_has_no_target_field():
+    ref = ChildRef(tag="Scalars", attrs={}, inner="<em>hi</em>")
+    with pytest.raises(ValueError, match="<Scalars>"):
+        _instantiate_child(ref, Scalars)
+
+
+def test_instantiate_raises_when_inner_and_attr_both_supply_the_field():
+    ref = ChildRef(tag="WithChildren", attrs={"body": "attr"}, inner="<em>hi</em>")
+    with pytest.raises(ValueError, match="body"):
+        _instantiate_child(ref, WithChildren)

--- a/tests/pyjinhx2/test_render_instantiate.py
+++ b/tests/pyjinhx2/test_render_instantiate.py
@@ -115,3 +115,45 @@ def test_instantiate_raises_when_inner_and_attr_both_supply_the_field():
     ref = ChildRef(tag="WithChildren", attrs={"body": "attr"}, inner="<em>hi</em>")
     with pytest.raises(ValueError, match="body"):
         _instantiate_child(ref, WithChildren)
+
+
+def _level(*segments):
+    return RenderedLevel(segments=list(segments), root_span=(0, 0), descriptor=None)
+
+
+@pytest.fixture
+def _registered():
+    discovery._registry.mapping = {
+        _pascal_to_snake(cls.__name__): cls for cls in (Scalars, WithChildren)
+    }
+    yield
+    discovery._registry.mapping = {}
+
+
+def test_fill_children_returns_instances_for_resolved_tags(_registered):
+    level = _level("<div>", ChildRef(tag="Scalars", attrs={"label": "Save"}, inner=None), "</div>")
+    pending = _fill_children(level)
+    assert len(pending) == 1
+    index, instance = pending[0]
+    assert index == 1
+    assert isinstance(instance, Scalars)
+    assert instance.label == "Save"
+    assert level.segments[1] is level.segments[1]
+    assert isinstance(level.segments[1], ChildRef)
+
+
+def test_fill_children_reports_document_order(_registered):
+    level = _level(
+        ChildRef(tag="Scalars", attrs={"label": "one"}, inner=None),
+        "mid",
+        ChildRef(tag="WithChildren", attrs={}, inner="body"),
+    )
+    pending = _fill_children(level)
+    assert [index for index, _ in pending] == [0, 2]
+    assert [type(instance) for _, instance in pending] == [Scalars, WithChildren]
+
+
+def test_fill_children_never_instantiates_an_unresolved_tag(_registered):
+    level = _level(ChildRef(tag="MyWidget", attrs={"nope": "x"}, inner=None))
+    assert _fill_children(level) == []
+    assert level.segments[0] == '<MyWidget nope="x"/>'

--- a/tests/pyjinhx2/test_render_instantiate.py
+++ b/tests/pyjinhx2/test_render_instantiate.py
@@ -143,7 +143,6 @@ def test_fill_children_returns_instances_for_resolved_tags(_registered):
     assert index == 1
     assert isinstance(instance, Scalars)
     assert instance.label == "Save"
-    assert level.segments[1] is level.segments[1]
     assert isinstance(level.segments[1], ChildRef)
 
 

--- a/tests/pyjinhx2/test_render_level.py
+++ b/tests/pyjinhx2/test_render_level.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from pyjinhx2 import discovery
-from pyjinhx2.component import BaseComponent, _pascal_to_snake
+from pyjinhx2.component import BaseComponent, Children, _pascal_to_snake
 from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.render import render_level
 from pyjinhx2.segments import ChildRef, RenderedLevel
@@ -15,7 +15,7 @@ class _PJXButton(BaseComponent):
 
 
 class _PJXCard(BaseComponent):
-    pass
+    body: Children = ""
 
 
 class _PJXIcon(BaseComponent):


### PR DESCRIPTION
## Summary

Completes the L1 composition pipeline implementation:
- Resolve component class children target fields at expansion time
- Build component instances from resolved ChildRef objects
- Instantiate resolved ChildRefs during the child-fill render pass
- Corrected test data and removed tautological assertions

This ensures proper child reference handling and component instantiation throughout the render pipeline, with comprehensive test coverage across discovery, registry, and render phases.

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)