### PR TITLE
feat(reactive): add mutations.py with @mutates and dirty()

### DIFF
--- a/pyjinhx2/reactive/mutations.py
+++ b/pyjinhx2/reactive/mutations.py
@@ -1,0 +1,73 @@
+"""``@mutates`` and ``dirty()``: the two ways an app marks reactive keys dirty."""
+
+import functools
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from pyjinhx2.reactive.keys import (
+    DynamicReactiveKey,
+    MutationKey,
+    coerce_reactive_keys,
+    reactive_key,
+)
+from pyjinhx2.session import add_dirtied
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def _require_mutation_keys(keys: tuple[Any, ...], caller: str) -> None:
+    invalid = sorted(
+        repr(key)
+        for key in keys
+        if not isinstance(key, (MutationKey, DynamicReactiveKey))
+    )
+    if invalid:
+        raise TypeError(
+            f"{caller} only accepts MutationKey members or reactive_key() values; "
+            f"got {', '.join(invalid)}"
+        )
+
+
+def mutates(
+    *keys: MutationKey, key: Callable[..., object] | None = None
+) -> Callable[[F], F]:
+    """
+    Decorator for mutation methods.
+
+    Records ``keys`` in this request's dirtied set after the wrapped function
+    returns. Keys must be ``MutationKey`` members or ``reactive_key()`` values.
+
+    Pass ``key=`` to derive a per-instance key instead of dirtying ``keys``
+    directly - it's called with the wrapped function's own arguments and its
+    return value feeds ``reactive_key()`` for every key in ``keys``, e.g.
+    ``@mutates(Keys.TODO, key=lambda self, todo_id: todo_id)``.
+    """
+    # Eager validation: a bad key fails when the class body is executed, not on
+    # the first call at runtime.
+    _require_mutation_keys(keys, "@mutates")
+
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            result = func(*args, **kwargs)
+            active_keys: tuple[object, ...] = keys
+            if key is not None:
+                arg = key(*args, **kwargs)
+                active_keys = tuple(reactive_key(k, arg) for k in keys)
+            add_dirtied(coerce_reactive_keys(active_keys))
+            return result
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def dirty(*keys: MutationKey | DynamicReactiveKey) -> None:
+    """
+    Imperatively dirty reactive keys, like ``@mutates`` without a decorator.
+
+    Records ``keys`` in this request's dirtied set. Keys must be ``MutationKey``
+    members or ``reactive_key()`` values.
+    """
+    _require_mutation_keys(keys, "dirty()")
+    add_dirtied(coerce_reactive_keys(keys))

--- a/pyjinhx2/session.py
+++ b/pyjinhx2/session.py
@@ -1,6 +1,6 @@
 """RenderSession, the per-request ContextVars, and the request_scope that owns them."""
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
@@ -141,6 +141,20 @@ def get_dirtied() -> set[str]:
     if dirtied is None:
         return set()
     return dirtied
+
+
+def add_dirtied(keys: Iterable[str]) -> None:
+    """Add already-normalized reactive keys to this request's dirtied set.
+
+    Args:
+        keys: Normalized string keys, as produced by coerce_reactive_keys().
+    """
+    dirtied = _dirtied.get()
+    # Outside a request_scope() there is nothing to dirty and nothing that will
+    # read it back; mirror get_dirtied()'s tolerance instead of raising.
+    if dirtied is None:
+        return
+    dirtied.update(keys)
 
 
 def get_cache_store() -> dict[object, object]:

