### PR TITLE
test: cover children-field precedence, overrides, and consistency (#369)

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -251,6 +251,59 @@ def _resolve_slot_fields(cls: type) -> frozenset[str]:
     return frozenset(name for name in fields if _is_slot_field(cls, name))
 
 
+def _resolve_children_field(cls: type) -> str | None:
+    """The declared field a PascalCase tag's body content lands on, or ``None``.
+
+    Precedence, highest first:
+    1. the single field flagged ``PjxSlot(children=True)`` (the ``Children`` alias);
+    2. the ``_pjx_children_field`` class override, when set (MRO-inherited);
+    3. a field literally named ``content``;
+    4. the single field carrying a bare ``PjxSlot()`` marker.
+    Anything else — no slots, or two-plus unflagged slots with no ``content``
+    and no override — is ambiguous and resolves to ``None``. Ambiguity is not an
+    error here: no caller has asked for a target yet, so whoever eventually needs
+    one raises when it gets ``None``.
+
+    An override naming a field that is not declared resolves to that name as
+    written, matching v0.x, which does not validate existence either.
+
+    Declared fields only — ``model_extra`` is never walked, matching
+    :func:`_resolve_slot_fields`.
+    """
+    fields = getattr(cls, "model_fields", {})
+    flagged = [
+        name
+        for name, field in fields.items()
+        if any(isinstance(m, PjxSlot) and m.children for m in field.metadata)
+    ]
+    if len(flagged) > 1:
+        raise ValueError(
+            f"{cls.__name__}: multiple fields flagged PjxSlot(children=True) "
+            f"({', '.join(flagged)}); only one may receive tag children"
+        )
+
+    override = getattr(cls, "_pjx_children_field", None)
+    if override is not None:
+        if flagged and flagged[0] != override:
+            raise ValueError(
+                f"{cls.__name__}: _pjx_children_field={override!r} conflicts with "
+                f"PjxSlot(children=True) on {flagged[0]!r}; declare only one"
+            )
+        return override
+
+    if flagged:
+        return flagged[0]
+    if "content" in fields:
+        return "content"
+
+    slots = [
+        name
+        for name, field in fields.items()
+        if any(isinstance(m, PjxSlot) for m in field.metadata)
+    ]
+    return slots[0] if len(slots) == 1 else None
+
+
 def _resolve_asset_paths(cls: type) -> tuple[tuple[Path, ...], tuple[Path, ...]]:
     """The co-located stylesheet and script ``cls`` ships with, each resolved by
     its own nearest-ancestor walk.
@@ -311,9 +364,18 @@ def _resolve_class_descriptor(cls: type[BaseModel]) -> ClassDescriptor:
         )
         if owner is not None
     }
+    slot_fields = _resolve_slot_fields(cls)
+    children_field = _resolve_children_field(cls)
+    declared_fields = getattr(cls, "model_fields", {})
+    assert (
+        children_field is None
+        or children_field not in declared_fields
+        or children_field in slot_fields
+    ), f"{cls.__name__}: children_field {children_field!r} is not a slot field"
     return ClassDescriptor(
         template_path=template_path,
-        slot_fields=_resolve_slot_fields(cls),
+        slot_fields=slot_fields,
+        children_field=children_field,
         css_paths=() if css_path is None else (css_path,),
         js_paths=() if js_path is None else (js_path,),
         strict=_resolve_strict(cls),
@@ -345,6 +407,10 @@ class BaseComponent(BaseModel):
     __pjx_descriptor__: ClassVar[ClassDescriptor]
 
     _pjx_replace: ClassVar[bool] = False
+
+    _pjx_children_field: ClassVar[str | None] = None
+    """Explicit children-target override. ``None`` means "infer" — see
+    :func:`_resolve_children_field`."""
 
     id: str = Field(
         default_factory=_auto_id,

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -367,10 +367,19 @@ def _resolve_class_descriptor(cls: type[BaseModel]) -> ClassDescriptor:
     slot_fields = _resolve_slot_fields(cls)
     children_field = _resolve_children_field(cls)
     declared_fields = getattr(cls, "model_fields", {})
+    # A children_field reached via the override or the flagged-field branch is
+    # a slot by construction: _is_slot_field already matches on those same two
+    # conditions. The one precedence branch this does not cover is a bare
+    # field literally named "content" with no PjxSlot marker and no override
+    # (rule 3) — _is_slot_field intentionally does not special-case that name,
+    # so it is exempted here rather than silently made a slot as a side effect
+    # of field-resolution (that would be a render-time/opacity decision, out
+    # of scope for #369).
     assert (
         children_field is None
         or children_field not in declared_fields
         or children_field in slot_fields
+        or children_field == "content"
     ), f"{cls.__name__}: children_field {children_field!r} is not a slot field"
     return ClassDescriptor(
         template_path=template_path,

--- a/pyjinhx2/descriptor.py
+++ b/pyjinhx2/descriptor.py
@@ -15,12 +15,13 @@ class ClassDescriptor:
     """Per-class resolution results, immutable after creation.
 
     Holds the single template probe result, asset paths (resolved per-kind up
-    the MRO), slot fields, strict mode flag, and provenance mapping (kind →
-    ancestor class).
+    the MRO), slot fields, the children target, strict mode flag, and
+    provenance mapping (kind → ancestor class).
     """
 
     template_path: Path
     slot_fields: frozenset[str]
+    children_field: str | None
     css_paths: tuple[Path, ...]
     js_paths: tuple[Path, ...]
     strict: bool

--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -10,7 +10,7 @@ from typing import cast
 
 import jinja2
 
-from pyjinhx2.component import BaseComponent, PjxSlot, _pascal_to_snake
+from pyjinhx2.component import BaseComponent, _pascal_to_snake
 from pyjinhx2.discovery import get_class
 from pyjinhx2.markers import SLOT_TOKEN_RE, collect_slot_tokens
 from pyjinhx2.render_context import build_context
@@ -40,32 +40,6 @@ def _passthrough_markup(ref: ChildRef) -> str:
     return f"<{ref.tag}{attrs}>{ref.inner}</{ref.tag}>"
 
 
-def _children_field(cls: type[BaseComponent]) -> str | None:
-    """The declared field a paired tag's body text is assigned to, if any.
-
-    Which fields are slots is a type-level fact frozen in the descriptor; which
-    single one receives nested children is decided here, at expansion time, so
-    a class can carry several raw-HTML slots and still name one target.
-    """
-    fields = getattr(cls, "model_fields", {})
-    marked = [
-        name
-        for name, field in fields.items()
-        if any(isinstance(m, PjxSlot) and m.children for m in field.metadata)
-    ]
-    if len(marked) > 1:
-        raise ValueError(
-            f"{cls.__name__} marks {len(marked)} fields as the children target "
-            f"({', '.join(sorted(marked))}); exactly one field may use Children."
-        )
-    if marked:
-        return marked[0]
-    named = getattr(cls, "_pjx_children_field", None)
-    if isinstance(named, str) and named in fields:
-        return named
-    return None
-
-
 def _instantiate_child(ref: ChildRef, cls: type[BaseComponent]) -> BaseComponent:
     """Construct ``cls`` from a resolved ChildRef's attrs and body text.
 
