### PR TITLE
L2: per-request session scope, asset pipeline, and instance registry

### DIFF
--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -16,6 +16,10 @@ class AssetMode(str, Enum):
 
     INLINE = "inline"
     NONE = "none"
+    # One member for both kinds: the asset kind already decides the tag shape
+    # (<link rel="stylesheet"> vs <script src>), so a separate SRC member would
+    # only create a way to set the wrong one on the wrong kind.
+    LINK = "link"
 
 
 def _inline_tags(paths: set[Path], open_tag: str, close_tag: str) -> list[str]:
@@ -31,26 +35,69 @@ def _inline_tags(paths: set[Path], open_tag: str, close_tag: str) -> list[str]:
     ]
 
 
-def emit_assets(session: "RenderSession") -> str:
+def _url_tags(
+    paths: set[Path], resolver: Callable[[Path], str], template: str
+) -> list[str]:
+    """Resolve each path to a URL and format it into the given tag, sorted by path.
+
+    Sorted for the same reason _inline_tags sorts: the accumulator is a set with
+    no stable iteration order, and two renders of the same tree must produce
+    byte-identical output. A resolver that raises is left to raise — an asset
+    silently dropped from the page fails invisibly in the browser.
+    """
+    return [template.format(url=resolver(path)) for path in sorted(paths, key=str)]
+
+
+def _require_resolver(
+    resolver: Callable[[Path], str] | None,
+) -> Callable[[Path], str]:
+    """Return the resolver, refusing to emit LINK tags without one.
+
+    Raising rather than skipping the kind: a page quietly missing its
+    stylesheets is harder to diagnose than a failed render.
+    """
+    if resolver is None:
+        raise ValueError("LINK mode needs a resolver to build asset URLs")
+    return resolver
+
+
+def emit_assets(
+    session: "RenderSession", *, resolver: Callable[[Path], str] | None = None
+) -> str:
     """Return the markup for this session's accumulated assets, per delivery mode.
 
     Args:
         session: The RenderSession whose css_assets/js_assets were populated by
             accumulate_assets during the render, and whose css_mode/js_mode say
             how each kind is delivered.
+        resolver: Maps an asset path to the URL it is served from, in the shape
+            asset_manifest() takes. Required only when a kind is in LINK mode.
 
     Returns:
-        Concatenated <style> tags then <script> tags, newline-joined. Empty
-        string when both kinds are NONE or nothing was accumulated.
+        Concatenated CSS tags then JS tags, newline-joined. Empty string when
+        both kinds are NONE or nothing was accumulated.
 
     Raises:
         OSError: If an asset file is missing or unreadable under INLINE mode.
+        ValueError: If a kind is in LINK mode and no resolver was given.
     """
     tags: list[str] = []
     if session.css_mode is AssetMode.INLINE:
         tags += _inline_tags(session.css_assets, "<style>", "</style>")
+    elif session.css_mode is AssetMode.LINK:
+        tags += _url_tags(
+            session.css_assets,
+            _require_resolver(resolver),
+            '<link rel="stylesheet" href="{url}">',
+        )
     if session.js_mode is AssetMode.INLINE:
         tags += _inline_tags(session.js_assets, "<script>", "</script>")
+    elif session.js_mode is AssetMode.LINK:
+        tags += _url_tags(
+            session.js_assets,
+            _require_resolver(resolver),
+            '<script src="{url}"></script>',
+        )
     return "\n".join(tags)
 
 

--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -1,0 +1,51 @@
+"""L2.2.2 assets — delivery modes and emission of a request's accumulated assets."""
+
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyjinhx2.session import RenderSession
+
+
+class AssetMode(str, Enum):
+    """How a kind of asset reaches the page for one render."""
+
+    INLINE = "inline"
+    NONE = "none"
+
+
+def _inline_tags(paths: set[Path], open_tag: str, close_tag: str) -> list[str]:
+    """Read each path and wrap its contents in the given tag pair, sorted by path.
+
+    Sorted because the accumulator stores paths in a set, which has no stable
+    iteration order; two renders of the same tree must produce byte-identical
+    output. A path that cannot be read raises: an asset silently dropped from
+    the page is a styling bug nobody can see in the response.
+    """
+    return [
+        f"{open_tag}{path.read_text()}{close_tag}" for path in sorted(paths, key=str)
+    ]
+
+
+def emit_assets(session: "RenderSession") -> str:
+    """Return the markup for this session's accumulated assets, per delivery mode.
+
+    Args:
+        session: The RenderSession whose css_assets/js_assets were populated by
+            accumulate_assets during the render, and whose css_mode/js_mode say
+            how each kind is delivered.
+
+    Returns:
+        Concatenated <style> tags then <script> tags, newline-joined. Empty
+        string when both kinds are NONE or nothing was accumulated.
+
+    Raises:
+        OSError: If an asset file is missing or unreadable under INLINE mode.
+    """
+    tags: list[str] = []
+    if session.css_mode is AssetMode.INLINE:
+        tags += _inline_tags(session.css_assets, "<style>", "</style>")
+    if session.js_mode is AssetMode.INLINE:
+        tags += _inline_tags(session.js_assets, "<script>", "</script>")
+    return "\n".join(tags)

--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -159,3 +159,51 @@ def resolver_with_hash(base_url: str, root: str) -> Callable[[Path], str]:
         return f"{prefix}/{relative_dir.as_posix()}/{hashed}"
 
     return resolve
+
+
+def _all_component_classes(root: type) -> set[type]:
+    """Every class below root in the subclass tree, root excluded.
+
+    Recursive rather than one level deep: a component that subclasses another
+    component is a distinct class with its own descriptor, and only leaves of
+    a deep hierarchy would be seen otherwise. Returned as a set because
+    multiple inheritance makes a class reachable by more than one path.
+    """
+    found: set[type] = set()
+    for subclass in root.__subclasses__():
+        found.add(subclass)
+        found |= _all_component_classes(subclass)
+    return found
+
+
+def all_assets() -> tuple[tuple[Path, ...], tuple[Path, ...]]:
+    """Return every CSS and JS path declared by any component class.
+
+    Registry-wide rather than session-scoped: a class contributes its assets
+    whether or not it was rendered, which is what a build step bundling the
+    whole asset tree needs, as opposed to asset_manifest's per-request view.
+
+    Only classes imported by the time of the call are visible, since Python
+    discovers subclasses as their modules execute — import the component
+    package before calling this from a build script.
+
+    Returns:
+        The CSS paths then the JS paths, each deduped and in path-sorted
+        order so repeated calls and repeated builds agree byte for byte.
+    """
+    # Imported here rather than at module scope: session imports this module
+    # and component imports session, so a top-level import would cycle.
+    from pyjinhx2.component import BaseComponent
+
+    css: set[Path] = set()
+    js: set[Path] = set()
+    for cls in _all_component_classes(BaseComponent):
+        # A class that never went through descriptor resolution — an abstract
+        # mixin, say — has no descriptor attribute at all, and contributes
+        # nothing rather than failing the whole enumeration.
+        descriptor = getattr(cls, "__pjx_descriptor__", None)
+        if descriptor is None:
+            continue
+        css.update(descriptor.css_paths)
+        js.update(descriptor.js_paths)
+    return tuple(sorted(css, key=str)), tuple(sorted(js, key=str))

--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -1,5 +1,6 @@
 """L2.2 assets — delivery modes, emission, and the manifest of a request's assets."""
 
+import hashlib
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
@@ -100,3 +101,61 @@ def asset_manifest(
         stylesheets=_resolved_urls(session.css_assets, resolver),
         scripts=_resolved_urls(session.js_assets, resolver),
     )
+
+
+_hash_filename_cache: dict[tuple[str, float, int], str] = {}
+
+
+def hashed_filename(path: Path, *, hash_len: int = 8) -> str:
+    """Return a cache-busted filename such as ``button.a1b2c3d4.js``.
+
+    Args:
+        path: The asset file on disk to hash.
+        hash_len: How many hex characters of the SHA-256 digest to keep.
+
+    Returns:
+        The file's stem, the truncated digest, and its suffix, dot-joined.
+
+    Raises:
+        OSError: If the file is missing or unreadable.
+    """
+    # Keyed on mtime as well as path so an edited asset re-hashes, while a
+    # repeated render of an untouched tree never re-reads the file.
+    key = (str(path.resolve()), path.stat().st_mtime, hash_len)
+    cached = _hash_filename_cache.get(key)
+    if cached is not None:
+        return cached
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()[:hash_len]
+    result = f"{path.stem}.{digest}{path.suffix}"
+    _hash_filename_cache[key] = result
+    return result
+
+
+def resolver_with_hash(base_url: str, root: str) -> Callable[[Path], str]:
+    """Build an asset resolver that embeds a content hash in each filename.
+
+    The returned callable has the shape asset_manifest expects for its
+    resolver, so a caller wires cache-busted URLs in with one argument.
+
+    Args:
+        base_url: URL prefix the asset tree is served from; a trailing slash
+            is ignored.
+        root: Directory the asset paths are laid out under; the part of a
+            path below it is preserved in the URL.
+
+    Returns:
+        A callable mapping an asset path to its hashed URL, which raises
+        OSError if the file is missing.
+    """
+
+    def resolve(path: Path) -> str:
+        relative_dir = path.parent.relative_to(root)
+        hashed = hashed_filename(path)
+        prefix = base_url.rstrip("/")
+        # relative_to returns Path(".") for a file sitting directly in root,
+        # which would otherwise render as a "/./" segment in the URL.
+        if relative_dir == Path("."):
+            return f"{prefix}/{hashed}"
+        return f"{prefix}/{relative_dir.as_posix()}/{hashed}"
+
+    return resolve

--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -1,7 +1,7 @@
 """L2.2 assets — delivery modes, emission, and the manifest of a request's assets."""
 
 import hashlib
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -35,17 +35,24 @@ def _inline_tags(paths: set[Path], open_tag: str, close_tag: str) -> list[str]:
     ]
 
 
+def _sorted_resolved(
+    paths: Iterable[Path], resolver: Callable[[Path], str]
+) -> tuple[str, ...]:
+    """Return the URLs for the given asset paths, in path-sorted order.
+
+    Sorted before resolving because the accumulator stores paths in a set,
+    which has no stable iteration order, and two renders of the same tree must
+    produce byte-identical output. A resolver that raises is left to raise — an
+    asset silently dropped from the page fails invisibly in the browser.
+    """
+    return tuple(resolver(path) for path in sorted(paths, key=str))
+
+
 def _url_tags(
     paths: set[Path], resolver: Callable[[Path], str], template: str
 ) -> list[str]:
