### PR TITLE
docs: record the .props design call in ADR 0003 (#372)

### DIFF
--- a/docs/superpowers/rebuild/adr/0003-slot-opacity.md
+++ b/docs/superpowers/rebuild/adr/0003-slot-opacity.md
@@ -28,6 +28,19 @@ String-valued slots (a `Slot` field assigned a plain string) are unaffected — 
 
 L1.3 (roadmap item 3) calls for `{{ field.props.x }}` alongside bare `{{ field }}` — reading a nested child's *validated field values* from the parent template, without breaking opacity. This is narrower than general attribute delegation: the wrapper exposes exactly `.props` (a read-only view over the child component's own fields, not arbitrary Python attributes/methods), plus interpolation and truthiness. It does not expose `__str__`/`__len__`/iteration or any other implicit stringification hook — those still raise the ADR's targeted opacity error. This keeps the "no hidden render forcing" guarantee: reading `.props.x` touches the child's *already-validated* field data, not its rendered output.
 
+**Implementation note (L1.3.6).** `.props` landed as a property on the
+existing `ComponentNode` rather than a separate `NestedComponentWrapper`
+type — the amendment's surface is props-only, so a second class would add
+no invariant. The view is a purpose-built `SlotProps` object, not a
+`MappingProxyType`: a mapping proxy would supply `__str__`, `__len__` and
+iteration, reopening the stringification hole this ADR closes. `SlotProps`
+exposes attribute and key access only; `str()` raises the same targeted
+opacity error as the node, and `len()`/iteration/comparison are simply not
+implemented. Unknown names raise `AttributeError`/`KeyError`, since a typo
+in the sanctioned escape hatch is a lookup failure, not an opacity
+violation. Component-valued props stay live child instances — dumping them
+would eventually stringify markup.
+
 ## Survey outcome (2026-07-30)
 
 L0.G ran the pre-RFC-1 survey this ADR calls for, split across three gate subtasks:

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -426,6 +426,29 @@ class BaseComponent(BaseModel):
         description="The unique ID for this component. Auto-generated when omitted.",
     )
 
+    def pjx_props(self) -> dict[str, Any]:
+        """This component's own validated field values, one shallow snapshot.
+
+        Component-valued fields keep their live instances instead of being
+        dumped: dumping them would walk into a child's slots and eventually
+        stringify markup, which is exactly what ADR 0003's opacity rule
+        forbids. Any other nested model is a plain data value, so it dumps.
+        """
+        props: dict[str, Any] = {}
+        for name in type(self).model_fields:
+            value = getattr(self, name)
+            if isinstance(value, BaseComponent):
+                props[name] = value
+            elif isinstance(value, list):
+                props[name] = list(value)
+            elif isinstance(value, dict):
+                props[name] = dict(value)
+            elif isinstance(value, BaseModel):
+                props[name] = value.model_dump()
+            else:
+                props[name] = value
+        return props
+
     def __init_subclass__(cls, *, pjx_replace: bool = False, **kwargs: Any) -> None:
         """Consume the ``pjx_replace`` class kwarg before it reaches
         ``object.__init_subclass__``, which accepts no keyword arguments.

--- a/pyjinhx2/markers.py
+++ b/pyjinhx2/markers.py
@@ -14,6 +14,51 @@ if TYPE_CHECKING:
     from pyjinhx2.component import BaseComponent
 
 
+class SlotProps:
+    """Read-only view over a slotted child's own validated field values.
+
+    ADR 0003's single sanctioned escape hatch. Attribute and key access are
+    the whole surface: a MappingProxyType would also hand back __str__,
+    __len__ and iteration, reopening exactly the stringification hole the
+    opaque node exists to close. Unknown names fail as ordinary lookups, so
+    a typo in `{{ field.props.x }}` reads as a typo and not as an opacity
+    violation.
+    """
+
+    __slots__ = ("_node", "_values")
+
+    def __init__(self, values: dict[str, object], node: ComponentNode) -> None:
+        object.__setattr__(self, "_values", values)
+        object.__setattr__(self, "_node", node)
+
+    def __getattr__(self, name: str) -> object:
+        values: dict[str, object] = object.__getattribute__(self, "_values")
+        if name not in values:
+            raise AttributeError(name)
+        return values[name]
+
+    def __getitem__(self, key: str) -> object:
+        # Guards against Python's legacy iteration protocol, which probes
+        # __getitem__ with integer indices when no __iter__ is defined;
+        # rejecting non-str keys keeps `list(props)` a TypeError, not a
+        # KeyError that leaks internal dict iteration as a side door.
+        if not isinstance(key, str):
+            raise TypeError(f"slot props keys must be str, got {type(key).__name__}")
+        values: dict[str, object] = object.__getattribute__(self, "_values")
+        return values[key]
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("slot props are read-only")
+
+    def __str__(self) -> str:
+        node: ComponentNode = object.__getattribute__(self, "_node")
+        raise node._opaque_error(".props")
+
+    def __repr__(self) -> str:
+        node: ComponentNode = object.__getattribute__(self, "_node")
+        return f"SlotProps({type(node.component).__name__})"
+
+
 class ComponentNode:
     """Opaque marker wrapping a component-valued Slot field.
 
