### PR TITLE
feat: add asset_manifest() and AssetManifest for L2.2.3

### DIFF
--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -1,5 +1,7 @@
-"""L2.2.2 assets — delivery modes and emission of a request's accumulated assets."""
+"""L2.2 assets — delivery modes, emission, and the manifest of a request's assets."""
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -49,3 +51,52 @@ def emit_assets(session: "RenderSession") -> str:
     if session.js_mode is AssetMode.INLINE:
         tags += _inline_tags(session.js_assets, "<script>", "</script>")
     return "\n".join(tags)
+
+
+@dataclass(frozen=True)
+class AssetManifest:
+    """The resolved asset URLs for one render, split by kind.
+
+    Attributes:
+        stylesheets: URLs of the render's CSS assets, in path order.
+        scripts: URLs of the render's JS assets, in path order.
+    """
+
+    stylesheets: tuple[str, ...]
+    scripts: tuple[str, ...]
+
+
+def _resolved_urls(
+    paths: set[Path], resolver: Callable[[Path], str]
+) -> tuple[str, ...]:
+    """Resolve each path to a URL, sorted by path for a stable order.
+
+    Sorted for the same reason _inline_tags sorts: the accumulator is a set,
+    and two renders of the same tree must produce the same manifest. A
+    resolver that raises is left to raise — a manifest missing one asset is a
+    page missing one stylesheet, which fails silently in the browser.
+    """
+    return tuple(resolver(path) for path in sorted(paths, key=str))
+
+
+def asset_manifest(
+    session: "RenderSession", *, resolver: Callable[[Path], str]
+) -> AssetManifest:
+    """Return the resolved URLs of this session's accumulated assets.
+
+    Kinds stay in separate tuples so a caller builds <link> and <script src>
+    tags without re-inspecting file extensions. Independent of css_mode/
+    js_mode: those govern emit_assets, not what the render used.
+
+    Args:
+        session: The RenderSession whose css_assets/js_assets were populated
+            by accumulate_assets during the render.
+        resolver: Maps an asset path to the URL it is served from.
+
+    Returns:
+        An AssetManifest of CSS then JS URLs, each in path-sorted order.
+    """
+    return AssetManifest(
+        stylesheets=_resolved_urls(session.css_assets, resolver),
+        scripts=_resolved_urls(session.js_assets, resolver),
+    )

