### PR TITLE
feat: add inert on_rendered registry subscriber for the reactive path

### DIFF
--- a/pyjinhx2/registry.py
+++ b/pyjinhx2/registry.py
@@ -7,8 +7,15 @@ concern, not this module's, and resolve() deduplicates nothing.
 """
 
 import logging
+from typing import TYPE_CHECKING, Any
 
 from pyjinhx2.session import _instances, get_instances
+
+if TYPE_CHECKING:
+    # Type-only: naming the spine's own types in a signature must not make this
+    # module import its consumers at runtime.
+    from pyjinhx2.segments import RenderedLevel
+    from pyjinhx2.session import RenderSession
 
 logger = logging.getLogger("pyjinhx2")
 
@@ -74,3 +81,22 @@ def register_instance(type_name: str, instance_id: str, entry: object) -> None:
     if key in instances:
         logger.warning("Key %r is already registered; overwriting.", key)
     instances[key] = entry
+
+
+def register_rendered_instance(
+    component: Any, level: "RenderedLevel", session: "RenderSession"
+) -> None:
+    """Register a just-rendered component's level under its composite key.
+
+    Shaped for ``RenderSession.on_rendered`` but subscribed by no production
+    code: the reactive Load path attaches it when it needs rendered levels
+    resolvable, and a session that never attaches it registers nothing.
+
+    Args:
+        component: The component that was just rendered; its class name and
+            ``id`` form the composite key.
+        level: That component's RenderedLevel, stored as the entry.
+        session: The RenderSession this render ran against (unused; on_rendered's
+            callback shape always passes it).
+    """
+    register_instance(type(component).__name__, component.id, level)

--- a/pyjinhx2/registry.py
+++ b/pyjinhx2/registry.py
@@ -1,12 +1,16 @@
-"""The request-scoped instance registry: composite keys and read-only resolve.
+"""The request-scoped instance registry: composite keys, resolve, and the writer.
 
-Read side only (ADR 0009). Entries are written by the Load path (#435); nothing
-here mutates the store. Callers on the Load path are expected to dedup by
-(type, load_arg) before loading — that is a Load-path concern, not this
-module's, and resolve() deduplicates nothing.
+Entries are written by the Load path through register_instance(), the module's
+single mutator; make_key() and resolve() only read. Callers on the Load path are
+expected to dedup by (type, load_arg) before loading — that is a Load-path
+concern, not this module's, and resolve() deduplicates nothing.
 """
 
-from pyjinhx2.session import get_instances
+import logging
+
+from pyjinhx2.session import _instances, get_instances
+
+logger = logging.getLogger("pyjinhx2")
 
 
 def make_key(type_name: str, instance_id: str) -> str:
@@ -44,3 +48,29 @@ def resolve(type_name: str, instance_id: str) -> object:
     if key not in instances:
         raise LookupError(f"No instance registered under key {key!r}")
     return instances[key]
+
+
+def register_instance(type_name: str, instance_id: str, entry: object) -> None:
+    """Store an entry in this request's registry under its composite key.
+
+    The only function that mutates the registry: resolve() and every other
+    reader leaves the store untouched.
+
+    Args:
+        type_name: The component type's name.
+        instance_id: The instance's id, unique within one request.
+        entry: What resolve() should hand back — a live instance or a cached
+            RenderedLevel, stored as-is.
+    """
+    key = make_key(type_name, instance_id)
+    # get_instances() answers a throwaway {} outside a scope, so writing there
+    # would silently vanish; say so instead of pretending the entry landed.
+    instances = get_instances()
+    if not instances and _instances.get() is None:
+        logger.warning(
+            "Entry for key %r registered outside request_scope(); dropped.", key
+        )
+        return
+    if key in instances:
+        logger.warning("Key %r is already registered; overwriting.", key)
+    instances[key] = entry

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -65,8 +65,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     ),
     "render_context": frozenset({"pyjinhx2.markers", "pyjinhx2.component"}),
     # The instance registry (ADR 0009) is read-only over session's ContextVar
-    # store; it consumes get_instances() and nothing else in pyjinhx2.
-    "registry": frozenset({"pyjinhx2.session"}),
+    # store; it consumes get_instances() and nothing else in pyjinhx2. The
+    # register_rendered_instance signature also names RenderedLevel, but that
+    # import is TYPE_CHECKING-only (see registry.py) — never a runtime edge.
+    "registry": frozenset({"pyjinhx2.session", "pyjinhx2.segments"}),
     "root_attrs": frozenset({"pyjinhx2.segments"}),
     "segments": frozenset(),
     # The on_rendered hook's signature names BaseComponent and RenderedLevel, but

--- a/tests/pyjinhx2/test_instance_registry.py
+++ b/tests/pyjinhx2/test_instance_registry.py
@@ -4,9 +4,14 @@ import logging
 
 import pytest
 
-from pyjinhx2.registry import make_key, register_instance, resolve
+from pyjinhx2.registry import (
+    make_key,
+    register_instance,
+    register_rendered_instance,
+    resolve,
+)
 from pyjinhx2.segments import RenderedLevel
-from pyjinhx2.session import _instances, get_instances, request_scope
+from pyjinhx2.session import RenderSession, _instances, get_instances, request_scope
 
 
 def test_make_key_joins_type_and_id_with_underscore():
