### PR TITLE
feat: inject pjx.js on cold renders (#480)

### DIFF
--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -81,7 +81,8 @@ def emit_assets(
             asset_manifest() takes. Required only when a kind is in LINK mode.
 
     Returns:
-        Concatenated CSS tags then JS tags, newline-joined. Empty string when
+        Concatenated CSS tags then JS tags, newline-joined, with the session's
+        inline runtime script (if any) leading the JS tags. Empty string when
         both kinds are NONE or nothing was accumulated.
 
     Raises:
@@ -98,6 +99,10 @@ def emit_assets(
             '<link rel="stylesheet" href="{url}">',
         )
     if session.js_mode is AssetMode.INLINE:
+        # Runtime first: component scripts may call into pjx/htmx as soon as
+        # they execute, so the tag that defines them has to precede them.
+        if session.runtime_script is not None:
+            tags.append(session.runtime_script)
         tags += _inline_tags(session.js_assets, "<script>", "</script>")
     elif session.js_mode is AssetMode.LINK:
         tags += _url_tags(

--- a/pyjinhx2/client/inject.py
+++ b/pyjinhx2/client/inject.py
@@ -1,0 +1,65 @@
+"""Cold-render injection of the pjx.js runtime into a session's output."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pyjinhx2.assets import AssetMode
+from pyjinhx2.client import read_pjx_runtime, read_vendored_htmx
+from pyjinhx2.session import RenderSession
+
+PJX_MOUNTED_HEADER = "X-PJX-Mounted"
+
+
+def _is_mounted_request(request: Any) -> bool:
+    """Whether the request says the browser already has the runtime loaded.
+
+    Presence only — the header's payload is parsed elsewhere. Accepts the
+    header value directly, anything with a ``.headers`` mapping, or None, and
+    anything else counts as not mounted: falling open means a page that would
+    otherwise ship no runtime at all, which is the recoverable direction.
+    """
+    if request is None:
+        return False
+    if isinstance(request, str):
+        return bool(request)
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return False
+    try:
+        value = headers.get(PJX_MOUNTED_HEADER)
+        if value is None:
+            # A real ASGI request's headers are case-insensitive; a plain dict
+            # in a test or a hand-rolled client is not.
+            value = headers.get(PJX_MOUNTED_HEADER.lower())
+    except AttributeError:
+        return False
+    return value is not None
+
+
+def inject_runtime(session: RenderSession, request: Any = None) -> None:
+    """Record the inline pjx.js runtime on ``session`` for a cold render.
+
+    No-ops when the request already carries the mounted header, when this
+    session was injected once already, or when JS is not delivered inline.
+
+    Args:
+        session: The RenderSession this render writes into.
+        request: The incoming request, its ``X-PJX-Mounted`` header value, or
+            None outside a request.
+
+    Raises:
+        OSError: If pjx.js or the vendored htmx source cannot be read.
+    """
+    if _is_mounted_request(request):
+        return
+    if session.runtime_injected:
+        return
+    if session.js_mode is not AssetMode.INLINE:
+        return
+    # htmx first, so window.htmx exists by the time pjx.js registers its
+    # listeners; its own guard makes re-defining a page's htmx a no-op.
+    session.runtime_script = (
+        f"<script>{read_vendored_htmx()}{read_pjx_runtime()}</script>"
+    )
+    session.runtime_injected = True

--- a/pyjinhx2/session.py
+++ b/pyjinhx2/session.py
@@ -69,6 +69,13 @@ class RenderSession:
         # assets some other way (a build step, a CDN) suppresses emission.
         self.css_mode: AssetMode = AssetMode.INLINE
         self.js_mode: AssetMode = AssetMode.INLINE
+        # The pjx.js + htmx payload for this render, set by client/inject.py and
+        # read by emit_assets. Kept off css_assets/js_assets because those hold
+        # file paths from component descriptors, while this is source text with
+        # no path of its own. The flag is what makes a nested render — or a
+        # second inject_runtime call on the same session — a no-op.
+        self.runtime_script: str | None = None
+        self.runtime_injected: bool = False
         # A plain list, not an event bus: render fires it once per component and
         # subscribers (asset accumulation, the reactive instance registry) just
         # append. Per-session so subscriptions die with the request. Callbacks

--- a/tests/pyjinhx2/client/conftest.py
+++ b/tests/pyjinhx2/client/conftest.py
@@ -1,31 +1,39 @@
 """Browser harness for the pjx.js runtime.
 
 Every function in pjx.js is DOM-bound, so the tests run the real file in real
-chromium rather than asserting on source strings. Skips the whole module when
-playwright or chromium is unavailable so `pytest tests/` stays green.
+chromium rather than asserting on source strings. Skips the browser fixtures
+when playwright or chromium is unavailable so `pytest tests/` stays green —
+the guard lives in the fixtures, not at module scope, because a module-scope
+importorskip would also skip the plain-Python tests in this package.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from pyjinhx2.client import read_pjx_runtime
 
-pytest.importorskip("playwright")
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
 
-from playwright.sync_api import Page
 
-
-@pytest.fixture(scope="session", autouse=True)
-def _require_chromium(browser_type) -> None:
-    # Check via pytest-playwright's own `browser_type` fixture rather than
-    # opening a second `sync_playwright()` context here: two independent
-    # sync_playwright instances in one process race and break every
-    # subsequent browser test in the suite ("using Playwright Sync API
-    # inside the asyncio event loop").
+@pytest.fixture(autouse=True)
+def _require_chromium(request: pytest.FixtureRequest) -> None:
+    # Function-scoped, not session-scoped: a session-scoped autouse fixture
+    # only runs its body once for the whole run, against whichever test
+    # triggers it first — if that first test doesn't need pjx_page, the
+    # chromium check would never fire again and a later browser test would
+    # hit a raw Playwright launch failure instead of a clean skip. Only the
+    # browser tests need chromium, so still avoid resolving `browser_type`
+    # (or importing playwright) for a test that never asked for a page.
+    if "pjx_page" not in request.fixturenames:
+        return
+    pytest.importorskip("playwright")
+    browser_type: Any = request.getfixturevalue("browser_type")
     executable = Path(browser_type.executable_path)
     if not executable.exists():
         pytest.skip(
@@ -34,14 +42,14 @@ def _require_chromium(browser_type) -> None:
 
 
 @pytest.fixture
-def pjx_page(page: Page) -> Iterator[Callable[..., Page]]:
+def pjx_page(page: "Page") -> Iterator[Callable[..., "Page"]]:
     """Load `body` into the page, then run pjx.js against it.
 
     `head` seeds pre-existing <head> assets; `with_htmx` stubs window.htmx so the
     runtime takes its normal path (the missing-htmx case opts out).
     """
 
-    def load(body: str, head: str = "", with_htmx: bool = True) -> Page:
+    def load(body: str, head: str = "", with_htmx: bool = True) -> "Page":
         page.set_content(f"<head>{head}</head><body>{body}</body>")
         if with_htmx:
             page.evaluate("window.htmx = {}")

--- a/tests/pyjinhx2/client/conftest.py
+++ b/tests/pyjinhx2/client/conftest.py
@@ -42,14 +42,14 @@ def _require_chromium(request: pytest.FixtureRequest) -> None:
 
 
 @pytest.fixture
-def pjx_page(page: "Page") -> Iterator[Callable[..., "Page"]]:
+def pjx_page(page: Page) -> Iterator[Callable[..., Page]]:
     """Load `body` into the page, then run pjx.js against it.
 
     `head` seeds pre-existing <head> assets; `with_htmx` stubs window.htmx so the
     runtime takes its normal path (the missing-htmx case opts out).
     """
 
-    def load(body: str, head: str = "", with_htmx: bool = True) -> "Page":
+    def load(body: str, head: str = "", with_htmx: bool = True) -> Page:
         page.set_content(f"<head>{head}</head><body>{body}</body>")
         if with_htmx:
             page.evaluate("window.htmx = {}")

--- a/tests/pyjinhx2/client/test_inject.py
+++ b/tests/pyjinhx2/client/test_inject.py
@@ -1,0 +1,107 @@
+"""Cold-render gating for the pjx.js runtime injection."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyjinhx2.assets import AssetMode
+from pyjinhx2.client import read_pjx_runtime, read_vendored_htmx
+from pyjinhx2.client.inject import PJX_MOUNTED_HEADER, inject_runtime
+from pyjinhx2.session import RenderSession
+
+
+class FakeRequest:
+    def __init__(self, headers: dict[str, str]):
+        self.headers = headers
+
+
+def test_cold_render_injects_htmx_then_pjx():
+    session = RenderSession()
+
+    inject_runtime(session)
+
+    script = session.runtime_script
+    assert script is not None
+    assert script.startswith("<script>") and script.endswith("</script>")
+    assert script.index("if (!window.htmx)") < script.index(read_pjx_runtime())
+    assert read_vendored_htmx() in script
+    assert session.runtime_injected is True
+
+
+def test_request_none_is_treated_as_cold():
+    session = RenderSession()
+
+    inject_runtime(session, None)
+
+    assert session.runtime_script is not None
+
+
+def test_mounted_header_as_string_skips_injection():
+    session = RenderSession()
+
+    inject_runtime(session, '["btn-1"]')
+
+    assert session.runtime_script is None
+    assert session.runtime_injected is False
+
+
+def test_mounted_header_on_request_object_skips_injection():
+    session = RenderSession()
+
+    inject_runtime(session, FakeRequest({PJX_MOUNTED_HEADER: '["btn-1"]'}))
+
+    assert session.runtime_script is None
+    assert session.runtime_injected is False
+
+
+def test_request_object_without_the_header_still_injects():
+    session = RenderSession()
+
+    inject_runtime(session, FakeRequest({"Accept": "text/html"}))
+
+    assert session.runtime_script is not None
+
+
+@pytest.mark.parametrize("mode", [AssetMode.NONE, AssetMode.LINK])
+def test_non_inline_js_mode_never_injects(mode: AssetMode):
+    session = RenderSession()
+    session.js_mode = mode
+
+    inject_runtime(session)
+
+    assert session.runtime_script is None
+    assert session.runtime_injected is False
+
+
+def test_second_call_on_the_same_session_is_a_no_op():
+    session = RenderSession()
+    inject_runtime(session)
+    first = session.runtime_script
+
+    inject_runtime(session)
+
+    assert session.runtime_script == first
+    assert session.runtime_script is not None
+    # Idempotency check: a re-injection would double the payload length, not
+    # just leave it unchanged, so this catches concatenation-on-top-of-itself
+    # bugs that `== first` alone would still pass if both calls produced
+    # identical (but doubled) output by coincidence.
+    assert len(session.runtime_script) == len(first)
+    assert session.runtime_injected is True
+
+
+def test_malformed_request_falls_open_to_cold_render():
+    session = RenderSession()
+
+    inject_runtime(session, object())
+
+    assert session.runtime_script is not None
+    assert session.runtime_injected is True
+
+
+def test_lowercase_header_key_also_skips_injection():
+    session = RenderSession()
+
+    inject_runtime(session, FakeRequest({PJX_MOUNTED_HEADER.lower(): '["btn-1"]'}))
+
+    assert session.runtime_script is None

--- a/tests/pyjinhx2/client/test_inject.py
+++ b/tests/pyjinhx2/client/test_inject.py
@@ -86,6 +86,7 @@ def test_second_call_on_the_same_session_is_a_no_op():
     # just leave it unchanged, so this catches concatenation-on-top-of-itself
     # bugs that `== first` alone would still pass if both calls produced
     # identical (but doubled) output by coincidence.
+    assert first is not None
     assert len(session.runtime_script) == len(first)
     assert session.runtime_injected is True
 

--- a/tests/pyjinhx2/test_asset_emission.py
+++ b/tests/pyjinhx2/test_asset_emission.py
@@ -406,3 +406,23 @@ def test_link_mode_repeated_calls_are_byte_identical(tmp_path):
     assert first.index("/static/a.css") < first.index("/static/m.css")
     assert first.index("/static/m.css") < first.index("/static/z.css")
     assert first.index("/static/q.css") < first.index("/static/a.js")
+
+
+def test_emit_assets_puts_runtime_script_before_component_scripts(tmp_path):
+    script = tmp_path / "widget.js"
+    script.write_text("widget();")
+    session = _session(tmp_path)
+    session.js_assets = {script}
+    session.runtime_script = "<script>RUNTIME</script>"
+
+    html = emit_assets(session)
+
+    assert html.index("RUNTIME") < html.index("widget();")
+
+
+def test_emit_assets_skips_runtime_script_when_js_mode_is_not_inline(tmp_path):
+    session = _session(tmp_path)
+    session.js_mode = AssetMode.NONE
+    session.runtime_script = "<script>RUNTIME</script>"
+
+    assert emit_assets(session) == ""

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -44,6 +44,13 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # off disk. Nothing in pyjinhx2 may be imported from here, or the browser
     # runtime's delivery would depend on the server tier that serves it.
     "client.__init__": frozenset(),
+    # The one sanctioned edge out of the client tier: inject.py writes the
+    # runtime payload onto RenderSession and gates on js_mode, mirroring the
+    # "dotted edge" architecture-overview.md calls out between L2's
+    # RenderSession and L3 (cold render's assets flow through the session).
+    "client.inject": frozenset(
+        {"pyjinhx2.assets", "pyjinhx2.client", "pyjinhx2.session"}
+    ),
     "component": frozenset(
         {"pyjinhx2.descriptor", "pyjinhx2.props_header"}
     ),  # the stale-header probe needs template_has_props_header

--- a/tests/pyjinhx2/test_session.py
+++ b/tests/pyjinhx2/test_session.py
@@ -317,3 +317,9 @@ def test_add_dirtied_updates_the_active_scopes_set():
 def test_add_dirtied_outside_a_scope_is_a_no_op():
     session_module.add_dirtied({"todos"})
     assert session_module.get_dirtied() == set()
+
+
+def test_session_starts_with_no_runtime_injected():
+    session = session_module.RenderSession()
+    assert session.runtime_injected is False
+    assert session.runtime_script is None


### PR DESCRIPTION
## Summary

Inject the pjx.js runtime on cold renders by adding `inject_runtime(session, request)`, called before `emit_assets`. The injection:
- Writes the htmx-then-pjx.js inline runtime onto RenderSession
- No-ops when X-PJX-Mounted header is present, session already injected, or js_mode isn't INLINE
- Checks header case-insensitively, fails open to cold-render on malformed requests
- Registers the client.inject edge in the import-graph allowlist

**Tests**: 9 new tests covering injection behavior and edge cases

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)