### PR TITLE
test: extend import-graph gate to cover subpackages (#452)

### DIFF
--- a/pyjinhx2/reactive/keys.py
+++ b/pyjinhx2/reactive/keys.py
@@ -1,0 +1,25 @@
+"""The reactive key vocabulary: the strings that name mutable app state.
+
+Stateless by construction — type definitions and pure functions only. Everything
+request-scoped (the dirtied-key set, ``@mutates``, ``dirty()``) lives in
+``pyjinhx2.reactive.mutations`` and imports from here.
+"""
+
+from collections.abc import Iterable
+from enum import Enum, StrEnum
+
+ReactiveKey = str | Enum
+
+
+def coerce_reactive_key(key: object) -> str:
+    """Normalize a reactive key: unwrap enums to ``.value``, then ``str``."""
+    if isinstance(key, Enum):
+        key = key.value
+    return str(key)
+
+
+def coerce_reactive_keys(keys: Iterable[object] | None) -> set[str]:
+    """Normalize a collection of reactive dependency keys."""
+    if not keys:
+        return set()
+    return {coerce_reactive_key(key) for key in keys}

--- a/pyjinhx2/reactive/keys.py
+++ b/pyjinhx2/reactive/keys.py
@@ -23,3 +23,29 @@ def coerce_reactive_keys(keys: Iterable[object] | None) -> set[str]:
     if not keys:
         return set()
     return {coerce_reactive_key(key) for key in keys}
+
+
+class MutationKey(StrEnum):
+    """
+    Base class for app-level reactive state keys.
+
+    Subclass and declare members; use the members in ``react={...}`` and ``@mutates`` —
+    all normalize to their string values.
+    """
+
+
+class DynamicReactiveKey(str):
+    """A key produced by ``reactive_key()`` — accepted by ``dirty()``/``@mutates()``
+    alongside ``MutationKey`` members. Not constructed directly."""
+
+
+def reactive_key(key: MutationKey, arg: object) -> DynamicReactiveKey:
+    """
+    Build a per-instance reactive key from a static ``MutationKey`` and an
+    instance's own load-key, e.g. ``reactive_key(ChatKeys.MESSAGE, message_id)``.
+
+    Use the result with ``dirty()``/``@mutates()`` to invalidate/reload only the
+    one mounted instance whose load-key matches ``arg``, instead of every
+    instance reacting to ``key``.
+    """
+    return DynamicReactiveKey(f"{coerce_reactive_key(key)}:{arg}")

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -67,6 +67,8 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
         }
     ),
     "render_context": frozenset({"pyjinhx2.markers", "pyjinhx2.component"}),
+    "reactive.__init__": frozenset(),
+    "reactive.keys": frozenset(),
     # The instance registry (ADR 0009) is read-only over session's ContextVar
     # store; it consumes get_instances() and nothing else in pyjinhx2. The
     # register_rendered_instance signature also names RenderedLevel, but that
@@ -89,7 +91,12 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
 
 
 def module_paths() -> list[Path]:
-    return sorted(PACKAGE_ROOT.glob("*.py"))
+    return sorted(PACKAGE_ROOT.rglob("*.py"))
+
+
+def module_name(path: Path) -> str:
+    """Dotted name relative to the package root, e.g. ``reactive.keys``."""
+    return ".".join(path.relative_to(PACKAGE_ROOT).with_suffix("").parts)
 
 
 def internal_imports(path: Path) -> set[str]:
@@ -113,13 +120,13 @@ def internal_imports(path: Path) -> set[str]:
 def test_every_module_is_covered_by_the_declared_edge_table():
     """A new module must declare its edges here before it can be imported
     anywhere — otherwise the table silently stops being a whole-package view."""
-    on_disk = {path.stem for path in module_paths()}
+    on_disk = {module_name(path) for path in module_paths()}
     assert on_disk == set(ALLOWED_INTERNAL_IMPORTS)
 
 
-@pytest.mark.parametrize("path", module_paths(), ids=lambda p: p.stem)
+@pytest.mark.parametrize("path", module_paths(), ids=module_name)
 def test_module_imports_only_declared_internal_modules(path: Path):
-    allowed = ALLOWED_INTERNAL_IMPORTS[path.stem]
+    allowed = ALLOWED_INTERNAL_IMPORTS[module_name(path)]
     unexpected = internal_imports(path) - allowed
     assert not unexpected, (
         f"{path.name} imports undeclared internal modules: {sorted(unexpected)}"
@@ -139,7 +146,7 @@ def test_component_is_the_only_importer_of_class_descriptor():
     importing ClassDescriptor means the fact sheet is being rebuilt somewhere it
     should be read from the class instead."""
     importers = {
-        path.stem
+        module_name(path)
         for path in module_paths()
         if "pyjinhx2.descriptor" in internal_imports(path)
     }


### PR DESCRIPTION
## Summary
- Add reactive key types (MutationKey, DynamicReactiveKey, reactive_key)
- Extend import-graph gate to cover subpackages in pyjinhx2
- Update tests to discover modules in nested directories

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)