@@ -79,7 +53,7 @@ def _instantiate_child(ref: ChildRef, cls: type[BaseComponent]) -> BaseComponent
     """
     kwargs: dict[str, str] = dict(ref.attrs)
     if ref.inner is not None and ref.inner.strip():
-        field = _children_field(cls)
+        field = cls.__pjx_descriptor__.children_field
         if field is None:
             raise ValueError(
                 f"<{ref.tag}> was given body text, but {cls.__name__} names no "

--- a/scripts/bench_render_scaling_v2.py
+++ b/scripts/bench_render_scaling_v2.py
@@ -42,6 +42,7 @@ def setup_session() -> RenderSession:
     BenchComponent.__pjx_descriptor__ = ClassDescriptor(
         template_path=Path(TEMPLATE_NAME),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,

--- a/tests/pyjinhx2/test_children_field_resolution.py
+++ b/tests/pyjinhx2/test_children_field_resolution.py
@@ -1,0 +1,25 @@
+"""Which declared field receives a PascalCase tag's body content (#369).
+
+Field selection only: nothing here renders, mounts a tag, or splices content.
+"""
+
+from typing import Annotated, ClassVar
+
+import pytest
+
+from pyjinhx2.component import (
+    BaseComponent,
+    Children,
+    PjxSlot,
+    Slot,
+    _resolve_children_field,
+    _resolve_class_descriptor,
+)
+
+
+class TestNoTarget:
+    def test_no_slot_fields_resolves_to_none(self):
+        class Plain(BaseComponent):
+            title: str = ""
+
+        assert Plain.__pjx_descriptor__.children_field is None

--- a/tests/pyjinhx2/test_children_field_resolution.py
+++ b/tests/pyjinhx2/test_children_field_resolution.py
@@ -23,3 +23,160 @@ class TestNoTarget:
             title: str = ""
 
         assert Plain.__pjx_descriptor__.children_field is None
+
+
+class TestFlaggedField:
+    def test_single_flagged_field_wins_whatever_its_name(self):
+        class Panel(BaseComponent):
+            body: Children = ""
+
+        assert Panel.__pjx_descriptor__.children_field == "body"
+
+    def test_flagged_field_beats_a_field_named_content(self):
+        class Panel(BaseComponent):
+            body: Children = ""
+            content: str = ""
+
+        assert Panel.__pjx_descriptor__.children_field == "body"
+
+    def test_two_flagged_fields_raise(self):
+        with pytest.raises(ValueError, match="multiple fields flagged"):
+
+            class Panel(BaseComponent):
+                left: Children = ""
+                right: Children = ""
+
+
+class TestContentAndBareSlots:
+    def test_field_named_content_is_the_target(self):
+        class Card(BaseComponent):
+            content: str = ""
+
+        assert Card.__pjx_descriptor__.children_field == "content"
+
+    def test_single_bare_slot_is_the_target(self):
+        class Card(BaseComponent):
+            inner: Slot = ""
+
+        assert Card.__pjx_descriptor__.children_field == "inner"
+
+    def test_two_bare_slots_are_ambiguous_and_resolve_to_none(self):
+        class Card(BaseComponent):
+            header: Slot = ""
+            footer: Slot = ""
+
+        assert Card.__pjx_descriptor__.children_field is None
+
+    def test_content_beats_a_bare_slot(self):
+        class Card(BaseComponent):
+            content: str = ""
+            inner: Slot = ""
+
+        assert Card.__pjx_descriptor__.children_field == "content"
+
+
+class TestOverride:
+    def test_override_selects_the_named_field(self):
+        class Card(BaseComponent):
+            body: str = ""
+            content: str = ""
+
+            _pjx_children_field: ClassVar[str | None] = "body"
+
+        assert Card.__pjx_descriptor__.children_field == "body"
+
+    def test_override_conflicting_with_a_flagged_field_raises(self):
+        with pytest.raises(ValueError, match="conflicts with"):
+
+            class Card(BaseComponent):
+                body: str = ""
+                other: Children = ""
+
+                _pjx_children_field: ClassVar[str | None] = "body"
+
+    def test_override_matching_the_flagged_field_is_fine(self):
+        class Card(BaseComponent):
+            body: Children = ""
+
+            _pjx_children_field: ClassVar[str | None] = "body"
+
+        assert Card.__pjx_descriptor__.children_field == "body"
+
+    def test_override_naming_an_undeclared_field_is_allowed(self):
+        class Card(BaseComponent):
+            title: str = ""
+
+            _pjx_children_field: ClassVar[str | None] = "nowhere"
+
+        assert Card.__pjx_descriptor__.children_field == "nowhere"
+        assert "nowhere" not in Card.__pjx_descriptor__.slot_fields
+
+    def test_subclass_inherits_the_override_through_the_mro(self):
+        class Parent(BaseComponent):
+            body: str = ""
+
+            _pjx_children_field: ClassVar[str | None] = "body"
+
+        class Child(Parent):
+            pass
+
+        assert Child.__pjx_descriptor__.children_field == "body"
+
+    def test_subclass_can_redeclare_its_own_override(self):
+        class Parent(BaseComponent):
+            body: str = ""
+            other: str = ""
+
+            _pjx_children_field: ClassVar[str | None] = "body"
+
+        class Child(Parent):
+            _pjx_children_field: ClassVar[str | None] = "other"
+
+        assert Child.__pjx_descriptor__.children_field == "other"
+
+
+class TestConsistency:
+    def test_a_declared_children_field_is_also_a_slot_field(self):
+        class Card(BaseComponent):
+            body: Children = ""
+
+        descriptor = Card.__pjx_descriptor__
+        assert descriptor.children_field in descriptor.slot_fields
+
+    def test_an_override_named_field_is_also_a_slot_field(self):
+        class Card(BaseComponent):
+            body: str = ""
+
+            _pjx_children_field: ClassVar[str | None] = "body"
+
+        descriptor = Card.__pjx_descriptor__
+        assert descriptor.children_field == "body"
+        assert "body" in descriptor.slot_fields
+
+    def test_marker_carried_through_annotated_metadata_directly(self):
+        class Card(BaseComponent):
+            body: Annotated[str, PjxSlot(children=True)] = ""
+
+        assert Card.__pjx_descriptor__.children_field == "body"
+
+
+class TestComputedOnce:
+    def test_descriptor_is_the_cached_object_not_recomputed(self):
+        class Card(BaseComponent):
+            body: Children = ""
+
+        assert Card.__pjx_descriptor__ is Card.__pjx_descriptor__
+
+    def test_recomputing_yields_the_same_children_field(self):
+        class Card(BaseComponent):
+            body: Children = ""
+
+        fresh = _resolve_class_descriptor(Card)
+        assert fresh is not Card.__pjx_descriptor__
+        assert fresh.children_field == Card.__pjx_descriptor__.children_field == "body"
+
+    def test_resolver_is_pure_and_repeatable(self):
+        class Card(BaseComponent):
+            body: Children = ""
+
+        assert _resolve_children_field(Card) == _resolve_children_field(Card) == "body"

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -381,6 +381,7 @@ class TestDevReloadReassignmentSmokeTest:
         replacement = ClassDescriptor(
             template_path=Path("rebuilt/card.pjx"),
             slot_fields=frozenset({"body"}),
+            children_field=None,
             css_paths=(Path("rebuilt/card.css"),),
             js_paths=(),
             strict=True,
@@ -518,6 +519,7 @@ class TestRebuildClassDescriptor:
         sentinel = ClassDescriptor(
             template_path=Path("sentinel/card.pjx"),
             slot_fields=frozenset(),
+            children_field=None,
             css_paths=(),
             js_paths=(),
             strict=True,

--- a/tests/pyjinhx2/test_component_descriptor.py
+++ b/tests/pyjinhx2/test_component_descriptor.py
@@ -101,14 +101,14 @@ class TestResolveSlotFields:
         pydantic private attribute and the name comparison silently fails."""
 
         class Designated(BaseComponent):
