### PR TITLE
feat: add the request-scoped LoadCache memoization store

### DIFF
--- a/pyjinhx2/reactive/cache.py
+++ b/pyjinhx2/reactive/cache.py
@@ -1,0 +1,81 @@
+"""The request-scoped load cache: ``(class, key) -> load() result``.
+
+Keys are plain ``(cls, key)`` tuples - both halves are already hashable, so
+there is no string composite to build or parse back. Entries live in the dict
+``session.get_cache_store()`` hands out, which ``request_scope()`` replaces per
+request; this module owns no state of its own.
+
+``cache_get()`` answers ``None`` for a miss, which a legitimately cached ``None``
+would be indistinguishable from - ``cache_has()`` is the way to tell the two
+apart, and the reason a private sentinel does the lookup internally rather than
+a plain ``.get()``.
+
+``cache_put()`` is the only mutator. Outside a request scope every function is a
+no-op: ``get_cache_store()`` answers a throwaway ``{}``, so writes vanish and
+reads miss. A cache that does nothing is a correct cache, so nothing raises.
+"""
+
+from pyjinhx2.session import get_cache_store
+
+# Distinguishes "no entry" from an entry whose value happens to be None.
+_MISS = object()
+
+
+def make_key(cls: type, key: object) -> tuple[type, object]:
+    """Build the composite cache key for a component class and a load key.
+
+    Args:
+        cls: The component class the cached value was loaded for.
+        key: That instance's load key; any hashable value.
+
+    Returns:
+        The ``(cls, key)`` pair used as the cache store's dict key.
+    """
+    return (cls, key)
+
+
+def cache_get(cls: type, key: object) -> object | None:
+    """Return the value cached for this class and key, or None.
+
+    A miss is ordinary, not exceptional, so this returns None rather than
+    raising. Use ``cache_has()`` when None could also be a cached value.
+
+    Args:
+        cls: The component class.
+        key: That instance's load key.
+
+    Returns:
+        The cached value, or None when nothing is cached - including every
+        lookup made outside an active request scope.
+    """
+    value = get_cache_store().get(make_key(cls, key), _MISS)
+    if value is _MISS:
+        return None
+    return value
+
+
+def cache_has(cls: type, key: object) -> bool:
+    """Report whether this class and key have a cached entry.
+
+    Args:
+        cls: The component class.
+        key: That instance's load key.
+
+    Returns:
+        True when an entry exists, whatever its value. Always False outside an
+        active request scope.
+    """
+    return make_key(cls, key) in get_cache_store()
+
+
+def cache_put(cls: type, key: object, value: object) -> None:
+    """Cache a load result for this class and key, replacing any existing entry.
+
+    The only function that mutates the cache store.
+
+    Args:
+        cls: The component class the value was loaded for.
+        key: That instance's load key; any hashable value.
+        value: The load result to store, kept as-is.
+    """
+    get_cache_store()[make_key(cls, key)] = value

--- a/tests/pyjinhx2/reactive/test_reactive_cache.py
+++ b/tests/pyjinhx2/reactive/test_reactive_cache.py
@@ -1,0 +1,90 @@
+from pyjinhx2.reactive.cache import cache_get, cache_has, cache_put, make_key
+from pyjinhx2.session import get_cache_store, request_scope
+
+
+class Widget:
+    pass
+
+
+class OtherWidget:
+    pass
+
+
+def test_make_key_pairs_the_class_with_the_key():
+    assert make_key(Widget, "todos") == (Widget, "todos")
+
+
+def test_make_key_separates_the_same_key_under_different_classes():
+    assert make_key(Widget, "todos") != make_key(OtherWidget, "todos")
+
+
+def test_put_then_get_round_trips_the_value():
+    with request_scope():
+        cache_put(Widget, "todos", [1, 2, 3])
+        assert cache_get(Widget, "todos") == [1, 2, 3]
+
+
+def test_get_returns_none_on_a_miss():
+    with request_scope():
+        assert cache_get(Widget, "todos") is None
+
+
+def test_has_is_false_on_a_miss_and_true_after_a_put():
+    with request_scope():
+        assert cache_has(Widget, "todos") is False
+        cache_put(Widget, "todos", "loaded")
+        assert cache_has(Widget, "todos") is True
+
+
+def test_a_cached_falsy_value_is_distinguishable_from_a_miss():
+    with request_scope():
+        cache_put(Widget, "empty", None)
+        cache_put(Widget, "zero", 0)
+        assert cache_get(Widget, "empty") is None
+        assert cache_has(Widget, "empty") is True
+        assert cache_get(Widget, "zero") == 0
+        assert cache_has(Widget, "zero") is True
+        assert cache_has(Widget, "never-stored") is False
+
+
+def test_put_overwrites_an_existing_entry():
+    with request_scope():
+        cache_put(Widget, "todos", "first")
+        cache_put(Widget, "todos", "second")
+        assert cache_get(Widget, "todos") == "second"
+
+
+def test_entries_do_not_leak_across_requests():
+    with request_scope():
+        cache_put(Widget, "todos", "first request")
+    with request_scope():
+        assert cache_has(Widget, "todos") is False
+        assert cache_get(Widget, "todos") is None
+
+
+def test_the_same_key_under_two_classes_stays_separate():
+    with request_scope():
+        cache_put(Widget, "todos", "widget value")
+        cache_put(OtherWidget, "todos", "other value")
+        assert cache_get(Widget, "todos") == "widget value"
+        assert cache_get(OtherWidget, "todos") == "other value"
+
+
+def test_it_stores_into_the_session_cache_store():
+    with request_scope():
+        cache_put(Widget, "todos", "value")
+        assert get_cache_store()[(Widget, "todos")] == "value"
+
+
+def test_outside_a_request_scope_it_is_a_silent_no_op():
+    cache_put(Widget, "todos", "dropped")
+    assert cache_get(Widget, "todos") is None
+    assert cache_has(Widget, "todos") is False
+
+
+def test_any_hashable_key_is_accepted():
+    with request_scope():
+        cache_put(Widget, 42, "int key")
+        cache_put(Widget, ("todo", 7), "tuple key")
+        assert cache_get(Widget, 42) == "int key"
+        assert cache_get(Widget, ("todo", 7)) == "tuple key"

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -80,6 +80,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "render_context": frozenset({"pyjinhx2.markers", "pyjinhx2.component"}),
     "reactive.__init__": frozenset(),
     "reactive.keys": frozenset(),
+    # cache.py is a store over session's cache ContextVar and nothing else: it
+    # owns no state, and it must not reach sideways into keys.py or up into the
+    # render spine to key or evict anything.
+    "reactive.cache": frozenset({"pyjinhx2.session"}),
     # mutations.py records dirtied keys through session's public writer; it owns
     # no ContextVar of its own and never reaches sideways into cache.py.
     "reactive.mutations": frozenset({"pyjinhx2.session", "pyjinhx2.reactive.keys"}),


### PR DESCRIPTION
## Summary
Implements a request-scoped LoadCache memoization store that provides efficient caching of load operations within a single request context. This enables performance optimizations for rendering operations that need to avoid redundant load calls.

## Changes
- Adds LoadCache memoization store with request-scoped lifecycle
- Integrates cache with render session context
- 1 test added validating cache behavior

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)