### PR TITLE
style: ruff format script-src test line wrap (#551)

### DIFF
--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -16,6 +16,10 @@ class AssetMode(str, Enum):
 
     INLINE = "inline"
     NONE = "none"
+    # One member for both kinds: the asset kind already decides the tag shape
+    # (<link rel="stylesheet"> vs <script src>), so a separate SRC member would
+    # only create a way to set the wrong one on the wrong kind.
+    LINK = "link"
 
 
 def _inline_tags(paths: set[Path], open_tag: str, close_tag: str) -> list[str]:

--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -92,6 +92,12 @@ def emit_assets(
         )
     if session.js_mode is AssetMode.INLINE:
         tags += _inline_tags(session.js_assets, "<script>", "</script>")
+    elif session.js_mode is AssetMode.LINK:
+        tags += _url_tags(
+            session.js_assets,
+            _require_resolver(resolver),
+            '<script src="{url}"></script>',
+        )
     return "\n".join(tags)
 
 

--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -35,24 +35,61 @@ def _inline_tags(paths: set[Path], open_tag: str, close_tag: str) -> list[str]:
     ]
 
 
-def emit_assets(session: "RenderSession") -> str:
+def _url_tags(
+    paths: set[Path], resolver: Callable[[Path], str], template: str
+) -> list[str]:
+    """Resolve each path to a URL and format it into the given tag, sorted by path.
+
+    Sorted for the same reason _inline_tags sorts: the accumulator is a set with
+    no stable iteration order, and two renders of the same tree must produce
+    byte-identical output. A resolver that raises is left to raise — an asset
+    silently dropped from the page fails invisibly in the browser.
+    """
+    return [template.format(url=resolver(path)) for path in sorted(paths, key=str)]
+
+
+def _require_resolver(
+    resolver: Callable[[Path], str] | None,
+) -> Callable[[Path], str]:
+    """Return the resolver, refusing to emit LINK tags without one.
+
+    Raising rather than skipping the kind: a page quietly missing its
+    stylesheets is harder to diagnose than a failed render.
+    """
+    if resolver is None:
+        raise ValueError("LINK mode needs a resolver to build asset URLs")
+    return resolver
+
+
+def emit_assets(
+    session: "RenderSession", *, resolver: Callable[[Path], str] | None = None
+) -> str:
     """Return the markup for this session's accumulated assets, per delivery mode.
 
     Args:
         session: The RenderSession whose css_assets/js_assets were populated by
             accumulate_assets during the render, and whose css_mode/js_mode say
             how each kind is delivered.
+        resolver: Maps an asset path to the URL it is served from, in the shape
+            asset_manifest() takes. Required only when a kind is in LINK mode.
 
     Returns:
-        Concatenated <style> tags then <script> tags, newline-joined. Empty
-        string when both kinds are NONE or nothing was accumulated.
+        Concatenated CSS tags then JS tags, newline-joined. Empty string when
+        both kinds are NONE or nothing was accumulated.
 
     Raises:
         OSError: If an asset file is missing or unreadable under INLINE mode.
+        ValueError: If a kind is in LINK mode and no resolver was given.
     """
     tags: list[str] = []
     if session.css_mode is AssetMode.INLINE:
         tags += _inline_tags(session.css_assets, "<style>", "</style>")
+    elif session.css_mode is AssetMode.LINK:
+        tags += _url_tags(
+            session.css_assets,
+            _require_resolver(resolver),
+            '<link rel="stylesheet" href="{url}">',
+        )
     if session.js_mode is AssetMode.INLINE:
         tags += _inline_tags(session.js_assets, "<script>", "</script>")
     return "\n".join(tags)

--- a/tests/pyjinhx2/test_asset_emission.py
+++ b/tests/pyjinhx2/test_asset_emission.py
@@ -6,10 +6,11 @@ from pyjinhx2.assets import AssetMode
 from pyjinhx2.session import RenderSession
 
 
-def test_asset_mode_has_exactly_inline_and_none():
+def test_asset_mode_members_are_inline_none_and_link():
     assert AssetMode.INLINE.value == "inline"
     assert AssetMode.NONE.value == "none"
-    assert set(AssetMode) == {AssetMode.INLINE, AssetMode.NONE}
+    assert AssetMode.LINK.value == "link"
+    assert set(AssetMode) == {AssetMode.INLINE, AssetMode.NONE, AssetMode.LINK}
 
 
 def test_session_defaults_both_kinds_to_inline():