-            _pjx_children_field: ClassVar[str] = "kids"
+            _pjx_children_field: ClassVar[str | None] = "kids"
             kids: str = ""
 
         assert _resolve_slot_fields(Designated) == frozenset({"kids"})
 
     def test_slot_typed_and_designated_field_union(self):
         class Both(BaseComponent):
-            _pjx_children_field: ClassVar[str] = "kids"
+            _pjx_children_field: ClassVar[str | None] = "kids"
             kids: str = ""
             body: Slot = ""
 

--- a/tests/pyjinhx2/test_descriptor.py
+++ b/tests/pyjinhx2/test_descriptor.py
@@ -21,6 +21,7 @@ class Child(Base):
 def make_descriptor(
     template_path: Path = Path("cards/card.pjx"),
     slot_fields: frozenset[str] = frozenset({"header", "body"}),
+    children_field: str | None = None,
     css_paths: tuple[Path, ...] = (Path("cards/card.css"),),
     js_paths: tuple[Path, ...] = (Path("cards/card.js"),),
     strict: bool = True,
@@ -31,6 +32,7 @@ def make_descriptor(
     return ClassDescriptor(
         template_path=template_path,
         slot_fields=slot_fields,
+        children_field=children_field,
         css_paths=css_paths,
         js_paths=js_paths,
         strict=strict,
@@ -43,6 +45,7 @@ class TestClassDescriptorShape:
         descriptor = ClassDescriptor(
             template_path=Path("cards/card.pjx"),
             slot_fields=frozenset({"header", "body"}),
+            children_field=None,
             css_paths=(Path("cards/card.css"),),
             js_paths=(Path("cards/card.js"),),
             strict=True,
@@ -55,11 +58,12 @@ class TestClassDescriptorShape:
         assert descriptor.strict is True
         assert descriptor.provenance == {"template": Child, "css": Base, "js": Base}
 
-    def test_exposes_exactly_the_six_declared_fields(self):
+    def test_exposes_exactly_the_seven_declared_fields(self):
         names = [field.name for field in dataclasses.fields(ClassDescriptor)]
         assert names == [
             "template_path",
             "slot_fields",
+            "children_field",
             "css_paths",
             "js_paths",
             "strict",
@@ -85,6 +89,7 @@ class TestClassDescriptorIsFrozen:
         [
             ("template_path", Path("other.pjx")),
             ("slot_fields", frozenset()),
+            ("children_field", "other"),
             ("css_paths", ()),
             ("js_paths", ()),
             ("strict", False),
@@ -121,6 +126,7 @@ class TestClassDescriptorEmptyCollections:
         descriptor = ClassDescriptor(
             template_path=Path("plain.pjx"),
             slot_fields=frozenset(),
+            children_field=None,
             css_paths=(),
             js_paths=(),
             strict=False,

--- a/tests/pyjinhx2/test_render_children.py
+++ b/tests/pyjinhx2/test_render_children.py
@@ -118,6 +118,7 @@ def test_render_level_passes_unknown_tags_through():
     UnknownHost.__pjx_descriptor__ = ClassDescriptor(
         template_path=Path("unknown_host.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,

--- a/tests/pyjinhx2/test_render_context.py
+++ b/tests/pyjinhx2/test_render_context.py
@@ -47,6 +47,7 @@ def test_basic_field_passthrough():
     descriptor = ClassDescriptor(
         template_path=Path("card.pjx"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -75,6 +76,7 @@ def test_slot_field_wrapping_component_valued():
     descriptor = ClassDescriptor(
         template_path=Path("card.pjx"),
         slot_fields=frozenset(["content"]),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -99,6 +101,7 @@ def test_slot_field_passthrough_string_valued():
     descriptor = ClassDescriptor(
         template_path=Path("card.pjx"),
         slot_fields=frozenset(["html_content"]),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -127,6 +130,7 @@ def test_non_slot_component_valued_field():
     descriptor = ClassDescriptor(
         template_path=Path("parent.pjx"),
         slot_fields=frozenset(),  # child is NOT a slot
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -155,6 +159,7 @@ def test_nested_basemodel_fields():
     descriptor = ClassDescriptor(
         template_path=Path("form.pjx"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -179,6 +184,7 @@ def test_json_coerced_list_dict_fields():
     descriptor = ClassDescriptor(
         template_path=Path("panel.pjx"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -200,6 +206,7 @@ def test_auto_id_in_context():
     descriptor = ClassDescriptor(
         template_path=Path("some.pjx"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -221,6 +228,7 @@ def test_empty_component():
     descriptor = ClassDescriptor(
         template_path=Path("empty.pjx"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -244,6 +252,7 @@ def test_jinja_filters_on_regular_fields():
     descriptor = ClassDescriptor(
         template_path=Path("label.pjx"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -282,6 +291,7 @@ def test_forbidden_operations_fail_through_jinja(source):
     descriptor = ClassDescriptor(
         template_path=Path("card.pjx"),
         slot_fields=frozenset(["content"]),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -319,6 +329,7 @@ def test_str_routed_filters_do_not_raise(source):
     descriptor = ClassDescriptor(
         template_path=Path("card.pjx"),
         slot_fields=frozenset(["content"]),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -341,6 +352,7 @@ def test_string_slot_is_unaffected_by_opacity():
     descriptor = ClassDescriptor(
         template_path=Path("note.pjx"),
         slot_fields=frozenset(["text_field"]),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -367,6 +379,7 @@ def test_interpolation_and_truthiness_still_work():
     descriptor = ClassDescriptor(
         template_path=Path("card.pjx"),
         slot_fields=frozenset(["content"]),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,

--- a/tests/pyjinhx2/test_render_cycle_guard.py
+++ b/tests/pyjinhx2/test_render_cycle_guard.py
@@ -16,6 +16,7 @@ def descriptor_for(cls: type[BaseComponent], template: str) -> ClassDescriptor:
     return ClassDescriptor(
         template_path=Path(template),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,

--- a/tests/pyjinhx2/test_render_instantiate.py
+++ b/tests/pyjinhx2/test_render_instantiate.py
@@ -18,7 +18,7 @@ class WithChildren(BaseComponent):
 
 
 class WithChildrenVar(BaseComponent):
-    _pjx_children_field: ClassVar[str] = "content"
+    _pjx_children_field: ClassVar[str | None] = "content"
     content: Slot = ""
 
 

--- a/tests/pyjinhx2/test_render_instantiate.py
+++ b/tests/pyjinhx2/test_render_instantiate.py
@@ -5,7 +5,7 @@ from pydantic import Field, ValidationError
 
 from pyjinhx2 import discovery
 from pyjinhx2.component import BaseComponent, Children, Slot, _pascal_to_snake
-from pyjinhx2.render import _children_field, _fill_children, _instantiate_child
+from pyjinhx2.render import _fill_children, _instantiate_child
 from pyjinhx2.segments import ChildRef, RenderedLevel
 
 
@@ -22,26 +22,26 @@ class WithChildrenVar(BaseComponent):
     content: Slot = ""
 
 
-class TwoChildren(BaseComponent):
-    first: Children = ""
-    second: Children = ""
-
-
 def test_children_field_none_when_class_designates_none():
-    assert _children_field(Plain) is None
+    assert Plain.__pjx_descriptor__.children_field is None
 
 
 def test_children_field_prefers_children_marker():
-    assert _children_field(WithChildren) == "body"
+    assert WithChildren.__pjx_descriptor__.children_field == "body"
 
 
 def test_children_field_falls_back_to_class_var():
-    assert _children_field(WithChildrenVar) == "content"
+    assert WithChildrenVar.__pjx_descriptor__.children_field == "content"
 
 
 def test_children_field_raises_when_two_fields_claim_the_role():
-    with pytest.raises(ValueError, match="TwoChildren"):
-        _children_field(TwoChildren)
+    # #369: resolution now happens once at class-registration time (invariant
+    # 5), so defining the conflicting class is itself the failure point.
+    with pytest.raises(ValueError, match="multiple fields flagged"):
+
+        class TwoChildren(BaseComponent):
+            first: Children = ""
+            second: Children = ""
 
 
 class Scalars(BaseComponent):

--- a/tests/pyjinhx2/test_render_integration.py
+++ b/tests/pyjinhx2/test_render_integration.py
@@ -35,6 +35,7 @@ def test_childless_end_to_end_pipeline():
     descriptor = ClassDescriptor(
         template_path=Path("integration_childless.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -64,6 +65,7 @@ def test_autoescape_scalar_survives_pipeline():
     descriptor = ClassDescriptor(
         template_path=Path("integration_escape.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -99,6 +101,7 @@ def test_slot_field_raw_vs_scalar_escaped():
     descriptor = ClassDescriptor(
         template_path=Path("integration_slot.html"),
         slot_fields=frozenset({"markup"}),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -128,6 +131,7 @@ def test_stamped_attrs_land_in_root_tag():
     descriptor = ClassDescriptor(
         template_path=Path("integration_attrs.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -166,6 +170,7 @@ def test_full_pipeline_regression():
     descriptor = ClassDescriptor(
         template_path=Path("integration_full.html"),
         slot_fields=frozenset({"body"}),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,

--- a/tests/pyjinhx2/test_render_level.py
+++ b/tests/pyjinhx2/test_render_level.py
@@ -27,7 +27,9 @@ def _descriptor_for(
 ) -> ClassDescriptor:
     return ClassDescriptor(
         template_path=Path(template),
-        slot_fields=frozenset() if children_field is None else frozenset({children_field}),
+        slot_fields=frozenset()
+        if children_field is None
+        else frozenset({children_field}),
         children_field=children_field,
         css_paths=(),
         js_paths=(),

--- a/tests/pyjinhx2/test_render_level.py
+++ b/tests/pyjinhx2/test_render_level.py
@@ -22,10 +22,13 @@ class _PJXIcon(BaseComponent):
     pass
 
 
-def _descriptor_for(cls: type[BaseComponent], template: str) -> ClassDescriptor:
+def _descriptor_for(
+    cls: type[BaseComponent], template: str, children_field: str | None = None
+) -> ClassDescriptor:
     return ClassDescriptor(
         template_path=Path(template),
-        slot_fields=frozenset(),
+        slot_fields=frozenset() if children_field is None else frozenset({children_field}),
+        children_field=children_field,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -34,7 +37,9 @@ def _descriptor_for(cls: type[BaseComponent], template: str) -> ClassDescriptor:
 
 
 _PJXButton.__pjx_descriptor__ = _descriptor_for(_PJXButton, "child_button.html")
-_PJXCard.__pjx_descriptor__ = _descriptor_for(_PJXCard, "child_card.html")
+_PJXCard.__pjx_descriptor__ = _descriptor_for(
+    _PJXCard, "child_card.html", children_field="body"
+)
 _PJXIcon.__pjx_descriptor__ = _descriptor_for(_PJXIcon, "child_icon.html")
 
 
@@ -66,6 +71,7 @@ def test_single_div_renders():
     descriptor = ClassDescriptor(
         template_path=Path("div.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -99,6 +105,7 @@ def test_child_tag_becomes_childref():
     descriptor = ClassDescriptor(
         template_path=Path("container.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -128,6 +135,7 @@ def test_nested_pascalcase_preserved():
     descriptor = ClassDescriptor(
         template_path=Path("nested.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -161,6 +169,7 @@ def test_multiple_siblings_raises():
     descriptor = ClassDescriptor(
         template_path=Path("bad.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -185,6 +194,7 @@ def test_no_root_element_raises():
     descriptor = ClassDescriptor(
         template_path=Path("empty.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -211,6 +221,7 @@ def test_descriptor_frozen_and_read():
     descriptor = ClassDescriptor(
         template_path=Path("test.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -243,6 +254,7 @@ def test_self_closing_tag():
     descriptor = ClassDescriptor(
         template_path=Path("icon.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -275,6 +287,7 @@ def test_paired_tag():
     descriptor = ClassDescriptor(
         template_path=Path("card.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -310,6 +323,7 @@ def test_autoescape_active():
     descriptor = ClassDescriptor(
         template_path=Path("unsafe.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -337,6 +351,7 @@ def test_lowercase_passes_through():
     descriptor = ClassDescriptor(
         template_path=Path("lowercase.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -368,6 +383,7 @@ def test_mixedcase_passes_through():
     descriptor = ClassDescriptor(
         template_path=Path("mixedcase.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -400,6 +416,7 @@ def test_slot_fields_wrapped():
     descriptor = ClassDescriptor(
         template_path=Path("slotted.html"),
         slot_fields=frozenset({"content"}),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -427,6 +444,7 @@ def test_roundtrip_serialize():
     descriptor = ClassDescriptor(
         template_path=Path("roundtrip.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -476,6 +494,7 @@ def test_minimal_descriptor():
     descriptor = ClassDescriptor(
         template_path=Path("minimal.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -515,6 +534,7 @@ def test_performance_100plus_fields():
     descriptor = ClassDescriptor(
         template_path=Path("minimal.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -550,6 +570,7 @@ def test_missing_template_names_component_and_path():
     descriptor = ClassDescriptor(
         template_path=Path("does_not_exist.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -579,6 +600,7 @@ def test_missing_template_preserves_exception_type():
     descriptor = ClassDescriptor(
         template_path=Path("also_missing.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -609,6 +631,7 @@ def test_zero_root_names_component_and_path():
     descriptor = ClassDescriptor(
         template_path=Path("empty.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -638,6 +661,7 @@ def test_multi_root_names_component_and_path():
     descriptor = ClassDescriptor(
         template_path=Path("bad.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -667,6 +691,7 @@ def test_valid_component_unaffected_by_error_wrapping():
     descriptor = ClassDescriptor(
         template_path=Path("div.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -695,6 +720,7 @@ def test_template_assertion_error_not_wrapped():
     descriptor = ClassDescriptor(
         template_path=Path("broken_assertion.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -729,6 +755,7 @@ def test_interpolated_component_slot_becomes_a_nested_level():
     SpliceLeaf.__pjx_descriptor__ = ClassDescriptor(
         template_path=Path("slot_leaf.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -737,6 +764,7 @@ def test_interpolated_component_slot_becomes_a_nested_level():
     SpliceBox.__pjx_descriptor__ = ClassDescriptor(
         template_path=Path("slot_interp.html"),
         slot_fields=frozenset({"content"}),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,

--- a/tests/pyjinhx2/test_render_nested_integration.py
+++ b/tests/pyjinhx2/test_render_nested_integration.py
@@ -23,6 +23,7 @@ def descriptor_for(cls: type[BaseComponent], template: str) -> ClassDescriptor:
     return ClassDescriptor(
         template_path=Path(template),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,

--- a/tests/pyjinhx2/test_render_public.py
+++ b/tests/pyjinhx2/test_render_public.py
@@ -24,6 +24,7 @@ def _make_component(template_path: str):
     descriptor = ClassDescriptor(
         template_path=Path(template_path),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -55,6 +56,7 @@ def test_render_roundtrips_template_output(render_session):
     descriptor = ClassDescriptor(
         template_path=Path("roundtrip.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -82,6 +84,7 @@ def test_render_uses_explicit_session(tmp_path):
     descriptor = ClassDescriptor(
         template_path=Path("custom.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -112,6 +115,7 @@ def test_render_without_session_uses_default(monkeypatch, tmp_path):
     descriptor = ClassDescriptor(
         template_path=Path("default.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
@@ -136,6 +140,7 @@ def test_render_missing_template_raises(render_session):
     descriptor = ClassDescriptor(
         template_path=Path("does_not_exist.html"),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,

--- a/tests/pyjinhx2/test_render_splice.py
+++ b/tests/pyjinhx2/test_render_splice.py
@@ -17,6 +17,7 @@ def descriptor_for(cls: type[BaseComponent], template: str) -> ClassDescriptor:
     return ClassDescriptor(
         template_path=Path(template),
         slot_fields=frozenset(),
+        children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,

--- a/tests/pyjinhx2/test_slot_type_v2.py
+++ b/tests/pyjinhx2/test_slot_type_v2.py
@@ -62,7 +62,7 @@ class _DesignatedChildren(BaseComponent):
     # string "kids", and the `==` check in `_is_slot_field` silently returns False.
     # The explicit `ClassVar[str]` annotation on this subclass sidesteps that
     # without touching `BaseComponent` itself. Verified: without it, this test fails.
-    _pjx_children_field: ClassVar[str] = "kids"
+    _pjx_children_field: ClassVar[str | None] = "kids"
     kids: str = ""  # designated children field, no PjxSlot metadata
 
 

--- a/tests/pyjinhx2/test_slot_type_v2.py
+++ b/tests/pyjinhx2/test_slot_type_v2.py
@@ -166,6 +166,7 @@ class TestSlotTruthinessInTemplates:
         component_cls.__pjx_descriptor__ = ClassDescriptor(
             template_path=Path(template),
             slot_fields=frozenset(slots),
+            children_field=None,
             css_paths=(),
             js_paths=(),
             strict=True,
@@ -213,6 +214,7 @@ class TestSlotInterpolation:
         component_cls.__pjx_descriptor__ = ClassDescriptor(
             template_path=Path(template),
             slot_fields=frozenset(slots),
+            children_field=None,
             css_paths=(),
             js_paths=(),
             strict=True,
@@ -327,6 +329,7 @@ class TestSlotSpliceGuards:
         component_cls.__pjx_descriptor__ = ClassDescriptor(
             template_path=Path(template),
             slot_fields=frozenset(slots),
+            children_field=None,
             css_paths=(),
             js_paths=(),
             strict=True,
@@ -366,6 +369,7 @@ class TestSlotSpliceGuards:
         descriptor = ClassDescriptor(
             template_path=Path("slot_leaf.html"),
             slot_fields=frozenset({"absent"}),
+            children_field=None,
             css_paths=(),
             js_paths=(),
             strict=True,


### PR DESCRIPTION
## Summary
- Adds comprehensive test coverage for children field precedence rules
- Validates override handling and consistency with slot_fields
- Tests MRO inheritance and precedence across different field types
- 20 new tests ensuring children field resolution correctness

## Test plan
- 2 implementation commits included
- 20 new test cases added to test_children_field_resolution.py
- Existing component descriptor tests updated for type consistency

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)