@@ -64,6 +109,16 @@ class ComponentNode:
 
     def __repr__(self) -> str:
         return f"ComponentNode({self.component!r})"
+
+    @property
+    def props(self) -> SlotProps:
+        """The wrapped child's validated field values, read-only.
+
+        Built on each access from the child's current field values; reading
+        them never touches the child's rendered output, so `{{ field.props.x }}`
+        cannot force a render the way stringifying the node would.
+        """
+        return SlotProps(self.component.pjx_props(), self)
 
     def _opaque_error(self, operation: str) -> TypeError:
         """The error for any operation ADR 0003 forbids on a component slot.

--- a/tests/pyjinhx2/test_slot_props_view.py
+++ b/tests/pyjinhx2/test_slot_props_view.py
@@ -137,7 +137,7 @@ class TestSlotPropsView:
         props = self.node(Leaf(title="hello")).props
 
         with pytest.raises(AttributeError):
-            props.nope
+            _ = props.nope
 
     def test_an_unknown_key_raises_key_error(self):
         props = self.node(Leaf(title="hello")).props
@@ -151,7 +151,7 @@ class TestSlotPropsView:
         props = self.node(Leaf(title="hello")).props
 
         with pytest.raises(AttributeError) as excinfo:
-            props.nope
+            _ = props.nope
         assert not isinstance(excinfo.value, TypeError)
 
     def test_str_raises_the_opacity_error(self):

--- a/tests/pyjinhx2/test_slot_props_view.py
+++ b/tests/pyjinhx2/test_slot_props_view.py
@@ -1,0 +1,380 @@
+"""L1.3.6 — the `.props` read-only view on a slot's ComponentNode (#372).
+
+`.props` is ADR 0003's single sanctioned escape hatch: it reads the child
+component's already-validated field values and never touches its rendered
+output.
+"""
+
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from pyjinhx2.component import BaseComponent, Children, Slot
+from pyjinhx2.descriptor import ClassDescriptor
+
+
+def descriptor(template: str, slots: frozenset[str], children: str | None = None):
+    """A ClassDescriptor pointing at a fixture template under tests/templates."""
+    return ClassDescriptor(
+        template_path=Path(template),
+        slot_fields=slots,
+        children_field=children,
+        css_paths=(),
+        js_paths=(),
+        strict=True,
+        provenance={},
+    )
+
+
+class Leaf(BaseComponent):
+    title: str = "x"
+    count: int = 0
+
+
+Leaf.__pjx_descriptor__ = descriptor("slot_leaf.html", frozenset())
+
+
+class TestPjxProps:
+    def test_it_returns_the_declared_field_values(self):
+        leaf = Leaf(title="hello", count=3)
+
+        props = leaf.pjx_props()
+
+        assert props["title"] == "hello"
+        assert props["count"] == 3
+
+    def test_it_includes_the_id_field(self):
+        leaf = Leaf(id="leaf-1")
+
+        assert leaf.pjx_props()["id"] == "leaf-1"
+
+    def test_a_component_valued_field_stays_the_live_instance(self):
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        leaf = Leaf(title="inner")
+        card = Card(content=leaf)
+
+        assert card.pjx_props()["content"] is leaf
+
+    def test_a_list_of_components_stays_a_list_of_instances(self):
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        a, b = Leaf(title="a"), Leaf(title="b")
+        card = Card(content=[a, b])
+
+        props = card.pjx_props()
+
+        assert props["content"] == [a, b]
+        assert props["content"][0] is a
+
+    def test_a_dict_of_components_stays_a_dict_of_instances(self):
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        a = Leaf(title="a")
+        card = Card(content={"one": a})
+
+        assert card.pjx_props()["content"]["one"] is a
+
+    def test_a_children_field_behaves_like_any_other_slot_field(self):
+        class Wrap(BaseComponent):
+            inner: Children = ""
+
+        leaf = Leaf(title="deep")
+
+        assert Wrap(inner=leaf).pjx_props()["inner"] is leaf
+
+    def test_a_plain_nested_basemodel_is_dumped(self):
+        class Meta(BaseModel):
+            author: str
+
+        class Article(BaseComponent):
+            meta: Meta
+
+        props = Article(meta=Meta(author="ada")).pjx_props()
+
+        assert props["meta"] == {"author": "ada"}
+
+    def test_the_returned_dict_is_a_fresh_copy(self):
+        leaf = Leaf(title="hello")
+
+        props = leaf.pjx_props()
+        props["title"] = "mutated"
+
+        assert leaf.title == "hello"
+        assert leaf.pjx_props()["title"] == "hello"
+
+
+class TestSlotPropsView:
+    def node(self, component: BaseComponent):
+        from pyjinhx2.markers import ComponentNode
+
+        return ComponentNode(
+            component,
+            owner_name="Card",
+            owner_template=Path("slot_props.html"),
+            field_name="content",
+        )
+
+    def test_attribute_access_returns_the_validated_value(self):
+        assert self.node(Leaf(title="hello")).props.title == "hello"
+
+    def test_attribute_access_preserves_the_python_type(self):
+        value = self.node(Leaf(count=3)).props.count
+
+        assert value == 3
+        assert type(value) is int
+
+    def test_subscript_access_is_equivalent_to_attribute_access(self):
+        props = self.node(Leaf(title="hello")).props
+
+        assert props["title"] == props.title
+
+    def test_an_unknown_attribute_raises_attribute_error(self):
+        props = self.node(Leaf(title="hello")).props
+
+        with pytest.raises(AttributeError):
+            props.nope
+
+    def test_an_unknown_key_raises_key_error(self):
+        props = self.node(Leaf(title="hello")).props
+
+        with pytest.raises(KeyError):
+            props["nope"]
+
+    def test_an_unknown_name_does_not_raise_the_opacity_type_error(self):
+        # `.props` is the sanctioned escape hatch, so a typo there is an
+        # ordinary lookup failure, not ADR 0003's opacity error.
+        props = self.node(Leaf(title="hello")).props
+
+        with pytest.raises(AttributeError) as excinfo:
+            props.nope
+        assert not isinstance(excinfo.value, TypeError)
+
+    def test_str_raises_the_opacity_error(self):
+        props = self.node(Leaf(title="hello")).props
+
+        with pytest.raises(TypeError, match=r"slot 'content' holds a rendered"):
+            str(props)
+
+    def test_len_is_not_supported(self):
+        props = self.node(Leaf(title="hello")).props
+
+        with pytest.raises(TypeError):
+            len(props)  # pyright: ignore[reportArgumentType]
+
+    def test_iteration_is_not_supported(self):
+        props = self.node(Leaf(title="hello")).props
+
+        with pytest.raises(TypeError):
+            list(props)  # pyright: ignore[reportCallIssue, reportArgumentType]
+
+    def test_the_view_is_read_only(self):
+        props = self.node(Leaf(title="hello")).props
+
+        with pytest.raises(AttributeError):
+            props.title = "mutated"
+
+    def test_repr_is_safe_for_debugging(self):
+        props = self.node(Leaf(title="hello")).props
+
+        assert "SlotProps" in repr(props)
+
+    def test_a_component_valued_prop_stays_the_live_child(self):
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        leaf = Leaf(title="inner")
+
+        assert self.node(Card(content=leaf)).props.content is leaf
+
+    def test_the_nodes_own_forbidden_ops_are_unchanged(self):
+        node = self.node(Leaf(title="hello"))
+
+        with pytest.raises(TypeError, match=r"slot 'content' holds a rendered"):
+            len(node)  # pyright: ignore[reportArgumentType]
+        with pytest.raises(TypeError, match=r"slot 'content' holds a rendered"):
+            list(node)  # pyright: ignore[reportCallIssue, reportArgumentType]
+        assert bool(node) is True
+
+
+class TestPropsThroughJinja:
+    def session(self):
+        from pyjinhx2.session import RenderSession
+
+        return RenderSession(template_dir="tests/templates")
+
+    def card_class(self, template: str):
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        Card.__pjx_descriptor__ = descriptor(template, frozenset({"content"}))
+        return Card
+
+    def test_a_props_field_renders_its_validated_value(self):
+        from pyjinhx2.render import render
+
+        Card = self.card_class("slot_props.html")
+
+        output = render(Card(content=Leaf(title="hello")), self.session())
+
+        assert output == '<div class="box">hello</div>'
+
+    def test_a_props_value_is_escaped_like_ordinary_text(self):
+        # `.props` hands back a plain str, so autoescape applies: only the
+        # bare `{{ field }}` path is exempt from escaping.
+        from pyjinhx2.render import render
+
+        Card = self.card_class("slot_props.html")
+
+        output = render(Card(content=Leaf(title="<b>x</b>")), self.session())
+
+        assert output == '<div class="box">&lt;b&gt;x&lt;/b&gt;</div>'
+
+    def test_reading_props_does_not_render_the_child(self):
+        import pyjinhx2.render as render_module
+
+        Card = self.card_class("slot_props.html")
+        seen: list[str] = []
+        original = render_module.render_level
+
+        def spy(component, session_, chain=()):
+            seen.append(type(component).__name__)
+            return original(component, session_, chain)
+
+        render_module.render_level = spy
+        try:
+            render_module.render_level(
+                Card(content=Leaf(title="hello")), self.session()
+            )
+        finally:
+            render_module.render_level = original
+
+        assert seen == ["Card"]
+
+    def test_reading_props_produces_no_slot_token(self):
+        from pyjinhx2.render import render_level
+
+        Card = self.card_class("slot_props.html")
+
+        level = render_level(Card(content=Leaf(title="hello")), self.session())
+        text = "".join(s for s in level.segments if isinstance(s, str))
+
+        assert "pjx-slot-" not in text
+
+    def test_reading_props_creates_no_nested_rendered_level(self):
+        from pyjinhx2.render import render_level
+        from pyjinhx2.segments import RenderedLevel
+
+        Card = self.card_class("slot_props.html")
+
+        level = render_level(Card(content=Leaf(title="hello")), self.session())
+
+        assert [s for s in level.segments if isinstance(s, RenderedLevel)] == []
+
+    def test_interpolating_the_view_itself_raises_the_opacity_error(self):
+        from pyjinhx2.render import render
+
+        Card = self.card_class("slot_props_bare_view.html")
+
+        with pytest.raises(
+            TypeError, match=r"slot 'content' holds a rendered component"
+        ):
+            render(Card(content=Leaf(title="hello")), self.session())
+
+
+class TestPropsRegressions:
+    def session(self):
+        from pyjinhx2.session import RenderSession
+
+        return RenderSession(template_dir="tests/templates")
+
+    def card_class(self, template: str):
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        Card.__pjx_descriptor__ = descriptor(template, frozenset({"content"}))
+        return Card
+
+    def test_bare_interpolation_still_splices_the_child(self):
+        from pyjinhx2.render import render
+
+        Card = self.card_class("slot_interp.html")
+
+        output = render(Card(content=Leaf(title="a")), self.session())
+
+        assert output == (
+            '<div class="box">before <span class="leaf">a</span> after</div>'
+        )
+
+    def test_truthiness_still_takes_the_present_branch(self):
+        from pyjinhx2.render import render
+
+        Card = self.card_class("slot_if.html")
+
+        assert render(Card(content=Leaf(title="a")), self.session()) == "<div>HAS</div>"
+
+    def test_truthiness_still_takes_the_absent_branch(self):
+        from pyjinhx2.render import render
+
+        Card = self.card_class("slot_if.html")
+
+        assert render(Card(content=""), self.session()) == "<div>NONE</div>"
+
+    def test_props_works_on_a_list_wrapped_entry(self):
+        from pyjinhx2.render import render
+
+        Card = self.card_class("slot_props_list.html")
+
+        output = render(
+            Card(content=[Leaf(title="a"), Leaf(title="b")]), self.session()
+        )
+
+        assert output == '<div class="list"><i>a</i><i>b</i></div>'
+
+    def test_props_works_on_a_dict_wrapped_entry(self):
+        from pyjinhx2.render import render
+
+        Card = self.card_class("slot_props_dict.html")
+
+        output = render(Card(content={"one": Leaf(title="a")}), self.session())
+
+        assert output == '<div class="map"><b>one</b><i>a</i></div>'
+
+    def test_wrapping_still_happens_in_build_context_unchanged(self):
+        # `.props` reads the component reference the node already carries, so
+        # the wrapping layer needed no change; this pins that.
+        from pyjinhx2.markers import ComponentNode
+        from pyjinhx2.render_context import build_context
+
+        Card = self.card_class("slot_props.html")
+        leaf = Leaf(title="hello")
+
+        context = build_context(Card(content=leaf), Card.__pjx_descriptor__)
+
+        assert type(context["content"]) is ComponentNode
+        assert context["content"].component is leaf
+        assert context["content"].props.title == "hello"
+
+    def test_a_nested_component_valued_prop_is_not_stringified(self):
+        from pyjinhx2.markers import ComponentNode
+        from pyjinhx2.render_context import build_context
+
+        class Wrap(BaseComponent):
+            inner: Children = ""
+
+        Wrap.__pjx_descriptor__ = descriptor(
+            "nest_wrap.html", frozenset({"inner"}), "inner"
+        )
+        Card = self.card_class("slot_props.html")
+        leaf = Leaf(title="deep")
+
+        context = build_context(Card(content=Wrap(inner=leaf)), Card.__pjx_descriptor__)
+        nested = context["content"].props.inner
+
+        assert nested is leaf
+        assert not isinstance(nested, str)
+        assert not isinstance(nested, ComponentNode)

--- a/tests/templates/slot_props.html
+++ b/tests/templates/slot_props.html
@@ -1,0 +1,1 @@
+<div class="box">{{ content.props.title }}</div>

--- a/tests/templates/slot_props_bare_view.html
+++ b/tests/templates/slot_props_bare_view.html
@@ -1,0 +1,1 @@
+<div class="box">{{ content.props }}</div>

--- a/tests/templates/slot_props_dict.html
+++ b/tests/templates/slot_props_dict.html
@@ -1,0 +1,1 @@
+<div class="map">{% for key, item in content.items() %}<b>{{ key }}</b><i>{{ item.props.title }}</i>{% endfor %}</div>

--- a/tests/templates/slot_props_list.html
+++ b/tests/templates/slot_props_list.html
@@ -1,0 +1,1 @@
+<div class="list">{% for item in content %}<i>{{ item.props.title }}</i>{% endfor %}</div>


### PR DESCRIPTION
## Summary

Records the design discussion and decision for .props access on ComponentNode in ADR 0003. Includes exposure of read-only .props view on ComponentNode, BaseComponent.pjx_props field snapshot, support for list/dict of components in Slot/Children, and comprehensive test coverage including real Jinja environment tests, collections, regressions, and edge cases.

## Changes

- **Docs**: Record .props design call and NestedComponentWrapper.props access in ADR 0003
- **Feat**: Expose read-only .props view on ComponentNode and add BaseComponent.pjx_props field snapshot
- **Feat**: Accept list/dict of components in Slot/Children fields
- **Fix**: Type annotation corrections and isinstance checks for basedpyright
- **Test**: 18+ new tests covering render chains, child precedence, components as slots, and determinism

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)