### PR TITLE
fix(#429): accumulate_assets reads the session passed to render(), not the ContextVar

### DIFF
--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -237,7 +237,7 @@ def render_level(
     # Fired after every child has already rendered and spliced in above, so a
     # nested tree fires depth-first, post-order, once per component.
     for hook in session.on_rendered:
-        hook(component, level)
+        hook(component, level, session)
     return level
 
 
@@ -258,8 +258,11 @@ def render(component: BaseComponent, session: "RenderSession | None" = None) -> 
     Returns:
         The component's rendered markup as a finished HTML string.
 
-    Fires each ``session.on_rendered`` callback with ``(component, level)``
-    after each component's level is built, depth-first post-order.
+    Fires each ``session.on_rendered`` callback with ``(component, level,
+    session)`` after each component's level is built, depth-first post-order.
+    ``session`` is always the one passed to (or defaulted inside) this call,
+    never read off any ContextVar, so hooks work whether or not ``session``
+    is also the active request_scope().
 
     Raises:
         ValueError: If template renders zero or 2+ root elements.

--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -234,6 +234,10 @@ def render_level(
     # Runs after tag-shaped holes are resolved, so the indexes above stay valid
     # while this step rebuilds the list.
     _splice_slot_nodes(level, slot_table, session, chain)
+    # Fired after every child has already rendered and spliced in above, so a
+    # nested tree fires depth-first, post-order, once per component.
+    for hook in session.on_rendered:
+        hook(component, level)
     return level
 
 
@@ -253,6 +257,9 @@ def render(component: BaseComponent, session: "RenderSession | None" = None) -> 
 
     Returns:
         The component's rendered markup as a finished HTML string.
+
+    Fires each ``session.on_rendered`` callback with ``(component, level)``
+    after each component's level is built, depth-first post-order.
 
     Raises:
         ValueError: If template renders zero or 2+ root elements.

--- a/pyjinhx2/session.py
+++ b/pyjinhx2/session.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from jinja2 import Environment, FileSystemLoader
@@ -28,6 +29,10 @@ _cache_store: ContextVar[dict[object, object] | None] = ContextVar(
 )
 
 
+class NoActiveRequestScope(RuntimeError):
+    """Raised when per-request state is touched outside an active request_scope()."""
+
+
 class RenderSession:
     """Session providing Jinja environment with autoescape enabled."""
 
@@ -47,6 +52,12 @@ class RenderSession:
         # Asset paths accumulate here as on_rendered fires bottom-up; a set because
         # the same component class contributes the same paths on every occurrence.
         self.asset_paths: set[str] = set()
+        # css_assets/js_assets are the L2.2.1 accumulator: descriptor paths
+        # set-added by accumulate_assets as on_rendered fires, kept separate
+        # from each other so later emission (#430) can tell <style> from
+        # <script> sources without re-inspecting any descriptor.
+        self.css_assets: set[Path] = set()
+        self.js_assets: set[Path] = set()
         # Callbacks fired once per component render, after that level's
         # RenderedLevel is built (depth-first post-order once nested renders
         # exist). Subscribers read the finished descriptor/level; they never
@@ -57,6 +68,34 @@ class RenderSession:
 def current_session() -> RenderSession | None:
     """Return the RenderSession bound to this request, or None outside a scope."""
     return _render_session.get()
+
+
+def accumulate_assets(component: Any, level: "RenderedLevel") -> None:
+    """Set-add the rendered class's descriptor asset paths into the request store.
+
+    Meant to be subscribed onto ``RenderSession.on_rendered``. Paths are read
+    straight from the frozen descriptor and never re-probed; duplicates across
+    instances or classes collapse because the store is a set keyed by path.
+
+    Args:
+        component: The component that was just rendered (unused; on_rendered's
+            callback shape always passes it).
+        level: The RenderedLevel carrying the class descriptor.
+
+    Raises:
+        NoActiveRequestScope: If fired outside an active request_scope().
+    """
+    session = current_session()
+    if session is None:
+        raise NoActiveRequestScope(
+            "accumulate_assets fired outside an active request_scope(); wrap "
+            "rendering in request_scope()"
+        )
+    # RenderedLevel.descriptor is typed as `object` to keep segments.py
+    # import-pure; read structurally here rather than importing ClassDescriptor.
+    descriptor: Any = level.descriptor
+    session.css_assets.update(descriptor.css_paths)
+    session.js_assets.update(descriptor.js_paths)
 
 
 def get_instances() -> dict[str, object]:
@@ -84,16 +123,24 @@ def get_cache_store() -> dict[object, object]:
 
 
 @contextmanager
-def request_scope(template_dir: str = "templates") -> Iterator[RenderSession]:
+def request_scope(
+    template_dir: str = "templates", session: "RenderSession | None" = None
+) -> Iterator[RenderSession]:
     """Bind fresh per-request state for the duration of the block.
 
     Args:
-        template_dir: Directory the new RenderSession loads templates from.
+        template_dir: Directory a newly-constructed RenderSession loads
+            templates from. Ignored when ``session`` is given.
+        session: An existing RenderSession to bind as this scope's current
+            session, instead of constructing a fresh one. Lets a caller wire
+            hooks (e.g. ``on_rendered``) onto a session before it becomes the
+            one ``current_session()``/``accumulate_assets`` see as active.
 
     Yields:
         The RenderSession bound for this scope.
     """
-    session = RenderSession(template_dir)
+    if session is None:
+        session = RenderSession(template_dir)
     session_token = _render_session.set(session)
     instances_token = _instances.set({})
     dirtied_token = _dirtied.set(set())

--- a/pyjinhx2/session.py
+++ b/pyjinhx2/session.py
@@ -49,8 +49,10 @@ class RenderSession:
             # hook swaps in a placeholder the render pipeline resolves later.
             finalize=finalize_slot_node,
         )
-        # Asset paths accumulate here as on_rendered fires bottom-up; a set because
-        # the same component class contributes the same paths on every occurrence.
+        # Generic per-request asset slot from the #423 ContextVar model
+        # (predates L2.2.1's descriptor accumulator below); no producer in
+        # this codebase writes to it yet, so it stays as-is for whatever
+        # future non-descriptor asset source needs a request-scoped set.
         self.asset_paths: set[str] = set()
         # css_assets/js_assets are the L2.2.1 accumulator: descriptor paths
         # set-added by accumulate_assets as on_rendered fires, kept separate
@@ -60,9 +62,11 @@ class RenderSession:
         self.js_assets: set[Path] = set()
         # Callbacks fired once per component render, after that level's
         # RenderedLevel is built (depth-first post-order once nested renders
-        # exist). Subscribers read the finished descriptor/level; they never
-        # trigger a second render.
-        self.on_rendered: list[Callable[[Any, RenderedLevel], None]] = []
+        # exist). Subscribers read the finished descriptor/level and the
+        # RenderSession that drove this render — never the request_scope
+        # ContextVar, which the render() caller may not have entered at all.
+        # Subscribers never trigger a second render.
+        self.on_rendered: list[Callable[[Any, RenderedLevel, RenderSession], None]] = []
 
 
 def current_session() -> RenderSession | None:
@@ -70,27 +74,27 @@ def current_session() -> RenderSession | None:
     return _render_session.get()
 
 
-def accumulate_assets(component: Any, level: "RenderedLevel") -> None:
-    """Set-add the rendered class's descriptor asset paths into the request store.
+def accumulate_assets(
+    component: Any, level: "RenderedLevel", session: "RenderSession"
+) -> None:
+    """Set-add the rendered class's descriptor asset paths into the session.
 
     Meant to be subscribed onto ``RenderSession.on_rendered``. Paths are read
     straight from the frozen descriptor and never re-probed; duplicates across
     instances or classes collapse because the store is a set keyed by path.
 
+    Writes into ``session`` — the RenderSession that actually drove this
+    render, passed through by render_level() — rather than reading
+    ``current_session()``. render(component, session) is the dominant calling
+    convention in this codebase and never requires the session to also be the
+    active request_scope(), so accumulate_assets must not either.
+
     Args:
         component: The component that was just rendered (unused; on_rendered's
             callback shape always passes it).
         level: The RenderedLevel carrying the class descriptor.
-
-    Raises:
-        NoActiveRequestScope: If fired outside an active request_scope().
+        session: The RenderSession this render ran against.
     """
-    session = current_session()
-    if session is None:
-        raise NoActiveRequestScope(
-            "accumulate_assets fired outside an active request_scope(); wrap "
-            "rendering in request_scope()"
-        )
     # RenderedLevel.descriptor is typed as `object` to keep segments.py
     # import-pure; read structurally here rather than importing ClassDescriptor.
     descriptor: Any = level.descriptor
@@ -134,7 +138,7 @@ def request_scope(
         session: An existing RenderSession to bind as this scope's current
             session, instead of constructing a fresh one. Lets a caller wire
             hooks (e.g. ``on_rendered``) onto a session before it becomes the
-            one ``current_session()``/``accumulate_assets`` see as active.
+            one ``current_session()`` sees as active.
 
     Yields:
         The RenderSession bound for this scope.

--- a/pyjinhx2/session.py
+++ b/pyjinhx2/session.py
@@ -1,12 +1,16 @@
 """RenderSession, the per-request ContextVars, and the request_scope that owns them."""
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
+from typing import TYPE_CHECKING, Any
 
 from jinja2 import Environment, FileSystemLoader
 
 from pyjinhx2.markers import finalize_slot_node
+
+if TYPE_CHECKING:
+    from pyjinhx2.segments import RenderedLevel
 
 # The four pieces of per-request mutable state. They live here rather than beside
 # their eventual consumers because the import rule runs one way only: reactive/
@@ -43,6 +47,11 @@ class RenderSession:
         # Asset paths accumulate here as on_rendered fires bottom-up; a set because
         # the same component class contributes the same paths on every occurrence.
         self.asset_paths: set[str] = set()
+        # Callbacks fired once per component render, after that level's
+        # RenderedLevel is built (depth-first post-order once nested renders
+        # exist). Subscribers read the finished descriptor/level; they never
+        # trigger a second render.
+        self.on_rendered: list[Callable[[Any, RenderedLevel], None]] = []
 
 
 def current_session() -> RenderSession | None:

--- a/tests/pyjinhx2/test_assets.py
+++ b/tests/pyjinhx2/test_assets.py
@@ -4,13 +4,10 @@ import threading
 from dataclasses import replace
 from pathlib import Path
 
-import pytest
-
 from pyjinhx2.component import BaseComponent
 from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.render import render
 from pyjinhx2.session import (
-    NoActiveRequestScope,
     RenderSession,
     accumulate_assets,
     request_scope,
@@ -61,9 +58,10 @@ def with_assets(cls, *, css=(), js=()):
 def _accumulating_session() -> RenderSession:
     """A fresh RenderSession with the asset accumulator wired to on_rendered.
 
-    Not entered into a request_scope() by itself: tests bind it explicitly via
-    ``request_scope(session=...)`` so the scope and the session under test are
-    the same object, matching how accumulate_assets reads current_session().
+    Deliberately not entered into a request_scope(): accumulate_assets reads
+    the session render_level() passes to it, not the request_scope ContextVar,
+    so a plain render(component, session) call — the convention used
+    throughout the rest of the suite — must accumulate on its own.
     """
     template_dir = str(Path(__file__).parent.parent / "templates")
     session = RenderSession(template_dir=template_dir)
@@ -155,10 +153,29 @@ def test_on_rendered_fires_once_per_component_not_per_reactive_update():
         assert session.js_assets == {JS}
 
 
-def test_raises_or_asserts_when_accumulating_outside_active_request_scope():
+def test_accumulates_without_any_active_request_scope():
+    """render(component, session) — the convention every other pyjinhx2 test
+    uses (see the shared render_session fixture) — must accumulate assets on
+    its own, since accumulate_assets reads the session passed to render_level
+    rather than the request_scope ContextVar. A session is a valid render
+    target whether or not it was ever entered into request_scope()."""
     with_assets(PlainBox, css=[CSS])
-    with pytest.raises(NoActiveRequestScope):
-        render(PlainBox(), _accumulating_session())
+    session = _accumulating_session()
+    render(PlainBox(), session)
+    assert session.css_assets == {CSS}
+
+
+def test_accumulates_into_the_render_session_even_when_a_different_session_is_the_active_scope():
+    """A caller who calls render(component, session_a) while some unrelated
+    session_b happens to be the active request_scope must still accumulate
+    into session_a — never into whichever session the ContextVar points at."""
+    with_assets(PlainBox, css=[CSS])
+    target = _accumulating_session()
+    other = _accumulating_session()
+    with request_scope(session=other):
+        render(PlainBox(), target)
+    assert target.css_assets == {CSS}
+    assert other.css_assets == set()
 
 
 def test_css_and_js_paths_tracked_distinguishably():

--- a/tests/pyjinhx2/test_assets.py
+++ b/tests/pyjinhx2/test_assets.py
@@ -1,0 +1,171 @@
+"""L2.2.1: per-request accumulation of descriptor CSS/JS paths, deduped by path."""
+
+import threading
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.descriptor import ClassDescriptor
+from pyjinhx2.render import render
+from pyjinhx2.session import (
+    NoActiveRequestScope,
+    RenderSession,
+    accumulate_assets,
+    request_scope,
+)
+
+CSS = Path("/app/components/box.css")
+JS = Path("/app/components/box.js")
+
+
+def _plain_descriptor(owner: type) -> ClassDescriptor:
+    """A hand-built descriptor pointed at the shared plain_div.html fixture.
+
+    Bypasses the real MRO/filesystem template walk on purpose (there is no
+    `__pjx_template__` override attribute in production code) — same pattern
+    test_render_level.py uses.
+    """
+    return ClassDescriptor(
+        template_path=Path("plain_div.html"),
+        slot_fields=frozenset(),
+        children_field=None,
+        css_paths=(),
+        js_paths=(),
+        strict=True,
+        provenance={"template": owner},
+    )
+
+
+class PlainBox(BaseComponent):
+    """Component rendered against a hand-built descriptor, not MRO discovery."""
+
+
+class PlainSibling(BaseComponent):
+    """Second class used to prove cross-class dedup on a shared asset path."""
+
+
+PlainBox.__pjx_descriptor__ = _plain_descriptor(PlainBox)
+PlainSibling.__pjx_descriptor__ = _plain_descriptor(PlainSibling)
+
+
+def with_assets(cls, *, css=(), js=()):
+    """Point a class's frozen descriptor at the given asset paths (read-only use)."""
+    cls.__pjx_descriptor__ = replace(
+        cls.__pjx_descriptor__, css_paths=tuple(css), js_paths=tuple(js)
+    )
+    return cls
+
+
+def _accumulating_session() -> RenderSession:
+    """A fresh RenderSession with the asset accumulator wired to on_rendered.
+
+    Not entered into a request_scope() by itself: tests bind it explicitly via
+    ``request_scope(session=...)`` so the scope and the session under test are
+    the same object, matching how accumulate_assets reads current_session().
+    """
+    template_dir = str(Path(__file__).parent.parent / "templates")
+    session = RenderSession(template_dir=template_dir)
+    session.on_rendered.append(accumulate_assets)
+    return session
+
+
+def test_accumulates_css_path_from_single_component():
+    with_assets(PlainBox, css=[CSS])
+    with request_scope(session=_accumulating_session()) as session:
+        render(PlainBox(), session)
+        assert session.css_assets == {CSS}
+
+
+def test_accumulates_js_path_from_single_component():
+    with_assets(PlainBox, js=[JS])
+    with request_scope(session=_accumulating_session()) as session:
+        render(PlainBox(), session)
+        assert session.js_assets == {JS}
+
+
+def test_dedups_same_path_across_two_instances_of_same_class():
+    with_assets(PlainBox, css=[CSS])
+    with request_scope(session=_accumulating_session()) as session:
+        render(PlainBox(), session)
+        render(PlainBox(), session)
+        assert session.css_assets == {CSS}
+
+
+def test_dedups_same_path_across_two_different_classes_sharing_a_co_located_asset():
+    with_assets(PlainBox, css=[CSS])
+    with_assets(PlainSibling, css=[CSS])
+    with request_scope(session=_accumulating_session()) as session:
+        render(PlainBox(), session)
+        render(PlainSibling(), session)
+        assert session.css_assets == {CSS}
+
+
+def test_no_op_for_component_with_no_css_or_js_paths():
+    with_assets(PlainBox)
+    with request_scope(session=_accumulating_session()) as session:
+        render(PlainBox(), session)
+        assert session.css_assets == set()
+        assert session.js_assets == set()
+
+
+def test_accumulator_resets_between_request_scopes():
+    with_assets(PlainBox, css=[CSS])
+    with request_scope(session=_accumulating_session()) as first:
+        render(PlainBox(), first)
+        assert first.css_assets == {CSS}
+    with request_scope(session=_accumulating_session()) as second:
+        assert second is not first
+        assert second.css_assets == set()
+
+
+def test_two_concurrent_request_scopes_do_not_leak_into_each_other():
+    with_assets(PlainBox, css=[CSS])
+    with_assets(PlainSibling, css=[Path("/app/components/sibling.css")])
+    seen: dict[str, set[Path]] = {}
+    started = threading.Barrier(2)
+
+    def run(name, component_cls):
+        with request_scope(session=_accumulating_session()) as session:
+            started.wait()
+            render(component_cls(), session)
+            seen[name] = set(session.css_assets)
+
+    threads = [
+        threading.Thread(target=run, args=("a", PlainBox)),
+        threading.Thread(target=run, args=("b", PlainSibling)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert seen["a"] == {CSS}
+    assert seen["b"] == {Path("/app/components/sibling.css")}
+
+
+def test_on_rendered_fires_once_per_component_not_per_reactive_update():
+    with_assets(PlainBox, css=[CSS], js=[JS])
+    box = PlainBox()
+    with request_scope(session=_accumulating_session()) as session:
+        render(box, session)
+        render(box, session)
+        assert session.css_assets == {CSS}
+        assert session.js_assets == {JS}
+
+
+def test_raises_or_asserts_when_accumulating_outside_active_request_scope():
+    with_assets(PlainBox, css=[CSS])
+    with pytest.raises(NoActiveRequestScope):
+        render(PlainBox(), _accumulating_session())
+
+
+def test_css_and_js_paths_tracked_distinguishably():
+    with_assets(PlainBox, css=[CSS], js=[JS])
+    with request_scope(session=_accumulating_session()) as session:
+        render(PlainBox(), session)
+        assert session.css_assets == {CSS}
+        assert session.js_assets == {JS}
+        assert CSS not in session.js_assets
+        assert JS not in session.css_assets

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -61,7 +61,9 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "render_context": frozenset({"pyjinhx2.markers", "pyjinhx2.component"}),
     "root_attrs": frozenset({"pyjinhx2.segments"}),
     "segments": frozenset(),
-    "session": frozenset({"pyjinhx2.markers"}),
+    # RenderedLevel is imported only under TYPE_CHECKING, for the on_rendered
+    # hook's annotation — session.py never touches segments at runtime.
+    "session": frozenset({"pyjinhx2.markers", "pyjinhx2.segments"}),
 }
 
 
@@ -128,7 +130,7 @@ def test_session_never_reaches_into_reactive():
     here. The reverse edge would invert the spine."""
     imports = internal_imports(PACKAGE_ROOT / "session.py")
     assert not any(name.startswith("pyjinhx2.reactive") for name in imports)
-    assert imports <= {"pyjinhx2.markers"}
+    assert imports <= {"pyjinhx2.markers", "pyjinhx2.segments"}
 
 
 def test_no_render_spine_module_declares_a_reactive_import():

--- a/tests/pyjinhx2/test_session.py
+++ b/tests/pyjinhx2/test_session.py
@@ -222,7 +222,9 @@ PlainBox.__pjx_descriptor__ = ClassDescriptor(
 
 def test_on_rendered_fires_once_per_render(render_session):
     seen = []
-    render_session.on_rendered.append(lambda component, level: seen.append(component))
+    render_session.on_rendered.append(
+        lambda component, level, session: seen.append(component)
+    )
     box = PlainBox()
     render(box, render_session)
     assert seen == [box]
@@ -230,6 +232,8 @@ def test_on_rendered_fires_once_per_render(render_session):
 
 def test_on_rendered_receives_the_rendered_level(render_session):
     captured = []
-    render_session.on_rendered.append(lambda component, level: captured.append(level))
+    render_session.on_rendered.append(
+        lambda component, level, session: captured.append(level)
+    )
     render(PlainBox(), render_session)
     assert captured[0].descriptor is PlainBox.__pjx_descriptor__

--- a/tests/pyjinhx2/test_session.py
+++ b/tests/pyjinhx2/test_session.py
@@ -8,8 +8,12 @@ which land with the modules that consume them.
 """
 
 import threading
+from pathlib import Path
 
 from pyjinhx2 import session as session_module
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.descriptor import ClassDescriptor
+from pyjinhx2.render import render
 
 
 def test_getters_return_empty_defaults_outside_any_scope():
@@ -194,3 +198,38 @@ def test_render_session_is_still_directly_constructible_with_autoescape_on():
 def test_scope_passes_template_dir_through_to_the_session():
     with session_module.request_scope(template_dir="tests/templates") as s:
         assert s.jinja_env.autoescape is True
+
+
+class PlainBox(BaseComponent):
+    """Component rendered against a hand-built descriptor, not MRO discovery."""
+
+
+# There is no `__pjx_template__` override attribute anywhere in pyjinhx2 —
+# template resolution is a pure MRO/filesystem walk (`class_name.pjx` beside
+# the defining module; see component.py's `_walk_template`). This test needs a
+# specific template, so it bypasses that walk entirely, the same way
+# test_render_level.py does: build a ClassDescriptor by hand and assign it.
+PlainBox.__pjx_descriptor__ = ClassDescriptor(
+    template_path=Path("plain_div.html"),
+    slot_fields=frozenset(),
+    children_field=None,
+    css_paths=(),
+    js_paths=(),
+    strict=True,
+    provenance={"template": PlainBox},
+)
+
+
+def test_on_rendered_fires_once_per_render(render_session):
+    seen = []
+    render_session.on_rendered.append(lambda component, level: seen.append(component))
+    box = PlainBox()
+    render(box, render_session)
+    assert seen == [box]
+
+
+def test_on_rendered_receives_the_rendered_level(render_session):
+    captured = []
+    render_session.on_rendered.append(lambda component, level: captured.append(level))
+    render(PlainBox(), render_session)
+    assert captured[0].descriptor is PlainBox.__pjx_descriptor__

--- a/tests/templates/plain_div.html
+++ b/tests/templates/plain_div.html
@@ -1,0 +1,1 @@
+<div id="{{ id }}">plain</div>


### PR DESCRIPTION
## Summary
- Fixes accumulate_assets to read the session passed to render() instead of relying on ContextVar
- Adds on_rendered hook firing to render pipeline
- Accumulates descriptor CSS/JS paths per request, deduped by path
- Includes test coverage

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)