### PR TITLE
feat: add ReactiveComponent with load() wrap at class-definition time (#458)

### DIFF
--- a/pyjinhx2/reactive/component.py
+++ b/pyjinhx2/reactive/component.py
@@ -1,0 +1,72 @@
+"""ReactiveComponent: a component whose ``load()`` is memoized per request.
+
+The wrap is installed once, when the subclass is defined, and rebound onto the
+class exactly like the ClassDescriptor is - per-class derived facts are computed
+at registration, never per render.
+"""
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.reactive.cache import cache_get, cache_has, cache_put
+from pyjinhx2.reactive.keys import coerce_reactive_key
+
+
+class ReactiveComponent(BaseComponent):
+    """Base for components that fetch their data in ``load()``.
+
+    Every subclass's ``load()`` is routed through the request-scoped load cache:
+    the first call in a request runs the real body, later calls in that same
+    request reuse its result. Declaring ``react=(...)`` on the subclass reverse-
+    indexes the cached result under those keys, so dirtying one evicts it.
+    """
+
+    _pjx_react_keys: tuple[str, ...] = ()
+    """Normalized reactive keys this class's cached load result depends on."""
+
+    def load(self) -> Any:
+        """Fetch this component's data. Override in subclasses.
+
+        The default does nothing, so a reactive component that has no data to
+        fetch stays valid and the wrap always has a body to call.
+        """
+        return None
+
+    def __init_subclass__(cls, *, react: Iterable[object] = (), **kwargs: Any) -> None:
+        """Consume the ``react`` class kwarg and record it as normalized keys.
+
+        Recorded on every subclass rather than inherited: a subclass declares
+        its own dependencies, and silently reusing a parent's set would tie its
+        cache entry to state it never reads.
+        """
+        cls._pjx_react_keys = tuple(coerce_reactive_key(key) for key in react or ())
+        super().__init_subclass__(**kwargs)
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+        """Run BaseComponent's registration, then install the load wrap."""
+        super().__pydantic_init_subclass__(**kwargs)
+        cls.load = _wrap_load(cls, cls.load)  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def _wrap_load(cls: type, real_load: Callable[[Any], Any]) -> Callable[[Any], Any]:
+    """Build the memoizing wrapper around one class's ``load``.
+
+    Called once per class definition; each call of the returned function only
+    does the cache get/call/put dance. Outside a request scope the cache reads
+    miss and the writes vanish, so the real body simply runs every time - no
+    special case is needed here for that.
+    """
+
+    def wrapped_load(self: Any) -> Any:
+        # Instance-level load keys do not exist yet, so every instance of a
+        # class shares one entry under the null key.
+        key = None
+        if cache_has(cls, key):
+            return cache_get(cls, key)
+        result = real_load(self)
+        cache_put(cls, key, result, react_keys=cls._pjx_react_keys)
+        return result
+
+    return wrapped_load

--- a/tests/pyjinhx2/reactive/test_reactive_component.py
+++ b/tests/pyjinhx2/reactive/test_reactive_component.py
@@ -1,0 +1,166 @@
+"""ReactiveComponent: the load() wrap installed at class-definition time."""
+
+from typing import Any
+
+import pytest
+
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.reactive.component import ReactiveComponent
+from pyjinhx2.session import request_scope
+
+
+def test_reactive_component_is_a_base_component():
+    assert issubclass(ReactiveComponent, BaseComponent)
+
+
+def test_defining_a_subclass_replaces_load_with_the_wrapper():
+    def original(self: Any) -> str:
+        return "value"
+
+    Widget = type("Widget", (ReactiveComponent,), {"load": original})
+
+    assert Widget.load is not original
+
+
+def test_load_body_runs_once_per_request_scope():
+    calls: list[int] = []
+
+    class Widget(ReactiveComponent):
+        def load(self) -> str:
+            calls.append(1)
+            return "loaded"
+
+    widget = Widget()
+    with request_scope():
+        assert widget.load() == "loaded"
+        assert widget.load() == "loaded"
+
+    assert len(calls) == 1
+
+
+def test_a_cached_none_is_not_reloaded():
+    calls: list[int] = []
+
+    class Widget(ReactiveComponent):
+        def load(self) -> None:
+            calls.append(1)
+            return None
+
+    widget = Widget()
+    with request_scope():
+        assert widget.load() is None
+        assert widget.load() is None
+
+    assert len(calls) == 1
+
+
+def test_load_runs_every_call_outside_a_request_scope():
+    calls: list[int] = []
+
+    class Widget(ReactiveComponent):
+        def load(self) -> str:
+            calls.append(1)
+            return "loaded"
+
+    widget = Widget()
+    assert widget.load() == "loaded"
+    assert widget.load() == "loaded"
+    assert len(calls) == 2
+
+
+def test_each_request_scope_starts_cold():
+    calls: list[int] = []
+
+    class Widget(ReactiveComponent):
+        def load(self) -> str:
+            calls.append(1)
+            return "loaded"
+
+    widget = Widget()
+    with request_scope():
+        widget.load()
+    with request_scope():
+        widget.load()
+
+    assert len(calls) == 2
+
+
+def test_react_keys_are_forwarded_to_cache_put():
+    from unittest.mock import patch
+
+    class Widget(ReactiveComponent, react=("todos",)):
+        def load(self) -> str:
+            return "loaded"
+
+    widget = Widget()
+    with (
+        request_scope(),
+        patch("pyjinhx2.reactive.component.cache_put") as spy,
+    ):
+        widget.load()
+
+    assert spy.call_args.kwargs["react_keys"] == ("todos",)
+
+
+def test_declared_react_keys_make_the_entry_evictable():
+    from pyjinhx2.reactive.cache import invalidate
+
+    calls: list[int] = []
+
+    class Widget(ReactiveComponent, react=("todos",)):
+        def load(self) -> str:
+            calls.append(1)
+            return "loaded"
+
+    widget = Widget()
+    with request_scope():
+        widget.load()
+        invalidate(["todos"])
+        widget.load()
+
+    assert len(calls) == 2
+
+
+def test_react_keys_default_to_empty():
+    class Widget(ReactiveComponent):
+        def load(self) -> str:
+            return "loaded"
+
+    assert Widget._pjx_react_keys == ()
+
+
+def test_enum_react_keys_are_normalized_to_their_values():
+    from pyjinhx2.reactive.keys import MutationKey
+
+    class Keys(MutationKey):
+        TODOS = "todos"
+
+    class Widget(ReactiveComponent, react=(Keys.TODOS,)):
+        def load(self) -> str:
+            return "loaded"
+
+    assert Widget._pjx_react_keys == ("todos",)
+
+
+def test_subclass_without_load_returns_none():
+    class Widget(ReactiveComponent):
+        pass
+
+    assert Widget().load() is None
+
+
+def test_base_component_registration_still_fires():
+    """super().__pydantic_init_subclass__() is not skipped - BaseComponent's
+    reserved-field validation still rejects a subclass that shadows auto_id."""
+    with pytest.raises(TypeError, match="auto_id"):
+
+        class Widget(ReactiveComponent):
+            auto_id: bool = False
+
+
+def test_the_descriptor_is_attached_to_reactive_subclasses():
+    class Widget(ReactiveComponent):
+        def load(self) -> str:
+            return "loaded"
+
+    assert Widget.__pjx_descriptor__ is not None

--- a/tests/pyjinhx2/reactive/test_reactive_component.py
+++ b/tests/pyjinhx2/reactive/test_reactive_component.py
@@ -44,7 +44,7 @@ def test_a_cached_none_is_not_reloaded():
     class Widget(ReactiveComponent):
         def load(self) -> None:
             calls.append(1)
-            return None
+            return None  # noqa: RET501, PLR1711 -- explicit for readability of the assertion below
 
     widget = Widget()
     with request_scope():
@@ -155,7 +155,7 @@ def test_base_component_registration_still_fires():
     with pytest.raises(TypeError, match="auto_id"):
 
         class Widget(ReactiveComponent):
-            auto_id: bool = False
+            auto_id: bool = False  # pyright: ignore[reportIncompatibleVariableOverride]
 
 
 def test_the_descriptor_is_attached_to_reactive_subclasses():

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -87,6 +87,16 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # mutations.py records dirtied keys through session's public writer; it owns
     # no ContextVar of its own and never reaches sideways into cache.py.
     "reactive.mutations": frozenset({"pyjinhx2.session", "pyjinhx2.reactive.keys"}),
+    # ReactiveComponent subclasses BaseComponent and routes load() through the
+    # cache: the two edges below are the whole design. The reverse - anything in
+    # the render spine importing reactive/ - stays forbidden.
+    "reactive.component": frozenset(
+        {
+            "pyjinhx2.component",
+            "pyjinhx2.reactive.cache",
+            "pyjinhx2.reactive.keys",
+        }
+    ),
     # The instance registry (ADR 0009) is read-only over session's ContextVar
     # store; it consumes get_instances() and nothing else in pyjinhx2. The
     # register_rendered_instance signature also names RenderedLevel, but that


### PR DESCRIPTION
## Summary
- Add `ReactiveComponent(BaseComponent)` in `pyjinhx2/reactive/component.py`, wrapping `load()` at class-definition time so calls route through `LoadCache`
- `react=` class kwarg threads declared keys into `cache_put`'s `react_keys` for targeted eviction
- 13 new unit tests + import-graph edge coverage

Closes #458

## Test plan
- [x] Full suite green (2631 passed, 5 skipped)
- [x] Mutation testing on the two core invariants (super-call still fires, react_keys forwarded)
- [x] basedpyright/ruff clean