### PR TITLE
feat(client): create pyjinhx2.client package with pjx.js runtime accessor

### DIFF
--- a/pyjinhx2/client/__init__.py
+++ b/pyjinhx2/client/__init__.py
@@ -1,0 +1,12 @@
+"""Client tier: the pjx.js browser runtime and the Python glue that ships it."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PJX_RUNTIME_PATH = Path(__file__).parent / "pjx.js"
+
+
+def read_pjx_runtime() -> str:
+    """Return the pjx.js source text."""
+    return PJX_RUNTIME_PATH.read_text(encoding="utf-8")

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -54,10 +54,50 @@
     }
   }
 
+  // htmx core silently drops hx-swap-oob swaps that target <head>, so the
+  // component assets the server carries alongside OOB fragments have to be
+  // parsed out of the raw response and appended here. Fresh nodes: a parsed
+  // <script> clone never executes. Dedup is per token, not per node, because
+  // swaps replace the nodes that carried the previous copy.
+  function pjxApplyHeadAssets(html) {
+    if (!html || html.indexOf('hx-swap-oob="beforeend:head"') === -1) {
+      return;
+    }
+    var doc = new DOMParser().parseFromString(html, "text/html");
+    Array.prototype.forEach.call(
+      doc.querySelectorAll("[data-pjx-asset]"),
+      function (node) {
+        var tag = node.tagName.toLowerCase();
+        if (tag !== "style" && tag !== "script") {
+          return;
+        }
+        var token = node.getAttribute("data-pjx-asset");
+        if (document.head.querySelector('[data-pjx-asset="' + token + '"]')) {
+          return;
+        }
+        var fresh = document.createElement(tag);
+        fresh.setAttribute("data-pjx-asset", token);
+        if (tag === "script" && node.src) {
+          fresh.src = node.src;
+        } else {
+          fresh.textContent = node.textContent;
+        }
+        document.head.appendChild(fresh);
+      }
+    );
+  }
+
+  function pjxApplyHeadAssetsFromRequest(evt) {
+    var xhr = evt.detail && evt.detail.xhr;
+    pjxApplyHeadAssets(xhr && xhr.responseText);
+  }
+
   pjx.manifest = pjxManifest;
   pjx.loadedAssets = pjxLoadedAssets;
   pjx.trigger = pjxTrigger;
+  pjx.applyHeadAssets = pjxApplyHeadAssets;
   window.pjx = pjx;
 
   document.body.addEventListener("htmx:configRequest", pjxConfigRequest);
+  document.body.addEventListener("htmx:afterRequest", pjxApplyHeadAssetsFromRequest);
 })();

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -1,3 +1,7 @@
+// pjx.js: scans the DOM for mounted [data-pjx-id] regions and stamps
+// X-PJX-Mounted/X-PJX-Assets/X-PJX-Trigger request headers on every htmx
+// request, and applies the one swap mechanic htmx core can't do natively --
+// relocating [data-pjx-asset] head assets that arrive via OOB or cold render.
 (function () {
   var pjx = {};
 

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -1,7 +1,25 @@
 (function () {
   var pjx = {};
 
+  function pjxManifest() {
+    return Array.prototype.map.call(
+      document.querySelectorAll("[data-pjx-id]"),
+      function (el) {
+        var entry = {
+          id: el.dataset.pjxId,
+          type: el.dataset.pjxType,
+          hash: el.dataset.pjxHash,
+        };
+        if (el.dataset.pjxLoad) {
+          entry.load = el.dataset.pjxLoad;
+        }
+        return entry;
+      }
+    );
+  }
+
   document.body.addEventListener("htmx:configRequest", function () {});
 
+  pjx.manifest = pjxManifest;
   window.pjx = pjx;
 })();

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -18,8 +18,23 @@
     );
   }
 
+  function pjxLoadedAssets() {
+    var tokens = [];
+    Array.prototype.forEach.call(
+      document.querySelectorAll("[data-pjx-asset]"),
+      function (el) {
+        var token = el.getAttribute("data-pjx-asset");
+        if (token && tokens.indexOf(token) === -1) {
+          tokens.push(token);
+        }
+      }
+    );
+    return tokens;
+  }
+
   document.body.addEventListener("htmx:configRequest", function () {});
 
   pjx.manifest = pjxManifest;
+  pjx.loadedAssets = pjxLoadedAssets;
   window.pjx = pjx;
 })();

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -1,0 +1,7 @@
+(function () {
+  var pjx = {};
+
+  document.body.addEventListener("htmx:configRequest", function () {});
+
+  window.pjx = pjx;
+})();

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -118,6 +118,13 @@
   pjx.promoteInlineAssets = pjxPromoteInlineAssets;
   window.pjx = pjx;
 
+  if (!window.htmx) {
+    console.error(
+      "[pyjinhx] htmx not found — reactivity (OOB swaps) will not work. " +
+        "Load htmx before pjx.js."
+    );
+  }
+
   pjxPromoteInlineAssets();
   document.body.addEventListener("htmx:configRequest", pjxConfigRequest);
   document.body.addEventListener("htmx:afterRequest", pjxApplyHeadAssetsFromRequest);

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -32,9 +32,19 @@
     return tokens;
   }
 
+  function pjxRoot(el) {
+    return el && el.closest ? el.closest("[data-pjx-id]") : null;
+  }
+
+  function pjxTrigger(elt) {
+    var root = pjxRoot(elt);
+    return root ? { id: root.dataset.pjxId } : null;
+  }
+
   document.body.addEventListener("htmx:configRequest", function () {});
 
   pjx.manifest = pjxManifest;
   pjx.loadedAssets = pjxLoadedAssets;
+  pjx.trigger = pjxTrigger;
   window.pjx = pjx;
 })();

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -92,12 +92,33 @@
     pjxApplyHeadAssets(xhr && xhr.responseText);
   }
 
+  // A cold render emits <style data-pjx-asset> inline in the body. If that style
+  // sits inside a region that later re-renders, the swap deletes it and the
+  // server -- seeing its token in X-PJX-Assets -- won't resend it, leaving the
+  // content unstyled. <head> is the durable home. Styles only: a <script>'s
+  // effect outlives its node, and re-appending it would re-execute it.
+  function pjxPromoteInlineAssets() {
+    Array.prototype.forEach.call(
+      document.body.querySelectorAll("style[data-pjx-asset]"),
+      function (node) {
+        var token = node.getAttribute("data-pjx-asset");
+        if (document.head.querySelector('[data-pjx-asset="' + token + '"]')) {
+          node.remove();
+          return;
+        }
+        document.head.appendChild(node); // appendChild relocates body -> head
+      }
+    );
+  }
+
   pjx.manifest = pjxManifest;
   pjx.loadedAssets = pjxLoadedAssets;
   pjx.trigger = pjxTrigger;
   pjx.applyHeadAssets = pjxApplyHeadAssets;
+  pjx.promoteInlineAssets = pjxPromoteInlineAssets;
   window.pjx = pjx;
 
+  pjxPromoteInlineAssets();
   document.body.addEventListener("htmx:configRequest", pjxConfigRequest);
   document.body.addEventListener("htmx:afterRequest", pjxApplyHeadAssetsFromRequest);
 })();

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -41,10 +41,23 @@
     return root ? { id: root.dataset.pjxId } : null;
   }
 
-  document.body.addEventListener("htmx:configRequest", function () {});
+  function pjxConfigRequest(evt) {
+    var headers = evt.detail && evt.detail.headers;
+    if (!headers) {
+      return;
+    }
+    headers["X-PJX-Mounted"] = JSON.stringify(pjxManifest());
+    headers["X-PJX-Assets"] = JSON.stringify(pjxLoadedAssets());
+    var trigger = pjxTrigger(evt.detail.elt);
+    if (trigger) {
+      headers["X-PJX-Trigger"] = JSON.stringify(trigger);
+    }
+  }
 
   pjx.manifest = pjxManifest;
   pjx.loadedAssets = pjxLoadedAssets;
   pjx.trigger = pjxTrigger;
   window.pjx = pjx;
+
+  document.body.addEventListener("htmx:configRequest", pjxConfigRequest);
 })();

--- a/tests/pyjinhx2/client/conftest.py
+++ b/tests/pyjinhx2/client/conftest.py
@@ -16,11 +16,11 @@ from pyjinhx2.client import read_pjx_runtime
 
 pytest.importorskip("playwright")
 
-from playwright.sync_api import Page  # noqa: E402
+from playwright.sync_api import Page
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _require_chromium(browser_type) -> None:  # noqa: ANN001
+def _require_chromium(browser_type) -> None:
     # Check via pytest-playwright's own `browser_type` fixture rather than
     # opening a second `sync_playwright()` context here: two independent
     # sync_playwright instances in one process race and break every

--- a/tests/pyjinhx2/client/conftest.py
+++ b/tests/pyjinhx2/client/conftest.py
@@ -16,13 +16,17 @@ from pyjinhx2.client import read_pjx_runtime
 
 pytest.importorskip("playwright")
 
-from playwright.sync_api import Page, sync_playwright  # noqa: E402
+from playwright.sync_api import Page  # noqa: E402
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _require_chromium() -> None:
-    with sync_playwright() as playwright:
-        executable = Path(playwright.chromium.executable_path)
+def _require_chromium(browser_type) -> None:  # noqa: ANN001
+    # Check via pytest-playwright's own `browser_type` fixture rather than
+    # opening a second `sync_playwright()` context here: two independent
+    # sync_playwright instances in one process race and break every
+    # subsequent browser test in the suite ("using Playwright Sync API
+    # inside the asyncio event loop").
+    executable = Path(browser_type.executable_path)
     if not executable.exists():
         pytest.skip(
             "chromium is not installed (run: uv run playwright install chromium)"

--- a/tests/pyjinhx2/client/conftest.py
+++ b/tests/pyjinhx2/client/conftest.py
@@ -1,0 +1,47 @@
+"""Browser harness for the pjx.js runtime.
+
+Every function in pjx.js is DOM-bound, so the tests run the real file in real
+chromium rather than asserting on source strings. Skips the whole module when
+playwright or chromium is unavailable so `pytest tests/` stays green.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from pyjinhx2.client import read_pjx_runtime
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import Page, sync_playwright  # noqa: E402
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _require_chromium() -> None:
+    with sync_playwright() as playwright:
+        executable = Path(playwright.chromium.executable_path)
+    if not executable.exists():
+        pytest.skip(
+            "chromium is not installed (run: uv run playwright install chromium)"
+        )
+
+
+@pytest.fixture
+def pjx_page(page: Page) -> Iterator[Callable[..., Page]]:
+    """Load `body` into the page, then run pjx.js against it.
+
+    `head` seeds pre-existing <head> assets; `with_htmx` stubs window.htmx so the
+    runtime takes its normal path (the missing-htmx case opts out).
+    """
+
+    def load(body: str, head: str = "", with_htmx: bool = True) -> Page:
+        page.set_content(f"<head>{head}</head><body>{body}</body>")
+        if with_htmx:
+            page.evaluate("window.htmx = {}")
+        page.add_script_tag(content=read_pjx_runtime())
+        return page
+
+    yield load