@@ -155,3 +160,36 @@ def test_registered_then_removed_entry_raises_instead_of_returning_stale_data():
         del get_instances()[make_key("Widget", "w1")]
         with pytest.raises(LookupError, match="Widget_w1"):
             resolve("Widget", "w1")
+
+
+class FakeComponent:
+    """Stand-in with the two attributes the subscriber reads off a component."""
+
+    def __init__(self, id: str):
+        self.id = id
+
+
+def test_register_rendered_instance_stores_the_level_under_type_and_id():
+    level = RenderedLevel(segments=["<p>x</p>"], root_span=(0, 3), descriptor=None)
+    component = FakeComponent("f1")
+    session = RenderSession()
+    with request_scope(session=session):
+        register_rendered_instance(component, level, session)
+        assert resolve("FakeComponent", "f1") is level
+
+
+def test_render_session_does_not_subscribe_the_registry_writer_by_default():
+    session = RenderSession()
+    assert register_rendered_instance not in session.on_rendered
+
+
+def test_emit_rendered_registers_nothing_until_the_writer_is_subscribed():
+    level = RenderedLevel(segments=["<p>x</p>"], root_span=(0, 3), descriptor=None)
+    component = FakeComponent("f1")
+    session = RenderSession()
+    with request_scope(session=session):
+        session.emit_rendered(component, level)  # type: ignore[arg-type]
+        assert get_instances() == {}
+        session.on_rendered.append(register_rendered_instance)
+        session.emit_rendered(component, level)  # type: ignore[arg-type]
+        assert resolve("FakeComponent", "f1") is level

--- a/tests/pyjinhx2/test_instance_registry.py
+++ b/tests/pyjinhx2/test_instance_registry.py
@@ -1,8 +1,10 @@
 """Tests for the minimal request-scoped instance registry (ADR 0009)."""
 
+import logging
+
 import pytest
 
-from pyjinhx2.registry import make_key, resolve
+from pyjinhx2.registry import make_key, register_instance, resolve
 from pyjinhx2.segments import RenderedLevel
 from pyjinhx2.session import _instances, get_instances, request_scope
 
@@ -83,5 +85,73 @@ def test_entry_removed_mid_scope_raises_instead_of_returning_stale_data():
         instances[make_key("Widget", "w1")] = widget
         assert resolve("Widget", "w1") is widget
         del instances[make_key("Widget", "w1")]
+        with pytest.raises(LookupError, match="Widget_w1"):
+            resolve("Widget", "w1")
+
+
+def test_register_instance_makes_the_entry_resolvable():
+    widget = Widget("written")
+    with request_scope():
+        register_instance("Widget", "w1", widget)
+        assert resolve("Widget", "w1") is widget
+
+
+def test_register_instance_stores_under_the_composite_key():
+    widget = Widget("written")
+    with request_scope():
+        register_instance("Widget", "w1", widget)
+        assert get_instances()["Widget_w1"] is widget
+
+
+def test_register_instance_accepts_a_cached_rendered_level():
+    level = RenderedLevel(segments=["<div>hi</div>"], root_span=(0, 5), descriptor=None)
+    with request_scope():
+        register_instance("Card", "c1", level)
+        resolved = resolve("Card", "c1")
+    assert resolved is level
+    assert isinstance(resolved, RenderedLevel)
+    assert resolved.root_span == (0, 5)
+
+
+def test_register_instance_duplicate_key_overwrites_last_write_wins():
+    first = Widget("first")
+    second = Widget("second")
+    with request_scope():
+        register_instance("Widget", "w1", first)
+        register_instance("Widget", "w1", second)
+        assert resolve("Widget", "w1") is second
+
+
+def test_register_instance_duplicate_key_warns_naming_the_key(caplog):
+    with request_scope(), caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        register_instance("Widget", "w1", Widget("first"))
+        assert caplog.records == []
+        register_instance("Widget", "w1", Widget("second"))
+    assert len(caplog.records) == 1
+    assert "Widget_w1" in caplog.records[0].getMessage()
+
+
+def test_register_instance_outside_request_scope_is_a_logged_no_op(caplog):
+    assert _instances.get() is None
+    with caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        register_instance("Widget", "w1", Widget("orphan"))
+    assert len(caplog.records) == 1
+    assert "Widget_w1" in caplog.records[0].getMessage()
+    with pytest.raises(LookupError, match="Widget_w1"):
+        resolve("Widget", "w1")
+
+
+def test_registered_entry_does_not_survive_the_scope_reset():
+    with request_scope():
+        register_instance("Widget", "w1", Widget("old"))
+        assert resolve("Widget", "w1") is not None
+    with request_scope(), pytest.raises(LookupError, match="Widget_w1"):
+        resolve("Widget", "w1")
+
+
+def test_registered_then_removed_entry_raises_instead_of_returning_stale_data():
+    with request_scope():
+        register_instance("Widget", "w1", Widget("doomed"))
+        del get_instances()[make_key("Widget", "w1")]
         with pytest.raises(LookupError, match="Widget_w1"):
             resolve("Widget", "w1")


### PR DESCRIPTION
## Summary
- Adds `register_rendered_instance` callback matching the `on_rendered` shape, subscribed by no production code yet
- Declares TYPE_CHECKING-only segments that `edge/registry.py` names in ALLOWED_INTERNAL_IMPORTS
- Includes `register_instance` as the registry's single writer for instance data
- Comprehensive test coverage for the new registry functionality

## Tests
Added/updated 112+ test lines covering the new registry subscribers and instance registration paths.

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)