### PR TITLE
feat: pjx.js loading indicators and toast API

### DIFF
--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -300,6 +300,38 @@
     );
   }
 
+  var pjxPageLoading = 0;
+
+  // Toggle the page-level CSS hook. Only a class is set: the overlay markup is
+  // an L4 page-loader builtin's business, this is the state it hangs off.
+  function pjxLoaderPage(on) {
+    if (on) {
+      pjxPageLoading += 1;
+      document.documentElement.classList.add("pjx-loading--page");
+      return;
+    }
+    pjxPageLoading = Math.max(0, pjxPageLoading - 1);
+    if (pjxPageLoading === 0) {
+      document.documentElement.classList.remove("pjx-loading--page");
+    }
+  }
+
+  // Same ref-count the htmx wiring uses, so a manual show and an in-flight
+  // request over the same region can't switch each other off.
+  function pjxLoaderRegion(id, on) {
+    var region = pjxRegion(id);
+    if (!region) {
+      return;
+    }
+    if (on) {
+      pjxLight(region, []);
+      return;
+    }
+    if (pjxLoading[id]) {
+      pjxRelease(id);
+    }
+  }
+
   pjx.manifest = pjxManifest;
   pjx.loadedAssets = pjxLoadedAssets;
   pjx.trigger = pjxTrigger;
@@ -307,6 +339,7 @@
   pjx.promoteInlineAssets = pjxPromoteInlineAssets;
   pjx.injectStyle = pjxInjectStyle;
   pjx.toast = pjxToast;
+  pjx.loader = { page: pjxLoaderPage, region: pjxLoaderRegion };
   pjx.loadingCount = function (id) {
     return pjxLoading[id] || 0;
   };

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -149,6 +149,113 @@
     document.head.appendChild(style);
   }
 
+  var pjxLoadingByXhr = new Map(); // xhr -> [region id, ...]
+  var pjxLoading = {}; // region id -> in-flight request count (ref-count)
+
+  function pjxReacts(el) {
+    var value = el.getAttribute("data-pjx-reacts");
+    return value ? value.split(" ").filter(Boolean) : [];
+  }
+
+  function pjxLoadingClass(el) {
+    return "pjx-loading--" + (el.getAttribute("data-pjx-loading") || "skeleton");
+  }
+
+  function pjxRegion(id) {
+    var key = window.CSS && CSS.escape ? CSS.escape(id) : id;
+    return document.querySelector('[data-pjx-id="' + key + '"]');
+  }
+
+  // the [data-pjx-loading] elements belonging to a region (itself and/or inner
+  // elements, but not those owned by a nested reactive region)
+  function pjxLoadingTargets(region) {
+    var targets = [];
+    if (region.getAttribute("data-pjx-loading")) {
+      targets.push(region);
+    }
+    Array.prototype.forEach.call(
+      region.querySelectorAll("[data-pjx-loading]"),
+      function (el) {
+        if (el.closest("[data-pjx-id][data-pjx-reacts]") === region) {
+          targets.push(el);
+        }
+      }
+    );
+    return targets;
+  }
+
+  function pjxLight(region, ids) {
+    var id = region.getAttribute("data-pjx-id");
+    if (!id || ids.indexOf(id) !== -1) {
+      return;
+    }
+    var targets = pjxLoadingTargets(region);
+    if (!targets.length) {
+      return;
+    }
+    targets.forEach(function (t) {
+      t.classList.add(pjxLoadingClass(t));
+    });
+    pjxLoading[id] = (pjxLoading[id] || 0) + 1;
+    ids.push(id);
+  }
+
+  function pjxBeginLoading(evt) {
+    if (evt.defaultPrevented) {
+      return; // cancelled request: its xhr is never sent, so loadend never fires
+    }
+    var xhr = evt.detail && evt.detail.xhr;
+    var elt = evt.detail && evt.detail.elt;
+    var root = elt && elt.closest ? elt.closest("[data-pjx-id][data-pjx-reacts]") : null;
+    if (!xhr || !root) {
+      return;
+    }
+    var dirty = {};
+    pjxReacts(root).forEach(function (key) {
+      dirty[key] = true;
+    });
+    var triggerLoad = root.getAttribute("data-pjx-load");
+    var ids = [];
+    Array.prototype.forEach.call(
+      document.querySelectorAll("[data-pjx-id][data-pjx-reacts]"),
+      function (region) {
+        var reacts = pjxReacts(region).some(function (key) {
+          return dirty[key];
+        });
+        if (!reacts) {
+          return;
+        }
+        // keyed regions: light only the instance matching the trigger's load key
+        var regionLoad = region.getAttribute("data-pjx-load");
+        if (regionLoad === null || regionLoad === triggerLoad) {
+          pjxLight(region, ids);
+        }
+      }
+    );
+    // a trigger may name extra regions to light (e.g. rows a bulk action removes)
+    var extra = root.getAttribute("data-pjx-loading-extra");
+    if (extra) {
+      Array.prototype.forEach.call(
+        document.querySelectorAll(extra),
+        function (region) {
+          pjxLight(region, ids);
+        }
+      );
+    }
+    if (ids.length) {
+      pjxLoadingByXhr.set(xhr, ids);
+      // loadend always fires (load/error/abort), even when htmx discards the
+      // response of a superseded request -- a reliable cue to release the refs
+      xhr.addEventListener("loadend", function () {
+        pjxEndLoading(xhr);
+      });
+    }
+  }
+
+  function pjxEndLoading(xhrOrEvt) {
+    void xhrOrEvt; // implemented in the end-loading step
+  }
+
   pjx.manifest = pjxManifest;
   pjx.loadedAssets = pjxLoadedAssets;
   pjx.trigger = pjxTrigger;
