### PR TITLE
feat: index cached loads by reactive key and evict on dirty

### DIFF
--- a/docs/superpowers/rebuild/architecture-overview.md
+++ b/docs/superpowers/rebuild/architecture-overview.md
@@ -165,7 +165,7 @@ All 60+ components. Pure consumers of everything above — no engine edges of th
 
 **Assets flow through two doors.** Cold render: RenderSession → inline tags at serialize. Reactive swap: fan-out compares session accumulation against `X-PJX-Assets` and ships only the delta as OOB fragments. Same accumulator, two emission paths — which is why RenderSession lives in L2 but has a dotted edge into L3.
 
-**Discovery and `{#def#}` are the only writers at import time; everything per-request is ContextVar.** The full mutable-state census (invariant 4): class registry + descriptors (built-then-swap, import/registration time), instance registry + RenderSession + dirtied keys + LoadCache request store (ContextVar, reset by `request_scope`). Nothing else. A mechanism needing mutable state not in this census amends this census first.
+**Discovery and `{#def#}` are the only writers at import time; everything per-request is ContextVar.** The full mutable-state census (invariant 4): class registry + descriptors (built-then-swap, import/registration time), instance registry + RenderSession + dirtied keys + LoadCache request store + LoadCache reverse index (ContextVar, reset by `request_scope`). Nothing else. A mechanism needing mutable state not in this census amends this census first.
 
 **Unknown PascalCase passes through.** `Expand`'s dotted edge to the class registry: a miss is not an error — the tag is emitted verbatim (it may be a web component or intentional markup). Only registered names become renders. This is unchanged from v0.x and load-bearing for the builtins' composed families.
 

--- a/pyjinhx2/reactive/cache.py
+++ b/pyjinhx2/reactive/cache.py
@@ -10,12 +10,17 @@ would be indistinguishable from - ``cache_has()`` is the way to tell the two
 apart, and the reason a private sentinel does the lookup internally rather than
 a plain ``.get()``.
 
-``cache_put()`` is the only mutator. Outside a request scope every function is a
-no-op: ``get_cache_store()`` answers a throwaway ``{}``, so writes vanish and
+``cache_put()`` is the only mutator, and the only writer of the reverse index -
+the ``reactive key -> {(cls, key)}`` map ``session.get_cache_reverse()`` hands
+out, which ``invalidate()`` reads to evict exactly the entries a dirtied key
+touched. Outside a request scope every function is a no-op: ``get_cache_store()``
+and ``get_cache_reverse()`` answer throwaway containers, so writes vanish and
 reads miss. A cache that does nothing is a correct cache, so nothing raises.
 """
 
-from pyjinhx2.session import get_cache_store
+from collections.abc import Iterable
+
+from pyjinhx2.session import get_cache_reverse, get_cache_store
 
 # Distinguishes "no entry" from an entry whose value happens to be None.
 _MISS = object()
@@ -68,7 +73,9 @@ def cache_has(cls: type, key: object) -> bool:
     return make_key(cls, key) in get_cache_store()
 
 
-def cache_put(cls: type, key: object, value: object) -> None:
+def cache_put(
+    cls: type, key: object, value: object, react_keys: Iterable[str] = ()
+) -> None:
     """Cache a load result for this class and key, replacing any existing entry.
 
     The only function that mutates the cache store.
@@ -77,5 +84,48 @@ def cache_put(cls: type, key: object, value: object) -> None:
         cls: The component class the value was loaded for.
         key: That instance's load key; any hashable value.
         value: The load result to store, kept as-is.
