### PR TITLE
test: assert the reverse index directly and confirm plain memoization survives invalidation (#457)

### DIFF
--- a/tests/pyjinhx2/reactive/test_reactive_cache.py
+++ b/tests/pyjinhx2/reactive/test_reactive_cache.py
@@ -119,3 +119,10 @@ def test_invalidate_on_a_key_with_no_entries_is_a_no_op():
         cache_put(Widget, "todos", "loaded", react_keys=["todos"])
         invalidate(["nothing-depends-on-this"])
         assert cache_get(Widget, "todos") == "loaded"
+
+
+def test_an_entry_registered_under_two_keys_is_evicted_by_either_one():
+    with request_scope():
+        cache_put(Widget, "todos", "loaded", react_keys={"todos", "users"})
+        invalidate(["users"])
+        assert cache_has(Widget, "todos") is False

--- a/tests/pyjinhx2/reactive/test_reactive_cache.py
+++ b/tests/pyjinhx2/reactive/test_reactive_cache.py
@@ -144,3 +144,13 @@ def test_one_dirtied_key_evicts_every_entry_registered_under_it():
         assert cache_has(Widget, "todos") is False
         assert cache_has(OtherWidget, "todos") is False
         assert cache_get(Widget, "users") == "user value"
+
+
+def test_re_putting_an_entry_drops_its_previous_reactive_keys():
+    with request_scope():
+        cache_put(Widget, "todos", "first", react_keys=["todos"])
+        cache_put(Widget, "todos", "second", react_keys=["users"])
+        invalidate(["todos"])
+        assert cache_get(Widget, "todos") == "second"
+        invalidate(["users"])
+        assert cache_has(Widget, "todos") is False

--- a/tests/pyjinhx2/reactive/test_reactive_cache.py
+++ b/tests/pyjinhx2/reactive/test_reactive_cache.py
@@ -126,3 +126,10 @@ def test_an_entry_registered_under_two_keys_is_evicted_by_either_one():
         cache_put(Widget, "todos", "loaded", react_keys={"todos", "users"})
         invalidate(["users"])
         assert cache_has(Widget, "todos") is False
+
+
+def test_eviction_clears_the_entry_from_every_key_it_was_registered_under():
+    with request_scope():
+        cache_put(Widget, "todos", "loaded", react_keys={"todos", "users"})
+        invalidate(["users"])
+        assert get_cache_reverse() == {"todos": set(), "users": set()}

--- a/tests/pyjinhx2/reactive/test_reactive_cache.py
+++ b/tests/pyjinhx2/reactive/test_reactive_cache.py
@@ -133,3 +133,14 @@ def test_eviction_clears_the_entry_from_every_key_it_was_registered_under():
         cache_put(Widget, "todos", "loaded", react_keys={"todos", "users"})
         invalidate(["users"])
         assert get_cache_reverse() == {"todos": set(), "users": set()}
+
+
+def test_one_dirtied_key_evicts_every_entry_registered_under_it():
+    with request_scope():
+        cache_put(Widget, "todos", "widget value", react_keys=["todos"])
+        cache_put(OtherWidget, "todos", "other value", react_keys=["todos"])
+        cache_put(Widget, "users", "user value", react_keys=["users"])
+        invalidate(["todos"])
+        assert cache_has(Widget, "todos") is False
+        assert cache_has(OtherWidget, "todos") is False
+        assert cache_get(Widget, "users") == "user value"

--- a/tests/pyjinhx2/reactive/test_reactive_cache.py
+++ b/tests/pyjinhx2/reactive/test_reactive_cache.py
@@ -154,3 +154,23 @@ def test_re_putting_an_entry_drops_its_previous_reactive_keys():
         assert cache_get(Widget, "todos") == "second"
         invalidate(["users"])
         assert cache_has(Widget, "todos") is False
+
+
+def test_the_reverse_index_maps_each_reactive_key_to_its_entries():
+    with request_scope():
+        cache_put(Widget, "todos", "widget value", react_keys=["todos"])
+        cache_put(OtherWidget, "todos", "other value", react_keys=["todos"])
+        cache_put(Widget, "users", "user value", react_keys=["users"])
+        assert get_cache_reverse() == {
+            "todos": {(Widget, "todos"), (OtherWidget, "todos")},
+            "users": {(Widget, "users")},
+        }
+
+
+def test_an_entry_with_no_reactive_keys_survives_any_invalidation():
+    with request_scope():
+        cache_put(Widget, "todos", "memoized")
+        invalidate(["todos"])
+        invalidate(["users", "anything-else"])
+        assert cache_get(Widget, "todos") == "memoized"
+        assert get_cache_reverse() == {}

--- a/tests/pyjinhx2/reactive/test_reactive_cache.py
+++ b/tests/pyjinhx2/reactive/test_reactive_cache.py
@@ -5,7 +5,7 @@ from pyjinhx2.reactive.cache import (
     invalidate,
     make_key,
 )
-from pyjinhx2.session import get_cache_store, request_scope
+from pyjinhx2.session import get_cache_reverse, get_cache_store, request_scope
 
 
 class Widget:


### PR DESCRIPTION
## Summary
- Add comprehensive test coverage for reactive cache eviction and invalidation edge cases
- Test reverse index cleanup, multi-key entry eviction, and memoization behavior
- Validates that plain memoization survives cache invalidation cycles

## Tests Added
- Eviction of multi-key cache entries by either key
- Reverse index cleanup after eviction
- Cross-entry eviction from a single invalidate call
- Re-put dropping stale reactive-key membership
- Reverse index assertions with memoization survival

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)