@@ -168,4 +275,5 @@
   pjxPromoteInlineAssets();
   document.body.addEventListener("htmx:configRequest", pjxConfigRequest);
   document.body.addEventListener("htmx:afterRequest", pjxApplyHeadAssetsFromRequest);
+  document.body.addEventListener("htmx:beforeRequest", pjxBeginLoading);
 })();

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -280,6 +280,18 @@
     }
   }
 
+  // a swap can replace a region another in-flight request still needs lit
+  function pjxReapplyLoading() {
+    Object.keys(pjxLoading).forEach(function (id) {
+      var region = pjxRegion(id);
+      if (region) {
+        pjxLoadingTargets(region).forEach(function (t) {
+          t.classList.add(pjxLoadingClass(t));
+        });
+      }
+    });
+  }
+
   pjx.manifest = pjxManifest;
   pjx.loadedAssets = pjxLoadedAssets;
   pjx.trigger = pjxTrigger;
@@ -308,4 +320,5 @@
   document.body.addEventListener("htmx:timeout", pjxEndLoading);
   document.body.addEventListener("htmx:sendError", pjxEndLoading);
   document.body.addEventListener("htmx:abort", pjxEndLoading);
+  document.body.addEventListener("htmx:afterSettle", pjxReapplyLoading);
 })();

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -292,12 +292,21 @@
     });
   }
 
+  // The dispatch half of the toast API. Rendering belongs to an L4 toast-host
+  // builtin listening for this event, so core stays DOM-template-free.
+  function pjxToast(payload) {
+    document.dispatchEvent(
+      new CustomEvent("pjx:toast", { detail: payload || {}, bubbles: false })
+    );
+  }
+
   pjx.manifest = pjxManifest;
   pjx.loadedAssets = pjxLoadedAssets;
   pjx.trigger = pjxTrigger;
   pjx.applyHeadAssets = pjxApplyHeadAssets;
   pjx.promoteInlineAssets = pjxPromoteInlineAssets;
   pjx.injectStyle = pjxInjectStyle;