+        react_keys: Normalized reactive keys this result depends on. Dirtying
+            any of them evicts this entry. Defaults to none, which makes the
+            entry plain memoization that only a fresh request clears.
     """
-    get_cache_store()[make_key(cls, key)] = value
+    cache_key = make_key(cls, key)
+    reverse = get_cache_reverse()
+    # A re-put may depend on a different set of keys than the entry it replaces,
+    # so drop every old membership before re-indexing rather than adding to it.
+    _unindex(reverse, cache_key)
+    for react_key in react_keys:
+        reverse.setdefault(react_key, set()).add(cache_key)
+    get_cache_store()[cache_key] = value
+
+
+def invalidate(dirtied_keys: Iterable[str]) -> None:
+    """Evict every cache entry that depends on any of these reactive keys.
+
+    Outside a request scope there is nothing indexed and nothing to drop, so
+    this is a silent no-op like the rest of the module.
+
+    Args:
+        dirtied_keys: Normalized string keys, as produced by
+            coerce_reactive_keys() and collected by session.add_dirtied().
+    """
+    reverse = get_cache_reverse()
+    store = get_cache_store()
+    evicted: set[tuple[type, object]] = set()
+    for react_key in dirtied_keys:
+        evicted |= reverse.get(react_key, set())
+    for cache_key in evicted:
+        # An entry reachable from two dirtied keys is popped once; the second
+        # pop is an ordinary miss, not an error.
+        store.pop(cache_key, None)
+        # Clean every key the entry was registered under, not just the dirtied
+        # ones that matched: the entry is gone from the store, so any surviving
+        # membership would name a cache_key nothing can look up.
+        _unindex(reverse, cache_key)
+
+
+def _unindex(
+    reverse: dict[str, set[tuple[type, object]]], cache_key: tuple[type, object]
+) -> None:
+    """Remove a cache key from every reverse-index set that holds it."""
+    for entries in reverse.values():
+        entries.discard(cache_key)

--- a/pyjinhx2/session.py
+++ b/pyjinhx2/session.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from pyjinhx2.component import BaseComponent
     from pyjinhx2.segments import RenderedLevel
 
-# The four pieces of per-request mutable state. They live here rather than beside
+# The five pieces of per-request mutable state. They live here rather than beside
 # their eventual consumers because the import rule runs one way only: reactive/
 # imports session, never the reverse. Each defaults to None so that reading one
 # outside a request is a miss, not a LookupError.
@@ -30,6 +30,9 @@ _instances: ContextVar[dict[str, object] | None] = ContextVar(
 _dirtied: ContextVar[set[str] | None] = ContextVar("pjx_dirtied", default=None)
 _cache_store: ContextVar[dict[object, object] | None] = ContextVar(
     "pjx_cache_store", default=None
+)
+_cache_reverse: ContextVar[dict[str, set[tuple[type, object]]] | None] = ContextVar(
+    "pjx_cache_reverse", default=None
 )
 
 
@@ -172,6 +175,18 @@ def get_cache_store() -> dict[object, object]:
     return store
 
 
+def get_cache_reverse() -> dict[str, set[tuple[type, object]]]:
+    """Return this request's reactive-key -> cache-entry index, empty outside a scope.
+
+    Maps a normalized reactive key to the set of ``(cls, key)`` cache entries
+    whose load depended on it, so dirtying a key can find exactly what to evict.
+    """
+    reverse = _cache_reverse.get()
+    if reverse is None:
+        return {}
+    return reverse
+
+
 @contextmanager
 def request_scope(
     template_dir: str = "templates", session: "RenderSession | None" = None
@@ -195,11 +210,13 @@ def request_scope(
     instances_token = _instances.set({})
     dirtied_token = _dirtied.set(set())
     cache_token = _cache_store.set({})
+    cache_reverse_token = _cache_reverse.set({})
     try:
         yield session
     finally:
         # Reset by token rather than assigning None: a nested scope must hand the
         # outer scope its own state back, not clear the variable outright.
+        _cache_reverse.reset(cache_reverse_token)
         _cache_store.reset(cache_token)
         _dirtied.reset(dirtied_token)
         _instances.reset(instances_token)

--- a/tests/pyjinhx2/reactive/test_reactive_cache.py
+++ b/tests/pyjinhx2/reactive/test_reactive_cache.py
@@ -1,4 +1,10 @@
-from pyjinhx2.reactive.cache import cache_get, cache_has, cache_put, make_key
+from pyjinhx2.reactive.cache import (
+    cache_get,
+    cache_has,
+    cache_put,
+    invalidate,
+    make_key,
+)
 from pyjinhx2.session import get_cache_store, request_scope
 
 
@@ -88,3 +94,28 @@ def test_any_hashable_key_is_accepted():
         cache_put(Widget, ("todo", 7), "tuple key")
         assert cache_get(Widget, 42) == "int key"
         assert cache_get(Widget, ("todo", 7)) == "tuple key"
+
+
+def test_invalidate_evicts_an_entry_registered_under_the_dirtied_key():
+    with request_scope():
+        cache_put(Widget, "todos", "loaded", react_keys=["todos"])
+        assert cache_has(Widget, "todos") is True
+        invalidate(["todos"])
+        assert cache_has(Widget, "todos") is False
+        assert cache_get(Widget, "todos") is None
+
+
+def test_invalidate_leaves_entries_registered_under_other_keys_alone():
+    with request_scope():
+        cache_put(Widget, "todos", "todo value", react_keys=["todos"])
+        cache_put(OtherWidget, "users", "user value", react_keys=["users"])
+        invalidate(["todos"])
+        assert cache_has(Widget, "todos") is False
+        assert cache_get(OtherWidget, "users") == "user value"
+
+
+def test_invalidate_on_a_key_with_no_entries_is_a_no_op():
+    with request_scope():
+        cache_put(Widget, "todos", "loaded", react_keys=["todos"])
+        invalidate(["nothing-depends-on-this"])
+        assert cache_get(Widget, "todos") == "loaded"

--- a/tests/pyjinhx2/test_session.py
+++ b/tests/pyjinhx2/test_session.py
@@ -1,10 +1,10 @@
-"""request_scope's four ContextVars: fresh in, prior state out.
+"""request_scope's five ContextVars: fresh in, prior state out.
 
-The four pieces of per-request mutable state (RenderSession asset slot, instance
-registry, dirtied keys, cache store) are the entire ContextVar half of the
-mutable-state census. These tests pin the container lifecycle - creation,
-nesting, exception cleanup, thread isolation - not any read/write semantics,
-which land with the modules that consume them.
+The five pieces of per-request mutable state (RenderSession asset slot, instance
+registry, dirtied keys, cache store, cache reverse index) are the entire
+ContextVar half of the mutable-state census. These tests pin the container
+lifecycle - creation, nesting, exception cleanup, thread isolation - not any
+read/write semantics, which land with the modules that consume them.
 """
 
 import threading
@@ -323,3 +323,19 @@ def test_session_starts_with_no_runtime_injected():
     session = session_module.RenderSession()
     assert session.runtime_injected is False
     assert session.runtime_script is None
+
+
+def test_cache_reverse_is_empty_outside_a_request_scope():
+    from pyjinhx2.session import get_cache_reverse
+
+    assert get_cache_reverse() == {}
+
+
+def test_cache_reverse_is_fresh_per_request_scope():
+    from pyjinhx2.session import get_cache_reverse, request_scope
+
+    with request_scope():
+        get_cache_reverse()["todos"] = {(int, 1)}
+        assert get_cache_reverse() == {"todos": {(int, 1)}}
+    with request_scope():
+        assert get_cache_reverse() == {}


### PR DESCRIPTION
## Summary
- Adds reverse index (_cache_reverse) mapping reactive keys to cache entries
- Implements targeted cache eviction on mutation via invalidate(dirtied_keys)
- Prepares mechanism for L3.3 (#444) and L3.5 (#446) component mutation wiring

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)