### PR TITLE
test: add nested-.props opacity matrix row; docs: amend ADR 0003 (#419)

### DIFF
--- a/docs/superpowers/rebuild/adr/0003-slot-opacity.md
+++ b/docs/superpowers/rebuild/adr/0003-slot-opacity.md
@@ -1,6 +1,6 @@
 # ADR 0003: Slots are opaque — truthiness, interpolation, and `.props` access only
 
-**Status:** Accepted, 2026-07-28. Amended 2026-07-30 to sanction `NestedComponentWrapper`; amended 2026-07-31 to make component-typed fields slots by default. Consequence of ADR 0002.
+**Status:** Accepted, 2026-07-28. Amended 2026-07-30 to sanction `NestedComponentWrapper`; amended 2026-07-31 to make component-typed fields slots by default; amended 2026-07-31 to close the two remaining opacity leaks (#419). Consequence of ADR 0002.
 
 ## Context
 
@@ -124,3 +124,25 @@ Two consequences worth stating plainly:
 
 - `PjxSlot`/`Slot` is now an escape hatch, needed only for a *string* field that should be emitted as raw HTML. Component-valued fields do not need it.
 - Tag-body routing is a separate, orthogonal concern. `_pjx_children_field` (and its `Children` alias) decides *which* field receives a PascalCase tag's nested markup, following the `content` convention. It says nothing about slot-ness, and slot-ness says nothing about it: a field can be one, the other, or both.
+
+## Amendment (2026-07-31): closing the two remaining opacity leaks (#419)
+
+Two gaps survived the L1.3 landing, both fixed in `pyjinhx2/markers.py`:
+
+- `ComponentNode.__str__` now raises the same opaque `TypeError` as the other
+  forbidden dunders. Filters that stringify before doing their own work
+  (`|upper`, `|trim`, `|striptags`) previously fell through to `__repr__` and
+  leaked `"ComponentNode(<component repr>)"` into rendered HTML instead of
+  failing loudly. Bare `{{ field }}` interpolation is unaffected —
+  `finalize_slot_node` still intercepts the node and substitutes a splice
+  token before Jinja would ever call `str()` on it.
+- `SlotProps.__getattr__`/`__getitem__` now wrap a component-valued prop in a
+  `ComponentNode` before returning it, labelled `<field>.props.<name>`.
+  Previously a component-typed prop (a nested component-typed field reached
+  through `.props`) came back as the live `BaseComponent` instance, bypassing
+  `ComponentNode` and hitting pydantic's own `__str__`/`__iter__` on failure —
+  a plain, unhelpful `TypeError` rather than the ADR's targeted message.
+  Non-component prop values are unaffected; they still return raw.
+
+`.props` remains the sole sanctioned escape hatch and is unchanged in kind:
+this closes a data-access hole in it, not a new capability.

--- a/pyjinhx2/markers.py
+++ b/pyjinhx2/markers.py
@@ -8,10 +8,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pyjinhx2.component import BaseComponent
+from pyjinhx2.component import BaseComponent
 
 
 class SlotProps:
@@ -31,11 +28,30 @@ class SlotProps:
         object.__setattr__(self, "_values", values)
         object.__setattr__(self, "_node", node)
 
+    def _wrap(self, name: str, value: object) -> object:
+        """Give a component-valued prop the same opacity as a top-level slot.
+
+        Without this a component-typed prop would come back as the live
+        instance and hit pydantic's own __str__/__iter__, so `.props.x` would
+        be a hole in ADR 0003's boundary rather than the narrow escape hatch
+        it is meant to be. The field label records the path the author wrote
+        so the error names `.props.<name>`, not the outer slot alone.
+        """
+        if not isinstance(value, BaseComponent):
+            return value
+        node: ComponentNode = object.__getattribute__(self, "_node")
+        return ComponentNode(
+            value,
+            owner_name=node.owner_name,
+            owner_template=node.owner_template,
+            field_name=f"{node.field_name}.props.{name}",
+        )
+
     def __getattr__(self, name: str) -> object:
         values: dict[str, object] = object.__getattribute__(self, "_values")
         if name not in values:
             raise AttributeError(name)
-        return values[name]
+        return self._wrap(name, values[name])
 
     def __getitem__(self, key: str) -> object:
         # Guards against Python's legacy iteration protocol, which probes
@@ -45,7 +61,7 @@ class SlotProps:
         if not isinstance(key, str):
             raise TypeError(f"slot props keys must be str, got {type(key).__name__}")
         values: dict[str, object] = object.__getattribute__(self, "_values")
-        return values[key]
+        return self._wrap(key, values[key])
 
     def __setattr__(self, name: str, value: object) -> None:
         raise AttributeError("slot props are read-only")

--- a/pyjinhx2/markers.py
+++ b/pyjinhx2/markers.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
+
 from pyjinhx2.component import BaseComponent
 
 

--- a/pyjinhx2/markers.py
+++ b/pyjinhx2/markers.py
@@ -63,10 +63,10 @@ class ComponentNode:
     """Opaque marker wrapping a component-valued Slot field.
 
     Not a string, so Jinja filters routed through a dunder (e.g. |length) fail
-    fast. Filters that stringify first (|upper, |trim, |striptags) fall
-    through to __str__ instead - a documented gap, see ADR 0003 / #368 PR
-    notes. Holds enough info for L1 to skip it during child expansion, and
-    enough about the component that declared the slot to name it in an error.
+    fast. Filters that stringify first (|upper, |trim, |striptags) reach
+    __str__, which raises the same opaque error. Holds enough info for L1 to
+    skip it during child expansion, and enough about the component that
+    declared the slot to name it in an error.
 
     ``owner_name``/``owner_template``/``field_name`` default to placeholders
     so call sites that only care about the wrapped component (e.g. token-table
@@ -109,6 +109,15 @@ class ComponentNode:
 
     def __repr__(self) -> str:
         return f"ComponentNode({self.component!r})"
+
+    def __str__(self) -> str:
+        # Filters that stringify before doing their work (|upper, |trim,
+        # |striptags) reach the node here rather than through a dunder the
+        # opaque errors already cover; without this they would fall through
+        # to __repr__ and leak "ComponentNode(...)" into rendered HTML.
+        # Bare `{{ field }}` never lands here: finalize_slot_node swaps the
+        # node for a placeholder token before Jinja stringifies anything.
+        raise self._opaque_error("str()")
 
     @property
     def props(self) -> SlotProps:

--- a/tests/pyjinhx2/test_markers.py
+++ b/tests/pyjinhx2/test_markers.py
@@ -154,8 +154,23 @@ def test_node_is_truthy():
     assert bool(make_node()) is True
 
 
-def test_str_renders_placeholder_not_object_repr():
-    """str() must not fall through to object's default repr-ish output."""
-    text = str(make_node())
+def test_str_raises_the_opacity_error():
+    """str() is a forbidden operation, not a silent repr leak (#419 gap 1)."""
+    node = make_node()
 
-    assert "<pyjinhx2.markers.ComponentNode object at" not in text
+    with pytest.raises(TypeError) as excinfo:
+        str(node)
+
+    message = str(excinfo.value)
+    assert "slot 'content' holds a rendered component" in message
+    assert "`str()`" in message
+
+
+def test_str_does_not_leak_the_component_repr():
+    """No path stringifies the node into HTML-visible text."""
+    node = make_node()
+
+    with pytest.raises(TypeError) as excinfo:
+        f"{node}"
+
+    assert "ComponentNode(" not in str(excinfo.value)

--- a/tests/pyjinhx2/test_render_context.py
+++ b/tests/pyjinhx2/test_render_context.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ValidationError
 
 from pyjinhx2.component import BaseComponent, Slot, _resolve_slot_fields
 from pyjinhx2.descriptor import ClassDescriptor
-from pyjinhx2.markers import ComponentNode
+from pyjinhx2.markers import ComponentNode, collect_slot_tokens, finalize_slot_node
 from pyjinhx2.render_context import build_context
 
 
@@ -342,12 +342,10 @@ def test_forbidden_operations_fail_through_jinja(source):
 @pytest.mark.parametrize(
     "source", ["{{ content|striptags }}", "{{ content|trim }}", "{{ content|upper }}"]
 )
-def test_str_routed_filters_do_not_raise(source):
-    """`|striptags`/`|trim`/`|upper` call str() first, so they render __str__'s
-    output instead of raising. This is a documented gap (see PR description),
-    not a bug: the ADR's opacity guarantee is delivered by raising from the
-    dunder each operation actually reaches, and these three filters never
-    reach one. Locking this in as a regression test rather than a TODO.
+def test_str_routed_filters_raise_the_opacity_error(source):
+    """`|striptags`/`|trim`/`|upper` call str() first, so they now raise the
+    same opaque TypeError as the other forbidden operations (#419 gap 1),
+    rather than falling through to a leaked component repr.
     """
 
     class Inner(BaseComponent):
@@ -369,8 +367,10 @@ def test_str_routed_filters_do_not_raise(source):
     context = build_context(card, descriptor)
 
     env = Environment(autoescape=True)
-    # Must not raise; exact output is __str__'s business, not this test's.
-    env.from_string(source).render(context)
+    with pytest.raises(TypeError) as excinfo:
+        env.from_string(source).render(context)
+
+    assert "Card (template: card.pjx): slot 'content'" in str(excinfo.value)
 
 
 def test_string_slot_is_unaffected_by_opacity():
@@ -421,8 +421,13 @@ def test_interpolation_and_truthiness_still_work():
     env = Environment(autoescape=True)
 
     assert env.from_string("{% if content %}yes{% endif %}").render(context) == "yes"
-    # Interpolation must not raise; its exact output is L1 child-expansion work.
-    env.from_string("{{ content }}").render(context)
+
+    # Interpolation goes through the finalize hook in real renders, which
+    # intercepts the node before Jinja would stringify it.
+    env_with_finalize = Environment(autoescape=True, finalize=finalize_slot_node)
+    with collect_slot_tokens():
+        output = env_with_finalize.from_string("{{ content }}").render(context)
+    assert output.startswith("pjx-slot-")
 
 
 def test_strict_component_no_extra_keys():
@@ -469,7 +474,8 @@ def test_component_node_truthiness_does_not_use_len():
         pass
     with pytest.raises(TypeError):
         len(node)  # type: ignore[arg-type]
-    assert not hasattr(node, "__str__") or type(node).__str__ is object.__str__
+    with pytest.raises(TypeError):
+        str(node)
     assert not hasattr(node, "__html__")
 
 

--- a/tests/pyjinhx2/test_slot_props_view.py
+++ b/tests/pyjinhx2/test_slot_props_view.py
@@ -245,7 +245,7 @@ class TestSlotPropsView:
 
         nested = self.node(Card(content=Leaf(title="inner"))).props.content
 
-        assert nested.props.title == "inner"
+        assert nested.props.title == "inner"  # pyright: ignore[reportAttributeAccessIssue]
 
     def test_the_nodes_own_forbidden_ops_are_unchanged(self):
         node = self.node(Leaf(title="hello"))

--- a/tests/pyjinhx2/test_slot_props_view.py
+++ b/tests/pyjinhx2/test_slot_props_view.py
@@ -183,13 +183,69 @@ class TestSlotPropsView:
 
         assert "SlotProps" in repr(props)
 
-    def test_a_component_valued_prop_stays_the_live_child(self):
+    def test_a_component_valued_prop_comes_back_wrapped(self):
+        from pyjinhx2.markers import ComponentNode
+
         class Card(BaseComponent):
             content: Slot = ""
 
         leaf = Leaf(title="inner")
 
-        assert self.node(Card(content=leaf)).props.content is leaf
+        nested = self.node(Card(content=leaf)).props.content
+
+        assert type(nested) is ComponentNode
+        assert nested.component is leaf
+
+    def test_a_component_valued_prop_is_wrapped_through_subscript_too(self):
+        from pyjinhx2.markers import ComponentNode
+
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        leaf = Leaf(title="inner")
+
+        assert type(self.node(Card(content=leaf)).props["content"]) is ComponentNode
+
+    def test_the_nested_node_names_the_props_path_in_its_error(self):
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        nested = self.node(Card(content=Leaf(title="inner"))).props.content
+
+        with pytest.raises(TypeError) as excinfo:
+            str(nested)
+
+        assert "slot 'content.props.content'" in str(excinfo.value)
+
+    def test_the_nested_node_is_opaque_to_every_forbidden_operation(self):
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        nested = self.node(Card(content=Leaf(title="inner"))).props.content
+
+        with pytest.raises(TypeError, match=r"\.props\.content"):
+            str(nested)
+        with pytest.raises(TypeError, match=r"\.props\.content"):
+            len(nested)  # pyright: ignore[reportArgumentType]
+        with pytest.raises(TypeError, match=r"\.props\.content"):
+            list(nested)  # pyright: ignore[reportCallIssue, reportArgumentType]
+        with pytest.raises(TypeError, match=r"\.props\.content"):
+            nested[1:2]  # pyright: ignore[reportIndexIssue]
+
+    def test_a_non_component_prop_is_still_returned_raw(self):
+        props = self.node(Leaf(title="hello", count=3)).props
+
+        assert props.title == "hello"
+        assert type(props.title) is str
+        assert type(props.count) is int
+
+    def test_a_nested_props_hop_keeps_working(self):
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        nested = self.node(Card(content=Leaf(title="inner"))).props.content
+
+        assert nested.props.title == "inner"
 
     def test_the_nodes_own_forbidden_ops_are_unchanged(self):
         node = self.node(Leaf(title="hello"))
@@ -359,7 +415,7 @@ class TestPropsRegressions:
         assert context["content"].component is leaf
         assert context["content"].props.title == "hello"
 
-    def test_a_nested_component_valued_prop_is_not_stringified(self):
+    def test_a_nested_component_valued_prop_is_opaque_not_raw(self):
         from pyjinhx2.markers import ComponentNode
         from pyjinhx2.render_context import build_context
 
@@ -375,6 +431,7 @@ class TestPropsRegressions:
         context = build_context(Card(content=Wrap(inner=leaf)), Card.__pjx_descriptor__)
         nested = context["content"].props.inner
 
-        assert nested is leaf
-        assert not isinstance(nested, str)
-        assert not isinstance(nested, ComponentNode)
+        assert type(nested) is ComponentNode
+        assert nested.component is leaf
+        with pytest.raises(TypeError, match=r"slot 'content\.props\.inner'"):
+            str(nested)

--- a/tests/pyjinhx2/test_slot_semantics_matrix.py
+++ b/tests/pyjinhx2/test_slot_semantics_matrix.py
@@ -515,6 +515,57 @@ class TestPropsBoundaries:
         with pytest.raises(TypeError, match=r"`\.props`"):
             str(node.props)
 
+
+class TestNestedPropsOpacity:
+    """A component-typed prop reached through `.props` is opaque too (#419)."""
+
+    def wrapper_card(self) -> BaseComponent:
+        class Inner(BaseComponent):
+            content: Slot = ""
+
+        Inner.__pjx_descriptor__ = descriptor(
+            "nest_content.html", frozenset({"content"})
+        )
+
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        Card.__pjx_descriptor__ = descriptor(
+            "nest_content.html", frozenset({"content"})
+        )
+        return Card(content=Inner(content=Leaf(text="deep")))
+
+    @pytest.mark.parametrize(
+        ("expr", "syntax"),
+        [
+            ("{{ content.props.content|length }}", "|length"),
+            ("{{ content.props.content|upper }}", "str()"),
+            (
+                "{% for x in content.props.content %}{{ x }}{% endfor %}",
+                "for",
+            ),
+        ],
+    )
+    def test_a_nested_component_prop_raises_the_opacity_error(self, expr, syntax):
+        with pytest.raises(TypeError) as excinfo:
+            render_expr(expr, self.wrapper_card())
+
+        message = str(excinfo.value)
+        assert "slot 'content.props.content'" in message
+        assert f"`{syntax}`" in message
+
+    def test_a_nested_component_prop_still_interpolates_through_the_token(self):
+        output = render_expr("{{ content.props.content }}", self.wrapper_card())
+
+        assert output.startswith("pjx-slot-")
+
+    def test_a_nested_scalar_prop_is_untouched(self):
+        output = render_expr(
+            "{{ content.props.content.props.text }}", self.wrapper_card()
+        )
+
+        assert output == "deep"
+
     def test_an_unknown_props_name_is_an_ordinary_lookup_failure(self):
         # A typo in `.props.x` must read as a typo, not as an opacity
         # violation, so it never raises the opaque TypeError.

--- a/tests/pyjinhx2/test_slot_semantics_matrix.py
+++ b/tests/pyjinhx2/test_slot_semantics_matrix.py
@@ -238,27 +238,32 @@ class TestHashingSurvivesForbiddenEquality:
         assert len({first, second}) == 2
 
 
-class TestStringifyingFilterGap:
-    """Filters that call str() before failing bypass the dunder path.
+class TestStringifyingFilters:
+    """Filters that call str() before doing their work raise, not leak (#419).
 
-    ADR 0003 asks these to raise the same targeted error; today they fall
-    through to the default object repr instead. Pinned as-is here — see the
-    gap note in docs/superpowers/rebuild/adr/0003-slot-opacity.md and the
-    ComponentNode docstring. Fixing it is not this subtask's job.
+    These route through ComponentNode.__str__ rather than through a dunder
+    the operation matrix above already covers, so they get their own row.
     """
 
     @pytest.mark.parametrize("filter_name", ["upper", "trim", "striptags"])
-    def test_a_stringifying_filter_does_not_raise_today(self, filter_name):
-        output = render_expr(f"{{{{ content|{filter_name} }}}}", opaque_card())
+    def test_a_stringifying_filter_raises_the_opacity_error(self, filter_name):
+        with pytest.raises(TypeError) as excinfo:
+            render_expr(f"{{{{ content|{filter_name} }}}}", opaque_card())
 
-        assert "ComponentNode" in output.replace("COMPONENTNODE", "ComponentNode")
+        message = str(excinfo.value)
+        assert "slot 'content' holds a rendered component" in message
+        assert "`str()`" in message
 
-    def test_the_stringified_output_is_the_repr_not_the_childs_markup(self):
-        output = render_expr("{{ content|upper }}", opaque_card())
+    def test_no_component_repr_reaches_the_output(self):
+        with pytest.raises(TypeError):
+            render_expr("{{ content|upper }}", opaque_card())
 
-        assert "COMPONENTNODE(" in output
-        assert "LEAF" in output
-        assert "<span" not in output
+    def test_bare_interpolation_is_unaffected_by_the_str_ban(self):
+        # finalize_slot_node intercepts the node before Jinja stringifies it,
+        # so the sanctioned `{{ field }}` form still yields a splice token.
+        output = render_expr("{{ content }}", opaque_card())
+
+        assert output.startswith("pjx-slot-")
 
 
 class TestInferenceWithDirectNesting:


### PR DESCRIPTION
## Summary
- Add nested-.props opacity matrix row test coverage
- Fix ComponentNode.__str__ to raise opaque error
- Fix SlotProps to wrap component-valued props in ComponentNode
- Rewrite stringify-first-filter pins as opacity assertions
- Amend ADR 0003 slot opacity documentation

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)