+  pjx.toast = pjxToast;
   pjx.loadingCount = function (id) {
     return pjxLoading[id] || 0;
   };

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -253,7 +253,31 @@
   }
 
   function pjxEndLoading(xhrOrEvt) {
-    void xhrOrEvt; // implemented in the end-loading step
+    var xhr = xhrOrEvt && xhrOrEvt.detail ? xhrOrEvt.detail.xhr : xhrOrEvt;
+    var ids = xhr && pjxLoadingByXhr.get(xhr);
+    if (!ids) {
+      return; // already released (loadend and the htmx event both fire)
+    }
+    pjxLoadingByXhr.delete(xhr);
+    ids.forEach(function (id) {
+      pjxRelease(id);
+    });
+  }
+
+  // one ref released; at zero the region goes dark. Clamped so a duplicate
+  // release can never drive the count negative and strand a region "lit".
+  function pjxRelease(id) {
+    pjxLoading[id] = (pjxLoading[id] || 0) - 1;
+    if (pjxLoading[id] > 0) {
+      return;
+    }
+    delete pjxLoading[id];
+    var region = pjxRegion(id);
+    if (region) {
+      pjxLoadingTargets(region).forEach(function (t) {
+        t.classList.remove(pjxLoadingClass(t));
+      });
+    }
   }
 
   pjx.manifest = pjxManifest;
@@ -262,6 +286,9 @@
   pjx.applyHeadAssets = pjxApplyHeadAssets;
   pjx.promoteInlineAssets = pjxPromoteInlineAssets;
   pjx.injectStyle = pjxInjectStyle;
+  pjx.loadingCount = function (id) {
+    return pjxLoading[id] || 0;
+  };
   window.pjx = pjx;
 
   if (!window.htmx) {
@@ -276,4 +303,9 @@
   document.body.addEventListener("htmx:configRequest", pjxConfigRequest);
   document.body.addEventListener("htmx:afterRequest", pjxApplyHeadAssetsFromRequest);
   document.body.addEventListener("htmx:beforeRequest", pjxBeginLoading);
+  document.body.addEventListener("htmx:afterOnLoad", pjxEndLoading);
+  document.body.addEventListener("htmx:responseError", pjxEndLoading);
+  document.body.addEventListener("htmx:timeout", pjxEndLoading);
+  document.body.addEventListener("htmx:sendError", pjxEndLoading);
+  document.body.addEventListener("htmx:abort", pjxEndLoading);
 })();

--- a/pyjinhx2/client/pjx.js
+++ b/pyjinhx2/client/pjx.js
@@ -115,11 +115,46 @@
     );
   }
 