--- a/tests/pyjinhx2/test_asset_emission.py
+++ b/tests/pyjinhx2/test_asset_emission.py
@@ -99,6 +99,28 @@ def test_no_assets_emits_empty_string(tmp_path):
     assert emit_assets(_session(tmp_path)) == ""
 
 
+def _stub_resolver(path: Path) -> str:
+    """Resolver of the shape #552 will thread in: path -> served URL."""
+    return f"/static/{path.name}"
+
+
+def test_link_mode_emits_stylesheet_links_sorted_by_path(tmp_path):
+    session = _session(tmp_path)
+    session.css_assets.update(
+        {tmp_path / "z.css", tmp_path / "a.css", tmp_path / "m.css"}
+    )
+    session.css_mode = AssetMode.LINK
+    session.js_mode = AssetMode.NONE
+
+    out = emit_assets(session, resolver=_stub_resolver)
+
+    assert out == (
+        '<link rel="stylesheet" href="/static/a.css">\n'
+        '<link rel="stylesheet" href="/static/m.css">\n'
+        '<link rel="stylesheet" href="/static/z.css">'
+    )
+
+
 from dataclasses import replace
 
 from pyjinhx2.component import BaseComponent

--- a/tests/pyjinhx2/test_asset_emission.py
+++ b/tests/pyjinhx2/test_asset_emission.py
@@ -130,8 +130,7 @@ def test_link_mode_emits_script_src_tags_sorted_by_path(tmp_path):
     out = emit_assets(session, resolver=_stub_resolver)
 
     assert out == (
-        '<script src="/static/a.js"></script>\n'
-        '<script src="/static/z.js"></script>'
+        '<script src="/static/a.js"></script>\n<script src="/static/z.js"></script>'
     )
 
 

--- a/tests/pyjinhx2/test_asset_emission.py
+++ b/tests/pyjinhx2/test_asset_emission.py
@@ -135,6 +135,36 @@ def test_link_mode_emits_script_src_tags_sorted_by_path(tmp_path):
     )
 
 
+def test_resolver_that_raises_propagates_out_of_emit_assets(tmp_path):
+    def boom(path: Path) -> str:
+        raise FileNotFoundError(path)
+
+    session = _session(tmp_path)
+    session.css_assets.add(tmp_path / "gone.css")
+    session.css_mode = AssetMode.LINK
+
+    with pytest.raises(FileNotFoundError):
+        emit_assets(session, resolver=boom)
+
+
+def test_link_css_with_inline_js_emits_both_css_first(tmp_path):
+    css = tmp_path / "box.css"
+    css.write_text(".box { color: red; }")
+    js = tmp_path / "box.js"
+    js.write_text("console.log('box');")
+    session = _session(tmp_path)
+    session.css_assets.add(css)
+    session.js_assets.add(js)
+    session.css_mode = AssetMode.LINK
+
+    out = emit_assets(session, resolver=_stub_resolver)
+
+    assert out == (
+        '<link rel="stylesheet" href="/static/box.css">\n'
+        "<script>console.log('box');</script>"
+    )
+
+
 from dataclasses import replace
 
 from pyjinhx2.component import BaseComponent

--- a/tests/pyjinhx2/test_asset_emission.py
+++ b/tests/pyjinhx2/test_asset_emission.py
@@ -121,6 +121,20 @@ def test_link_mode_emits_stylesheet_links_sorted_by_path(tmp_path):
     )
 
 
+def test_link_mode_emits_script_src_tags_sorted_by_path(tmp_path):
+    session = _session(tmp_path)
+    session.js_assets.update({tmp_path / "z.js", tmp_path / "a.js"})
+    session.css_mode = AssetMode.NONE
+    session.js_mode = AssetMode.LINK
+
+    out = emit_assets(session, resolver=_stub_resolver)
+
+    assert out == (
+        '<script src="/static/a.js"></script>\n'
+        '<script src="/static/z.js"></script>'
+    )
+
+
 from dataclasses import replace
 
 from pyjinhx2.component import BaseComponent


### PR DESCRIPTION
## Summary
- Implements `AssetMode.LINK` enum for emitting CSS and JS as `<link>` tags instead of embedded content
- Adds support for `css_mode=LINK` and `js_mode=LINK` in `emit_assets()`
- Includes comprehensive test coverage for independent CSS/JS LINK branches
- Applied ruff formatting to maintain code style

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)