### PR TITLE
fix: rename test_props_header.py to test_props_header_parse.py to avoid naming conflict

### DIFF
--- a/pyjinhx2/props_header.py
+++ b/pyjinhx2/props_header.py
@@ -1,0 +1,29 @@
+"""Parse a template's leading ``{#def ... #}`` prop header into a prop spec.
+
+A classless component template declares its props in a header that is the first
+non-whitespace in the file::
+
+    {#def title: str, count: int = 0, variant: str = "primary" #}
+
+The header is a valid (inert) Jinja comment; pyjinhx reads it out-of-band. This
+module only parses — turning the result into a component class is done by the
+caller.
+"""
+
+import ast
+import re
+from typing import Any
+
+_HEADER_RE = re.compile(r"\A\s*\{#\s*def\s+(?P<sig>.*?)\s*#\}", re.DOTALL)
+
+
+def parse_props_header(source: str) -> list[tuple[str, Any, Any]] | None:
+    """Parse a ``{#def ... #}`` header; return ``[(name, type, default), ...]`` or None.
+
+    ``default`` is ``Ellipsis`` (``...``) for a required prop. Raises ``ValueError``
+    for a malformed signature, a non-literal default, or a duplicate prop.
+    """
+    match = _HEADER_RE.match(source)
+    if match is None:
+        return None
+    return []

--- a/pyjinhx2/props_header.py
+++ b/pyjinhx2/props_header.py
@@ -32,6 +32,24 @@ def _resolve_annotation(node: ast.expr | None) -> Any:
         return Any
     if isinstance(node, ast.Name):
         return _TYPES.get(node.id, Any)
+    if isinstance(node, ast.Constant) and node.value is None:
+        return type(None)
+    # T | None  ->  Optional[T]
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left = _resolve_annotation(node.left)
+        right = _resolve_annotation(node.right)
+        if right is type(None):
+            return left | None
+        if left is type(None):
+            return right | None
+        return Any
+    # Optional[T]
+    if (
+        isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "Optional"
+    ):
+        return _resolve_annotation(node.slice) | None
     return Any
 
 

--- a/pyjinhx2/props_header.py
+++ b/pyjinhx2/props_header.py
@@ -66,7 +66,17 @@ def parse_props_header(source: str) -> list[tuple[str, Any, Any]] | None:
     tree = ast.parse(f"def __pjx_props__({signature}): pass")
     func = tree.body[0]
     assert isinstance(func, ast.FunctionDef)
+    arguments = func.args
+    args = arguments.args
+    defaults = arguments.defaults
+    # Defaults bind to the *last* N params, so this offset maps index -> default.
+    offset = len(args) - len(defaults)
     fields: list[tuple[str, Any, Any]] = []
-    for arg in func.args.args:
-        fields.append((arg.arg, _resolve_annotation(arg.annotation), ...))
+    for index, arg in enumerate(args):
+        annotation = _resolve_annotation(arg.annotation)
+        if index >= offset:
+            default = ast.literal_eval(defaults[index - offset])
+        else:
+            default = ...
+        fields.append((arg.arg, annotation, default))
     return fields

--- a/pyjinhx2/props_header.py
+++ b/pyjinhx2/props_header.py
@@ -63,20 +63,46 @@ def parse_props_header(source: str) -> list[tuple[str, Any, Any]] | None:
     if match is None:
         return None
     signature = match.group("sig")
-    tree = ast.parse(f"def __pjx_props__({signature}): pass")
+    try:
+        tree = ast.parse(f"def __pjx_props__({signature}): pass")
+    except SyntaxError as exc:
+        raise ValueError(
+            f"invalid {{#def#}} header signature {signature!r}: {exc.msg}"
+        ) from exc
     func = tree.body[0]
     assert isinstance(func, ast.FunctionDef)
     arguments = func.args
+    if (
+        arguments.vararg
+        or arguments.kwarg
+        or arguments.kwonlyargs
+        or arguments.posonlyargs
+    ):
+        raise ValueError(
+            f"{{#def#}} header may only use simple named props: {signature!r}"
+        )
     args = arguments.args
     defaults = arguments.defaults
     # Defaults bind to the *last* N params, so this offset maps index -> default.
     offset = len(args) - len(defaults)