+  // Injected once so loading indicators work with zero app CSS; every visual
+  // knob is a --pjx-* custom property the app can override in its own sheet.
+  function pjxInjectStyle() {
+    if (document.getElementById("pjx-style")) {
+      return;
+    }
+    var style = document.createElement("style");
+    style.id = "pjx-style";
+    style.textContent =
+      ".pjx-loading--skeleton,.pjx-loading--spinner{pointer-events:none}" +
+      ".pjx-loading--skeleton{color:transparent !important;" +
+      "border-radius:var(--pjx-skeleton-radius,6px);background-image:linear-gradient(90deg," +
+      "var(--pjx-skeleton-color,rgba(127,127,127,.12))," +
+      "var(--pjx-skeleton-highlight,rgba(127,127,127,.30)) 50%," +
+      "var(--pjx-skeleton-color,rgba(127,127,127,.12)));background-size:200% 100%;" +
+      "animation:pjx-shimmer var(--pjx-skeleton-speed,1.2s) ease-in-out infinite}" +
+      ".pjx-loading--skeleton *{visibility:hidden}" +
+      ".pjx-loading--spinner{position:relative}" +
+      ".pjx-loading--spinner::before{content:'';position:absolute;inset:0;" +
+      "background:var(--pjx-spinner-overlay,rgba(0,0,0,.45));" +
+      "backdrop-filter:blur(var(--pjx-spinner-blur,2px));" +
+      "-webkit-backdrop-filter:blur(var(--pjx-spinner-blur,2px));border-radius:inherit}" +
+      ".pjx-loading--spinner::after{content:'';position:absolute;top:50%;left:50%;" +
+      "width:var(--pjx-spinner-size,1.1em);height:var(--pjx-spinner-size,1.1em);" +
+      "margin:calc(var(--pjx-spinner-size,1.1em)/-2) 0 0 calc(var(--pjx-spinner-size,1.1em)/-2);" +
+      "box-sizing:border-box;border:var(--pjx-spinner-thickness,2px) solid " +
+      "var(--pjx-spinner-track,rgba(255,255,255,.4));" +
+      "border-top-color:var(--pjx-spinner-color,rgba(255,255,255,.95));" +
+      "border-radius:50%;animation:pjx-spin var(--pjx-spinner-speed,.6s) linear infinite}" +
+      "@keyframes pjx-shimmer{from{background-position:100% 0}to{background-position:-100% 0}}" +
+      "@keyframes pjx-spin{to{transform:rotate(360deg)}}";
+    document.head.appendChild(style);
+  }
+
   pjx.manifest = pjxManifest;
   pjx.loadedAssets = pjxLoadedAssets;
   pjx.trigger = pjxTrigger;
   pjx.applyHeadAssets = pjxApplyHeadAssets;
   pjx.promoteInlineAssets = pjxPromoteInlineAssets;
+  pjx.injectStyle = pjxInjectStyle;
   window.pjx = pjx;
 
   if (!window.htmx) {
@@ -129,6 +164,7 @@
     );
   }
 
+  pjxInjectStyle();
   pjxPromoteInlineAssets();
   document.body.addEventListener("htmx:configRequest", pjxConfigRequest);
   document.body.addEventListener("htmx:afterRequest", pjxApplyHeadAssetsFromRequest);

--- a/tests/pyjinhx2/client/test_pjx_htmx_guard.py
+++ b/tests/pyjinhx2/client/test_pjx_htmx_guard.py
@@ -36,3 +36,25 @@ def test_no_console_error_when_htmx_is_present(page: Page):
     page.evaluate("window.htmx = {}")
     page.add_script_tag(content=read_pjx_runtime())
     assert errors == []
+
+
+def test_loading_and_toast_apis_exist_without_htmx(pjx_page):
+    page = pjx_page("<div></div>", with_htmx=False)
+    assert page.evaluate("typeof pjx.toast") == "function"
+    assert page.evaluate("typeof pjx.loader.page") == "function"
+    assert page.evaluate("typeof pjx.loader.region") == "function"
+
+
+def test_style_is_injected_even_without_htmx(pjx_page):
+    page = pjx_page("<div></div>", with_htmx=False)
+    assert page.evaluate("document.querySelectorAll('#pjx-style').length") == 1
+
+
+def test_loader_and_toast_do_not_throw_without_htmx(pjx_page):
+    page = pjx_page("<div></div>", with_htmx=False)
+    assert (
+        page.evaluate(
+            "pjx.toast({message: 'x'}), pjx.loader.page(true), pjx.loader.page(false), 'ok'"
+        )
+        == "ok"
+    )

--- a/tests/pyjinhx2/client/test_pjx_loader_api.py
+++ b/tests/pyjinhx2/client/test_pjx_loader_api.py
@@ -23,7 +23,9 @@ def test_loader_page_on_sets_the_documented_css_hook(pjx_page):
 
 def test_loader_page_ref_counts_before_clearing(pjx_page):
     page = pjx_page("<div></div>")
-    page.evaluate("pjx.loader.page(true); pjx.loader.page(true); pjx.loader.page(false)")
+    page.evaluate(
+        "pjx.loader.page(true); pjx.loader.page(true); pjx.loader.page(false)"
+    )
     assert html_classes(page) == "pjx-loading--page"
     page.evaluate("pjx.loader.page(false)")
     assert html_classes(page) == ""

