### PR TITLE
feat: guard render chains against nesting cycles (#365)

### DIFF
--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -115,18 +115,26 @@ def _fill_children(level: RenderedLevel) -> list[tuple[int, BaseComponent]]:
     return pending
 
 
-def render_level(component: BaseComponent, session: "RenderSession") -> RenderedLevel:
+def render_level(
+    component: BaseComponent,
+    session: "RenderSession",
+    chain: tuple[str, ...] = (),
+) -> RenderedLevel:
     """Render one component level: template → one parse → RenderedLevel.
 
     Args:
         component: A valid BaseComponent instance (construction-time validation passed).
         session: RenderSession providing Jinja environment and hooks.
+        chain: Class names of the components already being rendered on this
+            call path, outermost first. Passed by value down the recursion so
+            each branch sees its own ancestors and nothing else.
 
     Returns:
         RenderedLevel with segments (str | ChildRef), root_span, descriptor.
 
     Raises:
         ValueError: If template renders zero or 2+ root elements.
+        ValueError: If a component re-enters its own render chain (cycle).
         jinja2.TemplateNotFound: If template file missing.
         jinja2.TemplateAssertionError: If Jinja evaluation fails.
     """
@@ -142,6 +150,17 @@ def render_level(component: BaseComponent, session: "RenderSession") -> Rendered
     # Phase 3: Jinja render with autoescape ON
     jinja_env = session.jinja_env
     prefix = f"{component.__class__.__name__} (template: {descriptor.template_path}): "
+
+    # A component whose subtree instantiates itself or an ancestor would recurse
+    # forever; the chain is the current call path only, so the same class on two
+    # sibling branches is fine (ADR 0004: nesting/load chains are the only cycle
+    # vector left in v2).
+    name = component.__class__.__name__
+    if name in chain:
+        cycle = chain[chain.index(name) :]
+        raise ValueError(f"{prefix}cycle detected: {' -> '.join((*cycle, name))}")
+    chain = (*chain, name)
+
     try:
         template = jinja_env.get_template(str(descriptor.template_path))
     except jinja2.TemplateNotFound as err:
@@ -173,7 +192,7 @@ def render_level(component: BaseComponent, session: "RenderSession") -> Rendered
         # Each child gets its own render_level call, so it does its own single
         # parse and enters this list as a whole object — never text spliced into
         # text, which is what keeps a child's markup un-reparsed and un-escaped.
-        level.segments[index] = render_level(child, session)
+        level.segments[index] = render_level(child, session, chain)
     return level
 
 

--- a/tests/pyjinhx2/test_render_cycle_guard.py
+++ b/tests/pyjinhx2/test_render_cycle_guard.py
@@ -1,0 +1,146 @@
+"""Tests for the render-chain cycle guard (nesting/load chains only, ADR 0004)."""
+
+from pathlib import Path
+
+import pytest
+
+from pyjinhx2 import discovery
+from pyjinhx2.component import BaseComponent, _pascal_to_snake
+from pyjinhx2.descriptor import ClassDescriptor
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+def descriptor_for(cls: type[BaseComponent], template: str) -> ClassDescriptor:
+    """Attach a minimal descriptor pointing at a fixture template."""
+    return ClassDescriptor(
+        template_path=Path(template),
+        slot_fields=frozenset(),
+        css_paths=(),
+        js_paths=(),
+        strict=True,
+        provenance={"template": cls},
+    )
+
+
+class PJXCycleSelf(BaseComponent):
+    pass
+
+
+class PJXCycleA(BaseComponent):
+    pass
+
+
+class PJXCycleB(BaseComponent):
+    pass
+
+
+class PJXCycleLongA(BaseComponent):
+    pass
+
+
+class PJXCycleLongB(BaseComponent):
+    pass
+
+
+class PJXCycleLongC(BaseComponent):
+    pass
+
+
+class PJXAcyclicA(BaseComponent):
+    pass
+
+
+class PJXAcyclicB(BaseComponent):
+    pass
+
+
+class PJXAcyclicC(BaseComponent):
+    pass
+
+
+class PJXDiamond(BaseComponent):
+    pass
+
+
+class PJXPassthroughCycle(BaseComponent):
+    pass
+
+
+TEMPLATES = {
+    PJXCycleSelf: "cycle_self.html",
+    PJXCycleA: "cycle_a.html",
+    PJXCycleB: "cycle_b.html",
+    PJXCycleLongA: "cycle_long_a.html",
+    PJXCycleLongB: "cycle_long_b.html",
+    PJXCycleLongC: "cycle_long_c.html",
+    PJXAcyclicA: "cycle_acyclic_a.html",
+    PJXAcyclicB: "cycle_acyclic_b.html",
+    PJXAcyclicC: "cycle_acyclic_c.html",
+    PJXDiamond: "cycle_diamond.html",
+    PJXPassthroughCycle: "cycle_passthrough.html",
+}
+
+for _cls, _template in TEMPLATES.items():
+    _cls.__pjx_descriptor__ = descriptor_for(_cls, _template)
+
+
+@pytest.fixture(autouse=True)
+def registry():
+    """Each test sees exactly the fixture components, keyed as discovery keys them."""
+    discovery._registry.mapping = {
+        _pascal_to_snake(cls.__name__): cls for cls in TEMPLATES
+    }
+    yield
+    discovery._registry.mapping = {}
+
+
+@pytest.fixture
+def session():
+    return RenderSession(template_dir="tests/templates")
+
+
+def test_direct_self_cycle_raises(session):
+    with pytest.raises(ValueError) as err:
+        render(PJXCycleSelf(), session)
+    assert "cycle detected: PJXCycleSelf -> PJXCycleSelf" in str(err.value)
+
+
+def test_indirect_cycle_names_the_whole_chain(session):
+    with pytest.raises(ValueError) as err:
+        render(PJXCycleA(), session)
+    assert "cycle detected: PJXCycleA -> PJXCycleB -> PJXCycleA" in str(err.value)
+
+
+def test_longer_cycle_names_the_chain_in_order(session):
+    with pytest.raises(ValueError) as err:
+        render(PJXCycleLongA(), session)
+    assert (
+        "cycle detected: PJXCycleLongA -> PJXCycleLongB -> PJXCycleLongC "
+        "-> PJXCycleLongA" in str(err.value)
+    )
+
+
+def test_cycle_error_keeps_the_existing_prefix(session):
+    with pytest.raises(ValueError) as err:
+        render(PJXCycleA(), session)
+    assert str(err.value).startswith("PJXCycleA (template: cycle_a.html): ")
+
+
+def test_acyclic_nesting_still_renders(session):
+    assert render(PJXAcyclicA(), session) == (
+        '<div class="aa"><div class="ab"><span class="ac">leaf</span></div></div>'
+    )
+
+
+def test_same_component_on_two_sibling_paths_is_not_a_cycle(session):
+    branch = '<div class="ab"><span class="ac">leaf</span></div>'
+    assert (
+        render(PJXDiamond(), session) == f'<div class="diamond">{branch}{branch}</div>'
+    )
+
+
+def test_passthrough_sibling_does_not_mask_the_cycle(session):
+    with pytest.raises(ValueError) as err:
+        render(PJXPassthroughCycle(), session)
+    assert "cycle detected: PJXCycleSelf -> PJXCycleSelf" in str(err.value)

--- a/tests/templates/cycle_a.html
+++ b/tests/templates/cycle_a.html
@@ -1,0 +1,1 @@
+<div class="a"><PJXCycleB/></div>

--- a/tests/templates/cycle_acyclic_a.html
+++ b/tests/templates/cycle_acyclic_a.html
@@ -1,0 +1,1 @@
+<div class="aa"><PJXAcyclicB/></div>

--- a/tests/templates/cycle_acyclic_b.html
+++ b/tests/templates/cycle_acyclic_b.html
@@ -1,0 +1,1 @@
+<div class="ab"><PJXAcyclicC/></div>

--- a/tests/templates/cycle_acyclic_c.html
+++ b/tests/templates/cycle_acyclic_c.html
@@ -1,0 +1,1 @@
+<span class="ac">leaf</span>

--- a/tests/templates/cycle_b.html
+++ b/tests/templates/cycle_b.html
@@ -1,0 +1,1 @@
+<div class="b"><PJXCycleA/></div>

--- a/tests/templates/cycle_diamond.html
+++ b/tests/templates/cycle_diamond.html
@@ -1,0 +1,1 @@
+<div class="diamond"><PJXAcyclicB/><PJXAcyclicB/></div>

--- a/tests/templates/cycle_long_a.html
+++ b/tests/templates/cycle_long_a.html
@@ -1,0 +1,1 @@
+<div class="la"><PJXCycleLongB/></div>

--- a/tests/templates/cycle_long_b.html
+++ b/tests/templates/cycle_long_b.html
@@ -1,0 +1,1 @@
+<div class="lb"><PJXCycleLongC/></div>

--- a/tests/templates/cycle_long_c.html
+++ b/tests/templates/cycle_long_c.html
@@ -1,0 +1,1 @@
+<div class="lc"><PJXCycleLongA/></div>

--- a/tests/templates/cycle_passthrough.html
+++ b/tests/templates/cycle_passthrough.html
@@ -1,0 +1,1 @@
+<div class="pt"><WebThing id="w"/><PJXCycleSelf/></div>

--- a/tests/templates/cycle_self.html
+++ b/tests/templates/cycle_self.html
@@ -1,0 +1,1 @@
+<div class="self"><PJXCycleSelf/></div>


### PR DESCRIPTION
## Summary
- Adds cycle detection to render chains by threading a by-value chain tuple through render_level
- Detects when a component re-enters its own chain and raises ValueError naming the full cycle
- Only nesting/load chains can cycle per ADR 0004; sibling paths are acyclic
- 7 tests covering direct self-cycles, indirect cycles, acyclic nesting, and diamond patterns

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)