### PR TITLE
feat: bench a real nested tree instead of N flat renders

### DIFF
--- a/scripts/bench_render_scaling_v2.py
+++ b/scripts/bench_render_scaling_v2.py
@@ -1,7 +1,12 @@
-"""Render-scaling benchmark for the pyjinhx2 kernel: N independent childless components.
+"""Render-scaling benchmark for the pyjinhx2 kernel: one nested component tree per size.
 
-L0 has no child composition, so the sweep is over N separate root-level render()
-calls rather than N nested children of one tree.
+L1 composition is in: a parent's rendered ChildRef holes are filled and recursed
+into, so the sweep renders a real tree rather than N independent root renders.
+The tree is three levels deep — BenchRoot -> many BenchMid siblings -> many
+BenchLeaf siblings under each mid — with breadth scaled per size to hit the
+requested component count. That is the shape a real page has (a few structural
+layers, many repeated leaves), and distinct classes per level keep the
+ancestor-chain cycle guard out of the measurement.
 
 Not a CI test (timing-sensitive). Run manually before/after render-path work:
 
@@ -18,6 +23,7 @@ import tempfile
 import time
 from pathlib import Path
 
+from pyjinhx2 import discovery
 from pyjinhx2.component import BaseComponent
 from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.render import render
@@ -44,57 +50,100 @@ def tree_size(mids: int, leaves: int) -> int:
     return 1 + mids + mids * leaves
 
 