--- a/tests/pyjinhx2/test_asset_manifest.py
+++ b/tests/pyjinhx2/test_asset_manifest.py
@@ -1,0 +1,145 @@
+"""L2.2.3: the per-session asset manifest — resolved, ordered CSS/JS URLs."""
+
+import dataclasses
+import threading
+from pathlib import Path
+
+import pytest
+
+from pyjinhx2.assets import AssetManifest, AssetMode, asset_manifest
+from pyjinhx2.session import RenderSession, request_scope
+
+A_CSS = Path("/app/components/a.css")
+B_CSS = Path("/app/components/b.css")
+Y_JS = Path("/app/components/y.js")
+Z_JS = Path("/app/components/z.js")
+
+
+def by_name(path: Path) -> str:
+    """A trivial resolver: URL is the filename under a fixed static prefix."""
+    return f"/static/{path.name}"
+
+
+def _session() -> RenderSession:
+    """A bare session; assets are set-added directly, no render needed.
+
+    Modes stay at their INLINE default and are never exercised — the manifest
+    is mode-independent, and nothing here reads a file off disk, so the
+    non-existent paths above are safe.
+    """
+    return RenderSession(template_dir=str(Path(__file__).parent.parent / "templates"))
+
+
+def test_manifest_empty_session_returns_empty_tuples():
+    manifest = asset_manifest(_session(), resolver=by_name)
+    assert manifest == AssetManifest(stylesheets=(), scripts=())
+
+
+def test_manifest_resolves_and_sorts_css_paths_alphabetically():
+    session = _session()
+    session.css_assets.add(B_CSS)
+    session.css_assets.add(A_CSS)
+    manifest = asset_manifest(session, resolver=by_name)
+    assert manifest.stylesheets == ("/static/a.css", "/static/b.css")
+
+
+def test_manifest_resolves_and_sorts_js_paths_alphabetically():
+    session = _session()
+    session.js_assets.add(Z_JS)
+    session.js_assets.add(Y_JS)
+    manifest = asset_manifest(session, resolver=by_name)
+    assert manifest.scripts == ("/static/y.js", "/static/z.js")
+
+
+def test_manifest_keeps_stylesheets_and_scripts_separate():
+    session = _session()
+    session.css_assets.add(A_CSS)
+    session.js_assets.add(Y_JS)
+    manifest = asset_manifest(session, resolver=by_name)
+    assert manifest.stylesheets == ("/static/a.css",)
+    assert manifest.scripts == ("/static/y.js",)
+
+
+def test_manifest_calls_resolver_exactly_once_per_path():
+    session = _session()
+    session.css_assets.update({A_CSS, B_CSS})
+    session.js_assets.add(Y_JS)
+    calls: list[Path] = []
+
+    def recording(path: Path) -> str:
+        calls.append(path)
+        return by_name(path)
+
+    asset_manifest(session, resolver=recording)
+    assert sorted(calls, key=str) == [A_CSS, B_CSS, Y_JS]
+
+
+def test_manifest_is_deterministic_across_repeated_calls():
+    session = _session()
+    session.css_assets.update({A_CSS, B_CSS})
+    session.js_assets.update({Y_JS, Z_JS})
+    assert asset_manifest(session, resolver=by_name) == asset_manifest(
+        session, resolver=by_name
+    )
+
+
+def test_manifest_ignores_css_js_mode():
+    session = _session()
+    session.css_assets.add(A_CSS)
+    session.js_assets.add(Y_JS)
+    session.css_mode = AssetMode.NONE
+    session.js_mode = AssetMode.NONE
+    manifest = asset_manifest(session, resolver=by_name)
+    assert manifest.stylesheets == ("/static/a.css",)
+    assert manifest.scripts == ("/static/y.js",)
+
+
+def test_manifest_reads_the_session_argument_not_active_scope():
+    target = _session()
+    target.css_assets.add(A_CSS)
+    other = _session()
+    other.css_assets.add(B_CSS)
+    with request_scope(session=other):
+        manifest = asset_manifest(target, resolver=by_name)
+    assert manifest.stylesheets == ("/static/a.css",)
+
+
+def test_concurrent_sessions_do_not_leak_into_each_others_manifest():
+    seen: dict[str, AssetManifest] = {}
+    started = threading.Barrier(2)
+
+    def run(name: str, css: Path) -> None:
+        session = _session()
+        session.css_assets.add(css)
+        with request_scope(session=session):
+            started.wait()
+            seen[name] = asset_manifest(session, resolver=by_name)
+
+    threads = [
+        threading.Thread(target=run, args=("a", A_CSS)),
+        threading.Thread(target=run, args=("b", B_CSS)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert seen["a"].stylesheets == ("/static/a.css",)
+    assert seen["b"].stylesheets == ("/static/b.css",)
+
+
+def test_resolver_exception_propagates():
+    session = _session()
+    session.css_assets.add(A_CSS)
+
+    def boom(path: Path) -> str:
+        raise RuntimeError("no url for you")
+
+    with pytest.raises(RuntimeError, match="no url for you"):
+        asset_manifest(session, resolver=boom)
+
+
+def test_asset_manifest_is_frozen():
+    manifest = asset_manifest(_session(), resolver=by_name)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        manifest.stylesheets = ("/static/injected.css",)  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Introduces `asset_manifest()` and the `AssetManifest` class to resolve each session's accumulated CSS/JS asset paths to URLs via an injected resolver. Manifests are sorted by path to ensure repeated renders produce identical results. Assets are separated by kind (CSS and JS) into distinct tuples, allowing callers to generate appropriate `<link>` and `<script>` tags without extension sniffing.

Closes #431

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)