--- a/tests/pyjinhx2/client/test_client_package.py
+++ b/tests/pyjinhx2/client/test_client_package.py
@@ -1,0 +1,16 @@
+"""The client/ package exists and exposes its runtime source to Python."""
+
+from __future__ import annotations
+
+from pyjinhx2.client import PJX_RUNTIME_PATH, read_pjx_runtime
+
+
+def test_runtime_path_points_at_pjx_js():
+    assert PJX_RUNTIME_PATH.name == "pjx.js"
+    assert PJX_RUNTIME_PATH.is_file()
+
+
+def test_read_pjx_runtime_returns_source():
+    source = read_pjx_runtime()
+    assert "window.pjx" in source
+    assert "htmx:configRequest" in source

--- a/tests/pyjinhx2/client/test_pjx_assets_scan.py
+++ b/tests/pyjinhx2/client/test_pjx_assets_scan.py
@@ -1,0 +1,25 @@
+"""pjxLoadedAssets(): the asset tokens already on the page, behind X-PJX-Assets."""
+
+from __future__ import annotations
+
+
+def test_loaded_assets_is_empty_without_asset_nodes(pjx_page):
+    page = pjx_page("<div></div>")
+    assert page.evaluate("pjx.loadedAssets()") == []
+
+
+def test_loaded_assets_collects_tokens_from_head_and_body(pjx_page):
+    page = pjx_page(
+        '<script data-pjx-asset="card.js"></script>',
+        head='<style data-pjx-asset="card.css"></style>',
+    )
+    assert sorted(page.evaluate("pjx.loadedAssets()")) == ["card.css", "card.js"]
+
+
+def test_loaded_assets_dedupes_repeated_tokens(pjx_page):
+    page = pjx_page(
+        '<style data-pjx-asset="card.css"></style>'
+        '<style data-pjx-asset="card.css"></style>'
+        '<style data-pjx-asset="badge.css"></style>'
+    )
+    assert sorted(page.evaluate("pjx.loadedAssets()")) == ["badge.css", "card.css"]

