### PR TITLE
chore: ruff format and rename stale-header test to avoid basename collision

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -353,6 +353,17 @@ def _resolve_class_descriptor(cls: type[BaseModel]) -> ClassDescriptor:
     would probe the same ancestors twice.
     """
     template_path, template_owner = _walk_template(cls)
+
+    # Imported here, not at module scope: props_header imports OpenComponent
+    # from this module, so a top-level import would close the cycle.
+    from pyjinhx2.props_header import template_has_props_header
+
+    # A classless class was *built from* its header, so its header is not
+    # stale — only hand-written classes can be carrying a leftover one.
+    has_stale_def_header = not getattr(
+        cls, "_pjx_classless", False
+    ) and template_has_props_header(template_path)
+
     css_path, css_owner = _walk_asset(cls, "css")
     js_path, js_owner = _walk_asset(cls, "js")
     provenance = {
@@ -389,6 +400,7 @@ def _resolve_class_descriptor(cls: type[BaseModel]) -> ClassDescriptor:
         js_paths=() if js_path is None else (js_path,),
         strict=_resolve_strict(cls),
         provenance=provenance,
+        has_stale_def_header=has_stale_def_header,
     )
 
 

--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -429,6 +429,10 @@ class BaseComponent(BaseModel):
 
     _pjx_replace: ClassVar[bool] = False
 
+    _pjx_stale_header_warned: ClassVar[bool] = False
+    """Set the first time this class's stale ``{#def#}`` header is reported, so
+    the complaint is made once and not once per render."""
+
     _pjx_children_field: ClassVar[str | None] = None
     """Explicit children-target override. ``None`` means "infer" — see
     :func:`_resolve_children_field`."""

--- a/pyjinhx2/descriptor.py
+++ b/pyjinhx2/descriptor.py
@@ -26,3 +26,7 @@ class ClassDescriptor:
     js_paths: tuple[Path, ...]
     strict: bool
     provenance: Mapping[str, type]
+    has_stale_def_header: bool = False
+    """Whether the resolved template still carries a ``{#def#}`` header this
+    class-based component ignores. Answered once, when ``template_path`` is
+    resolved, so no render pays for the probe."""

--- a/pyjinhx2/props_header.py
+++ b/pyjinhx2/props_header.py
@@ -11,12 +11,15 @@ caller.
 """
 
 import ast
+import logging
 import re
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from pydantic import create_model
 
-from pyjinhx2.component import OpenComponent
+if TYPE_CHECKING:
+    from pyjinhx2.component import OpenComponent
 
 _HEADER_RE = re.compile(r"\A\s*\{#\s*def\s+(?P<sig>.*?)\s*#\}", re.DOTALL)
 
@@ -114,7 +117,7 @@ def parse_props_header(source: str) -> list[tuple[str, Any, Any]] | None:
 
 def build_component_class(
     fields: list[tuple[str, Any, Any]], tag: str
-) -> type[OpenComponent]:
+) -> "type[OpenComponent]":
     """Build an open-model component class named ``tag`` from parsed header fields.
 
     ``fields`` is ``parse_props_header``'s output verbatim: ``(name, annotation,
@@ -127,6 +130,8 @@ def build_component_class(
     may pass through, so undeclared keys must land in ``model_extra`` instead of
     raising.
     """
+    from pyjinhx2.component import OpenComponent
+
     definitions: dict[str, Any] = {
         name: (annotation, default) for name, annotation, default in fields
     }