--- a/tests/pyjinhx2/reactive/test_reactive_mutations.py
+++ b/tests/pyjinhx2/reactive/test_reactive_mutations.py
@@ -1,0 +1,72 @@
+from enum import Enum
+
+import pytest
+
+from pyjinhx2.reactive.keys import MutationKey, reactive_key
+from pyjinhx2.reactive.mutations import dirty, mutates
+from pyjinhx2.session import get_dirtied, request_scope
+
+
+class Keys(MutationKey):
+    TODOS = "todos"
+    USER = "user"
+
+
+class PlainEnum(Enum):
+    NOPE = "nope"
+
+
+def test_dirty_records_the_normalized_key():
+    with request_scope():
+        dirty(Keys.TODOS)
+        assert get_dirtied() == {"todos"}
+
+
+def test_dirty_records_a_reactive_key():
+    with request_scope():
+        dirty(reactive_key(Keys.TODOS, 7))
+        assert get_dirtied() == {"todos:7"}
+
+
+@pytest.mark.parametrize("bad", ["not-a-key", PlainEnum.NOPE, 3])
+def test_dirty_rejects_non_mutation_keys(bad: object):
+    with pytest.raises(TypeError, match=r"dirty\(\) only accepts MutationKey"):
+        dirty(bad)  # type: ignore[arg-type]
+
+
+def test_mutates_records_the_key_and_returns_the_result():
+    @mutates(Keys.TODOS)
+    def add_todo(title: str) -> str:
+        return title.upper()
+
+    with request_scope():
+        assert add_todo("milk") == "MILK"
+        assert get_dirtied() == {"todos"}
+
+
+def test_mutates_with_key_records_a_per_instance_key():
+    class Store:
+        @mutates(Keys.TODOS, key=lambda self, todo_id: todo_id)
+        def toggle(self, todo_id: int) -> None:
+            pass
+
+    with request_scope():
+        Store().toggle(7)
+        assert get_dirtied() == {"todos:7"}
+
+
+def test_mutates_outside_a_scope_is_a_no_op():
+    @mutates(Keys.TODOS)
+    def add_todo() -> None:
+        pass
+
+    add_todo()
+    assert get_dirtied() == set()
+
+
+def test_mutates_rejects_bad_keys_at_decoration_time():
+    with pytest.raises(TypeError, match=r"@mutates only accepts MutationKey"):
+
+        @mutates("todos")  # type: ignore[arg-type]
+        def add_todo() -> None:
+            pass

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -69,6 +69,9 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "render_context": frozenset({"pyjinhx2.markers", "pyjinhx2.component"}),
     "reactive.__init__": frozenset(),
     "reactive.keys": frozenset(),
+    # mutations.py records dirtied keys through session's public writer; it owns
+    # no ContextVar of its own and never reaches sideways into cache.py.
+    "reactive.mutations": frozenset({"pyjinhx2.session", "pyjinhx2.reactive.keys"}),
     # The instance registry (ADR 0009) is read-only over session's ContextVar
     # store; it consumes get_instances() and nothing else in pyjinhx2. The
     # register_rendered_instance signature also names RenderedLevel, but that
@@ -172,7 +175,8 @@ def test_no_render_spine_module_declares_a_reactive_import():
     guards the allowlist table itself — it must fail the moment someone adds
     a pyjinhx2.reactive entry to any spine module's allowed set, before a
     single file under reactive/ is ever written."""
-    for module, allowed in ALLOWED_INTERNAL_IMPORTS.items():
+    for module in RENDER_SPINE_MODULES:
+        allowed = ALLOWED_INTERNAL_IMPORTS.get(module, frozenset())
         reactive_edges = {
             name
             for name in allowed

--- a/tests/pyjinhx2/test_session.py
+++ b/tests/pyjinhx2/test_session.py
@@ -305,3 +305,15 @@ def test_each_scope_gets_its_own_subscriber_list():
 
     with session_module.request_scope(template_dir="tests/templates") as later:
         assert later.on_rendered == []
+
+
+def test_add_dirtied_updates_the_active_scopes_set():
+    with session_module.request_scope():
+        session_module.add_dirtied({"todos"})
+        session_module.add_dirtied(["todos", "user"])
+        assert session_module.get_dirtied() == {"todos", "user"}
+
+
+def test_add_dirtied_outside_a_scope_is_a_no_op():
+    session_module.add_dirtied({"todos"})
+    assert session_module.get_dirtied() == set()


### PR DESCRIPTION
## Summary

Implements the two ways an app marks reactive keys dirty through @mutates decorator and dirty() function, validating that every key is a MutationKey member or a reactive_key() result. Records normalized keys through session.add_dirtied().

Also scopes the render-spine reactive-import guard to spine modules only, fixing a false positive that was flagging mutations.py's intra-reactive/ imports.

## Changes

- `pyjinhx2/reactive/mutations.py`: New module with @mutates and dirty() implementation (73 lines)
- `tests/pyjinhx2/reactive/test_reactive_mutations.py`: Comprehensive test coverage (72 lines)
- Updated import graph guard to exclude non-spine modules

## Tests

All 216 tests passing.

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)