### PR TITLE
fix: warn when register_class loses a tag to an existing owner (#416)

### DIFF
--- a/pyjinhx2/discovery.py
+++ b/pyjinhx2/discovery.py
@@ -205,8 +205,20 @@ def register_class(tag_name: str, cls: type) -> None:
     alone: a class registered on demand must never shadow a declared one.
     The mapping is copied and rebound rather than mutated, matching the build,
     so a concurrent reader sees a whole mapping either way.
+    The loser is named in a warning rather than dropped silently, since a
+    template that never becomes its own component is otherwise invisible.
     """
     with _registry_lock:
-        if tag_name in _registry.mapping:
+        existing = _registry.mapping.get(tag_name)
+        if existing is not None:
+            logger.warning(
+                "Tag %r was built without a class, but %s already declares it; "
+                "the declared class keeps the tag and %s is discarded. Give the "
+                "classless template a different name if it meant to be its own "
+                "component.",
+                tag_name,
+                _qualified_name(existing),
+                _qualified_name(cls),
+            )
             return
         _registry.mapping = {**_registry.mapping, tag_name: cls}

--- a/tests/pyjinhx2/test_registry.py
+++ b/tests/pyjinhx2/test_registry.py
@@ -265,6 +265,28 @@ def test_register_class_never_overwrites_an_existing_owner():
     assert get_class("owner") is Owner
 
 
+def test_register_class_warns_when_the_tag_is_already_owned(caplog):
+    """Losing the tag is not silent: the classless build says who kept it."""
+
+    class Owner(BaseComponent):
+        pass
+
+    class Intruder(BaseComponent):
+        pass
+
+    discovery.register_class("owner", Owner)
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        discovery.register_class("owner", Intruder)
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "owner" in message
+    assert Owner.__qualname__ in message
+    assert Intruder.__qualname__ in message
+    assert get_class("owner") is Owner
+
+
 def test_build_registry_remembers_the_directory_it_walked():
     discovery.build_registry(DISCOVERY_DIR, [])
 


### PR DESCRIPTION
## Summary
- A classless build that loses to a declared class was silently dropped
- Now logs a WARNING naming the tag and both classes so the loss is visible
- Added 1 test to verify the warning is raised

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)