--- a/tests/pyjinhx2/client/test_pjx_head_assets.py
+++ b/tests/pyjinhx2/client/test_pjx_head_assets.py
@@ -1,0 +1,74 @@
+"""Head assets arriving on an OOB swap: htmx drops head-targeted OOB, pjx.js applies them."""
+
+from __future__ import annotations
+
+SWAP_HTML = (
+    '<style data-pjx-asset="card.css" hx-swap-oob="beforeend:head">.c{color:red}</style>'
+    '<script data-pjx-asset="card.js" hx-swap-oob="beforeend:head">window.ran = true;</script>'
+)
+
+APPLY = "(html) => pjx.applyHeadAssets(html)"
+HEAD_TOKENS = (
+    "() => Array.from(document.head.querySelectorAll('[data-pjx-asset]'))"
+    ".map(n => n.getAttribute('data-pjx-asset'))"
+)
+
+
+def test_new_assets_are_appended_to_head(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(APPLY, SWAP_HTML)
+    assert sorted(page.evaluate(HEAD_TOKENS)) == ["card.css", "card.js"]
+
+
+def test_appended_script_executes(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(APPLY, SWAP_HTML)
+    assert page.evaluate("window.ran") is True
+
+
+def test_asset_already_in_head_is_not_duplicated(pjx_page):
+    page = pjx_page("<div></div>", head='<style data-pjx-asset="card.css"></style>')
+    page.evaluate(APPLY, SWAP_HTML)
+    assert page.evaluate(HEAD_TOKENS).count("card.css") == 1
+
+
+def test_same_token_twice_in_one_response_is_applied_once(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(APPLY, SWAP_HTML + SWAP_HTML)
+    assert page.evaluate(HEAD_TOKENS).count("card.css") == 1
+
+
+def test_non_asset_markup_is_ignored(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(APPLY, '<div data-pjx-id="a1" hx-swap-oob="beforeend:head"></div>')
+    assert page.evaluate(HEAD_TOKENS) == []
+
+
+def test_unparseable_body_is_a_no_op(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(APPLY, "not html <<< at all")
+    page.evaluate(APPLY, "")
+    assert page.evaluate(HEAD_TOKENS) == []
+
+
+def test_after_request_applies_assets_from_the_xhr(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(
+        """
+        (html) => document.body.dispatchEvent(new CustomEvent('htmx:afterRequest', {
+          detail: { xhr: { responseText: html } }, bubbles: true
+        }))
+        """,
+        SWAP_HTML,
+    )
+    assert sorted(page.evaluate(HEAD_TOKENS)) == ["card.css", "card.js"]
+
+
+def test_after_request_without_an_xhr_is_a_no_op(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(
+        """() => document.body.dispatchEvent(
+             new CustomEvent('htmx:afterRequest', { detail: {}, bubbles: true })
+           )"""
+    )
+    assert page.evaluate(HEAD_TOKENS) == []

--- a/tests/pyjinhx2/client/test_pjx_headers.py
+++ b/tests/pyjinhx2/client/test_pjx_headers.py
@@ -1,0 +1,45 @@
+"""The htmx:configRequest listener that stamps the three manifest headers."""
+
+from __future__ import annotations
+
+import json
+
+FIRE_EVENT = """
+    () => {
+      const detail = { headers: {}, elt: document.getElementById('btn') };
+      document.body.dispatchEvent(
+        new CustomEvent('htmx:configRequest', { detail, bubbles: true })
+      );
+      return detail.headers;
+    }
+"""
+
+PAGE = (
+    '<div data-pjx-id="a1" data-pjx-type="Card" data-pjx-hash="h1">'
+    '<style data-pjx-asset="card.css"></style>'
+    '<button id="btn">go</button>'
+    "</div>"
+)
+
+
+def test_config_request_sets_the_mounted_header(pjx_page):
+    headers = pjx_page(PAGE).evaluate(FIRE_EVENT)
+    assert json.loads(headers["X-PJX-Mounted"]) == [
+        {"id": "a1", "type": "Card", "hash": "h1"}
+    ]
+
+
+def test_config_request_sets_the_assets_header(pjx_page):
+    headers = pjx_page(PAGE).evaluate(FIRE_EVENT)
+    assert json.loads(headers["X-PJX-Assets"]) == ["card.css"]
+
+
+def test_config_request_sets_the_trigger_header(pjx_page):
+    headers = pjx_page(PAGE).evaluate(FIRE_EVENT)
+    assert json.loads(headers["X-PJX-Trigger"]) == {"id": "a1"}
+
+
+def test_config_request_omits_the_trigger_header_outside_a_region(pjx_page):
+    headers = pjx_page('<button id="btn">go</button>').evaluate(FIRE_EVENT)
+    assert "X-PJX-Trigger" not in headers
+    assert json.loads(headers["X-PJX-Mounted"]) == []

--- a/tests/pyjinhx2/client/test_pjx_htmx_guard.py
+++ b/tests/pyjinhx2/client/test_pjx_htmx_guard.py
@@ -9,7 +9,9 @@ from pyjinhx2.client import read_pjx_runtime
 
 def test_missing_htmx_logs_a_console_error(page: Page):
     errors = []
-    page.on("console", lambda msg: errors.append(msg.text) if msg.type == "error" else None)
+    page.on(
+        "console", lambda msg: errors.append(msg.text) if msg.type == "error" else None
+    )
     page.set_content("<body><div></div></body>")
     page.add_script_tag(content=read_pjx_runtime())
     assert any("htmx" in text for text in errors)
@@ -27,7 +29,9 @@ def test_runtime_still_loads_and_scans_without_htmx(pjx_page):
 
 def test_no_console_error_when_htmx_is_present(page: Page):
     errors = []
-    page.on("console", lambda msg: errors.append(msg.text) if msg.type == "error" else None)
+    page.on(
+        "console", lambda msg: errors.append(msg.text) if msg.type == "error" else None
+    )
     page.set_content("<body><div></div></body>")
     page.evaluate("window.htmx = {}")
     page.add_script_tag(content=read_pjx_runtime())

--- a/tests/pyjinhx2/client/test_pjx_htmx_guard.py
+++ b/tests/pyjinhx2/client/test_pjx_htmx_guard.py
@@ -1,0 +1,34 @@
+"""Without htmx, reactivity silently does nothing — pjx.js must say so, not throw."""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page
+
+from pyjinhx2.client import read_pjx_runtime
+
+
+def test_missing_htmx_logs_a_console_error(page: Page):
+    errors = []
+    page.on("console", lambda msg: errors.append(msg.text) if msg.type == "error" else None)
+    page.set_content("<body><div></div></body>")
+    page.add_script_tag(content=read_pjx_runtime())
+    assert any("htmx" in text for text in errors)
+
+
+def test_runtime_still_loads_and_scans_without_htmx(pjx_page):
+    page = pjx_page(
+        '<div data-pjx-id="a1" data-pjx-type="Card" data-pjx-hash="h1"></div>',
+        with_htmx=False,
+    )
+    assert page.evaluate("pjx.manifest()") == [
+        {"id": "a1", "type": "Card", "hash": "h1"}
+    ]
+
+
+def test_no_console_error_when_htmx_is_present(page: Page):
+    errors = []
+    page.on("console", lambda msg: errors.append(msg.text) if msg.type == "error" else None)
+    page.set_content("<body><div></div></body>")
+    page.evaluate("window.htmx = {}")
+    page.add_script_tag(content=read_pjx_runtime())
+    assert errors == []

--- a/tests/pyjinhx2/client/test_pjx_manifest.py
+++ b/tests/pyjinhx2/client/test_pjx_manifest.py
@@ -1,0 +1,57 @@
+"""pjxManifest(): the DOM -> mounted-regions scan behind X-PJX-Mounted."""
+
+from __future__ import annotations
+
+
+def test_manifest_is_empty_without_mounted_regions(pjx_page):
+    page = pjx_page("<div>plain</div>")
+    assert page.evaluate("pjx.manifest()") == []
+
+
+def test_manifest_reads_id_type_and_hash(pjx_page):
+    page = pjx_page(
+        '<div data-pjx-id="a1" data-pjx-type="Card" data-pjx-hash="h1"></div>'
+    )
+    assert page.evaluate("pjx.manifest()") == [
+        {"id": "a1", "type": "Card", "hash": "h1"}
+    ]
+
+
+def test_manifest_lists_every_mounted_region_in_document_order(pjx_page):
+    page = pjx_page(
+        '<div data-pjx-id="a1" data-pjx-type="Card" data-pjx-hash="h1">'
+        '<span data-pjx-id="b2" data-pjx-type="Badge" data-pjx-hash="h2"></span>'
+        "</div>"
+    )
+    assert [entry["id"] for entry in page.evaluate("pjx.manifest()")] == ["a1", "b2"]
+
+
+def test_manifest_includes_load_only_when_non_empty(pjx_page):
+    page = pjx_page(
+        '<div data-pjx-id="a1" data-pjx-type="Row" data-pjx-hash="h1" data-pjx-load="7"></div>'
+        '<div data-pjx-id="a2" data-pjx-type="Row" data-pjx-hash="h2" data-pjx-load=""></div>'
+    )
+    entries = page.evaluate("pjx.manifest()")
+    assert entries[0]["load"] == "7"
+    assert "load" not in entries[1]
+
+
+def test_manifest_skips_elements_without_an_id(pjx_page):
+    page = pjx_page('<div data-pjx-type="Card" data-pjx-hash="h1"></div>')
+    assert page.evaluate("pjx.manifest()") == []
+
+
+def test_manifest_tolerates_missing_type_and_hash(pjx_page):
+    page = pjx_page('<div data-pjx-id="a1"></div>')
+    assert page.evaluate("pjx.manifest()") == [{"id": "a1", "type": None, "hash": None}]
+
+
+def test_manifest_omits_undefined_type_and_hash_over_the_wire(pjx_page):
+    page = pjx_page('<div data-pjx-id="a1"></div>')
+    assert page.evaluate("JSON.stringify(pjx.manifest())") == '[{"id":"a1"}]'
+
+
+def test_manifest_reflects_the_dom_at_call_time(pjx_page):
+    page = pjx_page('<div data-pjx-id="a1" data-pjx-type="Card" data-pjx-hash="h1"></div>')
+    page.evaluate("document.querySelector('[data-pjx-id]').remove()")
+    assert page.evaluate("pjx.manifest()") == []

--- a/tests/pyjinhx2/client/test_pjx_manifest.py
+++ b/tests/pyjinhx2/client/test_pjx_manifest.py
@@ -52,6 +52,8 @@ def test_manifest_omits_undefined_type_and_hash_over_the_wire(pjx_page):
 
 
 def test_manifest_reflects_the_dom_at_call_time(pjx_page):
-    page = pjx_page('<div data-pjx-id="a1" data-pjx-type="Card" data-pjx-hash="h1"></div>')
+    page = pjx_page(
+        '<div data-pjx-id="a1" data-pjx-type="Card" data-pjx-hash="h1"></div>'
+    )
     page.evaluate("document.querySelector('[data-pjx-id]').remove()")
     assert page.evaluate("pjx.manifest()") == []

--- a/tests/pyjinhx2/client/test_pjx_promote_assets.py
+++ b/tests/pyjinhx2/client/test_pjx_promote_assets.py
@@ -21,7 +21,9 @@ def test_body_style_is_promoted_on_load(pjx_page):
 
 
 def test_promoted_style_keeps_its_css(pjx_page):
-    page = pjx_page('<style data-pjx-asset="card.css">.c{color:rgb(255, 0, 0)}</style><p class="c">x</p>')
+    page = pjx_page(
+        '<style data-pjx-asset="card.css">.c{color:rgb(255, 0, 0)}</style><p class="c">x</p>'
+    )
     color = page.evaluate("() => getComputedStyle(document.querySelector('.c')).color")
     assert color == "rgb(255, 0, 0)"
 

--- a/tests/pyjinhx2/client/test_pjx_promote_assets.py
+++ b/tests/pyjinhx2/client/test_pjx_promote_assets.py
@@ -1,0 +1,41 @@
+"""Cold-render inline <style data-pjx-asset> must move to <head> to survive swaps."""
+
+from __future__ import annotations
+
+HEAD_TOKENS = (
+    "() => Array.from(document.head.querySelectorAll('[data-pjx-asset]'))"
+    ".map(n => n.getAttribute('data-pjx-asset'))"
+)
+BODY_TOKENS = (
+    "() => Array.from(document.body.querySelectorAll('[data-pjx-asset]'))"
+    ".map(n => n.getAttribute('data-pjx-asset'))"
+)
+
+
+def test_body_style_is_promoted_on_load(pjx_page):
+    page = pjx_page(
+        '<div data-pjx-id="a1"><style data-pjx-asset="card.css">.c{color:red}</style></div>'
+    )
+    assert page.evaluate(HEAD_TOKENS) == ["card.css"]
+    assert page.evaluate(BODY_TOKENS) == []
+
+
+def test_promoted_style_keeps_its_css(pjx_page):
+    page = pjx_page('<style data-pjx-asset="card.css">.c{color:rgb(255, 0, 0)}</style><p class="c">x</p>')
+    color = page.evaluate("() => getComputedStyle(document.querySelector('.c')).color")
+    assert color == "rgb(255, 0, 0)"
+
+
+def test_duplicate_of_a_head_resident_token_is_dropped(pjx_page):
+    page = pjx_page(
+        '<style data-pjx-asset="card.css">.c{color:blue}</style>',
+        head='<style data-pjx-asset="card.css">.c{color:red}</style>',
+    )
+    assert page.evaluate(HEAD_TOKENS) == ["card.css"]
+    assert page.evaluate(BODY_TOKENS) == []
+
+
+def test_body_scripts_are_left_alone(pjx_page):
+    page = pjx_page('<script data-pjx-asset="card.js"></script>')
+    assert page.evaluate(HEAD_TOKENS) == []
+    assert page.evaluate(BODY_TOKENS) == ["card.js"]

--- a/tests/pyjinhx2/client/test_pjx_trigger.py
+++ b/tests/pyjinhx2/client/test_pjx_trigger.py
@@ -10,11 +10,15 @@ def test_trigger_returns_nearest_mounted_ancestor(pjx_page):
         '<button id="btn">go</button>'
         "</div></div>"
     )
-    assert page.evaluate("pjx.trigger(document.getElementById('btn'))") == {"id": "inner"}
+    assert page.evaluate("pjx.trigger(document.getElementById('btn'))") == {
+        "id": "inner"
+    }
 
 
 def test_trigger_matches_the_element_itself(pjx_page):
-    page = pjx_page('<div id="btn" data-pjx-id="a1" data-pjx-type="Row" data-pjx-hash="h"></div>')
+    page = pjx_page(
+        '<div id="btn" data-pjx-id="a1" data-pjx-type="Row" data-pjx-hash="h"></div>'
+    )
     assert page.evaluate("pjx.trigger(document.getElementById('btn'))") == {"id": "a1"}
 
 

--- a/tests/pyjinhx2/client/test_pjx_trigger.py
+++ b/tests/pyjinhx2/client/test_pjx_trigger.py
@@ -1,0 +1,28 @@
+"""pjxTrigger(): which mounted region a request came from, behind X-PJX-Trigger."""
+
+from __future__ import annotations
+
+
+def test_trigger_returns_nearest_mounted_ancestor(pjx_page):
+    page = pjx_page(
+        '<div data-pjx-id="outer" data-pjx-type="Page" data-pjx-hash="h1">'
+        '<div data-pjx-id="inner" data-pjx-type="Row" data-pjx-hash="h2">'
+        '<button id="btn">go</button>'
+        "</div></div>"
+    )
+    assert page.evaluate("pjx.trigger(document.getElementById('btn'))") == {"id": "inner"}
+
+
+def test_trigger_matches_the_element_itself(pjx_page):
+    page = pjx_page('<div id="btn" data-pjx-id="a1" data-pjx-type="Row" data-pjx-hash="h"></div>')
+    assert page.evaluate("pjx.trigger(document.getElementById('btn'))") == {"id": "a1"}
+
+
+def test_trigger_is_falsy_outside_any_mounted_region(pjx_page):
+    page = pjx_page('<button id="btn">go</button>')
+    assert not page.evaluate("pjx.trigger(document.getElementById('btn'))")
+
+
+def test_trigger_is_falsy_for_a_missing_element(pjx_page):
+    page = pjx_page("<div></div>")
+    assert not page.evaluate("pjx.trigger(null)")

--- a/tests/reactivity/conftest.py
+++ b/tests/reactivity/conftest.py
@@ -17,15 +17,18 @@ import httpx
 import pytest
 import uvicorn
 
+pytest.importorskip("playwright")
+
 
 @pytest.fixture(scope="session", autouse=True)
-def _require_chromium() -> None:
-    try:
-        from playwright.sync_api import sync_playwright
-    except ImportError:
-        pytest.skip("playwright is not installed")
-    with sync_playwright() as playwright:
-        executable = Path(playwright.chromium.executable_path)
+def _require_chromium(browser_type) -> None:  # noqa: ANN001
+    # Check via pytest-playwright's own `browser_type` fixture rather than
+    # opening a second `sync_playwright()` context here: two independent
+    # sync_playwright instances in one process race and break every
+    # subsequent browser test in the suite ("using Playwright Sync API
+    # inside the asyncio event loop") once another browser-test package
+    # (e.g. tests/pyjinhx2/client) runs earlier in the same session.
+    executable = Path(browser_type.executable_path)
     if not executable.exists():
         pytest.skip(
             "chromium is not installed (run: uv run playwright install chromium)"

--- a/tests/reactivity/conftest.py
+++ b/tests/reactivity/conftest.py
@@ -21,7 +21,7 @@ pytest.importorskip("playwright")
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _require_chromium(browser_type) -> None:  # noqa: ANN001
+def _require_chromium(browser_type) -> None:
     # Check via pytest-playwright's own `browser_type` fixture rather than
     # opening a second `sync_playwright()` context here: two independent
     # sync_playwright instances in one process race and break every


### PR DESCRIPTION
## Summary

Implements L3.7.1 of the pyjinhx2 rebuild blueprint by establishing the `pyjinhx2.client` package as the home for the browser-side reactive spine runtime.

**What:** Adds `pjx.js` with complete manifest/asset/trigger scanning and head-asset relocation for htmx swaps. Scans [data-pjx-id] regions, collects loaded assets, traces trigger ancestors, rewrites htmx headers (X-PJX-Mounted, X-PJX-Assets, X-PJX-Trigger), and relocates cold-render inline styles to head before htmx can delete them on region swap.

**Why:** The server can't know which assets are stale or which regions/elements triggered a swap without client-side scanning. Cold renders inject style tags into the response body, but htmx's OOB swaps can't target head, so pjx.js reads the raw response and applies them directly.

## Tests
- 36 new client tests covering manifest/asset scans, trigger lookup, head-asset relay, and OOB asset application
- Added pytest-playwright fixture harness to run pjx.js functions against real chromium
- Fixed double-bootstrap in sync_playwright contexts across reactivity and client test suites

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)