-    """Resolve each path to a URL and format it into the given tag, sorted by path.
-
-    Sorted for the same reason _inline_tags sorts: the accumulator is a set with
-    no stable iteration order, and two renders of the same tree must produce
-    byte-identical output. A resolver that raises is left to raise — an asset
-    silently dropped from the page fails invisibly in the browser.
-    """
-    return [template.format(url=resolver(path)) for path in sorted(paths, key=str)]
+    """Format each resolved asset URL into the given tag, in path-sorted order."""
+    return [template.format(url=url) for url in _sorted_resolved(paths, resolver)]
 
 
 def _require_resolver(
@@ -114,19 +121,6 @@ class AssetManifest:
     scripts: tuple[str, ...]
 
 
-def _resolved_urls(
-    paths: set[Path], resolver: Callable[[Path], str]
-) -> tuple[str, ...]:
-    """Resolve each path to a URL, sorted by path for a stable order.
-
-    Sorted for the same reason _inline_tags sorts: the accumulator is a set,
-    and two renders of the same tree must produce the same manifest. A
-    resolver that raises is left to raise — a manifest missing one asset is a
-    page missing one stylesheet, which fails silently in the browser.
-    """
-    return tuple(resolver(path) for path in sorted(paths, key=str))
-
-
 def asset_manifest(
     session: "RenderSession", *, resolver: Callable[[Path], str]
 ) -> AssetManifest:
@@ -145,8 +139,8 @@ def asset_manifest(
         An AssetManifest of CSS then JS URLs, each in path-sorted order.
     """
     return AssetManifest(
-        stylesheets=_resolved_urls(session.css_assets, resolver),
-        scripts=_resolved_urls(session.js_assets, resolver),
+        stylesheets=_sorted_resolved(session.css_assets, resolver),
+        scripts=_sorted_resolved(session.js_assets, resolver),
     )
 
 

--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -1,5 +1,7 @@
-"""L2.2.2 assets — delivery modes and emission of a request's accumulated assets."""
+"""L2.2 assets — delivery modes, emission, and the manifest of a request's assets."""
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -49,3 +51,52 @@ def emit_assets(session: "RenderSession") -> str:
     if session.js_mode is AssetMode.INLINE:
         tags += _inline_tags(session.js_assets, "<script>", "</script>")
     return "\n".join(tags)
+
+
+@dataclass(frozen=True)
+class AssetManifest:
+    """The resolved asset URLs for one render, split by kind.
+
+    Attributes:
+        stylesheets: URLs of the render's CSS assets, in path order.
+        scripts: URLs of the render's JS assets, in path order.
+    """
+
+    stylesheets: tuple[str, ...]
+    scripts: tuple[str, ...]
+
+
+def _resolved_urls(
+    paths: set[Path], resolver: Callable[[Path], str]
+) -> tuple[str, ...]:
+    """Resolve each path to a URL, sorted by path for a stable order.
+
+    Sorted for the same reason _inline_tags sorts: the accumulator is a set,
+    and two renders of the same tree must produce the same manifest. A
+    resolver that raises is left to raise — a manifest missing one asset is a
+    page missing one stylesheet, which fails silently in the browser.
+    """
+    return tuple(resolver(path) for path in sorted(paths, key=str))
+
+
+def asset_manifest(
+    session: "RenderSession", *, resolver: Callable[[Path], str]
+) -> AssetManifest:
+    """Return the resolved URLs of this session's accumulated assets.
+
+    Kinds stay in separate tuples so a caller builds <link> and <script src>
+    tags without re-inspecting file extensions. Independent of css_mode/
+    js_mode: those govern emit_assets, not what the render used.
+
+    Args:
+        session: The RenderSession whose css_assets/js_assets were populated
+            by accumulate_assets during the render.
+        resolver: Maps an asset path to the URL it is served from.
+
+    Returns:
+        An AssetManifest of CSS then JS URLs, each in path-sorted order.
+    """
+    return AssetManifest(
+        stylesheets=_resolved_urls(session.css_assets, resolver),
+        scripts=_resolved_urls(session.js_assets, resolver),
+    )

--- a/pyjinhx2/registry.py
+++ b/pyjinhx2/registry.py
@@ -1,12 +1,23 @@
-"""The request-scoped instance registry: composite keys and read-only resolve.
+"""The request-scoped instance registry: composite keys, resolve, and the writer.
 
-Read side only (ADR 0009). Entries are written by the Load path (#435); nothing
-here mutates the store. Callers on the Load path are expected to dedup by
-(type, load_arg) before loading — that is a Load-path concern, not this
-module's, and resolve() deduplicates nothing.
+Entries are written by the Load path through register_instance(), the module's
+single mutator; make_key() and resolve() only read. Callers on the Load path are
+expected to dedup by (type, load_arg) before loading — that is a Load-path
+concern, not this module's, and resolve() deduplicates nothing.
 """
 
-from pyjinhx2.session import get_instances
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pyjinhx2.session import _instances, get_instances
+
+if TYPE_CHECKING:
+    # Type-only: naming the spine's own types in a signature must not make this
+    # module import its consumers at runtime.
+    from pyjinhx2.segments import RenderedLevel
+    from pyjinhx2.session import RenderSession
+
+logger = logging.getLogger("pyjinhx2")
 
 
 def make_key(type_name: str, instance_id: str) -> str:
@@ -44,3 +55,48 @@ def resolve(type_name: str, instance_id: str) -> object:
     if key not in instances:
         raise LookupError(f"No instance registered under key {key!r}")
     return instances[key]
+
+
+def register_instance(type_name: str, instance_id: str, entry: object) -> None:
+    """Store an entry in this request's registry under its composite key.
+
+    The only function that mutates the registry: resolve() and every other
+    reader leaves the store untouched.
+
+    Args:
+        type_name: The component type's name.
+        instance_id: The instance's id, unique within one request.
+        entry: What resolve() should hand back — a live instance or a cached
+            RenderedLevel, stored as-is.
+    """
+    key = make_key(type_name, instance_id)
+    # get_instances() answers a throwaway {} outside a scope, so writing there
+    # would silently vanish; say so instead of pretending the entry landed.
+    instances = get_instances()
+    if not instances and _instances.get() is None:
+        logger.warning(
+            "Entry for key %r registered outside request_scope(); dropped.", key
+        )
+        return
+    if key in instances:
+        logger.warning("Key %r is already registered; overwriting.", key)
+    instances[key] = entry
+
+
+def register_rendered_instance(
+    component: Any, level: "RenderedLevel", session: "RenderSession"
+) -> None:
+    """Register a just-rendered component's level under its composite key.
+
+    Shaped for ``RenderSession.on_rendered`` but subscribed by no production
+    code: the reactive Load path attaches it when it needs rendered levels
+    resolvable, and a session that never attaches it registers nothing.
+
+    Args:
+        component: The component that was just rendered; its class name and
+            ``id`` form the composite key.
+        level: That component's RenderedLevel, stored as the entry.
+        session: The RenderSession this render ran against (unused; on_rendered's
+            callback shape always passes it).
+    """
+    register_instance(type(component).__name__, component.id, level)

--- a/pyjinhx2/registry.py
+++ b/pyjinhx2/registry.py
@@ -1,0 +1,46 @@
+"""The request-scoped instance registry: composite keys and read-only resolve.
+
+Read side only (ADR 0009). Entries are written by the Load path (#435); nothing
+here mutates the store. Callers on the Load path are expected to dedup by
+(type, load_arg) before loading — that is a Load-path concern, not this
+module's, and resolve() deduplicates nothing.
+"""
+
+from pyjinhx2.session import get_instances
+
+
+def make_key(type_name: str, instance_id: str) -> str:
+    """Build the composite registry key for a component type and instance id.
+
+    Args:
+        type_name: The component type's name.
+        instance_id: The instance's id, unique within one request.
+
+    Returns:
+        The composite key, e.g. ``"PJXButton_btn1"``.
+    """
+    return f"{type_name}_{instance_id}"
+
+
+def resolve(type_name: str, instance_id: str) -> object:
+    """Return the entry registered under this request's composite key.
+
+    Args:
+        type_name: The component type's name.
+        instance_id: The instance's id.
+
+    Returns:
+        Whatever the Load path stored — a live instance or a cached
+        RenderedLevel — returned as-is, never re-derived or re-parsed.
+
+    Raises:
+        LookupError: The key is not registered in this request, including
+            every key when called outside an active request_scope().
+    """
+    key = make_key(type_name, instance_id)
+    # get_instances() answers {} outside a scope, so an out-of-scope call is a
+    # plain miss rather than a distinct error — one lookup, one failure mode.
+    instances = get_instances()
+    if key not in instances:
+        raise LookupError(f"No instance registered under key {key!r}")
+    return instances[key]

--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -10,6 +10,7 @@ from typing import cast
 
 import jinja2
 
+from pyjinhx2.assets import emit_assets
 from pyjinhx2.component import BaseComponent, _pascal_to_snake
 from pyjinhx2.discovery import get_class
 from pyjinhx2.markers import SLOT_TOKEN_RE, collect_slot_tokens
@@ -259,7 +260,8 @@ def render(component: BaseComponent, session: "RenderSession | None" = None) -> 
             kernel don't need to construct one by hand.
 
     Returns:
-        The component's rendered markup as a finished HTML string.
+        The component's rendered markup as a finished HTML string, with the
+        session's accumulated assets appended per their delivery mode.
 
     Fires each ``session.on_rendered`` callback with ``(component, level,
     session)`` after each component's level is built, depth-first post-order.
@@ -277,4 +279,7 @@ def render(component: BaseComponent, session: "RenderSession | None" = None) -> 
     if session is None:
         session = RenderSession()
     level = render_level(component, session)
-    return serialize(level)
+    # The one join at the top, and the one place assets are emitted: every
+    # component in the tree has already fired on_rendered by now, so the
+    # session's asset sets are complete. render_level() never lands here.
+    return serialize(level) + emit_assets(session)

--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -261,6 +261,12 @@ def render(component: BaseComponent, session: "RenderSession | None" = None) -> 
     Returns:
         The component's rendered markup as a finished HTML string.
 
+    Fires each ``session.on_rendered`` callback with ``(component, level,
+    session)`` after each component's level is built, depth-first post-order.
+    ``session`` is always the one passed to (or defaulted inside) this call,
+    never read off any ContextVar, so hooks work whether or not ``session``
+    is also the active request_scope().
+
     Raises:
         ValueError: If template renders zero or 2+ root elements.
         jinja2.TemplateNotFound: If template file missing.

--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -171,6 +171,8 @@ def render_level(
         ValueError: If a component re-enters its own render chain (cycle).
         jinja2.TemplateNotFound: If template file missing.
         jinja2.TemplateAssertionError: If Jinja evaluation fails.
+        Exception: Whatever a session.on_rendered subscriber raises; the hook
+            does not isolate subscribers from the render.
     """
     # Phase 1: Descriptor read
     descriptor = component.__class__.__pjx_descriptor__
@@ -234,6 +236,11 @@ def render_level(
     # Runs after tag-shaped holes are resolved, so the indexes above stay valid
     # while this step rebuilds the list.
     _splice_slot_nodes(level, slot_table, session, chain)
+    # Last statement on purpose: children and slots already fired their own hooks
+    # from their own render_level calls, so subscribers see a finished subtree and
+    # session state accumulates bottom-up. Fired for every component, subscribers
+    # or not — an empty list is the zero-cost case, not a branch to skip.
+    session.emit_rendered(component, level)
     return level
 
 

--- a/pyjinhx2/session.py
+++ b/pyjinhx2/session.py
@@ -1,8 +1,27 @@
-"""RenderSession — provides Jinja environment and render hooks."""
+"""RenderSession, the per-request ContextVars, and the request_scope that owns them."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 
 from jinja2 import Environment, FileSystemLoader
 
 from pyjinhx2.markers import finalize_slot_node
+
+# The four pieces of per-request mutable state. They live here rather than beside
+# their eventual consumers because the import rule runs one way only: reactive/
+# imports session, never the reverse. Each defaults to None so that reading one
+# outside a request is a miss, not a LookupError.
+_render_session: ContextVar["RenderSession | None"] = ContextVar(
+    "pjx_render_session", default=None
+)
+_instances: ContextVar[dict[str, object] | None] = ContextVar(
+    "pjx_instances", default=None
+)
+_dirtied: ContextVar[set[str] | None] = ContextVar("pjx_dirtied", default=None)
+_cache_store: ContextVar[dict[object, object] | None] = ContextVar(
+    "pjx_cache_store", default=None
+)
 
 
 class RenderSession:
@@ -21,3 +40,61 @@ class RenderSession:
             # hook swaps in a placeholder the render pipeline resolves later.
             finalize=finalize_slot_node,
         )
+        # Asset paths accumulate here as on_rendered fires bottom-up; a set because
+        # the same component class contributes the same paths on every occurrence.
+        self.asset_paths: set[str] = set()
+
+
+def current_session() -> RenderSession | None:
+    """Return the RenderSession bound to this request, or None outside a scope."""
+    return _render_session.get()
+
+
+def get_instances() -> dict[str, object]:
+    """Return this request's instance registry, or an empty dict outside a scope."""
+    registry = _instances.get()
+    if registry is None:
+        return {}
+    return registry
+
+
+def get_dirtied() -> set[str]:
+    """Return this request's dirtied reactive keys, or an empty set outside a scope."""
+    dirtied = _dirtied.get()
+    if dirtied is None:
+        return set()
+    return dirtied
+
+
+def get_cache_store() -> dict[object, object]:
+    """Return this request's load cache store, or an empty dict outside a scope."""
+    store = _cache_store.get()
+    if store is None:
+        return {}
+    return store
+
+
+@contextmanager
+def request_scope(template_dir: str = "templates") -> Iterator[RenderSession]:
+    """Bind fresh per-request state for the duration of the block.
+
+    Args:
+        template_dir: Directory the new RenderSession loads templates from.
+
+    Yields:
+        The RenderSession bound for this scope.
+    """
+    session = RenderSession(template_dir)
+    session_token = _render_session.set(session)
+    instances_token = _instances.set({})
+    dirtied_token = _dirtied.set(set())
+    cache_token = _cache_store.set({})
+    try:
+        yield session
+    finally:
+        # Reset by token rather than assigning None: a nested scope must hand the
+        # outer scope its own state back, not clear the variable outright.
+        _cache_store.reset(cache_token)
+        _dirtied.reset(dirtied_token)
+        _instances.reset(instances_token)
+        _render_session.reset(session_token)

--- a/pyjinhx2/session.py
+++ b/pyjinhx2/session.py
@@ -3,7 +3,8 @@
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -31,6 +32,10 @@ _cache_store: ContextVar[dict[object, object] | None] = ContextVar(
 )
 
 
+class NoActiveRequestScope(RuntimeError):
+    """Raised when per-request state is touched outside an active request_scope()."""
+
+
 class RenderSession:
     """Session providing Jinja environment with autoescape enabled."""
 
@@ -47,13 +52,27 @@ class RenderSession:
             # hook swaps in a placeholder the render pipeline resolves later.
             finalize=finalize_slot_node,
         )
-        # Asset paths accumulate here as on_rendered fires bottom-up; a set because
-        # the same component class contributes the same paths on every occurrence.
+        # Generic per-request asset slot from the #423 ContextVar model
+        # (predates L2.2.1's descriptor accumulator below); no producer in
+        # this codebase writes to it yet, so it stays as-is for whatever
+        # future non-descriptor asset source needs a request-scoped set.
         self.asset_paths: set[str] = set()
+        # css_assets/js_assets are the L2.2.1 accumulator: descriptor paths
+        # set-added by accumulate_assets as on_rendered fires, kept separate
+        # from each other so later emission (#430) can tell <style> from
+        # <script> sources without re-inspecting any descriptor.
+        self.css_assets: set[Path] = set()
+        self.js_assets: set[Path] = set()
         # A plain list, not an event bus: render fires it once per component and
         # subscribers (asset accumulation, the reactive instance registry) just
-        # append. Per-session so subscriptions die with the request.
-        self.on_rendered: list[Callable[[BaseComponent, RenderedLevel], None]] = []
+        # append. Per-session so subscriptions die with the request. Callbacks
+        # take the session itself as a third argument — never the request_scope
+        # ContextVar, which the render() caller may not have entered at all —
+        # since accumulate_assets is registered directly (not via a closure)
+        # and needs a session reference to write into.
+        self.on_rendered: list[
+            Callable[[BaseComponent, RenderedLevel, RenderSession], None]
+        ] = []
 
     def emit_rendered(self, component: "BaseComponent", level: "RenderedLevel") -> None:
         """Notify subscribers that ``component``'s subtree finished rendering.
@@ -66,12 +85,40 @@ class RenderSession:
         # half-written, and a render that silently drops an asset or a registry
         # entry is worse than one that stops.
         for callback in self.on_rendered:
-            callback(component, level)
+            callback(component, level, self)
 
 
 def current_session() -> RenderSession | None:
     """Return the RenderSession bound to this request, or None outside a scope."""
     return _render_session.get()
+
+
+def accumulate_assets(
+    component: Any, level: "RenderedLevel", session: "RenderSession"
+) -> None:
+    """Set-add the rendered class's descriptor asset paths into the session.
+
+    Meant to be subscribed onto ``RenderSession.on_rendered``. Paths are read
+    straight from the frozen descriptor and never re-probed; duplicates across
+    instances or classes collapse because the store is a set keyed by path.
+
+    Writes into ``session`` — the RenderSession that actually drove this
+    render, passed through by render_level() — rather than reading
+    ``current_session()``. render(component, session) is the dominant calling
+    convention in this codebase and never requires the session to also be the
+    active request_scope(), so accumulate_assets must not either.
+
+    Args:
+        component: The component that was just rendered (unused; on_rendered's
+            callback shape always passes it).
+        level: The RenderedLevel carrying the class descriptor.
+        session: The RenderSession this render ran against.
+    """
+    # RenderedLevel.descriptor is typed as `object` to keep segments.py
+    # import-pure; read structurally here rather than importing ClassDescriptor.
+    descriptor: Any = level.descriptor
+    session.css_assets.update(descriptor.css_paths)
+    session.js_assets.update(descriptor.js_paths)
 
 
 def get_instances() -> dict[str, object]:
@@ -99,16 +146,24 @@ def get_cache_store() -> dict[object, object]:
 
 
 @contextmanager
-def request_scope(template_dir: str = "templates") -> Iterator[RenderSession]:
+def request_scope(
+    template_dir: str = "templates", session: "RenderSession | None" = None
+) -> Iterator[RenderSession]:
     """Bind fresh per-request state for the duration of the block.
 
     Args:
-        template_dir: Directory the new RenderSession loads templates from.
+        template_dir: Directory a newly-constructed RenderSession loads
+            templates from. Ignored when ``session`` is given.
+        session: An existing RenderSession to bind as this scope's current
+            session, instead of constructing a fresh one. Lets a caller wire
+            hooks (e.g. ``on_rendered``) onto a session before it becomes the
+            one ``current_session()`` sees as active.
 
     Yields:
         The RenderSession bound for this scope.
     """
-    session = RenderSession(template_dir)
+    if session is None:
+        session = RenderSession(template_dir)
     session_token = _render_session.set(session)
     instances_token = _instances.set({})
     dirtied_token = _dirtied.set(set())

--- a/pyjinhx2/session.py
+++ b/pyjinhx2/session.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from jinja2 import Environment, FileSystemLoader
 
+from pyjinhx2.assets import AssetMode
 from pyjinhx2.markers import finalize_slot_node
 
 if TYPE_CHECKING:
@@ -63,6 +64,11 @@ class RenderSession:
         # <script> sources without re-inspecting any descriptor.
         self.css_assets: set[Path] = set()
         self.js_assets: set[Path] = set()
+        # Per-kind delivery mode for this render. INLINE by default so a cold
+        # render works with no configuration; NONE is how a caller that ships
+        # assets some other way (a build step, a CDN) suppresses emission.
+        self.css_mode: AssetMode = AssetMode.INLINE
+        self.js_mode: AssetMode = AssetMode.INLINE
         # A plain list, not an event bus: render fires it once per component and
         # subscribers (asset accumulation, the reactive instance registry) just
         # append. Per-session so subscriptions die with the request. Callbacks

--- a/pyjinhx2/session.py
+++ b/pyjinhx2/session.py
@@ -1,12 +1,19 @@
 """RenderSession, the per-request ContextVars, and the request_scope that owns them."""
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
+from typing import TYPE_CHECKING
 
 from jinja2 import Environment, FileSystemLoader
 
 from pyjinhx2.markers import finalize_slot_node
+
+if TYPE_CHECKING:
+    # Type-only: the hook's signature names the spine's own types, but importing
+    # them at runtime would point session at its own consumers.
+    from pyjinhx2.component import BaseComponent
+    from pyjinhx2.segments import RenderedLevel
 
 # The four pieces of per-request mutable state. They live here rather than beside
 # their eventual consumers because the import rule runs one way only: reactive/
@@ -43,6 +50,23 @@ class RenderSession:
         # Asset paths accumulate here as on_rendered fires bottom-up; a set because
         # the same component class contributes the same paths on every occurrence.
         self.asset_paths: set[str] = set()
+        # A plain list, not an event bus: render fires it once per component and
+        # subscribers (asset accumulation, the reactive instance registry) just
+        # append. Per-session so subscriptions die with the request.
+        self.on_rendered: list[Callable[[BaseComponent, RenderedLevel], None]] = []
+
+    def emit_rendered(self, component: "BaseComponent", level: "RenderedLevel") -> None:
+        """Notify subscribers that ``component``'s subtree finished rendering.
+
+        Args:
+            component: The instance whose level just completed.
+            level: That component's RenderedLevel, children and slots spliced in.
+        """
+        # Exceptions propagate: a subscriber that fails has left session state
+        # half-written, and a render that silently drops an asset or a registry
+        # entry is worse than one that stops.
+        for callback in self.on_rendered:
+            callback(component, level)
 
 
 def current_session() -> RenderSession | None:

--- a/tests/pyjinhx2/test_asset_emission.py
+++ b/tests/pyjinhx2/test_asset_emission.py
@@ -6,10 +6,11 @@ from pyjinhx2.assets import AssetMode
 from pyjinhx2.session import RenderSession
 
 
-def test_asset_mode_has_exactly_inline_and_none():
+def test_asset_mode_members_are_inline_none_and_link():
     assert AssetMode.INLINE.value == "inline"
     assert AssetMode.NONE.value == "none"
-    assert set(AssetMode) == {AssetMode.INLINE, AssetMode.NONE}
+    assert AssetMode.LINK.value == "link"
+    assert set(AssetMode) == {AssetMode.INLINE, AssetMode.NONE, AssetMode.LINK}
 
 
 def test_session_defaults_both_kinds_to_inline():
@@ -96,6 +97,71 @@ def test_missing_asset_file_raises(tmp_path):
 
 def test_no_assets_emits_empty_string(tmp_path):
     assert emit_assets(_session(tmp_path)) == ""
+
+
+def _stub_resolver(path: Path) -> str:
+    """Resolver of the shape #552 will thread in: path -> served URL."""
+    return f"/static/{path.name}"
+
+
+def test_link_mode_emits_stylesheet_links_sorted_by_path(tmp_path):
+    session = _session(tmp_path)
+    session.css_assets.update(
+        {tmp_path / "z.css", tmp_path / "a.css", tmp_path / "m.css"}
+    )
+    session.css_mode = AssetMode.LINK
+    session.js_mode = AssetMode.NONE
+
+    out = emit_assets(session, resolver=_stub_resolver)
+
+    assert out == (
+        '<link rel="stylesheet" href="/static/a.css">\n'
+        '<link rel="stylesheet" href="/static/m.css">\n'
+        '<link rel="stylesheet" href="/static/z.css">'
+    )
+
+
+def test_link_mode_emits_script_src_tags_sorted_by_path(tmp_path):
+    session = _session(tmp_path)
+    session.js_assets.update({tmp_path / "z.js", tmp_path / "a.js"})
+    session.css_mode = AssetMode.NONE
+    session.js_mode = AssetMode.LINK
+
+    out = emit_assets(session, resolver=_stub_resolver)
+
+    assert out == (
+        '<script src="/static/a.js"></script>\n<script src="/static/z.js"></script>'
+    )
+
+
+def test_resolver_that_raises_propagates_out_of_emit_assets(tmp_path):
+    def boom(path: Path) -> str:
+        raise FileNotFoundError(path)
+
+    session = _session(tmp_path)
+    session.css_assets.add(tmp_path / "gone.css")
+    session.css_mode = AssetMode.LINK
+
+    with pytest.raises(FileNotFoundError):
+        emit_assets(session, resolver=boom)
+
+
+def test_link_css_with_inline_js_emits_both_css_first(tmp_path):
+    css = tmp_path / "box.css"
+    css.write_text(".box { color: red; }")
+    js = tmp_path / "box.js"
+    js.write_text("console.log('box');")
+    session = _session(tmp_path)
+    session.css_assets.add(css)
+    session.js_assets.add(js)
+    session.css_mode = AssetMode.LINK
+
+    out = emit_assets(session, resolver=_stub_resolver)
+
+    assert out == (
+        '<link rel="stylesheet" href="/static/box.css">\n'
+        "<script>console.log('box');</script>"
+    )
 
 
 from dataclasses import replace

--- a/tests/pyjinhx2/test_asset_emission.py
+++ b/tests/pyjinhx2/test_asset_emission.py
@@ -1,0 +1,249 @@
+"""L2.2.2: INLINE/NONE emission of accumulated assets at the top-level serialize."""
+
+from pathlib import Path
+
+from pyjinhx2.assets import AssetMode
+from pyjinhx2.session import RenderSession
+
+
+def test_asset_mode_has_exactly_inline_and_none():
+    assert AssetMode.INLINE.value == "inline"
+    assert AssetMode.NONE.value == "none"
+    assert set(AssetMode) == {AssetMode.INLINE, AssetMode.NONE}
+
+
+def test_session_defaults_both_kinds_to_inline():
+    session = RenderSession(template_dir=str(Path("tests/templates")))
+    assert session.css_mode is AssetMode.INLINE
+    assert session.js_mode is AssetMode.INLINE
+
+
+import pytest
+
+from pyjinhx2.assets import emit_assets
+
+
+def _session(tmp_path: Path) -> RenderSession:
+    return RenderSession(template_dir=str(tmp_path))
+
+
+def test_inline_emits_style_and_script_with_exact_file_contents(tmp_path):
+    css = tmp_path / "box.css"
+    css.write_text(".box { color: red; }")
+    js = tmp_path / "box.js"
+    js.write_text("console.log('box');")
+    session = _session(tmp_path)
+    session.css_assets.add(css)
+    session.js_assets.add(js)
+
+    out = emit_assets(session)
+
+    assert "<style>.box { color: red; }</style>" in out
+    assert "<script>console.log('box');</script>" in out
+
+
+def test_none_mode_emits_nothing_for_that_kind(tmp_path):
+    css = tmp_path / "box.css"
+    css.write_text(".box { color: red; }")
+    js = tmp_path / "box.js"
+    js.write_text("console.log('box');")
+    session = _session(tmp_path)
+    session.css_assets.add(css)
+    session.js_assets.add(js)
+    session.css_mode = AssetMode.NONE
+    session.js_mode = AssetMode.NONE
+
+    assert emit_assets(session) == ""
+
+
+def test_mixed_modes_emit_css_only(tmp_path):
+    css = tmp_path / "box.css"
+    css.write_text(".box { color: red; }")
+    js = tmp_path / "box.js"
+    js.write_text("console.log('box');")
+    session = _session(tmp_path)
+    session.css_assets.add(css)
+    session.js_assets.add(js)
+    session.js_mode = AssetMode.NONE
+
+    out = emit_assets(session)
+
+    assert "<style>" in out
+    assert "<script>" not in out
+
+
+def test_emission_order_is_sorted_by_path_and_stable(tmp_path):
+    for name, body in (("z.css", ".z {}"), ("a.css", ".a {}"), ("m.css", ".m {}")):
+        (tmp_path / name).write_text(body)
+    session = _session(tmp_path)
+    session.css_assets.update(
+        {tmp_path / "z.css", tmp_path / "a.css", tmp_path / "m.css"}
+    )
+
+    first = emit_assets(session)
+
+    assert first.index(".a {}") < first.index(".m {}") < first.index(".z {}")
+    assert emit_assets(session) == first
+
+
+def test_missing_asset_file_raises(tmp_path):
+    session = _session(tmp_path)
+    session.css_assets.add(tmp_path / "gone.css")
+
+    with pytest.raises(OSError):
+        emit_assets(session)
+
+
+def test_no_assets_emits_empty_string(tmp_path):
+    assert emit_assets(_session(tmp_path)) == ""
+
+
+from dataclasses import replace
+
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.descriptor import ClassDescriptor
+from pyjinhx2.render import render, render_level
+from pyjinhx2.segments import serialize
+from pyjinhx2.session import accumulate_assets, request_scope
+
+TEMPLATES = str(Path(__file__).parent.parent / "templates")
+
+
+def _plain_descriptor(owner: type) -> ClassDescriptor:
+    """Hand-built descriptor pointed at the shared plain_div.html fixture."""
+    return ClassDescriptor(
+        template_path=Path("plain_div.html"),
+        slot_fields=frozenset(),
+        children_field=None,
+        css_paths=(),
+        js_paths=(),
+        strict=True,
+        provenance={"template": owner},
+    )
+
+
+class EmitBox(BaseComponent):
+    """Component rendered against a hand-built descriptor, not MRO discovery."""
+
+
+class EmitSibling(BaseComponent):
+    """Second class used to prove a shared asset inlines exactly once."""
+
+
+EmitBox.__pjx_descriptor__ = _plain_descriptor(EmitBox)
+EmitSibling.__pjx_descriptor__ = _plain_descriptor(EmitSibling)
+
+
+def _with_assets(cls, *, css=(), js=()):
+    cls.__pjx_descriptor__ = replace(
+        cls.__pjx_descriptor__, css_paths=tuple(css), js_paths=tuple(js)
+    )
+    return cls
+
+
+def _accumulating_session() -> RenderSession:
+    session = RenderSession(template_dir=TEMPLATES)
+    session.on_rendered.append(accumulate_assets)
+    return session
+
+
+def test_render_inlines_accumulated_css_and_js(tmp_path):
+    css = tmp_path / "box.css"
+    css.write_text(".box { color: red; }")
+    js = tmp_path / "box.js"
+    js.write_text("console.log('box');")
+    _with_assets(EmitBox, css=[css], js=[js])
+    session = _accumulating_session()
+
+    out = render(EmitBox(), session)
+
+    assert "<style>.box { color: red; }</style>" in out
+    assert "<script>console.log('box');</script>" in out
+
+
+def test_render_with_none_modes_returns_plain_markup(tmp_path):
+    css = tmp_path / "box.css"
+    css.write_text(".box { color: red; }")
+    _with_assets(EmitBox, css=[css])
+    session = _accumulating_session()
+    session.css_mode = AssetMode.NONE
+    session.js_mode = AssetMode.NONE
+
+    out = render(EmitBox(), session)
+
+    assert "<style>" not in out
+    assert "<script>" not in out
+
+
+def test_shared_asset_inlined_exactly_once(tmp_path):
+    css = tmp_path / "shared.css"
+    css.write_text(".shared { color: blue; }")
+    _with_assets(EmitBox, css=[css])
+    _with_assets(EmitSibling, css=[css])
+    session = _accumulating_session()
+
+    render(EmitBox(), session)
+    out = render(EmitSibling(), session)
+
+    assert out.count(".shared { color: blue; }") == 1
+
+
+def test_render_without_assets_equals_plain_serialize():
+    """With nothing accumulated, render()'s output is exactly serialize(level).
+    Reuses one component instance across both calls: auto_id is minted once at
+    construction (a process-wide counter), so two separate instances would
+    differ by id regardless of asset emission."""
+    _with_assets(EmitBox)
+    component = EmitBox()
+
+    out = render(component, _accumulating_session())
+    expected = serialize(render_level(component, _accumulating_session()))
+
+    assert out == expected
+
+
+def test_render_level_alone_carries_no_inlined_tags(tmp_path):
+    css = tmp_path / "box.css"
+    css.write_text(".box { color: red; }")
+    _with_assets(EmitBox, css=[css])
+    session = _accumulating_session()
+
+    level = render_level(EmitBox(), session)
+
+    assert "<style>" not in serialize(level)
+    assert session.css_assets == {css}
+
+
+import threading
+
+
+def test_concurrent_scopes_do_not_leak_emitted_assets(tmp_path):
+    red = tmp_path / "red.css"
+    red.write_text(".red {}")
+    blue = tmp_path / "blue.css"
+    blue.write_text(".blue {}")
+    results: dict[str, str] = {}
+    barrier = threading.Barrier(2)
+
+    def run(name: str, asset: Path, mode: AssetMode) -> None:
+        session = RenderSession(template_dir=TEMPLATES)
+        session.on_rendered.append(accumulate_assets)
+        session.css_mode = mode
+        with request_scope(session=session):
+            session.css_assets.add(asset)
+            barrier.wait()
+            results[name] = render(EmitSibling(), session)
+
+    _with_assets(EmitSibling)
+    threads = [
+        threading.Thread(target=run, args=("a", red, AssetMode.INLINE)),
+        threading.Thread(target=run, args=("b", blue, AssetMode.NONE)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert ".red {}" in results["a"]
+    assert ".blue {}" not in results["a"]
+    assert "<style>" not in results["b"]

--- a/tests/pyjinhx2/test_asset_emission.py
+++ b/tests/pyjinhx2/test_asset_emission.py
@@ -313,3 +313,32 @@ def test_concurrent_scopes_do_not_leak_emitted_assets(tmp_path):
     assert ".red {}" in results["a"]
     assert ".blue {}" not in results["a"]
     assert "<style>" not in results["b"]
+
+
+def test_sorted_resolved_sorts_paths_by_str_before_resolving():
+    from pyjinhx2.assets import _sorted_resolved
+
+    seen: list[Path] = []
+
+    def resolver(path: Path) -> str:
+        seen.append(path)
+        return f"/static/{path.name}"
+
+    paths = {Path("/a/z.css"), Path("/a/b.css"), Path("/a/m.css")}
+
+    assert _sorted_resolved(paths, resolver) == (
+        "/static/b.css",
+        "/static/m.css",
+        "/static/z.css",
+    )
+    assert seen == [Path("/a/b.css"), Path("/a/m.css"), Path("/a/z.css")]
+
+
+def test_sorted_resolved_lets_a_raising_resolver_propagate():
+    from pyjinhx2.assets import _sorted_resolved
+
+    def resolver(path: Path) -> str:
+        raise OSError("gone")
+
+    with pytest.raises(OSError):
+        _sorted_resolved({Path("/a/b.css")}, resolver)

--- a/tests/pyjinhx2/test_asset_emission.py
+++ b/tests/pyjinhx2/test_asset_emission.py
@@ -342,3 +342,67 @@ def test_sorted_resolved_lets_a_raising_resolver_propagate():
 
     with pytest.raises(OSError):
         _sorted_resolved({Path("/a/b.css")}, resolver)
+
+
+def test_link_mode_without_resolver_raises_value_error(tmp_path):
+    session = _session(tmp_path)
+    session.css_assets.add(tmp_path / "box.css")
+    session.css_mode = AssetMode.LINK
+
+    with pytest.raises(ValueError, match="LINK mode needs a resolver"):
+        emit_assets(session)
+
+
+def test_link_mode_css_and_js_together_sorted_independently_and_css_first(tmp_path):
+    session = _session(tmp_path)
+    session.css_assets.update({tmp_path / "z.css", tmp_path / "a.css"})
+    session.js_assets.update({tmp_path / "z.js", tmp_path / "a.js"})
+    session.css_mode = AssetMode.LINK
+    session.js_mode = AssetMode.LINK
+
+    out = emit_assets(session, resolver=_stub_resolver)
+
+    assert out == (
+        '<link rel="stylesheet" href="/static/a.css">\n'
+        '<link rel="stylesheet" href="/static/z.css">\n'
+        '<script src="/static/a.js"></script>\n'
+        '<script src="/static/z.js"></script>'
+    )
+
+
+def test_link_mode_js_resolver_raise_propagates(tmp_path):
+    """A resolver raising on the JS branch is not swallowed by the CSS branch
+    having already succeeded."""
+
+    def boom(path: Path) -> str:
+        raise FileNotFoundError(path)
+
+    session = _session(tmp_path)
+    session.js_assets.add(tmp_path / "gone.js")
+    session.css_mode = AssetMode.NONE
+    session.js_mode = AssetMode.LINK
+
+    with pytest.raises(FileNotFoundError):
+        emit_assets(session, resolver=boom)
+
+
+def test_link_mode_repeated_calls_are_byte_identical(tmp_path):
+    session = _session(tmp_path)
+    # Enough members that a set's iteration order would plausibly differ from
+    # sorted order, so an unsorted implementation cannot pass by luck.
+    session.css_assets.update(
+        {tmp_path / name for name in ("z.css", "a.css", "m.css", "b.css", "q.css")}
+    )
+    session.js_assets.update(
+        {tmp_path / name for name in ("z.js", "a.js", "m.js", "b.js", "q.js")}
+    )
+    session.css_mode = AssetMode.LINK
+    session.js_mode = AssetMode.LINK
+
+    first = emit_assets(session, resolver=_stub_resolver)
+    second = emit_assets(session, resolver=_stub_resolver)
+
+    assert first == second
+    assert first.index("/static/a.css") < first.index("/static/m.css")
+    assert first.index("/static/m.css") < first.index("/static/z.css")
+    assert first.index("/static/q.css") < first.index("/static/a.js")

--- a/tests/pyjinhx2/test_asset_hashing.py
+++ b/tests/pyjinhx2/test_asset_hashing.py
@@ -1,0 +1,118 @@
+"""L2.2.4: content-hash filenames and the hashing asset URL resolver."""
+
+import hashlib
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from pyjinhx2.assets import asset_manifest, hashed_filename, resolver_with_hash
+from pyjinhx2.session import RenderSession
+
+HEX8 = re.compile(r"^button\.[0-9a-f]{8}\.js$")
+
+
+def _write(path: Path, text: str) -> Path:
+    """Write text to path, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+def test_hashed_filename_inserts_eight_hex_chars_between_stem_and_suffix(tmp_path):
+    path = _write(tmp_path / "button.js", "console.log(1)")
+    assert HEX8.match(hashed_filename(path))
+
+
+def test_hashed_filename_digest_matches_sha256_of_file_bytes(tmp_path):
+    path = _write(tmp_path / "button.js", "console.log(1)")
+    expected = hashlib.sha256(b"console.log(1)").hexdigest()[:8]
+    assert hashed_filename(path) == f"button.{expected}.js"
+
+
+def test_hashed_filename_is_identical_for_identical_content_at_two_paths(tmp_path):
+    a = _write(tmp_path / "a" / "button.js", "same bytes")
+    b = _write(tmp_path / "b" / "button.js", "same bytes")
+    assert hashed_filename(a) == hashed_filename(b)
+
+
+def test_hashed_filename_changes_when_content_changes(tmp_path):
+    path = _write(tmp_path / "button.js", "before")
+    first = hashed_filename(path)
+    path.write_text("after")
+    # Bump mtime explicitly: the cache is keyed on it, and a same-second
+    # rewrite can otherwise land on an unchanged timestamp.
+    stat = path.stat()
+    os.utime(path, (stat.st_atime + 10, stat.st_mtime + 10))
+    assert hashed_filename(path) != first
+
+
+def test_hashed_filename_respects_custom_hash_len(tmp_path):
+    path = _write(tmp_path / "button.js", "console.log(1)")
+    result = hashed_filename(path, hash_len=16)
+    assert re.match(r"^button\.[0-9a-f]{16}\.js$", result)
+
+
+def test_hashed_filename_raises_for_a_missing_file(tmp_path):
+    with pytest.raises(OSError):
+        hashed_filename(tmp_path / "nope.js")
+
+
+def test_hashed_filename_handles_a_file_without_a_suffix(tmp_path):
+    path = _write(tmp_path / "LICENSE", "text")
+    digest = hashlib.sha256(b"text").hexdigest()[:8]
+    assert hashed_filename(path) == f"LICENSE.{digest}"
+
+
+def test_resolver_puts_a_top_level_file_directly_under_base_url(tmp_path):
+    path = _write(tmp_path / "button.js", "console.log(1)")
+    resolve = resolver_with_hash("/static", str(tmp_path))
+    assert resolve(path) == f"/static/{hashed_filename(path)}"
+
+
+def test_resolver_keeps_the_directory_relative_to_root(tmp_path):
+    path = _write(tmp_path / "components" / "ui" / "button.js", "console.log(1)")
+    resolve = resolver_with_hash("/static", str(tmp_path))
+    assert resolve(path) == f"/static/components/ui/{hashed_filename(path)}"
+
+
+def test_resolver_strips_a_trailing_slash_from_base_url(tmp_path):
+    path = _write(tmp_path / "button.js", "console.log(1)")
+    resolve = resolver_with_hash("https://cdn.example.com/", str(tmp_path))
+    assert resolve(path) == f"https://cdn.example.com/{hashed_filename(path)}"
+
+
+def test_resolver_raises_for_a_missing_file(tmp_path):
+    resolve = resolver_with_hash("/static", str(tmp_path))
+    with pytest.raises(OSError):
+        resolve(tmp_path / "nope.js")
+
+
+def _session() -> RenderSession:
+    """A bare session; assets are set-added directly, no render needed."""
+    return RenderSession(template_dir=str(Path(__file__).parent.parent / "templates"))
+
+
+def test_manifest_with_hashing_resolver_hashes_both_kinds_in_path_order(tmp_path):
+    a_css = _write(tmp_path / "a.css", "a{}")
+    b_css = _write(tmp_path / "nested" / "b.css", "b{}")
+    y_js = _write(tmp_path / "y.js", "y")
+    z_js = _write(tmp_path / "nested" / "z.js", "z")
+
+    session = _session()
+    session.css_assets.update({b_css, a_css})
+    session.js_assets.update({z_js, y_js})
+
+    manifest = asset_manifest(
+        session, resolver=resolver_with_hash("/static", str(tmp_path))
+    )
+
+    assert manifest.stylesheets == (
+        f"/static/{hashed_filename(a_css)}",
+        f"/static/nested/{hashed_filename(b_css)}",
+    )
+    assert manifest.scripts == (
+        f"/static/nested/{hashed_filename(z_js)}",
+        f"/static/{hashed_filename(y_js)}",
+    )

--- a/tests/pyjinhx2/test_asset_manifest.py
+++ b/tests/pyjinhx2/test_asset_manifest.py
@@ -1,0 +1,145 @@
+"""L2.2.3: the per-session asset manifest — resolved, ordered CSS/JS URLs."""
+
+import dataclasses
+import threading
+from pathlib import Path
+
+import pytest
+
+from pyjinhx2.assets import AssetManifest, AssetMode, asset_manifest
+from pyjinhx2.session import RenderSession, request_scope
+
+A_CSS = Path("/app/components/a.css")
+B_CSS = Path("/app/components/b.css")
+Y_JS = Path("/app/components/y.js")
+Z_JS = Path("/app/components/z.js")
+
+
+def by_name(path: Path) -> str:
+    """A trivial resolver: URL is the filename under a fixed static prefix."""
+    return f"/static/{path.name}"
+
+
+def _session() -> RenderSession:
+    """A bare session; assets are set-added directly, no render needed.
+
+    Modes stay at their INLINE default and are never exercised — the manifest
+    is mode-independent, and nothing here reads a file off disk, so the
+    non-existent paths above are safe.
+    """
+    return RenderSession(template_dir=str(Path(__file__).parent.parent / "templates"))
+
+
+def test_manifest_empty_session_returns_empty_tuples():
+    manifest = asset_manifest(_session(), resolver=by_name)
+    assert manifest == AssetManifest(stylesheets=(), scripts=())
+
+
+def test_manifest_resolves_and_sorts_css_paths_alphabetically():
+    session = _session()
+    session.css_assets.add(B_CSS)
+    session.css_assets.add(A_CSS)
+    manifest = asset_manifest(session, resolver=by_name)
+    assert manifest.stylesheets == ("/static/a.css", "/static/b.css")
+
+
+def test_manifest_resolves_and_sorts_js_paths_alphabetically():
+    session = _session()
+    session.js_assets.add(Z_JS)
+    session.js_assets.add(Y_JS)
+    manifest = asset_manifest(session, resolver=by_name)
+    assert manifest.scripts == ("/static/y.js", "/static/z.js")
+
+
+def test_manifest_keeps_stylesheets_and_scripts_separate():
+    session = _session()
+    session.css_assets.add(A_CSS)
+    session.js_assets.add(Y_JS)
+    manifest = asset_manifest(session, resolver=by_name)
+    assert manifest.stylesheets == ("/static/a.css",)
+    assert manifest.scripts == ("/static/y.js",)
+
+
+def test_manifest_calls_resolver_exactly_once_per_path():
+    session = _session()
+    session.css_assets.update({A_CSS, B_CSS})
+    session.js_assets.add(Y_JS)
+    calls: list[Path] = []
+
+    def recording(path: Path) -> str:
+        calls.append(path)
+        return by_name(path)
+
+    asset_manifest(session, resolver=recording)
+    assert sorted(calls, key=str) == [A_CSS, B_CSS, Y_JS]
+
+
+def test_manifest_is_deterministic_across_repeated_calls():
+    session = _session()
+    session.css_assets.update({A_CSS, B_CSS})
+    session.js_assets.update({Y_JS, Z_JS})
+    assert asset_manifest(session, resolver=by_name) == asset_manifest(
+        session, resolver=by_name
+    )
+
+
+def test_manifest_ignores_css_js_mode():
+    session = _session()
+    session.css_assets.add(A_CSS)
+    session.js_assets.add(Y_JS)
+    session.css_mode = AssetMode.NONE
+    session.js_mode = AssetMode.NONE
+    manifest = asset_manifest(session, resolver=by_name)
+    assert manifest.stylesheets == ("/static/a.css",)
+    assert manifest.scripts == ("/static/y.js",)
+
+
+def test_manifest_reads_the_session_argument_not_active_scope():
+    target = _session()
+    target.css_assets.add(A_CSS)
+    other = _session()
+    other.css_assets.add(B_CSS)
+    with request_scope(session=other):
+        manifest = asset_manifest(target, resolver=by_name)
+    assert manifest.stylesheets == ("/static/a.css",)
+
+
+def test_concurrent_sessions_do_not_leak_into_each_others_manifest():
+    seen: dict[str, AssetManifest] = {}
+    started = threading.Barrier(2)
+
+    def run(name: str, css: Path) -> None:
+        session = _session()
+        session.css_assets.add(css)
+        with request_scope(session=session):
+            started.wait()
+            seen[name] = asset_manifest(session, resolver=by_name)
+
+    threads = [
+        threading.Thread(target=run, args=("a", A_CSS)),
+        threading.Thread(target=run, args=("b", B_CSS)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert seen["a"].stylesheets == ("/static/a.css",)
+    assert seen["b"].stylesheets == ("/static/b.css",)
+
+
+def test_resolver_exception_propagates():
+    session = _session()
+    session.css_assets.add(A_CSS)
+
+    def boom(path: Path) -> str:
+        raise RuntimeError("no url for you")
+
+    with pytest.raises(RuntimeError, match="no url for you"):
+        asset_manifest(session, resolver=boom)
+
+
+def test_asset_manifest_is_frozen():
+    manifest = asset_manifest(_session(), resolver=by_name)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        manifest.stylesheets = ("/static/injected.css",)  # type: ignore[misc]

--- a/tests/pyjinhx2/test_assets.py
+++ b/tests/pyjinhx2/test_assets.py
@@ -1,0 +1,188 @@
+"""L2.2.1: per-request accumulation of descriptor CSS/JS paths, deduped by path."""
+
+import threading
+from dataclasses import replace
+from pathlib import Path
+
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.descriptor import ClassDescriptor
+from pyjinhx2.render import render
+from pyjinhx2.session import (
+    RenderSession,
+    accumulate_assets,
+    request_scope,
+)
+
+CSS = Path("/app/components/box.css")
+JS = Path("/app/components/box.js")
+
+
+def _plain_descriptor(owner: type) -> ClassDescriptor:
+    """A hand-built descriptor pointed at the shared plain_div.html fixture.
+
+    Bypasses the real MRO/filesystem template walk on purpose (there is no
+    `__pjx_template__` override attribute in production code) — same pattern
+    test_render_level.py uses.
+    """
+    return ClassDescriptor(
+        template_path=Path("plain_div.html"),
+        slot_fields=frozenset(),
+        children_field=None,
+        css_paths=(),
+        js_paths=(),
+        strict=True,
+        provenance={"template": owner},
+    )
+
+
+class PlainBox(BaseComponent):
+    """Component rendered against a hand-built descriptor, not MRO discovery."""
+
+
+class PlainSibling(BaseComponent):
+    """Second class used to prove cross-class dedup on a shared asset path."""
+
+
+PlainBox.__pjx_descriptor__ = _plain_descriptor(PlainBox)
+PlainSibling.__pjx_descriptor__ = _plain_descriptor(PlainSibling)
+
+
+def with_assets(cls, *, css=(), js=()):
+    """Point a class's frozen descriptor at the given asset paths (read-only use)."""
+    cls.__pjx_descriptor__ = replace(
+        cls.__pjx_descriptor__, css_paths=tuple(css), js_paths=tuple(js)
+    )
+    return cls
+
+
+def _accumulating_session() -> RenderSession:
+    """A fresh RenderSession with the asset accumulator wired to on_rendered.
+
+    Deliberately not entered into a request_scope(): accumulate_assets reads
+    the session render_level() passes to it, not the request_scope ContextVar,
+    so a plain render(component, session) call — the convention used
+    throughout the rest of the suite — must accumulate on its own.
+    """
+    template_dir = str(Path(__file__).parent.parent / "templates")
+    session = RenderSession(template_dir=template_dir)
+    session.on_rendered.append(accumulate_assets)
+    return session
+
+
+def test_accumulates_css_path_from_single_component():
+    with_assets(PlainBox, css=[CSS])
+    with request_scope(session=_accumulating_session()) as session:
+        render(PlainBox(), session)
+        assert session.css_assets == {CSS}
+
+
+def test_accumulates_js_path_from_single_component():
+    with_assets(PlainBox, js=[JS])
+    with request_scope(session=_accumulating_session()) as session:
+        render(PlainBox(), session)
+        assert session.js_assets == {JS}
+
+
+def test_dedups_same_path_across_two_instances_of_same_class():
+    with_assets(PlainBox, css=[CSS])
+    with request_scope(session=_accumulating_session()) as session:
+        render(PlainBox(), session)
+        render(PlainBox(), session)
+        assert session.css_assets == {CSS}
+
+
+def test_dedups_same_path_across_two_different_classes_sharing_a_co_located_asset():
+    with_assets(PlainBox, css=[CSS])
+    with_assets(PlainSibling, css=[CSS])
+    with request_scope(session=_accumulating_session()) as session:
+        render(PlainBox(), session)
+        render(PlainSibling(), session)
+        assert session.css_assets == {CSS}
+
+
+def test_no_op_for_component_with_no_css_or_js_paths():
+    with_assets(PlainBox)
+    with request_scope(session=_accumulating_session()) as session:
+        render(PlainBox(), session)
+        assert session.css_assets == set()
+        assert session.js_assets == set()
+
+
+def test_accumulator_resets_between_request_scopes():
+    with_assets(PlainBox, css=[CSS])
+    with request_scope(session=_accumulating_session()) as first:
+        render(PlainBox(), first)
+        assert first.css_assets == {CSS}
+    with request_scope(session=_accumulating_session()) as second:
+        assert second is not first
+        assert second.css_assets == set()
+
+
+def test_two_concurrent_request_scopes_do_not_leak_into_each_other():
+    with_assets(PlainBox, css=[CSS])
+    with_assets(PlainSibling, css=[Path("/app/components/sibling.css")])
+    seen: dict[str, set[Path]] = {}
+    started = threading.Barrier(2)
+
+    def run(name, component_cls):
+        with request_scope(session=_accumulating_session()) as session:
+            started.wait()
+            render(component_cls(), session)
+            seen[name] = set(session.css_assets)
+
+    threads = [
+        threading.Thread(target=run, args=("a", PlainBox)),
+        threading.Thread(target=run, args=("b", PlainSibling)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert seen["a"] == {CSS}
+    assert seen["b"] == {Path("/app/components/sibling.css")}
+
+
+def test_on_rendered_fires_once_per_component_not_per_reactive_update():
+    with_assets(PlainBox, css=[CSS], js=[JS])
+    box = PlainBox()
+    with request_scope(session=_accumulating_session()) as session:
+        render(box, session)
+        render(box, session)
+        assert session.css_assets == {CSS}
+        assert session.js_assets == {JS}
+
+
+def test_accumulates_without_any_active_request_scope():
+    """render(component, session) — the convention every other pyjinhx2 test
+    uses (see the shared render_session fixture) — must accumulate assets on
+    its own, since accumulate_assets reads the session passed to render_level
+    rather than the request_scope ContextVar. A session is a valid render
+    target whether or not it was ever entered into request_scope()."""
+    with_assets(PlainBox, css=[CSS])
+    session = _accumulating_session()
+    render(PlainBox(), session)
+    assert session.css_assets == {CSS}
+
+
+def test_accumulates_into_the_render_session_even_when_a_different_session_is_the_active_scope():
+    """A caller who calls render(component, session_a) while some unrelated
+    session_b happens to be the active request_scope must still accumulate
+    into session_a — never into whichever session the ContextVar points at."""
+    with_assets(PlainBox, css=[CSS])
+    target = _accumulating_session()
+    other = _accumulating_session()
+    with request_scope(session=other):
+        render(PlainBox(), target)
+    assert target.css_assets == {CSS}
+    assert other.css_assets == set()
+
+
+def test_css_and_js_paths_tracked_distinguishably():
+    with_assets(PlainBox, css=[CSS], js=[JS])
+    with request_scope(session=_accumulating_session()) as session:
+        render(PlainBox(), session)
+        assert session.css_assets == {CSS}
+        assert session.js_assets == {JS}
+        assert CSS not in session.js_assets
+        assert JS not in session.css_assets

--- a/tests/pyjinhx2/test_assets.py
+++ b/tests/pyjinhx2/test_assets.py
@@ -4,7 +4,7 @@ import threading
 from dataclasses import replace
 from pathlib import Path
 
-from pyjinhx2.assets import AssetMode
+from pyjinhx2.assets import AssetMode, all_assets
 from pyjinhx2.component import BaseComponent
 from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.render import render
@@ -196,3 +196,67 @@ def test_css_and_js_paths_tracked_distinguishably():
         assert session.js_assets == {JS}
         assert CSS not in session.js_assets
         assert JS not in session.css_assets
+
+
+class UnrenderedWidget(BaseComponent):
+    """Never instantiated in any test — proves all_assets() is registry-wide."""
+
+
+class EmptyAssetComponent(BaseComponent):
+    """Declares no assets — must contribute nothing to all_assets()."""
+
+
+UnrenderedWidget.__pjx_descriptor__ = _plain_descriptor(UnrenderedWidget)
+EmptyAssetComponent.__pjx_descriptor__ = _plain_descriptor(EmptyAssetComponent)
+
+WIDGET_CSS = Path("/app/components/widget.css")
+WIDGET_JS = Path("/app/components/widget.js")
+
+
+def test_all_assets_returns_sorted_deduped_pairs():
+    with_assets(PlainBox, css=[CSS, WIDGET_CSS], js=[JS])
+    with_assets(PlainSibling, css=[CSS], js=[JS, WIDGET_JS])
+    css, js = all_assets()
+    assert css == tuple(sorted(css, key=str))
+    assert js == tuple(sorted(js, key=str))
+    assert list(css).count(CSS) == 1
+    assert list(js).count(JS) == 1
+    assert WIDGET_CSS in css
+    assert WIDGET_JS in js
+
+
+def test_all_assets_includes_unrendered_classes():
+    with_assets(UnrenderedWidget, css=[WIDGET_CSS], js=[WIDGET_JS])
+    css, js = all_assets()
+    assert WIDGET_CSS in css
+    assert WIDGET_JS in js
+
+
+def test_all_assets_excludes_classes_without_assets():
+    with_assets(PlainBox)
+    with_assets(PlainSibling)
+    with_assets(UnrenderedWidget)
+    with_assets(EmptyAssetComponent)
+    css, js = all_assets()
+    for path in (CSS, WIDGET_CSS):
+        assert path not in css
+    for path in (JS, WIDGET_JS):
+        assert path not in js
+
+
+def test_all_assets_does_not_mutate_session_state():
+    with_assets(PlainBox, css=[CSS])
+    with_assets(PlainSibling, css=[WIDGET_CSS])
+    session = _accumulating_session()
+    all_assets()
+    render(PlainBox(), session)
+    all_assets()
+    assert session.css_assets == {CSS}
+    assert session.js_assets == set()
+
+
+def test_all_assets_returns_paths_not_strings():
+    with_assets(PlainBox, css=[CSS], js=[JS])
+    css, js = all_assets()
+    assert all(isinstance(path, Path) for path in css)
+    assert all(isinstance(path, Path) for path in js)

--- a/tests/pyjinhx2/test_assets.py
+++ b/tests/pyjinhx2/test_assets.py
@@ -4,6 +4,7 @@ import threading
 from dataclasses import replace
 from pathlib import Path
 
+from pyjinhx2.assets import AssetMode
 from pyjinhx2.component import BaseComponent
 from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.render import render
@@ -62,10 +63,19 @@ def _accumulating_session() -> RenderSession:
     the session render_level() passes to it, not the request_scope ContextVar,
     so a plain render(component, session) call — the convention used
     throughout the rest of the suite — must accumulate on its own.
+
+    Modes set to NONE: this file exercises accumulation into css_assets/
+    js_assets (#429), not #430's emission. The CSS/JS constants above point at
+    paths that don't exist on disk on purpose (accumulation never reads the
+    file); #430 wired render() to inline-read accumulated paths by default,
+    so leaving these sessions on INLINE would make render() raise on a path
+    that was never meant to be readable.
     """
     template_dir = str(Path(__file__).parent.parent / "templates")
     session = RenderSession(template_dir=template_dir)
     session.on_rendered.append(accumulate_assets)
+    session.css_mode = AssetMode.NONE
+    session.js_mode = AssetMode.NONE
     return session
 
 

--- a/tests/pyjinhx2/test_concurrency.py
+++ b/tests/pyjinhx2/test_concurrency.py
@@ -1,0 +1,354 @@
+"""L2.4.1: a FastAPI-threadpool-shaped harness over the real render pipeline.
+
+FastAPI dispatches sync path-operation functions onto a ThreadPoolExecutor, so
+a pyjinhx request runs on a borrowed worker thread with sibling requests running
+beside it. These tests reproduce that shape: N threads, each in its own
+request_scope(), each driving render() against shared component classes, shared
+descriptors, a shared Jinja template cache and shared asset files on disk.
+
+What is proven here is the ContextVar half of invariant 4 - that per-request
+state never crosses threads - and that concurrent real file reads (template
+loads, emit_assets' INLINE reads) never produce FileNotFoundError-class races.
+The census enumeration itself belongs to #437, which plugs its assertion into
+this harness through run_concurrent_requests' `inspect` hook.
+"""
+
+import threading
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.descriptor import ClassDescriptor
+from pyjinhx2.registry import register_rendered_instance
+from pyjinhx2.render import render
+from pyjinhx2.session import (
+    RenderSession,
+    accumulate_assets,
+    get_dirtied,
+    get_instances,
+    request_scope,
+)
+
+# 8 matches the v0.x test_thread_safety.py precedent: enough threads that a
+# non-isolated store is hit reliably, few enough that the barrier timeouts below
+# stay generous on a loaded CI box.
+WORKERS = 8
+
+TEMPLATE_DIR = str(Path(__file__).parent.parent / "templates")
+
+# Barrier waits carry a timeout so a genuine deadlock fails the suite instead of
+# hanging it; the value is a liveness backstop, not a performance assertion.
+BARRIER_TIMEOUT = 15.0
+
+
+class _ConcAlpha(BaseComponent):
+    """Shared across half the workers, so its descriptor is read concurrently."""
+
+    title: str = ""
+
+
+class _ConcBeta(BaseComponent):
+    """The other half's class. Distinct assets make cross-thread bleed visible."""
+
+    title: str = ""
+
+
+@dataclass(frozen=True)
+class Observation:
+    """One worker's snapshot of its own request-scoped state.
+
+    Attributes:
+        index: The worker's index, 0-based.
+        thread_name: The thread the worker actually ran on.
+        html: What render() returned, assets included.
+        released_at: perf_counter() reading taken the moment the start barrier
+            released this worker, used by the barrier sanity check.
+        css_assets: The session's accumulated CSS paths at snapshot time.
+        js_assets: The session's accumulated JS paths at snapshot time.
+        instance_keys: This request's instance registry keys at snapshot time.
+        dirtied: This request's dirtied keys at snapshot time.
+    """
+
+    index: int
+    thread_name: str
+    html: str
+    released_at: float
+    css_assets: frozenset[Path]
+    js_assets: frozenset[Path]
+    instance_keys: frozenset[str]
+    dirtied: frozenset[str]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def concurrency_assets(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Write the real CSS/JS files these components declare and bind descriptors.
+
+    The files are real because emit_assets under INLINE mode read_text()s them on
+    every render - that read is one of the two race surfaces under test, so it
+    must not be stubbed out. Descriptors are built by hand and assigned, the same
+    way test_render_level.py and test_session.py do, since template and asset
+    resolution is an MRO/filesystem walk with no override attribute.
+    """
+    assets = tmp_path_factory.mktemp("concurrency_assets")
+    alpha_css = assets / "alpha.css"
+    alpha_css.write_text(".alpha { color: red; }")
+    alpha_js = assets / "alpha.js"
+    alpha_js.write_text("console.log('alpha');")
+    beta_css = assets / "beta.css"
+    beta_css.write_text(".beta { color: blue; }")
+    beta_js = assets / "beta.js"
+    beta_js.write_text("console.log('beta');")
+
+    _ConcAlpha.__pjx_descriptor__ = ClassDescriptor(
+        template_path=Path("div.html"),
+        slot_fields=frozenset(),
+        children_field=None,
+        css_paths=(alpha_css,),
+        js_paths=(alpha_js,),
+        strict=True,
+        provenance={"template": _ConcAlpha},
+    )
+    _ConcBeta.__pjx_descriptor__ = ClassDescriptor(
+        template_path=Path("div.html"),
+        slot_fields=frozenset(),
+        children_field=None,
+        css_paths=(beta_css,),
+        js_paths=(beta_js,),
+        strict=True,
+        provenance={"template": _ConcBeta},
+    )
+    return assets
+
+
+def _component_for(index: int) -> BaseComponent:
+    """The component worker `index` renders: alternating class, per-worker id.
+
+    Alternating rather than one class each so several threads share one
+    descriptor and one template-cache entry (real contention), while the two
+    asset sets still differ - a worker seeing the other class's CSS is bleed.
+    """
+    cls = _ConcAlpha if index % 2 == 0 else _ConcBeta
+    return cls(id=f"w{index}", title=f"worker-{index}")
+
+
+def render_shared_components(index: int, session: RenderSession) -> str:
+    """Default harness job: render this worker's component through render()."""
+    return render(_component_for(index), session)
+
+
+def expected_for(
+    index: int,
+) -> tuple[frozenset[Path], frozenset[Path], frozenset[str], frozenset[str]]:
+    """Exactly what worker `index` must observe - no more, no less."""
+    cls = _ConcAlpha if index % 2 == 0 else _ConcBeta
+    descriptor = cls.__pjx_descriptor__
+    return (
+        frozenset(descriptor.css_paths),
+        frozenset(descriptor.js_paths),
+        frozenset({f"{cls.__name__}_w{index}"}),
+        frozenset({f"dirty-{index}"}),
+    )
+
+
+def fail_on_errors(errors: list[BaseException]) -> None:
+    """Fail the test with every worker exception spelled out, never silently."""
+    if errors:
+        pytest.fail(
+            "worker threads raised:\n"
+            + "\n".join(f"  {type(e).__name__}: {e}" for e in errors)
+        )
+
+
+def run_concurrent_requests(
+    job: Callable[[int, RenderSession], str],
+    *,
+    workers: int = WORKERS,
+    template_dir: str = TEMPLATE_DIR,
+    inspect: Callable[[int, RenderSession, Observation], None] | None = None,
+) -> tuple[dict[int, Observation], list[BaseException]]:
+    """Run `job` in `workers` threads, each in its own request_scope().
+
+    Shaped like FastAPI's sync dispatch: a ThreadPoolExecutor, one request per
+    worker thread. Two barriers do the work. The first releases every worker at
+    once so the renders genuinely overlap. The second holds every worker after
+    its render but *before* its snapshot, so all N requests' ContextVar state is
+    alive simultaneously - which is the only arrangement in which cross-thread
+    bleed is observable at all.
+
+    Args:
+        job: Called as job(index, session) inside the worker's live scope;
+            returns the rendered HTML.
+        workers: How many threads/requests to run.
+        template_dir: Template directory the per-worker RenderSession loads from.
+        inspect: Optional callback run inside the still-open scope, after the
+            snapshot is taken. This is the extension point for #437's
+            invariant-4 census assertion; anything it raises is collected into
+            the returned errors list like any other worker failure.
+
+    Returns:
+        A (observations by worker index, collected exceptions) pair. Callers
+        pass the second to fail_on_errors() before asserting on the first.
+    """
+    start = threading.Barrier(workers)
+    mid = threading.Barrier(workers)
+    observations: dict[int, Observation] = {}
+    errors: list[BaseException] = []
+
+    def worker(index: int) -> None:
+        try:
+            with request_scope(template_dir=template_dir) as session:
+                # request_scope subscribes nothing by itself; a request that
+                # wants assets accumulated and instances registered wires its
+                # own hooks, exactly as an app's request middleware would.
+                session.on_rendered.append(accumulate_assets)
+                session.on_rendered.append(register_rendered_instance)
+                start.wait(timeout=BARRIER_TIMEOUT)
+                released_at = time.perf_counter()
+                html = job(index, session)
+                get_dirtied().add(f"dirty-{index}")
+                mid.wait(timeout=BARRIER_TIMEOUT)
+                observation = Observation(
+                    index=index,
+                    thread_name=threading.current_thread().name,
+                    html=html,
+                    released_at=released_at,
+                    css_assets=frozenset(session.css_assets),
+                    js_assets=frozenset(session.js_assets),
+                    instance_keys=frozenset(get_instances()),
+                    dirtied=frozenset(get_dirtied()),
+                )
+                if inspect is not None:
+                    inspect(index, session, observation)
+                observations[index] = observation
+        except BaseException as exc:  # noqa: BLE001 - surfaced on the main thread
+            errors.append(exc)
+            # A worker that died before a barrier would strand its siblings
+            # there for the full timeout; break both so the failure is reported
+            # in seconds and the real exception is the first one in the list.
+            start.abort()
+            mid.abort()
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        list(pool.map(worker, range(workers)))
+    return observations, errors
+
+
+def assert_no_bleed(
+    observations: dict[int, Observation], workers: int = WORKERS
+) -> None:
+    """Assert every worker saw its own state and nothing any sibling produced."""
+    assert set(observations) == set(range(workers)), (
+        f"missing observations from workers {sorted(set(range(workers)) - set(observations))}"
+    )
+    for index, observed in sorted(observations.items()):
+        css, js, keys, dirtied = expected_for(index)
+        for label, actual, wanted in (
+            ("css_assets", observed.css_assets, css),
+            ("js_assets", observed.js_assets, js),
+            ("instance_keys", observed.instance_keys, keys),
+            ("dirtied", observed.dirtied, dirtied),
+        ):
+            assert actual == wanted, (
+                f"worker {index} ({observed.thread_name}) {label} bled: "
+                f"leaked-in={sorted(str(x) for x in actual - wanted)} "
+                f"missing={sorted(str(x) for x in wanted - actual)}"
+            )
+
+
+def test_concurrent_renders_no_state_bleed():
+    """Each request's assets, registry and dirtied set stay its own."""
+    observations, errors = run_concurrent_requests(render_shared_components)
+
+    fail_on_errors(errors)
+    assert_no_bleed(observations)
+    for index, observed in observations.items():
+        assert f"worker-{index}" in observed.html
+
+
+def _slow(original, delay: float):
+    """Wrap `original` so it yields the GIL mid-call, widening the race window."""
+
+    def wrapper(*args, **kwargs):
+        time.sleep(delay)
+        return original(*args, **kwargs)
+
+    return wrapper
+
+
+def test_concurrent_renders_no_filenotfound_races(monkeypatch):
+    """Slowed-down real disk I/O must not turn into missing-file failures.
+
+    Both file-touching surfaces are widened: the Jinja FileSystemLoader's
+    get_source (template loads) and emit_assets' INLINE reads via
+    pyjinhx2.assets._inline_tags. Without this the test could pass simply
+    because each render finishes before the next thread starts - the same
+    reason the v0.x Finder thread-safety test monkeypatches a slow os.walk.
+    """
+    from jinja2 import FileSystemLoader
+
+    import pyjinhx2.assets as assets_module
+
+    monkeypatch.setattr(
+        FileSystemLoader, "get_source", _slow(FileSystemLoader.get_source, 0.02)
+    )
+    monkeypatch.setattr(
+        assets_module, "_inline_tags", _slow(assets_module._inline_tags, 0.02)
+    )
+
+    observations, errors = run_concurrent_requests(render_shared_components)
+
+    missing = [e for e in errors if isinstance(e, FileNotFoundError | OSError)]
+    assert not missing, (
+        "concurrent file reads raised missing-file errors:\n"
+        + "\n".join(f"  {type(e).__name__}: {e}" for e in missing)
+    )
+    fail_on_errors(errors)
+    assert_no_bleed(observations)
+    for observed in observations.values():
+        assert "<style>" in observed.html
+        assert "<script>" in observed.html
+
+
+def test_harness_barrier_actually_synchronizes():
+    """The start barrier must release all workers together, or the other two
+    tests prove nothing: serialised 'concurrent' renders never contend."""
+    observations, errors = run_concurrent_requests(render_shared_components)
+
+    fail_on_errors(errors)
+    release_times = [o.released_at for o in observations.values()]
+    spread = max(release_times) - min(release_times)
+    assert spread < 1.0, (
+        f"workers were released {spread:.3f}s apart; the barrier is not "
+        "synchronising them, so the renders may never have overlapped"
+    )
+    thread_names = {o.thread_name for o in observations.values()}
+    assert len(thread_names) == WORKERS, (
+        f"expected {WORKERS} distinct worker threads, saw {sorted(thread_names)}"
+    )
+
+
+def test_inspect_hook_runs_inside_the_live_scope():
+    """#437 plugs its invariant-4 census in here, so the hook must see live
+    per-request state - not a scope already torn down."""
+    seen: dict[int, object] = {}
+
+    def census_probe(index: int, session: RenderSession, observed: Observation) -> None:
+        # get_instances() always returns a dict (never None, even outside a
+        # scope), so the meaningful check is that it's non-empty and matches
+        # this worker's own observation - proof the hook sees live, populated
+        # per-request state rather than a torn-down or throwaway container.
+        assert get_instances(), "hook ran outside an active request_scope()"
+        assert set(get_instances()) == observed.instance_keys
+        seen[index] = observed.instance_keys
+
+    observations, errors = run_concurrent_requests(
+        render_shared_components, inspect=census_probe
+    )
+
+    fail_on_errors(errors)
+    assert set(seen) == set(observations) == set(range(WORKERS))

--- a/tests/pyjinhx2/test_concurrency.py
+++ b/tests/pyjinhx2/test_concurrency.py
@@ -9,8 +9,8 @@ descriptors, a shared Jinja template cache and shared asset files on disk.
 What is proven here is the ContextVar half of invariant 4 - that per-request
 state never crosses threads - and that concurrent real file reads (template
 loads, emit_assets' INLINE reads) never produce FileNotFoundError-class races.
-The census enumeration itself belongs to #437, which plugs its assertion into
-this harness through run_concurrent_requests' `inspect` hook.
+The census enumeration itself is test_invariant_4_census below, which plugs
+into this harness through run_concurrent_requests' `inspect` hook.
 """
 
 import threading
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import pytest
 
+from pyjinhx2 import discovery
 from pyjinhx2.component import BaseComponent
 from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.registry import register_rendered_instance
@@ -29,6 +30,8 @@ from pyjinhx2.render import render
 from pyjinhx2.session import (
     RenderSession,
     accumulate_assets,
+    current_session,
+    get_cache_store,
     get_dirtied,
     get_instances,
     request_scope,
@@ -141,6 +144,25 @@ def render_shared_components(index: int, session: RenderSession) -> str:
     return render(_component_for(index), session)
 
 
+def cache_marker_for(index: int) -> str:
+    """The key worker `index` stamps into its own LoadCache request store."""
+    return f"cache-{index}"
+
+
+def census_job(index: int, session: RenderSession) -> str:
+    """Render as usual, but first stamp this worker's LoadCache store.
+
+    Nothing in the render path writes to the cache store yet (LoadCache lands
+    later), so the store would otherwise be empty in every worker and an
+    isolation assertion over it would hold vacuously. Writing the marker inside
+    the job puts it in before the mid barrier, so by the time the probe runs
+    every worker has written - which is the only arrangement where one worker
+    seeing a sibling's marker is actually observable.
+    """
+    get_cache_store()[cache_marker_for(index)] = index
+    return render_shared_components(index, session)
+
+
 def expected_for(
     index: int,
 ) -> tuple[frozenset[Path], frozenset[Path], frozenset[str], frozenset[str]]:
@@ -186,9 +208,9 @@ def run_concurrent_requests(
         workers: How many threads/requests to run.
         template_dir: Template directory the per-worker RenderSession loads from.
         inspect: Optional callback run inside the still-open scope, after the
-            snapshot is taken. This is the extension point for #437's
-            invariant-4 census assertion; anything it raises is collected into
-            the returned errors list like any other worker failure.
+            snapshot is taken. This is where the invariant-4 census assertion
+            plugs in; anything it raises is collected into the returned errors
+            list like any other worker failure.
 
     Returns:
         A (observations by worker index, collected exceptions) pair. Callers
@@ -333,8 +355,8 @@ def test_harness_barrier_actually_synchronizes():
 
 
 def test_inspect_hook_runs_inside_the_live_scope():
-    """#437 plugs its invariant-4 census in here, so the hook must see live
-    per-request state - not a scope already torn down."""
+    """test_invariant_4_census below plugs into this hook, so the hook must see
+    live per-request state - not a scope already torn down."""
     seen: dict[int, object] = {}
 
     def census_probe(index: int, session: RenderSession, observed: Observation) -> None:
@@ -352,3 +374,81 @@ def test_inspect_hook_runs_inside_the_live_scope():
 
     fail_on_errors(errors)
     assert set(seen) == set(observations) == set(range(WORKERS))
+
+
+def test_invariant_4_census():
+    """Every member of the invariant-4 census, asserted under real concurrency.
+
+    Invariant 4 (architecture-overview.md:107, :168) names exactly what mutable
+    state pyjinhx has: a class registry + descriptors built once and swapped in
+    at import/registration time, and four ContextVar-held per-request stores -
+    instance registry, RenderSession, dirtied keys, LoadCache request store.
+    The two halves get opposite assertions. The four request stores must differ
+    per worker; the registry and descriptors must be the *same objects* in every
+    worker, since a per-thread copy would mean the build-then-swap discipline
+    had quietly become per-request rebuilding.
+    """
+    shared_sightings: dict[int, tuple[int, int, int]] = {}
+    sessions_seen: dict[int, int] = {}
+
+    def census_probe(index: int, session: RenderSession, observed: Observation) -> None:
+        _, _, expected_keys, expected_dirtied = expected_for(index)
+
+        # 1. Instance registry: this worker's keys, nothing a sibling made.
+        assert set(get_instances()) == set(expected_keys), (
+            f"worker {index} instance registry bled: {sorted(get_instances())}"
+        )
+        # 2. Dirtied keys: likewise.
+        assert get_dirtied() == set(expected_dirtied), (
+            f"worker {index} dirtied set bled: {sorted(get_dirtied())}"
+        )
+        # 3. RenderSession: identity, not equality - a sibling's session would
+        # compare unequal only by accident, but must never be the same object.
+        assert current_session() is session, (
+            f"worker {index} current_session() is not its own session object"
+        )
+        # 4. LoadCache request store: only this worker's marker, and it is a
+        # distinct dict object per request.
+        store = get_cache_store()
+        assert set(store) == {cache_marker_for(index)}, (
+            f"worker {index} cache store bled: {sorted(map(str, store))}"
+        )
+        sessions_seen[index] = id(store)
+
+        # 5. The shared, read-only half: descriptors and the class registry are
+        # recorded here and compared across workers after the run.
+        component = _component_for(index)
+        shared_sightings[index] = (
+            id(type(component).__pjx_descriptor__),
+            # Private module attribute accessed deliberately: asserting the
+            # built-then-swap holder's identity is precisely what census point
+            # 5 requires, and no public wrapper exposes it.
+            id(discovery._registry),
+            id(discovery._registry.mapping),
+        )
+
+    observations, errors = run_concurrent_requests(census_job, inspect=census_probe)
+
+    fail_on_errors(errors)
+    assert set(observations) == set(range(WORKERS))
+
+    # Every worker's cache store was a distinct object, not one dict shared by
+    # reference that merely happened to hold one key at snapshot time.
+    assert len(set(sessions_seen.values())) == WORKERS, (
+        "cache stores were not distinct objects per request"
+    )
+
+    # Workers rendering the same class must have seen one descriptor object;
+    # every worker must have seen one class registry and one mapping object.
+    alpha = {shared_sightings[i][0] for i in range(0, WORKERS, 2)}
+    beta = {shared_sightings[i][0] for i in range(1, WORKERS, 2)}
+    assert len(alpha) == 1 and len(beta) == 1, (
+        "descriptors were duplicated per thread instead of shared read-only"
+    )
+    assert alpha != beta, "the two classes' descriptors collapsed into one object"
+    assert len({s[1] for s in shared_sightings.values()}) == 1, (
+        "the class registry holder differed per thread"
+    )
+    assert len({s[2] for s in shared_sightings.values()}) == 1, (
+        "the class registry mapping was rebuilt per thread"
+    )

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -21,6 +21,10 @@ PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "pyjinhx2"
 # failing test go green.
 ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "__init__": frozenset(),
+    # The TYPE_CHECKING-only RenderSession import mirrors session's own
+    # component/segments entries below, for the same reason: the enum/function
+    # signature names the type, runtime never touches it.
+    "assets": frozenset({"pyjinhx2.session"}),
     # The classless factory is a consumer: it validates a tag name, reads the
     # template discovery found, hands the header to props_header and publishes
     # the result through discovery's own write path. Nothing imports it back.
@@ -49,6 +53,7 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # an unregistered tag is emitted verbatim, so this is a read-only edge.
     "render": frozenset(
         {
+            "pyjinhx2.assets",
             "pyjinhx2.component",
             "pyjinhx2.discovery",
             "pyjinhx2.markers",
@@ -64,11 +69,16 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "registry": frozenset({"pyjinhx2.session"}),
     "root_attrs": frozenset({"pyjinhx2.segments"}),
     "segments": frozenset(),
-    # The on_rendered hook's signature names BaseComponent and RenderedLevel.
-    # Both imports are TYPE_CHECKING-only — at runtime session still depends on
-    # nothing but markers, so the spine's direction is unchanged.
+    # The on_rendered hook's signature names BaseComponent and RenderedLevel, but
+    # both imports are TYPE_CHECKING-only. At runtime session also imports
+    # AssetMode from assets, a real edge alongside markers.
     "session": frozenset(
-        {"pyjinhx2.markers", "pyjinhx2.component", "pyjinhx2.segments"}
+        {
+            "pyjinhx2.markers",
+            "pyjinhx2.component",
+            "pyjinhx2.segments",
+            "pyjinhx2.assets",
+        }
     ),
 }
 
@@ -136,7 +146,12 @@ def test_session_never_reaches_into_reactive():
     here. The reverse edge would invert the spine."""
     imports = internal_imports(PACKAGE_ROOT / "session.py")
     assert not any(name.startswith("pyjinhx2.reactive") for name in imports)
-    assert imports <= {"pyjinhx2.markers", "pyjinhx2.component", "pyjinhx2.segments"}
+    assert imports <= {
+        "pyjinhx2.markers",
+        "pyjinhx2.component",
+        "pyjinhx2.segments",
+        "pyjinhx2.assets",
+    }
 
 
 def test_no_render_spine_module_declares_a_reactive_import():

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -123,6 +123,14 @@ def test_component_is_the_only_importer_of_class_descriptor():
     assert importers == {"component"}
 
 
+def test_session_never_reaches_into_reactive():
+    """session.py owns the per-request ContextVars; reactive/ imports them from
+    here. The reverse edge would invert the spine."""
+    imports = internal_imports(PACKAGE_ROOT / "session.py")
+    assert not any(name.startswith("pyjinhx2.reactive") for name in imports)
+    assert imports <= {"pyjinhx2.markers"}
+
+
 def test_no_render_spine_module_declares_a_reactive_import():
     """FORBIDDEN per architecture-overview.md: anything in the render spine
     importing reactive/. pyjinhx2/reactive/ doesn't exist yet (#288), so this

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -24,7 +24,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # The TYPE_CHECKING-only RenderSession import mirrors session's own
     # component/segments entries below, for the same reason: the enum/function
     # signature names the type, runtime never touches it.
-    "assets": frozenset({"pyjinhx2.session"}),
+    # component is a real runtime edge: all_assets() reads
+    # BaseComponent.__subclasses__() and each class's descriptor, imported
+    # locally to avoid a module-level cycle (session imports assets).
+    "assets": frozenset({"pyjinhx2.session", "pyjinhx2.component"}),
     # The classless factory is a consumer: it validates a tag name, reads the
     # template discovery found, hands the header to props_header and publishes
     # the result through discovery's own write path. Nothing imports it back.

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -65,8 +65,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     ),
     "render_context": frozenset({"pyjinhx2.markers", "pyjinhx2.component"}),
     # The instance registry (ADR 0009) is read-only over session's ContextVar
-    # store; it consumes get_instances() and nothing else in pyjinhx2.
-    "registry": frozenset({"pyjinhx2.session"}),
+    # store; it consumes get_instances() and nothing else in pyjinhx2. The
+    # register_rendered_instance signature also names RenderedLevel, but that
+    # import is TYPE_CHECKING-only (see registry.py) — never a runtime edge.
+    "registry": frozenset({"pyjinhx2.session", "pyjinhx2.segments"}),
     "root_attrs": frozenset({"pyjinhx2.segments"}),
     "segments": frozenset(),
     # The on_rendered hook's signature names BaseComponent and RenderedLevel, but

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -59,6 +59,9 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
         }
     ),
     "render_context": frozenset({"pyjinhx2.markers", "pyjinhx2.component"}),
+    # The instance registry (ADR 0009) is read-only over session's ContextVar
+    # store; it consumes get_instances() and nothing else in pyjinhx2.
+    "registry": frozenset({"pyjinhx2.session"}),
     "root_attrs": frozenset({"pyjinhx2.segments"}),
     "segments": frozenset(),
     # The on_rendered hook's signature names BaseComponent and RenderedLevel.

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -61,7 +61,12 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "render_context": frozenset({"pyjinhx2.markers", "pyjinhx2.component"}),
     "root_attrs": frozenset({"pyjinhx2.segments"}),
     "segments": frozenset(),
-    "session": frozenset({"pyjinhx2.markers"}),
+    # The on_rendered hook's signature names BaseComponent and RenderedLevel.
+    # Both imports are TYPE_CHECKING-only — at runtime session still depends on
+    # nothing but markers, so the spine's direction is unchanged.
+    "session": frozenset(
+        {"pyjinhx2.markers", "pyjinhx2.component", "pyjinhx2.segments"}
+    ),
 }
 
 
@@ -128,7 +133,7 @@ def test_session_never_reaches_into_reactive():
     here. The reverse edge would invert the spine."""
     imports = internal_imports(PACKAGE_ROOT / "session.py")
     assert not any(name.startswith("pyjinhx2.reactive") for name in imports)
-    assert imports <= {"pyjinhx2.markers"}
+    assert imports <= {"pyjinhx2.markers", "pyjinhx2.component", "pyjinhx2.segments"}
 
 
 def test_no_render_spine_module_declares_a_reactive_import():

--- a/tests/pyjinhx2/test_instance_registry.py
+++ b/tests/pyjinhx2/test_instance_registry.py
@@ -1,0 +1,87 @@
+"""Tests for the minimal request-scoped instance registry (ADR 0009)."""
+
+import pytest
+
+from pyjinhx2.registry import make_key, resolve
+from pyjinhx2.segments import RenderedLevel
+from pyjinhx2.session import _instances, get_instances, request_scope
+
+
+def test_make_key_joins_type_and_id_with_underscore():
+    assert make_key("PJXButton", "btn1") == "PJXButton_btn1"
+    assert make_key("Card", "42") == "Card_42"
+    assert make_key("", "") == "_"
+
+
+class Widget:
+    """Stand-in for a live component instance."""
+
+    def __init__(self, label: str):
+        self.label = label
+
+
+def test_resolve_returns_the_stored_live_instance():
+    widget = Widget("hello")
+    with request_scope():
+        get_instances()[make_key("Widget", "w1")] = widget
+        assert resolve("Widget", "w1") is widget
+
+
+def test_resolve_returns_cached_rendered_level_with_root_span_intact():
+    level = RenderedLevel(segments=["<div>hi</div>"], root_span=(0, 5), descriptor=None)
+    with request_scope():
+        get_instances()[make_key("Card", "c1")] = level
+        resolved = resolve("Card", "c1")
+    assert resolved is level
+    assert isinstance(resolved, RenderedLevel)
+    assert resolved.root_span == (0, 5)
+    assert resolved.segments == ["<div>hi</div>"]
+
+
+def test_resolve_unknown_key_raises_lookup_error_naming_the_key():
+    with request_scope(), pytest.raises(LookupError, match="Widget_missing"):
+        resolve("Widget", "missing")
+
+
+def test_resolve_outside_request_scope_always_raises():
+    assert _instances.get() is None
+    with pytest.raises(LookupError, match="Widget_w1"):
+        resolve("Widget", "w1")
+
+
+def test_resolve_with_empty_names_is_an_ordinary_miss():
+    with request_scope(), pytest.raises(LookupError):
+        resolve("", "")
+
+
+def test_key_from_a_previous_scope_does_not_survive_the_reset():
+    widget = Widget("old")
+    with request_scope():
+        get_instances()[make_key("Widget", "w1")] = widget
+        assert resolve("Widget", "w1") is widget
+    with request_scope(), pytest.raises(LookupError, match="Widget_w1"):
+        resolve("Widget", "w1")
+
+
+def test_two_requests_reusing_one_key_each_see_only_their_own_entry():
+    first = Widget("first")
+    second = Widget("second")
+    with request_scope():
+        get_instances()[make_key("Widget", "w1")] = first
+        assert resolve("Widget", "w1") is first
+    with request_scope():
+        get_instances()[make_key("Widget", "w1")] = second
+        assert resolve("Widget", "w1") is second
+
+
+def test_entry_removed_mid_scope_raises_instead_of_returning_stale_data():
+    # Stands in for the invalidation #435's writer will perform: once the entry
+    # is gone, resolve must miss rather than hand back what it saw a moment ago.
+    widget = Widget("doomed")
+    with request_scope():
+        instances = get_instances()
+        instances[make_key("Widget", "w1")] = widget
+        assert resolve("Widget", "w1") is widget
+        del instances[make_key("Widget", "w1")]
+        with pytest.raises(LookupError, match="Widget_w1"):
+            resolve("Widget", "w1")

--- a/tests/pyjinhx2/test_instance_registry.py
+++ b/tests/pyjinhx2/test_instance_registry.py
@@ -1,10 +1,17 @@
 """Tests for the minimal request-scoped instance registry (ADR 0009)."""
 
+import logging
+
 import pytest
 
-from pyjinhx2.registry import make_key, resolve
+from pyjinhx2.registry import (
+    make_key,
+    register_instance,
+    register_rendered_instance,
+    resolve,
+)
 from pyjinhx2.segments import RenderedLevel
-from pyjinhx2.session import _instances, get_instances, request_scope
+from pyjinhx2.session import RenderSession, _instances, get_instances, request_scope
 
 
 def test_make_key_joins_type_and_id_with_underscore():
@@ -85,3 +92,104 @@ def test_entry_removed_mid_scope_raises_instead_of_returning_stale_data():
         del instances[make_key("Widget", "w1")]
         with pytest.raises(LookupError, match="Widget_w1"):
             resolve("Widget", "w1")
+
+
+def test_register_instance_makes_the_entry_resolvable():
+    widget = Widget("written")
+    with request_scope():
+        register_instance("Widget", "w1", widget)
+        assert resolve("Widget", "w1") is widget
+
+
+def test_register_instance_stores_under_the_composite_key():
+    widget = Widget("written")
+    with request_scope():
+        register_instance("Widget", "w1", widget)
+        assert get_instances()["Widget_w1"] is widget
+
+
+def test_register_instance_accepts_a_cached_rendered_level():
+    level = RenderedLevel(segments=["<div>hi</div>"], root_span=(0, 5), descriptor=None)
+    with request_scope():
+        register_instance("Card", "c1", level)
+        resolved = resolve("Card", "c1")
+    assert resolved is level
+    assert isinstance(resolved, RenderedLevel)
+    assert resolved.root_span == (0, 5)
+
+
+def test_register_instance_duplicate_key_overwrites_last_write_wins():
+    first = Widget("first")
+    second = Widget("second")
+    with request_scope():
+        register_instance("Widget", "w1", first)
+        register_instance("Widget", "w1", second)
+        assert resolve("Widget", "w1") is second
+
+
+def test_register_instance_duplicate_key_warns_naming_the_key(caplog):
+    with request_scope(), caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        register_instance("Widget", "w1", Widget("first"))
+        assert caplog.records == []
+        register_instance("Widget", "w1", Widget("second"))
+    assert len(caplog.records) == 1
+    assert "Widget_w1" in caplog.records[0].getMessage()
+
+
+def test_register_instance_outside_request_scope_is_a_logged_no_op(caplog):
+    assert _instances.get() is None
+    with caplog.at_level(logging.WARNING, logger="pyjinhx2"):
+        register_instance("Widget", "w1", Widget("orphan"))
+    assert len(caplog.records) == 1
+    assert "Widget_w1" in caplog.records[0].getMessage()
+    with pytest.raises(LookupError, match="Widget_w1"):
+        resolve("Widget", "w1")
+
+
+def test_registered_entry_does_not_survive_the_scope_reset():
+    with request_scope():
+        register_instance("Widget", "w1", Widget("old"))
+        assert resolve("Widget", "w1") is not None
+    with request_scope(), pytest.raises(LookupError, match="Widget_w1"):
+        resolve("Widget", "w1")
+
+
+def test_registered_then_removed_entry_raises_instead_of_returning_stale_data():
+    with request_scope():
+        register_instance("Widget", "w1", Widget("doomed"))
+        del get_instances()[make_key("Widget", "w1")]
+        with pytest.raises(LookupError, match="Widget_w1"):
+            resolve("Widget", "w1")
+
+
+class FakeComponent:
+    """Stand-in with the two attributes the subscriber reads off a component."""
+
+    def __init__(self, id: str):
+        self.id = id
+
+
+def test_register_rendered_instance_stores_the_level_under_type_and_id():
+    level = RenderedLevel(segments=["<p>x</p>"], root_span=(0, 3), descriptor=None)
+    component = FakeComponent("f1")
+    session = RenderSession()
+    with request_scope(session=session):
+        register_rendered_instance(component, level, session)
+        assert resolve("FakeComponent", "f1") is level
+
+
+def test_render_session_does_not_subscribe_the_registry_writer_by_default():
+    session = RenderSession()
+    assert register_rendered_instance not in session.on_rendered
+
+
+def test_emit_rendered_registers_nothing_until_the_writer_is_subscribed():
+    level = RenderedLevel(segments=["<p>x</p>"], root_span=(0, 3), descriptor=None)
+    component = FakeComponent("f1")
+    session = RenderSession()
+    with request_scope(session=session):
+        session.emit_rendered(component, level)  # type: ignore[arg-type]
+        assert get_instances() == {}
+        session.on_rendered.append(register_rendered_instance)
+        session.emit_rendered(component, level)  # type: ignore[arg-type]
+        assert resolve("FakeComponent", "f1") is level

--- a/tests/pyjinhx2/test_render_hook.py
+++ b/tests/pyjinhx2/test_render_hook.py
@@ -69,7 +69,7 @@ def test_hook_fires_children_before_parents(session):
     """nested_root -> nested_mid -> nested_leaf, so the leaf must be first."""
     order: list[str] = []
     session.on_rendered.append(
-        lambda component, level: order.append(type(component).__name__)
+        lambda component, level, session: order.append(type(component).__name__)
     )
 
     render_level(PJXNestedRoot(), session)
@@ -79,7 +79,7 @@ def test_hook_fires_children_before_parents(session):
 
 def test_hook_fires_exactly_once_per_component(session):
     seen: list[BaseComponent] = []
-    session.on_rendered.append(lambda component, level: seen.append(component))
+    session.on_rendered.append(lambda component, level, session: seen.append(component))
 
     render_level(PJXNestedRoot(), session)
 
@@ -91,7 +91,9 @@ def test_hook_receives_the_components_own_completed_level(session):
     """Each callback must get the level whose subtree just finished, not the root's."""
     pairs: list[tuple[str, RenderedLevel]] = []
     session.on_rendered.append(
-        lambda component, level: pairs.append((type(component).__name__, level))
+        lambda component, level, session: pairs.append(
+            (type(component).__name__, level)
+        )
     )
 
     root_level = render_level(PJXNestedRoot(), session)
@@ -110,7 +112,9 @@ def test_leaf_level_is_complete_when_its_own_hook_fires(session):
 
     holes: list[str] = []
 
-    def check(component: BaseComponent, level: RenderedLevel) -> None:
+    def check(
+        component: BaseComponent, level: RenderedLevel, session: RenderSession
+    ) -> None:
         if any(isinstance(segment, ChildRef) for segment in level.segments):
             holes.append(type(component).__name__)
 
@@ -123,7 +127,7 @@ def test_leaf_level_is_complete_when_its_own_hook_fires(session):
 def test_render_public_api_fires_the_hook_too(session):
     order: list[str] = []
     session.on_rendered.append(
-        lambda component, level: order.append(type(component).__name__)
+        lambda component, level, session: order.append(type(component).__name__)
     )
 
     render(PJXNestedRoot(), session)

--- a/tests/pyjinhx2/test_render_hook.py
+++ b/tests/pyjinhx2/test_render_hook.py
@@ -1,0 +1,141 @@
+"""render_level fires session.on_rendered once per component, bottom-up.
+
+The ordering is load-bearing: subscribers accumulate session state (assets, the
+reactive instance registry) and each one runs knowing its children already ran.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from pyjinhx2 import discovery
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.descriptor import ClassDescriptor
+from pyjinhx2.render import render, render_level
+from pyjinhx2.segments import RenderedLevel
+from pyjinhx2.session import RenderSession
+
+
+def descriptor_for(cls: type[BaseComponent], template: str) -> ClassDescriptor:
+    """Attach a minimal descriptor pointing at a fixture template."""
+    return ClassDescriptor(
+        template_path=Path(template),
+        slot_fields=frozenset(),
+        children_field=None,
+        css_paths=(),
+        js_paths=(),
+        strict=True,
+        provenance={"template": cls},
+    )
+
+
+class PJXNestedLeaf(BaseComponent):
+    label: str = ""
+
+
+PJXNestedLeaf.__pjx_descriptor__ = descriptor_for(PJXNestedLeaf, "nested_leaf.html")
+
+
+class PJXNestedMid(BaseComponent):
+    label: str = ""
+
+
+PJXNestedMid.__pjx_descriptor__ = descriptor_for(PJXNestedMid, "nested_mid.html")
+
+
+class PJXNestedRoot(BaseComponent):
+    pass
+
+
+PJXNestedRoot.__pjx_descriptor__ = descriptor_for(PJXNestedRoot, "nested_root.html")
+
+
+@pytest.fixture(autouse=True)
+def registry():
+    discovery._registry.mapping = {
+        "pjx_nested_leaf": PJXNestedLeaf,
+        "pjx_nested_mid": PJXNestedMid,
+    }
+    yield
+    discovery._registry.mapping = {}
+
+
+@pytest.fixture
+def session():
+    return RenderSession(template_dir="tests/templates")
+
+
+def test_hook_fires_children_before_parents(session):
+    """nested_root -> nested_mid -> nested_leaf, so the leaf must be first."""
+    order: list[str] = []
+    session.on_rendered.append(
+        lambda component, level: order.append(type(component).__name__)
+    )
+
+    render_level(PJXNestedRoot(), session)
+
+    assert order == ["PJXNestedLeaf", "PJXNestedMid", "PJXNestedRoot"]
+
+
+def test_hook_fires_exactly_once_per_component(session):
+    seen: list[BaseComponent] = []
+    session.on_rendered.append(lambda component, level: seen.append(component))
+
+    render_level(PJXNestedRoot(), session)
+
+    assert len(seen) == 3
+    assert len({id(component) for component in seen}) == 3
+
+
+def test_hook_receives_the_components_own_completed_level(session):
+    """Each callback must get the level whose subtree just finished, not the root's."""
+    pairs: list[tuple[str, RenderedLevel]] = []
+    session.on_rendered.append(
+        lambda component, level: pairs.append((type(component).__name__, level))
+    )
+
+    root_level = render_level(PJXNestedRoot(), session)
+
+    by_name = {name: level for name, level in pairs}
+    assert by_name["PJXNestedRoot"] is root_level
+    assert by_name["PJXNestedMid"].descriptor is PJXNestedMid.__pjx_descriptor__
+    assert by_name["PJXNestedLeaf"].descriptor is PJXNestedLeaf.__pjx_descriptor__
+    # The mid level's child slot already holds the finished leaf when mid fires.
+    assert isinstance(by_name["PJXNestedMid"].segments[2], RenderedLevel)
+
+
+def test_leaf_level_is_complete_when_its_own_hook_fires(session):
+    """Post-order means no ChildRef holes are left in the level handed over."""
+    from pyjinhx2.segments import ChildRef
+
+    holes: list[str] = []
+
+    def check(component: BaseComponent, level: RenderedLevel) -> None:
+        if any(isinstance(segment, ChildRef) for segment in level.segments):
+            holes.append(type(component).__name__)
+
+    session.on_rendered.append(check)
+    render_level(PJXNestedRoot(), session)
+
+    assert holes == []
+
+
+def test_render_public_api_fires_the_hook_too(session):
+    order: list[str] = []
+    session.on_rendered.append(
+        lambda component, level: order.append(type(component).__name__)
+    )
+
+    render(PJXNestedRoot(), session)
+
+    assert order == ["PJXNestedLeaf", "PJXNestedMid", "PJXNestedRoot"]
+
+
+def test_rendering_with_no_subscribers_still_works(session):
+    """The unconditional fire must cost nothing observable when nobody listens."""
+    assert session.on_rendered == []
+
+    html = render(PJXNestedRoot(), session)
+
+    assert "leaf" in html
+    assert session.on_rendered == []

--- a/tests/pyjinhx2/test_session.py
+++ b/tests/pyjinhx2/test_session.py
@@ -8,6 +8,9 @@ which land with the modules that consume them.
 """
 
 import threading
+from typing import Any, cast
+
+import pytest
 
 from pyjinhx2 import session as session_module
 
@@ -194,3 +197,68 @@ def test_render_session_is_still_directly_constructible_with_autoescape_on():
 def test_scope_passes_template_dir_through_to_the_session():
     with session_module.request_scope(template_dir="tests/templates") as s:
         assert s.jinja_env.autoescape is True
+
+
+def test_on_rendered_starts_empty_on_a_fresh_session():
+    session = session_module.RenderSession(template_dir="tests/templates")
+
+    assert session.on_rendered == []
+
+
+def test_emit_rendered_calls_each_subscriber_in_registration_order():
+    session = session_module.RenderSession(template_dir="tests/templates")
+    calls: list[tuple[str, object, object]] = []
+    # Plumbing only cares that emit_rendered forwards its args unchanged, so a
+    # sentinel object stands in for a real BaseComponent/RenderedLevel here;
+    # emit_rendered is typed against the real classes, so the sentinel needs
+    # the cast to satisfy basedpyright.
+    component = cast(Any, object())
+    level = cast(Any, object())
+
+    session.on_rendered.append(lambda c, lv: calls.append(("first", c, lv)))
+    session.on_rendered.append(lambda c, lv: calls.append(("second", c, lv)))
+    session.emit_rendered(component, level)
+
+    assert calls == [("first", component, level), ("second", component, level)]
+
+
+def test_emit_rendered_with_no_subscribers_is_a_no_op():
+    session = session_module.RenderSession(template_dir="tests/templates")
+
+    assert session.emit_rendered(cast(Any, object()), cast(Any, object())) is None
+
+
+def test_emit_rendered_lets_a_subscriber_exception_propagate():
+    """A broken subscriber is a bug in the subscriber, not something the spine
+    hides; swallowing it would make a missing asset or a missing registry write
+    look like a successful render."""
+
+    class Boom(Exception):
+        pass
+
+    session = session_module.RenderSession(template_dir="tests/templates")
+    reached: list[str] = []
+
+    def explode(component: object, level: object) -> None:
+        raise Boom
+
+    session.on_rendered.append(explode)
+    session.on_rendered.append(lambda c, lv: reached.append("after"))
+
+    with pytest.raises(Boom):
+        session.emit_rendered(cast(Any, object()), cast(Any, object()))
+    assert reached == []
+
+
+def test_each_scope_gets_its_own_subscriber_list():
+    with session_module.request_scope(template_dir="tests/templates") as outer:
+        outer.on_rendered.append(lambda c, lv: None)
+
+        with session_module.request_scope(template_dir="tests/templates") as inner:
+            assert inner.on_rendered == []
+            inner.on_rendered.append(lambda c, lv: None)
+
+        assert len(outer.on_rendered) == 1
+
+    with session_module.request_scope(template_dir="tests/templates") as later:
+        assert later.on_rendered == []

--- a/tests/pyjinhx2/test_session.py
+++ b/tests/pyjinhx2/test_session.py
@@ -1,0 +1,196 @@
+"""request_scope's four ContextVars: fresh in, prior state out.
+
+The four pieces of per-request mutable state (RenderSession asset slot, instance
+registry, dirtied keys, cache store) are the entire ContextVar half of the
+mutable-state census. These tests pin the container lifecycle - creation,
+nesting, exception cleanup, thread isolation - not any read/write semantics,
+which land with the modules that consume them.
+"""
+
+import threading
+
+from pyjinhx2 import session as session_module
+
+
+def test_getters_return_empty_defaults_outside_any_scope():
+    """An unset ContextVar must read as an empty container, never raise. Callers
+    outside a request (tests, scripts, module import time) are legitimate."""
+    assert session_module.current_session() is None
+    assert session_module.get_instances() == {}
+    assert session_module.get_dirtied() == set()
+    assert session_module.get_cache_store() == {}
+
+
+def test_request_scope_binds_fresh_empty_state_for_all_four_pieces():
+    with session_module.request_scope() as session:
+        assert isinstance(session, session_module.RenderSession)
+        assert session_module.current_session() is session
+        assert session.asset_paths == set()
+        assert session_module.get_instances() == {}
+        assert session_module.get_dirtied() == set()
+        assert session_module.get_cache_store() == {}
+
+
+def test_containers_bound_by_the_scope_are_the_live_ones():
+    """Writes through the getters must land in the scope's containers, not copies."""
+    with session_module.request_scope():
+        session_module.get_instances()["Card_a"] = "instance"
+        session_module.get_dirtied().add("Card.title")
+        session_module.get_cache_store()["k"] = "v"
+
+        assert session_module.get_instances() == {"Card_a": "instance"}
+        assert session_module.get_dirtied() == {"Card.title"}
+        assert session_module.get_cache_store() == {"k": "v"}
+
+
+def test_default_getters_hand_back_throwaway_containers():
+    """Mutating a default must not become the next caller's starting state."""
+    session_module.get_instances()["leaked"] = object()
+    session_module.get_dirtied().add("leaked")
+    session_module.get_cache_store()["leaked"] = object()
+
+    assert session_module.get_instances() == {}
+    assert session_module.get_dirtied() == set()
+    assert session_module.get_cache_store() == {}
+
+
+def test_exit_clears_all_four_at_top_level():
+    with session_module.request_scope():
+        session_module.get_instances()["Card_a"] = "instance"
+        session_module.get_dirtied().add("Card.title")
+        session_module.get_cache_store()["k"] = "v"
+
+    assert session_module.current_session() is None
+    assert session_module.get_instances() == {}
+    assert session_module.get_dirtied() == set()
+    assert session_module.get_cache_store() == {}
+
+
+def test_nested_scope_restores_the_outer_scope_not_the_global_default():
+    with session_module.request_scope() as outer:
+        session_module.get_instances()["outer"] = "o"
+        session_module.get_dirtied().add("outer")
+        session_module.get_cache_store()["outer"] = "o"
+        outer.asset_paths.add("outer.css")
+
+        with session_module.request_scope() as inner:
+            assert inner is not outer
+            assert session_module.current_session() is inner
+            assert session_module.get_instances() == {}
+            assert session_module.get_dirtied() == set()
+            assert session_module.get_cache_store() == {}
+
+            session_module.get_instances()["inner"] = "i"
+            session_module.get_dirtied().add("inner")
+            session_module.get_cache_store()["inner"] = "i"
+            inner.asset_paths.add("inner.css")
+
+        assert session_module.current_session() is outer
+        assert session_module.get_instances() == {"outer": "o"}
+        assert session_module.get_dirtied() == {"outer"}
+        assert session_module.get_cache_store() == {"outer": "o"}
+        assert outer.asset_paths == {"outer.css"}
+
+
+def test_two_sequential_top_level_scopes_share_nothing():
+    with session_module.request_scope() as first:
+        session_module.get_instances()["first"] = "1"
+        session_module.get_dirtied().add("first")
+        session_module.get_cache_store()["first"] = "1"
+        first.asset_paths.add("first.css")
+
+    with session_module.request_scope() as second:
+        assert second is not first
+        assert second.asset_paths == set()
+        assert session_module.get_instances() == {}
+        assert session_module.get_dirtied() == set()
+        assert session_module.get_cache_store() == {}
+
+
+def test_exception_inside_the_block_still_resets_all_four():
+    class Boom(Exception):
+        pass
+
+    try:
+        with session_module.request_scope():
+            session_module.get_instances()["Card_a"] = "instance"
+            session_module.get_dirtied().add("Card.title")
+            session_module.get_cache_store()["k"] = "v"
+            raise Boom
+    except Boom:
+        pass
+
+    assert session_module.current_session() is None
+    assert session_module.get_instances() == {}
+    assert session_module.get_dirtied() == set()
+    assert session_module.get_cache_store() == {}
+
+
+def test_exception_in_a_nested_scope_leaves_the_outer_scope_intact():
+    class Boom(Exception):
+        pass
+
+    with session_module.request_scope() as outer:
+        session_module.get_instances()["outer"] = "o"
+
+        try:
+            with session_module.request_scope():
+                session_module.get_instances()["inner"] = "i"
+                raise Boom
+        except Boom:
+            pass
+
+        assert session_module.current_session() is outer
+        assert session_module.get_instances() == {"outer": "o"}
+
+
+def test_two_threads_do_not_see_each_others_scope_state():
+    """ContextVars give each thread its own binding. Two concurrent scopes writing
+    the same keys must each read back only their own writes."""
+    start = threading.Barrier(2)
+    mid = threading.Barrier(2)
+    observed: dict[str, tuple[dict[str, object], dict[object, object]]] = {}
+    errors: list[BaseException] = []
+
+    def worker(name: str) -> None:
+        try:
+            with session_module.request_scope():
+                start.wait(timeout=5)
+                session_module.get_instances()[name] = name
+                session_module.get_cache_store()[name] = name
+                mid.wait(timeout=5)
+                observed[name] = (
+                    dict(session_module.get_instances()),
+                    dict(session_module.get_cache_store()),
+                )
+        except BaseException as exc:  # noqa: BLE001 - surfaced on the main thread below
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=worker, args=("a",)),
+        threading.Thread(target=worker, args=("b",)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors, errors
+    assert observed == {"a": ({"a": "a"}, {"a": "a"}), "b": ({"b": "b"}, {"b": "b"})}
+    assert session_module.get_instances() == {}
+    assert session_module.get_cache_store() == {}
+
+
+def test_render_session_is_still_directly_constructible_with_autoescape_on():
+    """render.py constructs a RenderSession directly and reads .jinja_env; growing
+    the module must not force callers through request_scope."""
+    session = session_module.RenderSession(template_dir="tests/templates")
+
+    assert session.jinja_env.autoescape is True
+    assert session.jinja_env.from_string("{{ v }}").render(v="<b>") == "&lt;b&gt;"
+    assert session.asset_paths == set()
+
+
+def test_scope_passes_template_dir_through_to_the_session():
+    with session_module.request_scope(template_dir="tests/templates") as s:
+        assert s.jinja_env.autoescape is True

--- a/tests/pyjinhx2/test_session.py
+++ b/tests/pyjinhx2/test_session.py
@@ -8,11 +8,15 @@ which land with the modules that consume them.
 """
 
 import threading
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
 from pyjinhx2 import session as session_module
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.descriptor import ClassDescriptor
+from pyjinhx2.render import render
 
 
 def test_getters_return_empty_defaults_outside_any_scope():
@@ -199,6 +203,45 @@ def test_scope_passes_template_dir_through_to_the_session():
         assert s.jinja_env.autoescape is True
 
 
+class PlainBox(BaseComponent):
+    """Component rendered against a hand-built descriptor, not MRO discovery."""
+
+
+# There is no `__pjx_template__` override attribute anywhere in pyjinhx2 —
+# template resolution is a pure MRO/filesystem walk (`class_name.pjx` beside
+# the defining module; see component.py's `_walk_template`). This test needs a
+# specific template, so it bypasses that walk entirely, the same way
+# test_render_level.py does: build a ClassDescriptor by hand and assign it.
+PlainBox.__pjx_descriptor__ = ClassDescriptor(
+    template_path=Path("plain_div.html"),
+    slot_fields=frozenset(),
+    children_field=None,
+    css_paths=(),
+    js_paths=(),
+    strict=True,
+    provenance={"template": PlainBox},
+)
+
+
+def test_on_rendered_fires_once_per_render(render_session):
+    seen = []
+    render_session.on_rendered.append(
+        lambda component, level, session: seen.append(component)
+    )
+    box = PlainBox()
+    render(box, render_session)
+    assert seen == [box]
+
+
+def test_on_rendered_receives_the_rendered_level(render_session):
+    captured = []
+    render_session.on_rendered.append(
+        lambda component, level, session: captured.append(level)
+    )
+    render(PlainBox(), render_session)
+    assert captured[0].descriptor is PlainBox.__pjx_descriptor__
+
+
 def test_on_rendered_starts_empty_on_a_fresh_session():
     session = session_module.RenderSession(template_dir="tests/templates")
 
@@ -215,8 +258,8 @@ def test_emit_rendered_calls_each_subscriber_in_registration_order():
     component = cast(Any, object())
     level = cast(Any, object())
 
-    session.on_rendered.append(lambda c, lv: calls.append(("first", c, lv)))
-    session.on_rendered.append(lambda c, lv: calls.append(("second", c, lv)))
+    session.on_rendered.append(lambda c, lv, s: calls.append(("first", c, lv)))
+    session.on_rendered.append(lambda c, lv, s: calls.append(("second", c, lv)))
     session.emit_rendered(component, level)
 
     assert calls == [("first", component, level), ("second", component, level)]
@@ -239,11 +282,11 @@ def test_emit_rendered_lets_a_subscriber_exception_propagate():
     session = session_module.RenderSession(template_dir="tests/templates")
     reached: list[str] = []
 
-    def explode(component: object, level: object) -> None:
+    def explode(component: object, level: object, session: object) -> None:
         raise Boom
 
     session.on_rendered.append(explode)
-    session.on_rendered.append(lambda c, lv: reached.append("after"))
+    session.on_rendered.append(lambda c, lv, s: reached.append("after"))
 
     with pytest.raises(Boom):
         session.emit_rendered(cast(Any, object()), cast(Any, object()))
@@ -252,11 +295,11 @@ def test_emit_rendered_lets_a_subscriber_exception_propagate():
 
 def test_each_scope_gets_its_own_subscriber_list():
     with session_module.request_scope(template_dir="tests/templates") as outer:
-        outer.on_rendered.append(lambda c, lv: None)
+        outer.on_rendered.append(lambda c, lv, s: None)
 
         with session_module.request_scope(template_dir="tests/templates") as inner:
             assert inner.on_rendered == []
-            inner.on_rendered.append(lambda c, lv: None)
+            inner.on_rendered.append(lambda c, lv, s: None)
 
         assert len(outer.on_rendered) == 1
 

--- a/tests/templates/plain_div.html
+++ b/tests/templates/plain_div.html
@@ -1,0 +1,1 @@
+<div id="{{ id }}">plain</div>


### PR DESCRIPTION
Milestone #3 (L2 of the pyjinhx2 rebuild). Closes #423, #424, #425, #426.

## Summary
- **L2.1** — `request_scope()` binds per-request `ContextVar`s (session, instances, dirtied, cache_store); `RenderSession.on_rendered` is the extension hook subscribers plug into after each component's subtree renders.
- **L2.2** — asset pipeline: accumulation off descriptors (dedup via set), `emit_assets()` for INLINE/NONE delivery, `asset_manifest()`/`AssetManifest` for resolved URLs, `resolver_with_hash()` + `hashed_filename()` for cache-busted filenames, `all_assets()` for a registry-wide (not per-request) enumeration used by build steps.
- **L2.3** — minimal instance registry: composite `type_name_instance_id` keys, `register_instance()`/`resolve()`, and an `on_rendered` subscriber (`register_rendered_instance`) wired but not yet attached by any production code — plumbing for the reactive Load path in a later milestone.
- **L2.4** — concurrency tests proving the `ContextVar` isolation actually holds under FastAPI's threadpool (parallel renders, invariant-4 census).

## Test plan
- [x] All subtask PRs merged individually with passing CI (14 files touched, ~2400 lines added, all in `pyjinhx2/` + `tests/pyjinhx2/`)
- [x] Concurrency harness (`test_concurrency.py`) exercises real thread-pool parallelism, not mocked isolation
- [ ] Final human review before merge

**Not merging yet — opened as a checkpoint for review per milestone-gate process.**