### PR TITLE
feat: add registry-wide all_assets() enumeration (#433)

### DIFF
--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -159,3 +159,51 @@ def resolver_with_hash(base_url: str, root: str) -> Callable[[Path], str]:
         return f"{prefix}/{relative_dir.as_posix()}/{hashed}"
 
     return resolve
+
+
+def _all_component_classes(root: type) -> set[type]:
+    """Every class below root in the subclass tree, root excluded.
+
+    Recursive rather than one level deep: a component that subclasses another
+    component is a distinct class with its own descriptor, and only leaves of
+    a deep hierarchy would be seen otherwise. Returned as a set because
+    multiple inheritance makes a class reachable by more than one path.
+    """
+    found: set[type] = set()
+    for subclass in root.__subclasses__():
+        found.add(subclass)
+        found |= _all_component_classes(subclass)
+    return found
+
+
+def all_assets() -> tuple[tuple[Path, ...], tuple[Path, ...]]:
+    """Return every CSS and JS path declared by any component class.
+
+    Registry-wide rather than session-scoped: a class contributes its assets
+    whether or not it was rendered, which is what a build step bundling the
+    whole asset tree needs, as opposed to asset_manifest's per-request view.
+
+    Only classes imported by the time of the call are visible, since Python
+    discovers subclasses as their modules execute — import the component
+    package before calling this from a build script.
+
+    Returns:
+        The CSS paths then the JS paths, each deduped and in path-sorted
+        order so repeated calls and repeated builds agree byte for byte.
+    """
+    # Imported here rather than at module scope: session imports this module
+    # and component imports session, so a top-level import would cycle.
+    from pyjinhx2.component import BaseComponent
+
+    css: set[Path] = set()
+    js: set[Path] = set()
+    for cls in _all_component_classes(BaseComponent):
+        # A class that never went through descriptor resolution — an abstract
+        # mixin, say — has no descriptor attribute at all, and contributes
+        # nothing rather than failing the whole enumeration.
+        descriptor = getattr(cls, "__pjx_descriptor__", None)
+        if descriptor is None:
+            continue
+        css.update(descriptor.css_paths)
+        js.update(descriptor.js_paths)
+    return tuple(sorted(css, key=str)), tuple(sorted(js, key=str))

--- a/tests/pyjinhx2/test_assets.py
+++ b/tests/pyjinhx2/test_assets.py
@@ -4,7 +4,7 @@ import threading
 from dataclasses import replace
 from pathlib import Path
 
-from pyjinhx2.assets import AssetMode
+from pyjinhx2.assets import AssetMode, all_assets
 from pyjinhx2.component import BaseComponent
 from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.render import render
@@ -196,3 +196,67 @@ def test_css_and_js_paths_tracked_distinguishably():
         assert session.js_assets == {JS}
         assert CSS not in session.js_assets
         assert JS not in session.css_assets
+
+
+class UnrenderedWidget(BaseComponent):
+    """Never instantiated in any test — proves all_assets() is registry-wide."""
+
+
+class EmptyAssetComponent(BaseComponent):
+    """Declares no assets — must contribute nothing to all_assets()."""
+
+
+UnrenderedWidget.__pjx_descriptor__ = _plain_descriptor(UnrenderedWidget)
+EmptyAssetComponent.__pjx_descriptor__ = _plain_descriptor(EmptyAssetComponent)
+
+WIDGET_CSS = Path("/app/components/widget.css")
+WIDGET_JS = Path("/app/components/widget.js")
+
+
+def test_all_assets_returns_sorted_deduped_pairs():
+    with_assets(PlainBox, css=[CSS, WIDGET_CSS], js=[JS])
+    with_assets(PlainSibling, css=[CSS], js=[JS, WIDGET_JS])
+    css, js = all_assets()
+    assert css == tuple(sorted(css, key=str))
+    assert js == tuple(sorted(js, key=str))
+    assert list(css).count(CSS) == 1
+    assert list(js).count(JS) == 1
+    assert WIDGET_CSS in css
+    assert WIDGET_JS in js
+
+
+def test_all_assets_includes_unrendered_classes():
+    with_assets(UnrenderedWidget, css=[WIDGET_CSS], js=[WIDGET_JS])
+    css, js = all_assets()
+    assert WIDGET_CSS in css
+    assert WIDGET_JS in js
+
+
+def test_all_assets_excludes_classes_without_assets():
+    with_assets(PlainBox)
+    with_assets(PlainSibling)
+    with_assets(UnrenderedWidget)
+    with_assets(EmptyAssetComponent)
+    css, js = all_assets()
+    for path in (CSS, WIDGET_CSS):
+        assert path not in css
+    for path in (JS, WIDGET_JS):
+        assert path not in js
+
+
+def test_all_assets_does_not_mutate_session_state():
+    with_assets(PlainBox, css=[CSS])
+    with_assets(PlainSibling, css=[WIDGET_CSS])
+    session = _accumulating_session()
+    all_assets()
+    render(PlainBox(), session)
+    all_assets()
+    assert session.css_assets == {CSS}
+    assert session.js_assets == set()
+
+
+def test_all_assets_returns_paths_not_strings():
+    with_assets(PlainBox, css=[CSS], js=[JS])
+    css, js = all_assets()
+    assert all(isinstance(path, Path) for path in css)
+    assert all(isinstance(path, Path) for path in js)

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -24,7 +24,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # The TYPE_CHECKING-only RenderSession import mirrors session's own
     # component/segments entries below, for the same reason: the enum/function
     # signature names the type, runtime never touches it.
-    "assets": frozenset({"pyjinhx2.session"}),
+    # component is a real runtime edge: all_assets() reads
+    # BaseComponent.__subclasses__() and each class's descriptor, imported
+    # locally to avoid a module-level cycle (session imports assets).
+    "assets": frozenset({"pyjinhx2.session", "pyjinhx2.component"}),
     # The classless factory is a consumer: it validates a tag name, reads the
     # template discovery found, hands the header to props_header and publishes
     # the result through discovery's own write path. Nothing imports it back.


### PR DESCRIPTION
## Summary

- Implement registry-wide `all_assets()` enumeration that walks the BaseComponent subclass tree
- Unions each class's descriptor css_paths/js_paths into deduped, sorted tuples
- Works independently of any RenderSession
- Declares new assets->component import edge in test_import_graph

## Changes
- 48 lines added to pyjinhx2/assets.py
- 66 lines added to tests/pyjinhx2/test_assets.py
- 5 lines modified in test_import_graph.py

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)