--- a/tests/pyjinhx2/client/test_pjx_loader_api.py
+++ b/tests/pyjinhx2/client/test_pjx_loader_api.py
@@ -1,0 +1,65 @@
+"""pjx.loader: ref-counted show/hide primitives app code and L4 builtins call directly."""
+
+from __future__ import annotations
+
+REGION = (
+    '<div data-pjx-id="t" data-pjx-reacts="count" data-pjx-loading="skeleton"></div>'
+)
+
+
+def html_classes(page):
+    return page.evaluate("document.documentElement.className")
+
+
+def region_classes(page):
+    return page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className")
+
+
+def test_loader_page_on_sets_the_documented_css_hook(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate("pjx.loader.page(true)")
+    assert html_classes(page) == "pjx-loading--page"
+
+
+def test_loader_page_ref_counts_before_clearing(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate("pjx.loader.page(true); pjx.loader.page(true); pjx.loader.page(false)")
+    assert html_classes(page) == "pjx-loading--page"
+    page.evaluate("pjx.loader.page(false)")
+    assert html_classes(page) == ""
+
+
+def test_loader_page_clamps_at_zero(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate("pjx.loader.page(false); pjx.loader.page(false)")
+    page.evaluate("pjx.loader.page(true); pjx.loader.page(false)")
+    assert html_classes(page) == ""
+
+
+def test_loader_region_lights_and_clears_the_regions_targets(pjx_page):
+    page = pjx_page(REGION)
+    page.evaluate("pjx.loader.region('t', true)")
+    assert region_classes(page) == "pjx-loading--skeleton"
+    page.evaluate("pjx.loader.region('t', false)")
+    assert region_classes(page) == ""
+
+
+def test_loader_region_shares_the_ref_count_with_htmx_driven_loading(pjx_page):
+    page = pjx_page(REGION)
+    page.evaluate("pjx.loader.region('t', true); pjx.loader.region('t', true)")
+    assert page.evaluate("pjx.loadingCount('t')") == 2
+    page.evaluate("pjx.loader.region('t', false)")
+    assert region_classes(page) == "pjx-loading--skeleton"
+
+
+def test_loader_region_clamps_at_zero(pjx_page):
+    page = pjx_page(REGION)
+    page.evaluate("pjx.loader.region('t', false)")
+    assert page.evaluate("pjx.loadingCount('t')") == 0
+    assert region_classes(page) == ""
+
+
+def test_loader_region_for_an_unknown_id_is_a_no_op(pjx_page):
+    page = pjx_page(REGION)
+    assert page.evaluate("pjx.loader.region('nope', true), 'ok'") == "ok"
+    assert page.evaluate("pjx.loadingCount('nope')") == 0

--- a/tests/pyjinhx2/client/test_pjx_loading.py
+++ b/tests/pyjinhx2/client/test_pjx_loading.py
@@ -149,3 +149,29 @@ def test_duplicate_completion_events_are_a_no_op(pjx_page):
     end(page, "htmx:afterOnLoad")
     assert classes(page, '[data-pjx-id="t"]') == [""]
     assert page.evaluate("pjx.loadingCount('t')") == 0
+
+
+SWAP = """
+() => {
+  const old = document.querySelector('[data-pjx-id="t"]');
+  const fresh = document.createElement('div');
+  fresh.setAttribute('data-pjx-id', 't');
+  fresh.setAttribute('data-pjx-reacts', 'count');
+  fresh.setAttribute('data-pjx-loading', 'skeleton');
+  old.replaceWith(fresh);
+  document.body.dispatchEvent(new CustomEvent('htmx:afterSettle', { bubbles: true }));
+}
+"""
+
+
+def test_aftersettle_relights_a_region_swapped_while_in_flight(pjx_page):
+    page = pjx_page(BODY)
+    fire(page, "#btn")
+    page.evaluate(SWAP)
+    assert classes(page, '[data-pjx-id="t"]') == ["pjx-loading--skeleton"]
+
+
+def test_aftersettle_leaves_idle_regions_dark(pjx_page):
+    page = pjx_page(BODY)
+    page.evaluate(SWAP)
+    assert classes(page, '[data-pjx-id="t"]') == [""]

--- a/tests/pyjinhx2/client/test_pjx_loading.py
+++ b/tests/pyjinhx2/client/test_pjx_loading.py
@@ -1,0 +1,59 @@
+"""Loading indicators: which regions light on htmx:beforeRequest, and why."""
+
+from __future__ import annotations
+
+# htmx is never loaded in these tests; the runtime only listens for the events,
+# so a hand-dispatched CustomEvent with a fake xhr exercises the real code path.
+FIRE = """
+(arg) => {
+  const elt = document.querySelector(arg.trigger);
+  const xhr = { handlers: [], addEventListener(t, fn) { this.handlers.push([t, fn]); },
+                loadend() { this.handlers.forEach(([t, fn]) => t === 'loadend' && fn()); } };
+  window.__xhrs = window.__xhrs || {};
+  window.__xhrs[arg.name] = xhr;
+  const evt = new CustomEvent('htmx:beforeRequest',
+    { bubbles: true, cancelable: true, detail: { elt: elt, xhr: xhr } });
+  if (arg.cancel) { evt.preventDefault(); }
+  elt.dispatchEvent(evt);
+}
+"""
+
+CLASSES = "(sel) => [...document.querySelectorAll(sel)].map(el => el.className)"
+
+
+def fire(page, trigger, name="a", cancel=False):
+    page.evaluate(FIRE, {"trigger": trigger, "name": name, "cancel": cancel})
+
+
+def classes(page, selector):
+    return page.evaluate(CLASSES, selector)
+
+
+def test_beforerequest_lights_a_region_reacting_to_the_dirtied_keys(pjx_page):
+    page = pjx_page(
+        '<div data-pjx-id="t" data-pjx-reacts="count" data-pjx-loading="skeleton">'
+        '<button id="btn"></button></div>'
+    )
+    fire(page, "#btn")
+    assert classes(page, '[data-pjx-id="t"]') == ["pjx-loading--skeleton"]
+
+
+def test_beforerequest_leaves_regions_reacting_to_other_keys_dark(pjx_page):
+    page = pjx_page(
+        '<div data-pjx-id="t" data-pjx-reacts="count"><button id="btn"></button></div>'
+        '<div data-pjx-id="o" data-pjx-reacts="name" data-pjx-loading="skeleton"></div>'
+    )
+    fire(page, "#btn")
+    assert classes(page, '[data-pjx-id="o"]') == [""]
+
+
+def test_keyed_regions_light_only_the_instance_matching_the_trigger_load(pjx_page):
+    page = pjx_page(
+        '<div data-pjx-id="t" data-pjx-reacts="rows" data-pjx-load="7">'
+        '<button id="btn"></button></div>'
+        '<div data-pjx-id="r7" data-pjx-reacts="rows" data-pjx-load="7" data-pjx-loading="skeleton"></div>'
+        '<div data-pjx-id="r8" data-pjx-reacts="rows" data-pjx-load="8" data-pjx-loading="skeleton"></div>'
+    )
+    fire(page, "#btn")
+    assert classes(page, '[data-pjx-id="r7"]') == ["pjx-loading--skeleton"]
+    assert classes(page, '[data-pjx-id="r8"]') == [""]

--- a/tests/pyjinhx2/client/test_pjx_loading.py
+++ b/tests/pyjinhx2/client/test_pjx_loading.py
@@ -57,3 +57,25 @@ def test_keyed_regions_light_only_the_instance_matching_the_trigger_load(pjx_pag
     fire(page, "#btn")
     assert classes(page, '[data-pjx-id="r7"]') == ["pjx-loading--skeleton"]
     assert classes(page, '[data-pjx-id="r8"]') == [""]
+
+
+def test_nested_reactive_region_targets_are_not_owned_by_the_parent(pjx_page):
+    page = pjx_page(
+        '<div data-pjx-id="p" data-pjx-reacts="count"><button id="btn"></button>'
+        '<span id="own" data-pjx-loading="skeleton"></span>'
+        '<div data-pjx-id="c" data-pjx-reacts="other">'
+        '<span id="inner" data-pjx-loading="skeleton"></span></div></div>'
+    )
+    fire(page, "#btn")
+    assert classes(page, "#own") == ["pjx-loading--skeleton"]
+    assert classes(page, "#inner") == [""]
+
+
+def test_loading_extra_selector_lights_regions_that_do_not_react(pjx_page):
+    page = pjx_page(
+        '<div data-pjx-id="t" data-pjx-reacts="count" data-pjx-loading-extra=".row">'
+        '<button id="btn"></button></div>'
+        '<div class="row" data-pjx-id="r1" data-pjx-reacts="name" data-pjx-loading="spinner"></div>'
+    )
+    fire(page, "#btn")
+    assert classes(page, ".row") == ["row pjx-loading--spinner"]

--- a/tests/pyjinhx2/client/test_pjx_loading.py
+++ b/tests/pyjinhx2/client/test_pjx_loading.py
@@ -79,3 +79,73 @@ def test_loading_extra_selector_lights_regions_that_do_not_react(pjx_page):
     )
     fire(page, "#btn")
     assert classes(page, ".row") == ["row pjx-loading--spinner"]
+
+
+END_EVENTS = [
+    "htmx:afterOnLoad",
+    "htmx:responseError",
+    "htmx:timeout",
+    "htmx:sendError",
+    "htmx:abort",
+]
+
+END = """
+(arg) => {
+  const xhr = window.__xhrs[arg.name];
+  document.body.dispatchEvent(new CustomEvent(arg.event,
+    { bubbles: true, detail: { xhr: xhr } }));
+}
+"""
+
+BODY = (
+    '<div data-pjx-id="t" data-pjx-reacts="count" data-pjx-loading="skeleton">'
+    '<button id="btn"></button></div>'
+)
+
+
+def end(page, event, name="a"):
+    page.evaluate(END, {"event": event, "name": name})
+
+
+import pytest
+
+
+@pytest.mark.parametrize("event", END_EVENTS)
+def test_each_completion_event_strips_the_loading_class(pjx_page, event):
+    page = pjx_page(BODY)
+    fire(page, "#btn")
+    end(page, event)
+    assert classes(page, '[data-pjx-id="t"]') == [""]
+
+
+def test_xhr_loadend_releases_the_region(pjx_page):
+    page = pjx_page(BODY)
+    fire(page, "#btn")
+    page.evaluate("window.__xhrs.a.loadend()")
+    assert classes(page, '[data-pjx-id="t"]') == [""]
+
+
+def test_overlapping_requests_keep_the_region_lit_until_the_last_resolves(pjx_page):
+    page = pjx_page(BODY)
+    fire(page, "#btn", name="a")
+    fire(page, "#btn", name="b")
+    end(page, "htmx:afterOnLoad", name="a")
+    assert classes(page, '[data-pjx-id="t"]') == ["pjx-loading--skeleton"]
+    end(page, "htmx:afterOnLoad", name="b")
+    assert classes(page, '[data-pjx-id="t"]') == [""]
+
+
+def test_cancelled_request_neither_lights_nor_registers_a_loadend_listener(pjx_page):
+    page = pjx_page(BODY)
+    fire(page, "#btn", cancel=True)
+    assert classes(page, '[data-pjx-id="t"]') == [""]
+    assert page.evaluate("window.__xhrs.a.handlers.length") == 0
+
+
+def test_duplicate_completion_events_are_a_no_op(pjx_page):
+    page = pjx_page(BODY)
+    fire(page, "#btn")
+    end(page, "htmx:afterOnLoad")
+    end(page, "htmx:afterOnLoad")
+    assert classes(page, '[data-pjx-id="t"]') == [""]
+    assert page.evaluate("pjx.loadingCount('t')") == 0

--- a/tests/pyjinhx2/client/test_pjx_style.py
+++ b/tests/pyjinhx2/client/test_pjx_style.py
@@ -1,0 +1,28 @@
+"""pjxInjectStyle(): one <style id="pjx-style"> per page, no matter how often it runs."""
+
+from __future__ import annotations
+
+
+def test_style_tag_is_injected_on_load(pjx_page):
+    page = pjx_page("<div></div>")
+    assert page.evaluate("!!document.getElementById('pjx-style')")
+
+
+def test_style_defines_the_skeleton_and_spinner_classes(pjx_page):
+    page = pjx_page("<div></div>")
+    css = page.evaluate("document.getElementById('pjx-style').textContent")
+    assert ".pjx-loading--skeleton" in css
+    assert ".pjx-loading--spinner" in css
+
+
+def test_style_rules_read_overridable_custom_properties(pjx_page):
+    page = pjx_page("<div></div>")
+    css = page.evaluate("document.getElementById('pjx-style').textContent")
+    assert "--pjx-skeleton-color" in css
+    assert "--pjx-spinner-size" in css
+
+
+def test_reinjecting_keeps_a_single_style_tag(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate("pjx.injectStyle(); pjx.injectStyle()")
+    assert page.evaluate("document.querySelectorAll('#pjx-style').length") == 1

--- a/tests/pyjinhx2/client/test_pjx_toast.py
+++ b/tests/pyjinhx2/client/test_pjx_toast.py
@@ -1,0 +1,41 @@
+"""pjx.toast(): the dispatch half of the toast API — an L4 host renders it later."""
+
+from __future__ import annotations
+
+LISTEN = """
+() => {
+  window.__toasts = [];
+  document.addEventListener('pjx:toast', (e) => window.__toasts.push(e.detail));
+}
+"""
+
+
+def test_toast_dispatches_a_pjx_toast_event_carrying_the_payload(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(LISTEN)
+    page.evaluate("pjx.toast({ message: 'saved', variant: 'success', duration: 3000 })")
+    assert page.evaluate("window.__toasts") == [
+        {"message": "saved", "variant": "success", "duration": 3000}
+    ]
+
+
+def test_toast_event_is_dispatched_on_document(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(
+        "window.__target = null;"
+        "document.addEventListener('pjx:toast', (e) => { window.__target = e.target === document; })"
+    )
+    page.evaluate("pjx.toast({ message: 'hi' })")
+    assert page.evaluate("window.__target") is True
+
+
+def test_toast_without_a_listener_does_not_throw(pjx_page):
+    page = pjx_page("<div></div>")
+    assert page.evaluate("pjx.toast({ message: 'hi' }), 'ok'") == "ok"
+
+
+def test_toast_with_no_payload_dispatches_an_empty_detail(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(LISTEN)
+    page.evaluate("pjx.toast()")
+    assert page.evaluate("window.__toasts") == [{}]


### PR DESCRIPTION
## Summary

Implement pjx.js loading indicator and toast dispatch functionality with comprehensive test coverage:

- **Loading CSS**: injectStyle for skeleton/spinner rules driven by --pjx-* custom properties
- **Loading state**: beforeRequest lighting, ref counting (pjx.loadingCount), afterSettle re-application
- **Toast API**: dispatch mechanism for toast notifications  
- **Loader primitives**: ref-counted show/hide for loader.page and loader.region
- **Test coverage**: 2 tests locking behavior (nested-region ownership, loading-extra, inert-but-present)

All 9 commits tested, ruff format verified.

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)