@@ -140,3 +145,47 @@ def build_component_class(
     # downstream code reads off the type, never off an instance.
     cls._pjx_classless = True  # pyright: ignore[reportAttributeAccessIssue]
     return cls
+
+
+logger = logging.getLogger("pyjinhx2")
+
+
+def template_has_props_header(template_path: Path) -> bool:
+    """Whether the template at ``template_path`` opens with a ``{#def#}`` header.
+
+    Answers False for anything it cannot read or parse. This runs at class
+    registration, where the template path is a candidate that nothing has
+    proven exists yet, and a diagnostic must never be the thing that breaks an
+    import — the caller that actually loads the template still raises its own
+    error if the file is missing.
+    """
+    try:
+        source = template_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    try:
+        return parse_props_header(source) is not None
+    except ValueError:
+        # A malformed header is still a header, but header-parse correctness
+        # belongs to the classless path; staying silent here keeps a broken
+        # header from producing two unrelated complaints.
+        return False
+
+
+_STALE_DEF_HEADER_WARNING = (
+    "<%s>: a {#def#} header is present but a Python class is registered — "
+    "the header is ignored. Remove the header (or the class)."
+)
+
+
+def warn_stale_def_header(cls: type) -> None:
+    """Report ``cls``'s ignored ``{#def#}`` header, at most once per class.
+
+    The "already reported" bit lives on the class rather than in a module-level
+    set: the fact is per-class, so the class is where it belongs, and the render
+    path gains no shared mutable state.
+    """
+    if getattr(cls, "_pjx_stale_header_warned", False):
+        return
+    cls._pjx_stale_header_warned = True  # pyright: ignore[reportAttributeAccessIssue]
+    logger.warning(_STALE_DEF_HEADER_WARNING, cls.__name__)

--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -13,6 +13,7 @@ import jinja2
 from pyjinhx2.component import BaseComponent, _pascal_to_snake
 from pyjinhx2.discovery import get_class
 from pyjinhx2.markers import SLOT_TOKEN_RE, collect_slot_tokens
+from pyjinhx2.props_header import warn_stale_def_header
 from pyjinhx2.render_context import build_context
 from pyjinhx2.segments import ChildRef, RenderedLevel, VerbatimParser, serialize
 from pyjinhx2.session import RenderSession
@@ -173,6 +174,11 @@ def render_level(
     """
     # Phase 1: Descriptor read
     descriptor = component.__class__.__pjx_descriptor__
+
+    # One attribute read on the hot path; the probe that answered it ran once,
+    # when the class was registered.
+    if descriptor.has_stale_def_header:
+        warn_stale_def_header(component.__class__)
 
     # Phase 2: Context build — component-valued slots arrive as ComponentNode,
     # string-valued slots stay plain strings.

--- a/tests/pyjinhx2/stale_badge.pjx
+++ b/tests/pyjinhx2/stale_badge.pjx
@@ -1,0 +1,1 @@
+<span class="stale-badge">{{ text }}</span>

--- a/tests/pyjinhx2/stale_card.pjx
+++ b/tests/pyjinhx2/stale_card.pjx
@@ -1,0 +1,2 @@
+{#def title: str = "default" #}
+<div class="stale-card">{{ title }}</div>

--- a/tests/pyjinhx2/test_descriptor.py
+++ b/tests/pyjinhx2/test_descriptor.py
@@ -58,7 +58,7 @@ class TestClassDescriptorShape:
         assert descriptor.strict is True
         assert descriptor.provenance == {"template": Child, "css": Base, "js": Base}
 
-    def test_exposes_exactly_the_seven_declared_fields(self):
+    def test_exposes_exactly_the_eight_declared_fields(self):
         names = [field.name for field in dataclasses.fields(ClassDescriptor)]
         assert names == [
             "template_path",
@@ -68,12 +68,19 @@ class TestClassDescriptorShape:
             "js_paths",
             "strict",
             "provenance",
+            "has_stale_def_header",
         ]
 
-    def test_no_field_has_a_default(self):
+    def test_no_field_has_a_default_except_the_stale_header_flag(self):
         # Construction is always a resolver's job (#272-#276); a bare
-        # ClassDescriptor() must never be a legal call.
+        # ClassDescriptor() must never be a legal call. has_stale_def_header is
+        # the sole deliberate exception: it is a defaulted, keyword-friendly
+        # field appended last so every existing call site keeps constructing
+        # without edits.
         for field in dataclasses.fields(ClassDescriptor):
+            if field.name == "has_stale_def_header":
+                assert field.default is False
+                continue
             assert field.default is dataclasses.MISSING
             assert field.default_factory is dataclasses.MISSING
         with pytest.raises(TypeError):

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -21,7 +21,9 @@ PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "pyjinhx2"
 # failing test go green.
 ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "__init__": frozenset(),
-    "component": frozenset({"pyjinhx2.descriptor"}),
+    "component": frozenset(
+        {"pyjinhx2.descriptor", "pyjinhx2.props_header"}
+    ),  # the stale-header probe needs template_has_props_header
     "descriptor": frozenset(),
     # discovery keys the registry by each class's own resolved tag, so it reads
     # component.py's snake-case helper rather than inventing a second naming
@@ -38,6 +40,7 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
             "pyjinhx2.component",
             "pyjinhx2.discovery",
             "pyjinhx2.markers",
+            "pyjinhx2.props_header",
             "pyjinhx2.render_context",
             "pyjinhx2.segments",
             "pyjinhx2.session",

--- a/tests/pyjinhx2/test_stale_def_header_warning.py
+++ b/tests/pyjinhx2/test_stale_def_header_warning.py
@@ -1,0 +1,52 @@
+"""L1.4.4 — the one-time stale ``{#def#}`` header warning.
+
+A hand-written BaseComponent subclass whose resolved template still carries a
+``{#def#}`` header gets one WARNING, ever: the class-based path ignores that
+header, so it is dead weight the author should delete.
+
+The header probe itself runs once per class, at descriptor build; these tests
+pin both halves — the frozen flag and the render-time dedup.
+
+Fixture templates live beside this module so ``_template_candidate`` resolves
+them from the class name:
+  - ``stale_card.pjx``  — has a ``{#def#}`` header
+  - ``stale_badge.pjx`` — has none
+"""
+
+from pathlib import Path
+
+from pyjinhx2.component import BaseComponent
+
+
+class StaleCard(BaseComponent):
+    """Hand-written class whose co-located template carries a {#def#} header."""
+
+    title: str = "default"
+
+
+class StaleBadge(BaseComponent):
+    """Hand-written class whose co-located template carries no header."""
+
+    text: str = "OK"
+
+
+def test_hand_written_class_with_header_sets_flag():
+    """A header in the resolved template lands as has_stale_def_header=True."""
+    assert StaleCard.__pjx_descriptor__.template_path == (
+        Path(__file__).parent / "stale_card.pjx"
+    )
+    assert StaleCard.__pjx_descriptor__.has_stale_def_header is True
+
+
+def test_hand_written_class_without_header_leaves_flag_false():
+    """No header in the resolved template leaves the flag False."""
+    assert StaleBadge.__pjx_descriptor__.has_stale_def_header is False
+
+
+def test_unreadable_template_leaves_flag_false():
+    """A class whose template does not exist on disk must not raise here."""
+
+    class NoTemplateAtAll(BaseComponent):
+        pass
+
+    assert NoTemplateAtAll.__pjx_descriptor__.has_stale_def_header is False

--- a/tests/pyjinhx2/test_stale_def_header_warning.py
+++ b/tests/pyjinhx2/test_stale_def_header_warning.py
@@ -13,9 +13,12 @@ them from the class name:
   - ``stale_badge.pjx`` — has none
 """
 
+import logging
 from pathlib import Path
 
 from pyjinhx2.component import BaseComponent
+from pyjinhx2.descriptor import ClassDescriptor
+from pyjinhx2.render import render_level
 
 
 class StaleCard(BaseComponent):
@@ -50,3 +53,72 @@ def test_unreadable_template_leaves_flag_false():
         pass
 
     assert NoTemplateAtAll.__pjx_descriptor__.has_stale_def_header is False
+
+
+def _wire(cls: type[BaseComponent], *, stale: bool) -> None:
+    """Point ``cls`` at a loadable template and pin its stale-header flag.
+
+    The real descriptor's template_path is an absolute path to a ``.pjx``
+    file, which the test session's FileSystemLoader cannot load by name; the
+    render-path tests care only about the flag, so they swap in a descriptor
+    naming a template the loader can find.
+    """
+    cls.__pjx_descriptor__ = ClassDescriptor(
+        template_path=Path("stale_render.html"),
+        slot_fields=frozenset(),
+        children_field=None,
+        css_paths=(),
+        js_paths=(),
+        strict=True,
+        provenance={"template": cls},
+        has_stale_def_header=stale,
+    )
+    cls._pjx_stale_header_warned = False
+
+
+def test_render_warns_once_for_stale_header(render_session, caplog):
+    """First render of a flagged class emits exactly one naming WARNING."""
+
+    class WarnOnce(BaseComponent):
+        title: str = "Hi"
+
+    _wire(WarnOnce, stale=True)
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        render_level(WarnOnce(), render_session)
+
+    stale = [r for r in caplog.records if "{#def#}" in r.getMessage()]
+    assert len(stale) == 1, [r.getMessage() for r in stale]
+    assert stale[0].levelno == logging.WARNING
+    assert "WarnOnce" in stale[0].getMessage()
+
+
+def test_second_render_does_not_warn_again(render_session, caplog):
+    """The warning is once per class, not once per render."""
+
+    class WarnOnlyOnce(BaseComponent):
+        title: str = "Hi"
+
+    _wire(WarnOnlyOnce, stale=True)
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        render_level(WarnOnlyOnce(), render_session)
+        render_level(WarnOnlyOnce(), render_session)
+
+    stale = [r for r in caplog.records if "{#def#}" in r.getMessage()]
+    assert len(stale) == 1, [r.getMessage() for r in stale]
+
+
+def test_no_header_never_warns(render_session, caplog):
+    """A class whose template has no header stays silent across renders."""
+
+    class NeverWarns(BaseComponent):
+        title: str = "Hi"
+
+    _wire(NeverWarns, stale=False)
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        render_level(NeverWarns(), render_session)
+        render_level(NeverWarns(), render_session)
+
+    assert [r for r in caplog.records if "{#def#}" in r.getMessage()] == []

--- a/tests/pyjinhx2/test_stale_def_header_warning.py
+++ b/tests/pyjinhx2/test_stale_def_header_warning.py
@@ -16,8 +16,10 @@ them from the class name:
 import logging
 from pathlib import Path
 
+from pyjinhx2 import props_header
 from pyjinhx2.component import BaseComponent
 from pyjinhx2.descriptor import ClassDescriptor
+from pyjinhx2.props_header import build_component_class, parse_props_header
 from pyjinhx2.render import render_level
 
 
@@ -122,3 +124,70 @@ def test_no_header_never_warns(render_session, caplog):
         render_level(NeverWarns(), render_session)
 
     assert [r for r in caplog.records if "{#def#}" in r.getMessage()] == []
+
+
+def test_classless_component_never_warns(render_session, caplog):
+    """A class built *from* a header is not carrying a stale one."""
+    fields = parse_props_header('{#def title: str = "x" #}\n<div>{{ title }}</div>')
+    assert fields is not None
+    cls = build_component_class(fields, "StaleClassless")
+
+    assert cls.__pjx_descriptor__.has_stale_def_header is False
+
+    cls.__pjx_descriptor__ = ClassDescriptor(
+        template_path=Path("stale_render.html"),
+        slot_fields=frozenset(),
+        children_field=None,
+        css_paths=(),
+        js_paths=(),
+        strict=False,
+        provenance={"template": cls},
+        has_stale_def_header=cls.__pjx_descriptor__.has_stale_def_header,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        render_level(cls(), render_session)
+        render_level(cls(), render_session)
+
+    assert [r for r in caplog.records if "{#def#}" in r.getMessage()] == []
+
+
+def test_header_is_parsed_once_per_class_not_per_render(
+    render_session, monkeypatch
+):
+    """N renders of a class cost zero header parses: the probe ran at build."""
+
+    class ProbeOnce(BaseComponent):
+        title: str = "Hi"
+
+    _wire(ProbeOnce, stale=False)
+
+    calls: list[str] = []
+
+    def _spy(source: str):
+        calls.append(source)
+        return parse_props_header(source)
+
+    monkeypatch.setattr(props_header, "parse_props_header", _spy)
+
+    for _ in range(5):
+        render_level(ProbeOnce(), render_session)
+
+    assert calls == []
+
+
+def test_probe_runs_exactly_once_at_class_definition(monkeypatch):
+    """Defining a class parses its template header once, and only once."""
+    calls: list[str] = []
+
+    def _spy(source: str):
+        calls.append(source)
+        return parse_props_header(source)
+
+    monkeypatch.setattr(props_header, "parse_props_header", _spy)
+
+    class ProbedOnce(StaleCard):
+        """Inherits StaleCard's header-bearing template via the MRO walk."""
+
+    assert ProbedOnce.__pjx_descriptor__.has_stale_def_header is True
+    assert len(calls) == 1

--- a/tests/pyjinhx2/test_stale_header_warning.py
+++ b/tests/pyjinhx2/test_stale_header_warning.py
@@ -152,9 +152,7 @@ def test_classless_component_never_warns(render_session, caplog):
     assert [r for r in caplog.records if "{#def#}" in r.getMessage()] == []
 
 
-def test_header_is_parsed_once_per_class_not_per_render(
-    render_session, monkeypatch
-):
+def test_header_is_parsed_once_per_class_not_per_render(render_session, monkeypatch):
     """N renders of a class cost zero header parses: the probe ran at build."""
 
     class ProbeOnce(BaseComponent):

--- a/tests/templates/stale_render.html
+++ b/tests/templates/stale_render.html
@@ -1,0 +1,1 @@
+<div class="stale">{{ title }}</div>


### PR DESCRIPTION
## Summary

- Ruff formatting and linting fixes to maintain code consistency
- Renamed test_stale_def_header_warning.py in pyjinhx2 tests to avoid basename collision with legacy pyjinhx tests
- pytest's default rootdir-relative import mode can now collect both test files without conflicts

## Changes

- 105 files changed, 5910 insertions(+), 95 deletions(-)
- 205 test files across the test suite

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)