### PR TITLE
test: cover the tag filter and src branch in applyHeadAssets

### DIFF
--- a/tests/pyjinhx2/client/test_pjx_head_assets.py
+++ b/tests/pyjinhx2/client/test_pjx_head_assets.py
@@ -72,3 +72,29 @@ def test_after_request_without_an_xhr_is_a_no_op(pjx_page):
            )"""
     )
     assert page.evaluate(HEAD_TOKENS) == []
+
+
+def test_asset_tagged_link_is_not_applied(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(
+        APPLY,
+        '<link data-pjx-asset="card.css" rel="stylesheet" href="/card.css"'
+        ' hx-swap-oob="beforeend:head">',
+    )
+    assert page.evaluate(HEAD_TOKENS) == []
+
+
+def test_external_script_keeps_its_src(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(
+        APPLY,
+        '<script data-pjx-asset="card.js" src="/card.js"'
+        ' hx-swap-oob="beforeend:head"></script>',
+    )
+    assert (
+        page.evaluate(
+            "() => document.head.querySelector('script[data-pjx-asset]')"
+            ".getAttribute('src')"
+        )
+        == "/card.js"
+    )


### PR DESCRIPTION
## Summary

Adds two characterization tests for `pjxApplyHeadAssets`:
- Asset-tagged `<link>` must be ignored (only style/script are applied)
- External `<script src>` asset must keep its src when re-appended

Both tests are load-bearing — verified by temporarily reverting the corresponding branches in pjx.js locally and confirming failure.

**Test count:** 2 new tests

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)