-TEMPLATE_NAME = "bench_component.pjx"
-TEMPLATE_SOURCE = '<div class="bench">{{ label }}</div>'
+TEMPLATES = {
+    "bench_root.pjx": (
+        '<div class="bench-root">'
+        "{% for i in range(mids) %}"
+        '<BenchMid label="mid {{ i }}" leaves="{{ leaves }}"/>'
+        "{% endfor %}"
+        "</div>"
+    ),
+    "bench_mid.pjx": (
+        '<section class="bench-mid">{{ label }}'
+        "{% for j in range(leaves) %}"
+        '<BenchLeaf label="leaf {{ j }}"/>'
+        "{% endfor %}"
+        "</section>"
+    ),
+    "bench_leaf.pjx": '<em class="bench-leaf">{{ label }}</em>',
+}
 
 
-class BenchComponent(BaseComponent):
-    label: str = "bench"
+class BenchLeaf(BaseComponent):
+    label: str = "leaf"
 
 
-def setup_session() -> RenderSession:
-    """Write the benchmark template to a temp dir and point a session at it."""
-    template_dir = Path(tempfile.mkdtemp())
-    (template_dir / TEMPLATE_NAME).write_text(TEMPLATE_SOURCE)
-    # render() reads __pjx_descriptor__ and hands template_path straight to the
-    # Jinja loader, which resolves names relative to template_dir — so the path
-    # recorded here must stay relative.
-    BenchComponent.__pjx_descriptor__ = ClassDescriptor(
-        template_path=Path(TEMPLATE_NAME),
+class BenchMid(BaseComponent):
+    label: str = "mid"
+    leaves: int = 0
+
+
+class BenchRoot(BaseComponent):
+    mids: int = 0
+    leaves: int = 0
+
+
+def _descriptor(cls: type[BaseComponent], template: str) -> ClassDescriptor:
+    """Minimal descriptor pointing at a temp-dir template, no children field."""
+    return ClassDescriptor(
+        template_path=Path(template),
         slot_fields=frozenset(),
         children_field=None,
         css_paths=(),
         js_paths=(),
         strict=True,
-        provenance={"template": BenchComponent},
+        provenance={"template": cls},
     )
+
+
+def setup_session() -> RenderSession:
+    """Write the three bench templates to a temp dir, attach descriptors, publish
+    the tag registry, and point a session at the dir.
+
+    The registry is poked directly instead of going through build_registry: the
+    classes live in this script, not on disk under a package, and the benchmark
+    is measuring render, not discovery.
+    """
+    template_dir = Path(tempfile.mkdtemp())
+    for name, source in TEMPLATES.items():
+        (template_dir / name).write_text(source)
+    # render() hands template_path straight to the Jinja loader, which resolves
+    # names relative to template_dir — so these paths must stay relative.
+    BenchRoot.__pjx_descriptor__ = _descriptor(BenchRoot, "bench_root.pjx")
+    BenchMid.__pjx_descriptor__ = _descriptor(BenchMid, "bench_mid.pjx")
+    BenchLeaf.__pjx_descriptor__ = _descriptor(BenchLeaf, "bench_leaf.pjx")
+    discovery._registry.mapping = {
+        "bench_root": BenchRoot,
+        "bench_mid": BenchMid,
+        "bench_leaf": BenchLeaf,
+    }
     return RenderSession(template_dir=str(template_dir))
 
 
-def render_one(session: RenderSession, index: int) -> str:
-    """Construct one component and render it, returning its markup."""
-    component = BenchComponent(label=f"item {index}")
-    return render(component, session)
+def render_tree(session: RenderSession, mids: int, leaves: int) -> str:
+    """Build one whole nested tree of the given shape and render it once."""
+    return render(BenchRoot(mids=mids, leaves=leaves), session)
 
 
 def main() -> None:
     session = setup_session()
 
-    out = render_one(session, 1)  # warmup + sanity
-    assert "item 1" in out, f"unexpected warmup output: {out!r}"
+    out = render_tree(session, 2, 2)  # warmup + sanity
+    assert '<em class="bench-leaf">leaf 1</em>' in out, f"unexpected warmup: {out!r}"
 
-    for n in COMPONENT_COUNTS:
+    for requested in COMPONENT_COUNTS:
+        mids, leaves = tree_shape(requested)
+        n = tree_size(mids, leaves)
         t0 = time.perf_counter()
-        for i in range(n):
-            render_one(session, i)
+        render_tree(session, mids, leaves)
         dt = time.perf_counter() - t0
-        print(f"n={n:4d}  {dt * 1000:8.1f} ms  {dt * 1000 / n:6.2f} ms/component")
+        print(f"n={n:6d}  {dt * 1000:8.1f} ms  {dt * 1000 / n:6.3f} ms/component")
 
     if "--profile" in sys.argv:
+        mids, leaves = tree_shape(COMPONENT_COUNTS[-1])
         profiler = cProfile.Profile()
         profiler.enable()
-        for i in range(COMPONENT_COUNTS[-1]):
-            render_one(session, i)
+        render_tree(session, mids, leaves)
         profiler.disable()
         for sort_key in ("cumulative", "tottime"):
             stream = io.StringIO()

--- a/scripts/bench_render_scaling_v2.py
+++ b/scripts/bench_render_scaling_v2.py
@@ -11,6 +11,7 @@ Not a CI test (timing-sensitive). Run manually before/after render-path work:
 
 import cProfile
 import io
+import math
 import pstats
 import sys
 import tempfile
@@ -23,6 +24,25 @@ from pyjinhx2.render import render
 from pyjinhx2.session import RenderSession
 
 COMPONENT_COUNTS = (50, 100, 200, 500, 1000, 2000, 5000, 10000)
+
+
+def tree_shape(n: int) -> tuple[int, int]:
+    """Breadth at each level for a 3-level tree of roughly ``n`` components.
+
+    Breadth is split evenly between the two non-root levels so neither depth
+    dominates the reading. An exact ``n`` is not always reachable with integer
+    breadths, so the shape rounds and the caller prints the count it actually
+    built.
+    """
+    mids = max(1, math.isqrt(max(n - 1, 1)))
+    leaves = max(0, round((n - 1 - mids) / mids))
+    return mids, leaves
+
+
+def tree_size(mids: int, leaves: int) -> int:
+    """Total component count for a shape: root + mids + leaves under each mid."""
+    return 1 + mids + mids * leaves
+
 
 TEMPLATE_NAME = "bench_component.pjx"
 TEMPLATE_SOURCE = '<div class="bench">{{ label }}</div>'

--- a/scripts/bench_render_scaling_v2.py
+++ b/scripts/bench_render_scaling_v2.py
@@ -22,7 +22,7 @@ from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.render import render
 from pyjinhx2.session import RenderSession
 
-COMPONENT_COUNTS = (50, 100, 200, 438)
+COMPONENT_COUNTS = (50, 100, 200, 500, 1000, 2000, 5000, 10000)
 
 TEMPLATE_NAME = "bench_component.pjx"
 TEMPLATE_SOURCE = '<div class="bench">{{ label }}</div>'

--- a/tests/pyjinhx2/test_bench_script_v2.py
+++ b/tests/pyjinhx2/test_bench_script_v2.py
@@ -28,6 +28,17 @@ def test_bench_script_renders_one_component():
     assert '<div class="bench">' in out
 
 
+def test_tree_shape_is_deterministic_and_close_to_requested_size():
+    bench = load_bench_module()
+    for n in (50, 100, 200, 500, 1000, 2000, 5000, 10000):
+        mids, leaves = bench.tree_shape(n)
+        assert mids >= 1
+        assert leaves >= 0
+        total = 1 + mids + mids * leaves
+        assert abs(total - n) <= mids  # rounding slack is at most one leaf per mid
+        assert bench.tree_shape(n) == (mids, leaves)  # deterministic
+
+
 def test_bench_sweep_tops_out_at_ten_thousand():
     bench = load_bench_module()
     counts = bench.COMPONENT_COUNTS

--- a/tests/pyjinhx2/test_bench_script_v2.py
+++ b/tests/pyjinhx2/test_bench_script_v2.py
@@ -20,12 +20,14 @@ def load_bench_module():
     return module
 
 
-def test_bench_script_renders_one_component():
+def test_bench_renders_a_nested_tree_at_every_level():
     bench = load_bench_module()
     session = bench.setup_session()
-    out = bench.render_one(session, 7)
-    assert "item 7" in out
-    assert '<div class="bench">' in out
+    mids, leaves = bench.tree_shape(bench.COMPONENT_COUNTS[0])
+    out = bench.render_tree(session, mids, leaves)
+    assert '<div class="bench-root">' in out
+    assert out.count('<section class="bench-mid">') == mids
+    assert out.count('<em class="bench-leaf">') == mids * leaves
 
 
 def test_tree_shape_is_deterministic_and_close_to_requested_size():

--- a/tests/pyjinhx2/test_bench_script_v2.py
+++ b/tests/pyjinhx2/test_bench_script_v2.py
@@ -1,6 +1,7 @@
 """The v2 benchmark script is not timed in CI, but it must keep importing and rendering."""
 
 import importlib.util
+import itertools
 import sys
 from pathlib import Path
 
@@ -27,6 +28,9 @@ def test_bench_script_renders_one_component():
     assert '<div class="bench">' in out
 
 
-def test_bench_sweep_sizes_match_v1():
+def test_bench_sweep_tops_out_at_ten_thousand():
     bench = load_bench_module()
-    assert bench.COMPONENT_COUNTS == (50, 100, 200, 438)
+    counts = bench.COMPONENT_COUNTS
+    assert counts[-1] == 10_000
+    assert max(counts) == 10_000
+    assert all(a < b for a, b in itertools.pairwise(counts))


### PR DESCRIPTION
## Summary

- Replace the single-class flat benchmark with a 3-level BenchRoot -> BenchMid -> BenchLeaf tree, each rendered once per sweep size via render_tree()
- Add tree_shape helper for bench sweep
- Pin bench sweep to 10k endpoint and monotonicity

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)