+    seen: set[str] = set()
     fields: list[tuple[str, Any, Any]] = []
     for index, arg in enumerate(args):
+        name = arg.arg
+        if name in seen:
+            raise ValueError(f"{{#def#}} header has duplicate prop {name!r}")
+        seen.add(name)
         annotation = _resolve_annotation(arg.annotation)
         if index >= offset:
-            default = ast.literal_eval(defaults[index - offset])
+            default_node = defaults[index - offset]
+            try:
+                default = ast.literal_eval(default_node)
+            except (ValueError, SyntaxError) as exc:
+                raise ValueError(
+                    f"{{#def#}} header default for {name!r} must be a literal: "
+                    f"{ast.unparse(default_node)!r}"
+                ) from exc
         else:
             default = ...
-        fields.append((arg.arg, annotation, default))
+        fields.append((name, annotation, default))
     return fields

--- a/pyjinhx2/props_header.py
+++ b/pyjinhx2/props_header.py
@@ -16,6 +16,24 @@ from typing import Any
 
 _HEADER_RE = re.compile(r"\A\s*\{#\s*def\s+(?P<sig>.*?)\s*#\}", re.DOTALL)
 
+_TYPES: dict[str, Any] = {
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "list": list,
+    "dict": dict,
+    "Any": Any,
+}
+
+
+def _resolve_annotation(node: ast.expr | None) -> Any:
+    if node is None:
+        return Any
+    if isinstance(node, ast.Name):
+        return _TYPES.get(node.id, Any)
+    return Any
+
 
 def parse_props_header(source: str) -> list[tuple[str, Any, Any]] | None:
     """Parse a ``{#def ... #}`` header; return ``[(name, type, default), ...]`` or None.
@@ -26,4 +44,11 @@ def parse_props_header(source: str) -> list[tuple[str, Any, Any]] | None:
     match = _HEADER_RE.match(source)
     if match is None:
         return None
-    return []
+    signature = match.group("sig")
+    tree = ast.parse(f"def __pjx_props__({signature}): pass")
+    func = tree.body[0]
+    assert isinstance(func, ast.FunctionDef)
+    fields: list[tuple[str, Any, Any]] = []
+    for arg in func.args.args:
+        fields.append((arg.arg, _resolve_annotation(arg.annotation), ...))
+    return fields

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -28,6 +28,7 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # scheme that could drift from the one templates are probed with.
     "discovery": frozenset({"pyjinhx2.component"}),
     "markers": frozenset({"pyjinhx2.component"}),
+    "props_header": frozenset(),
     # render resolves each ChildRef tag against the published class registry;
     # an unregistered tag is emitted verbatim, so this is a read-only edge.
     "render": frozenset(

--- a/tests/pyjinhx2/test_props_header.py
+++ b/tests/pyjinhx2/test_props_header.py
@@ -96,3 +96,34 @@ def test_required_and_defaulted_props_mix_in_declared_order():
         ("count", int, 0),
         ("variant", str, "primary"),
     ]
+
+
+def test_duplicate_prop_name_is_rejected():
+    with pytest.raises(ValueError, match="duplicate prop 'title'"):
+        parse_props_header("{#def title: str, title: int #}")
+
+
+@pytest.mark.parametrize(
+    "signature",
+    ["*args", "**kwargs", "*, x: int", "x, /", "title: str, *rest"],
+)
+def test_non_simple_parameters_are_rejected(signature: str):
+    """Props are plain named keywords — varargs and slot markers have no meaning."""
+    with pytest.raises(ValueError, match="simple named props"):
+        parse_props_header(f"{{#def {signature} #}}")
+
+
+def test_non_literal_default_is_rejected():
+    with pytest.raises(ValueError, match="default for 'x' must be a literal"):
+        parse_props_header("{#def x: int = some_call() #}")
+
+
+def test_name_reference_default_is_rejected():
+    """A bare name would need evaluation; the parser never executes header code."""
+    with pytest.raises(ValueError, match="default for 'x' must be a literal"):
+        parse_props_header("{#def x: int = DEFAULT_X #}")
+
+
+def test_malformed_signature_is_rejected():
+    with pytest.raises(ValueError, match="invalid"):
+        parse_props_header("{#def title: str = ( #}")

--- a/tests/pyjinhx2/test_props_header.py
+++ b/tests/pyjinhx2/test_props_header.py
@@ -65,3 +65,34 @@ def test_optional_subscript_becomes_the_same_union():
     assert parse_props_header("{#def value: Optional[int] #}") == [
         ("value", int | None, ...)
     ]
+
+
+@pytest.mark.parametrize(
+    "source_default, expected",
+    [
+        ('"primary"', "primary"),
+        ("0", 0),
+        ("1.5", 1.5),
+        ("True", True),
+        ("None", None),
+        ("[1, 2]", [1, 2]),
+        ('{"a": 1}', {"a": 1}),
+    ],
+)
+def test_literal_default_is_captured_instead_of_ellipsis(
+    source_default: str, expected: Any
+):
+    fields = parse_props_header(f"{{#def value = {source_default} #}}")
+    assert fields is not None
+    name, _annotation, default = fields[0]
+    assert (name, default) == ("value", expected)
+
+
+def test_required_and_defaulted_props_mix_in_declared_order():
+    assert parse_props_header(
+        '{#def title: str, count: int = 0, variant: str = "primary" #}'
+    ) == [
+        ("title", str, ...),
+        ("count", int, 0),
+        ("variant", str, "primary"),
+    ]

--- a/tests/pyjinhx2/test_props_header.py
+++ b/tests/pyjinhx2/test_props_header.py
@@ -19,3 +19,30 @@ def test_source_without_a_header_returns_none():
 def test_header_with_no_props_returns_an_empty_list():
     """An empty header still declares the template classless, with zero props."""
     assert parse_props_header("{#def #}<div></div>") == []
+
+
+def test_unannotated_prop_is_any_and_required():
+    assert parse_props_header("{#def title #}") == [("title", Any, ...)]
+
+
+@pytest.mark.parametrize(
+    "annotation, expected",
+    [("str", str), ("int", int), ("float", float), ("bool", bool), ("list", list), ("dict", dict)],
+)
+def test_each_supported_annotation_resolves_to_its_type(annotation: str, expected: type):
+    assert parse_props_header(f"{{#def value: {annotation} #}}") == [
+        ("value", expected, ...)
+    ]
+
+
+def test_unrecognized_annotation_falls_back_to_any():
+    """The vocabulary is deliberately closed: a header cannot import names."""
+    assert parse_props_header("{#def value: SomeModel #}") == [("value", Any, ...)]
+
+
+def test_required_props_keep_their_declared_order():
+    assert parse_props_header("{#def title: str, count: int, flag: bool #}") == [
+        ("title", str, ...),
+        ("count", int, ...),
+        ("flag", bool, ...),
+    ]

--- a/tests/pyjinhx2/test_props_header.py
+++ b/tests/pyjinhx2/test_props_header.py
@@ -148,3 +148,23 @@ def test_header_after_leading_content_is_not_a_header():
 
 def test_a_plain_jinja_comment_is_not_a_header():
     assert parse_props_header("{# just a comment #}<div></div>") is None
+
+
+def test_props_header_is_import_pure():
+    """Parsing must not drag pydantic or the component spine into discovery."""
+    import ast as ast_module
+    from pathlib import Path
+
+    source = Path(__file__).resolve().parents[2] / "pyjinhx2" / "props_header.py"
+    tree = ast_module.parse(source.read_text(encoding="utf-8"))
+    imported = {
+        node.module or ""
+        for node in ast_module.walk(tree)
+        if isinstance(node, ast_module.ImportFrom)
+    } | {
+        alias.name
+        for node in ast_module.walk(tree)
+        if isinstance(node, ast_module.Import)
+        for alias in node.names
+    }
+    assert imported == {"ast", "re", "typing"}

--- a/tests/pyjinhx2/test_props_header.py
+++ b/tests/pyjinhx2/test_props_header.py
@@ -127,3 +127,24 @@ def test_name_reference_default_is_rejected():
 def test_malformed_signature_is_rejected():
     with pytest.raises(ValueError, match="invalid"):
         parse_props_header("{#def title: str = ( #}")
+
+
+def test_header_may_span_multiple_lines_and_carry_extra_whitespace():
+    source = """
+
+    {#def
+        title: str,
+        count: int = 0
+    #}
+    <div>{{ title }}</div>
+    """
+    assert parse_props_header(source) == [("title", str, ...), ("count", int, 0)]
+
+
+def test_header_after_leading_content_is_not_a_header():
+    """Only a leading header is out-of-band config; later ones are plain comments."""
+    assert parse_props_header("<div></div>{#def title: str #}") is None
+
+
+def test_a_plain_jinja_comment_is_not_a_header():
+    assert parse_props_header("{# just a comment #}<div></div>") is None

--- a/tests/pyjinhx2/test_props_header.py
+++ b/tests/pyjinhx2/test_props_header.py
@@ -1,0 +1,21 @@
+"""Unit tests for the ``{#def ... #}`` header parser.
+
+Parsing only — building a model class from the parsed spec belongs to #376,
+so nothing here imports pydantic or pyjinhx2.component.
+"""
+
+from typing import Any
+
+import pytest
+
+from pyjinhx2.props_header import parse_props_header
+
+
+def test_source_without_a_header_returns_none():
+    """No header is the common case, not an error — most templates are strict."""
+    assert parse_props_header("<div>hello</div>") is None
+
+
+def test_header_with_no_props_returns_an_empty_list():
+    """An empty header still declares the template classless, with zero props."""
+    assert parse_props_header("{#def #}<div></div>") == []

--- a/tests/pyjinhx2/test_props_header.py
+++ b/tests/pyjinhx2/test_props_header.py
@@ -46,3 +46,22 @@ def test_required_props_keep_their_declared_order():
         ("count", int, ...),
         ("flag", bool, ...),
     ]
+
+
+def test_pipe_none_annotation_becomes_optional():
+    assert parse_props_header("{#def value: str | None #}") == [
+        ("value", str | None, ...)
+    ]
+
+
+def test_none_pipe_t_annotation_becomes_optional():
+    """Order does not matter: ``None | str`` is the same type as ``str | None``."""
+    assert parse_props_header("{#def value: None | str #}") == [
+        ("value", str | None, ...)
+    ]
+
+
+def test_optional_subscript_becomes_the_same_union():
+    assert parse_props_header("{#def value: Optional[int] #}") == [
+        ("value", int | None, ...)
+    ]

--- a/tests/pyjinhx2/test_props_header_parse.py
+++ b/tests/pyjinhx2/test_props_header_parse.py
@@ -27,9 +27,18 @@ def test_unannotated_prop_is_any_and_required():
 
 @pytest.mark.parametrize(
     "annotation, expected",
-    [("str", str), ("int", int), ("float", float), ("bool", bool), ("list", list), ("dict", dict)],
+    [
+        ("str", str),
+        ("int", int),
+        ("float", float),
+        ("bool", bool),
+        ("list", list),
+        ("dict", dict),
+    ],
 )
-def test_each_supported_annotation_resolves_to_its_type(annotation: str, expected: type):
+def test_each_supported_annotation_resolves_to_its_type(
+    annotation: str, expected: type
+):
     assert parse_props_header(f"{{#def value: {annotation} #}}") == [
         ("value", expected, ...)
     ]


### PR DESCRIPTION
## Summary
- Implement props_header module for parsing and validating Python template prop declarations
- Add comprehensive test coverage for header detection, validation, and error handling
- Register props_header as a stdlib-only leaf in the import graph
- Support Optional[T] and T | None type annotations, literal default values, and comprehensive validation

## Test Coverage
- 8 commits with fixture additions, parsing logic, validation, and type resolution
- Full regression coverage for header placement, whitespace, malformed headers, and duplicate parameters

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)