### PR TITLE
test: exhaustive coverage for state hash, root-span stamping, registry write (#465)

### DIFF
--- a/tests/pyjinhx2/reactive/test_reactive_root_attrs.py
+++ b/tests/pyjinhx2/reactive/test_reactive_root_attrs.py
@@ -1,21 +1,22 @@
-"""L3.4.2 — the reactive on_rendered branch stamps data-pjx-id/data-pjx-hash.
+"""L3.4 — the reactive on_rendered branch stamps data-pjx-id/data-pjx-hash.
 
-Proof-of-work coverage only: that the subscriber stamps a ReactiveComponent's
-root tag, no-ops on a plain one, carries state_hash() through unchanged, and
-composes with an L0 pass-through stamp on the same RenderedLevel. The
-exhaustive suite is #465.
+The exhaustive suite (#465) for stamp_reactive_root_attrs and, transitively,
+root_attrs.stamp_root_attrs/_override_tag as reached through a real
+render_level() pass: tag shapes, override-vs-insert, quoting, composition with
+an L0 pass-through stamp, and non-corruption of everything outside root_span.
+Assertions are string-level throughout; the stamp is a splice, never a reparse.
 """
 
 from pathlib import Path
 
 import pytest
 
-from pyjinhx2.component import BaseComponent
+from pyjinhx2.component import BaseComponent, Slot
 from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.reactive.component import ReactiveComponent
 from pyjinhx2.reactive.root_attrs import stamp_reactive_root_attrs
 from pyjinhx2.render import render_level
-from pyjinhx2.root_attrs import stamp_root_attrs
+from pyjinhx2.root_attrs import serialize_attr, stamp_root_attrs
 from pyjinhx2.segments import serialize
 from pyjinhx2.session import RenderSession
 
@@ -44,6 +45,45 @@ ReactiveWidget.__pjx_descriptor__ = _descriptor_for(
     ReactiveWidget, "reactive_widget.html"
 )
 PlainWidget.__pjx_descriptor__ = _descriptor_for(PlainWidget, "plain_widget.html")
+
+
+class VoidWidget(ReactiveComponent):
+    pass
+
+
+class PreStampedWidget(ReactiveComponent):
+    pass
+
+
+class AttrsWidget(ReactiveComponent):
+    pass
+
+
+class QuotingWidget(ReactiveComponent):
+    title: str = 'a "quoted" title'
+
+
+class ReactiveShell(ReactiveComponent):
+    body: Slot = ""
+
+
+VoidWidget.__pjx_descriptor__ = _descriptor_for(VoidWidget, "reactive_void.html")
+PreStampedWidget.__pjx_descriptor__ = _descriptor_for(
+    PreStampedWidget, "reactive_prestamped.html"
+)
+AttrsWidget.__pjx_descriptor__ = _descriptor_for(AttrsWidget, "reactive_attrs.html")
+QuotingWidget.__pjx_descriptor__ = _descriptor_for(
+    QuotingWidget, "reactive_widget.html"
+)
+ReactiveShell.__pjx_descriptor__ = ClassDescriptor(
+    template_path=Path("reactive_shell.html"),
+    slot_fields=frozenset({"body"}),
+    children_field=None,
+    css_paths=(),
+    js_paths=(),
+    strict=True,
+    provenance={"template": ReactiveShell},
+)
 
 
 @pytest.fixture
@@ -109,3 +149,163 @@ def test_re_stamping_the_same_level_overrides_rather_than_duplicates(
 
     assert html.count("data-pjx-id=") == 1
     assert html.count("data-pjx-hash=") == 1
+
+
+def test_self_closing_root_tag_gets_both_attrs_inserted(session: RenderSession):
+    component = VoidWidget(id="v1")
+
+    html = serialize(render_level(component, session))
+
+    assert 'data-pjx-id="v1"' in html
+    assert f'data-pjx-hash="{component.state_hash()}"' in html
+    assert html.endswith("/>")
+    assert " />" not in html  # no stray space introduced before the solidus
+
+
+def test_self_closing_root_keeps_its_original_attributes(session: RenderSession):
+    html = serialize(render_level(VoidWidget(id="v2"), session))
+
+    assert 'src="x.png"' in html
+    assert 'alt="a"' in html
+
+
+def test_existing_data_pjx_attrs_are_overridden_not_duplicated(
+    session: RenderSession,
+):
+    component = PreStampedWidget(id="p1")
+
+    html = serialize(render_level(component, session))
+
+    assert html.count("data-pjx-id=") == 1
+    assert html.count("data-pjx-hash=") == 1
+    assert 'data-pjx-id="p1"' in html
+    assert 'data-pjx-id="stale"' not in html
+    assert 'data-pjx-hash="deadbeef"' not in html
+    assert f'data-pjx-hash="{component.state_hash()}"' in html
+
+
+def test_override_happens_in_place_not_appended(session: RenderSession):
+    """The stale attr's slot is reused, so the id stays left of the hash."""
+    html = serialize(render_level(PreStampedWidget(id="p2"), session))
+
+    assert html.index("data-pjx-id=") < html.index("data-pjx-hash=")
+
+
+def test_fresh_insertion_when_the_root_has_no_data_pjx_attrs(session: RenderSession):
+    html = serialize(render_level(ReactiveWidget(id="f1"), session))
+
+    assert html.startswith("<span ")
+    assert html.count("data-pjx-id=") == 1
+    assert html.count("data-pjx-hash=") == 1
+
+
+def test_unrelated_existing_attributes_are_preserved(session: RenderSession):
+    html = serialize(render_level(AttrsWidget(id="a1"), session))
+
+    assert 'id="outer"' in html
+    assert 'class="a b"' in html
+    assert 'data-keep="1"' in html
+    assert "hidden" in html
+
+
+def test_boolean_attribute_is_not_rewritten_into_a_valued_one(
+    session: RenderSession,
+):
+    html = serialize(render_level(AttrsWidget(id="a2"), session))
+
+    assert 'hidden=""' not in html
+    assert 'hidden="hidden"' not in html
+
+
+def test_a_hash_value_never_needs_quote_escaping(session: RenderSession):
+    """A hex digest is quote-free by construction, so the stamp always uses '"'."""
+    html = serialize(render_level(QuotingWidget(id="q1"), session))
+
+    assert "data-pjx-hash='" not in html
+    assert 'data-pjx-hash="' in html
+
+
+def test_an_id_containing_a_double_quote_falls_back_to_single_quotes(
+    session: RenderSession,
+):
+    component = QuotingWidget(id='we"ird')
+
+    html = serialize(render_level(component, session))
+
+    assert "data-pjx-id='we\"ird'" in html
+    assert html.count("data-pjx-id=") == 1
+
+
+def test_an_attr_value_with_both_quote_kinds_is_rejected():
+    """serialize_attr has no escape hatch left, so it says so rather than
+    emitting a tag that cannot be parsed back."""
+    with pytest.raises(ValueError, match="data-pjx-id"):
+        serialize_attr("data-pjx-id", "we\"ir'd")
+
+
+def test_markup_outside_the_root_tag_is_byte_identical_after_stamping(
+    session: RenderSession,
+):
+    """Everything the splice did not touch must survive unchanged."""
+    plain = RenderSession(template_dir="tests/templates")
+    component = AttrsWidget(id="a3")
+
+    level = render_level(component, plain)  # no subscriber attached
+    before = serialize(level)
+    before_start, before_end = level.root_span
+
+    stamp_reactive_root_attrs(component, level, plain)
+    after = serialize(level)
+    after_start, after_end = level.root_span
+
+    assert before[:before_start] == after[:after_start]
+    assert before[before_end:] == after[after_end:]
+    assert before[before_end:] == "<span>left</span>middle<b>right</b></div>"
+
+
+def test_root_span_still_bounds_exactly_the_root_tag_after_stamping(
+    session: RenderSession,
+):
+    component = AttrsWidget(id="a4")
+
+    level = render_level(component, session)
+    start, end = level.root_span
+    root_segment = level.segments[0]
+
+    assert isinstance(root_segment, str)
+    tag = root_segment[start:end]
+    assert tag.startswith("<div")
+    assert tag.endswith(">")
+    assert "data-pjx-id=" in tag
+    assert "</div>" not in tag
+
+
+def test_child_level_segments_are_untouched_by_the_parents_stamp(
+    session: RenderSession,
+):
+    """A nested RenderedLevel is a sibling segment of the parent's root tag:
+    the parent's splice edits segments[0] only and never reaches into it."""
+    child = ReactiveWidget(id="inner")
+    parent = ReactiveShell(id="outer", body=child)
+
+    html = serialize(render_level(parent, session))
+
+    assert "<p>before</p>" in html
+    assert "<p>after</p>" in html
+    assert 'data-pjx-id="outer"' in html
+    assert 'data-pjx-id="inner"' in html
+    assert html.count("data-pjx-id=") == 2
+    assert html.index('data-pjx-id="outer"') < html.index("<p>before</p>")
+
+
+def test_stamping_the_parent_does_not_move_the_childs_attrs(
+    session: RenderSession,
+):
+    child = ReactiveWidget(id="inner2")
+
+    html = serialize(render_level(ReactiveShell(id="outer2", body=child), session))
+
+    assert (
+        f'<span data-pjx-id="inner2" data-pjx-hash="{child.state_hash()}">widget</span>'
+        in html
+    )

--- a/tests/pyjinhx2/reactive/test_reactive_state_hash.py
+++ b/tests/pyjinhx2/reactive/test_reactive_state_hash.py
@@ -2,6 +2,8 @@ import re
 from datetime import date
 from enum import Enum
 
+from pydantic import BaseModel
+
 from pyjinhx2.reactive.component import ReactiveComponent
 
 
@@ -25,6 +27,40 @@ class Loose(ReactiveComponent):
     count: int = 0
 
     state_hash_exclude = frozenset({"id", "count"})
+
+
+class Inner(BaseModel):
+    label: str = "a"
+    weight: int = 1
+
+
+class Collected(ReactiveComponent):
+    tags: list[str] = []  # noqa: RUF012 — pydantic's own default-factory handling
+    meta: dict[str, int] = {}  # noqa: RUF012 — pydantic's own default-factory handling
+    inner: Inner = Inner()
+    note: str | None = None
+
+
+class Parent(ReactiveComponent):
+    a: str = "a"
+    b: str = "b"
+    c: str = "c"
+
+
+class Child(Parent):
+    state_hash_exclude = frozenset({"id", "b"})
+
+
+class GrandChild(Child):
+    state_hash_exclude = frozenset({"id", "c"})
+
+
+class MultiExcluded(ReactiveComponent):
+    kept: str = "k"
+    skip1: str = "1"
+    skip2: str = "2"
+
+    state_hash_exclude = frozenset({"id", "skip1", "skip2"})
 
 
 def test_default_exclude_is_just_id():
@@ -68,3 +104,134 @@ def test_non_json_native_field_types_hash_stably():
         Dated(when=date(2020, 1, 2)).state_hash()
         != Dated(when=date(2021, 1, 2)).state_hash()
     )
+
+
+def test_hash_stable_across_repeated_calls_same_instance():
+    collected = Collected(id="c1", tags=["a", "b"], meta={"x": 1})
+    first = collected.state_hash()
+    assert first == collected.state_hash() == collected.state_hash()
+
+
+def test_hash_stable_across_distinct_instances_same_relevant_state():
+    left = Collected(id="left", tags=["a"], meta={"x": 1}, inner=Inner(label="z"))
+    right = Collected(id="right", tags=["a"], meta={"x": 1}, inner=Inner(label="z"))
+    assert left.state_hash() == right.state_hash()
+
+
+def test_dict_key_insertion_order_does_not_change_the_hash():
+    """sort_keys is what makes an unchanged mapping hash the same."""
+    forward = Collected(meta={"a": 1, "b": 2})
+    reversed_ = Collected(meta={"b": 2, "a": 1})
+    assert forward.state_hash() == reversed_.state_hash()
+
+
+def test_list_append_changes_the_hash():
+    base = Collected(tags=["a"])
+    assert base.state_hash() != Collected(tags=["a", "b"]).state_hash()
+
+
+def test_list_removal_changes_the_hash():
+    assert Collected(tags=["a", "b"]).state_hash() != Collected(tags=["a"]).state_hash()
+
+
+def test_list_reorder_changes_the_hash():
+    """A list is ordered state: reordering it is a different render."""
+    assert (
+        Collected(tags=["a", "b"]).state_hash()
+        != Collected(tags=["b", "a"]).state_hash()
+    )
+
+
+def test_empty_and_populated_list_hash_differently():
+    assert Collected(tags=[]).state_hash() != Collected(tags=["a"]).state_hash()
+
+
+def test_dict_value_mutation_changes_the_hash():
+    assert (
+        Collected(meta={"x": 1}).state_hash() != Collected(meta={"x": 2}).state_hash()
+    )
+
+
+def test_dict_key_rename_changes_the_hash():
+    assert (
+        Collected(meta={"x": 1}).state_hash() != Collected(meta={"y": 1}).state_hash()
+    )
+
+
+def test_empty_and_populated_dict_hash_differently():
+    assert Collected(meta={}).state_hash() != Collected(meta={"x": 1}).state_hash()
+
+
+def test_nested_model_field_change_changes_the_hash():
+    assert (
+        Collected(inner=Inner(label="a")).state_hash()
+        != Collected(inner=Inner(label="b")).state_hash()
+    )
+
+
+def test_nested_model_untouched_field_keeps_the_hash():
+    assert (
+        Collected(inner=Inner(label="a", weight=1)).state_hash()
+        == Collected(inner=Inner(label="a", weight=1)).state_hash()
+    )
+
+
+def test_optional_field_none_to_value_changes_the_hash():
+    assert Collected(note=None).state_hash() != Collected(note="x").state_hash()
+
+
+def test_optional_field_value_to_none_changes_the_hash():
+    populated = Collected(note="x")
+    assert populated.state_hash() != Collected(note=None).state_hash()
+
+
+def test_in_place_mutation_of_a_list_field_changes_the_hash():
+    """state_hash reads live field values, so a mutation between calls shows up."""
+    collected = Collected(tags=["a"])
+    before = collected.state_hash()
+    collected.tags.append("b")
+    assert collected.state_hash() != before
+
+
+def test_parent_hashes_every_field_but_id():
+    assert Parent(a="x").state_hash() != Parent(a="y").state_hash()
+    assert Parent(b="x").state_hash() != Parent(b="y").state_hash()
+    assert Parent(c="x").state_hash() != Parent(c="y").state_hash()
+
+
+def test_child_exclude_hides_only_its_own_named_field():
+    assert Child(b="x").state_hash() == Child(b="y").state_hash()
+    assert Child(c="x").state_hash() != Child(c="y").state_hash()
+
+
+def test_grandchild_exclude_replaces_rather_than_extends_the_parents():
+    """A subclass's value wins outright: 'b' is hashed again, 'c' is not."""
+    assert GrandChild(c="x").state_hash() == GrandChild(c="y").state_hash()
+    assert GrandChild(b="x").state_hash() != GrandChild(b="y").state_hash()
+
+
+def test_id_stays_excluded_at_every_level_of_the_chain():
+    assert Parent(id="p1").state_hash() == Parent(id="p2").state_hash()
+    assert Child(id="c1").state_hash() == Child(id="c2").state_hash()
+    assert GrandChild(id="g1").state_hash() == GrandChild(id="g2").state_hash()
+
+
+def test_multiple_excluded_fields_are_all_ignored():
+    assert (
+        MultiExcluded(skip1="a", skip2="b").state_hash()
+        == MultiExcluded(skip1="z", skip2="z").state_hash()
+    )
+
+
+def test_excluded_field_ignored_regardless_of_value_type_or_size():
+    """An excluded field can hold anything; the digest never moves."""
+    base = MultiExcluded(kept="k").state_hash()
+    assert MultiExcluded(kept="k", skip1="x" * 5000).state_hash() == base
+    assert MultiExcluded(kept="k", skip1="").state_hash() == base
+
+
+def test_a_class_that_excludes_nothing_hashes_its_id_too():
+    class Bare(ReactiveComponent):
+        state_hash_exclude = frozenset()
+
+    assert Bare(id="one").state_hash() != Bare(id="two").state_hash()

--- a/tests/pyjinhx2/test_instance_registry.py
+++ b/tests/pyjinhx2/test_instance_registry.py
@@ -1,16 +1,20 @@
 """Tests for the minimal request-scoped instance registry (ADR 0009)."""
 
 import logging
+from pathlib import Path
 
 import pytest
 
+from pyjinhx2.descriptor import ClassDescriptor
+from pyjinhx2.reactive.component import ReactiveComponent
 from pyjinhx2.registry import (
     make_key,
     register_instance,
     register_rendered_instance,
     resolve,
 )
-from pyjinhx2.segments import RenderedLevel
+from pyjinhx2.render import render_level
+from pyjinhx2.segments import RenderedLevel, serialize
 from pyjinhx2.session import RenderSession, _instances, get_instances, request_scope
 
 
@@ -193,3 +197,84 @@ def test_emit_rendered_registers_nothing_until_the_writer_is_subscribed():
         session.on_rendered.append(register_rendered_instance)
         session.emit_rendered(component, level)  # type: ignore[arg-type]
         assert resolve("FakeComponent", "f1") is level
+
+
+class RegisteredWidget(ReactiveComponent):
+    """A real component rendered through the real pipeline for these tests."""
+
+
+RegisteredWidget.__pjx_descriptor__ = ClassDescriptor(
+    template_path=Path("reactive_widget.html"),
+    slot_fields=frozenset(),
+    children_field=None,
+    css_paths=(),
+    js_paths=(),
+    strict=True,
+    provenance={"template": RegisteredWidget},
+)
+
+
+def _wired_session() -> RenderSession:
+    """A session whose on_rendered carries the registry writer, as the Load path wires it."""
+    session = RenderSession(template_dir="tests/templates")
+    session.on_rendered.append(register_rendered_instance)
+    return session
+
+
+def test_real_render_with_the_writer_subscribed_registers_a_resolvable_entry():
+    session = _wired_session()
+    component = RegisteredWidget(id="r1")
+
+    with request_scope(session=session):
+        level = render_level(component, session)
+        assert resolve("RegisteredWidget", "r1") is level
+
+
+def test_the_registered_entry_is_the_rendered_level_not_a_copy():
+    session = _wired_session()
+    component = RegisteredWidget(id="r2")
+
+    with request_scope(session=session):
+        level = render_level(component, session)
+        resolved = resolve("RegisteredWidget", "r2")
+        assert isinstance(resolved, RenderedLevel)
+        assert serialize(resolved) == serialize(level)
+
+
+def test_the_real_render_stores_under_the_composite_key():
+    session = _wired_session()
+
+    with request_scope(session=session):
+        render_level(RegisteredWidget(id="r3"), session)
+        assert make_key("RegisteredWidget", "r3") in get_instances()
+
+
+def test_a_real_render_entry_does_not_survive_the_request_scope():
+    session = _wired_session()
+
+    with request_scope(session=session):
+        render_level(RegisteredWidget(id="r4"), session)
+        assert resolve("RegisteredWidget", "r4") is not None
+
+    with pytest.raises(LookupError, match="RegisteredWidget_r4"):
+        resolve("RegisteredWidget", "r4")
+
+
+def test_a_real_render_registers_nothing_when_the_writer_is_not_wired():
+    session = RenderSession(template_dir="tests/templates")
+
+    with request_scope(session=session):
+        render_level(RegisteredWidget(id="r5"), session)
+        assert get_instances() == {}
+        with pytest.raises(LookupError, match="RegisteredWidget_r5"):
+            resolve("RegisteredWidget", "r5")
+
+
+def test_two_instances_of_one_class_register_under_their_own_ids():
+    session = _wired_session()
+
+    with request_scope(session=session):
+        first = render_level(RegisteredWidget(id="r6"), session)
+        second = render_level(RegisteredWidget(id="r7"), session)
+        assert resolve("RegisteredWidget", "r6") is first
+        assert resolve("RegisteredWidget", "r7") is second

--- a/tests/templates/reactive_attrs.html
+++ b/tests/templates/reactive_attrs.html
@@ -1,0 +1,1 @@
+<div id="outer" class="a b" data-keep="1" hidden><span>left</span>middle<b>right</b></div>

--- a/tests/templates/reactive_prestamped.html
+++ b/tests/templates/reactive_prestamped.html
@@ -1,0 +1,1 @@
+<div data-pjx-id="stale" data-pjx-hash="deadbeef">body</div>

--- a/tests/templates/reactive_shell.html
+++ b/tests/templates/reactive_shell.html
@@ -1,0 +1,1 @@
+<section class="shell"><p>before</p>{{ body }}<p>after</p></section>

--- a/tests/templates/reactive_void.html
+++ b/tests/templates/reactive_void.html
@@ -1,0 +1,1 @@
+<img src="x.png" alt="a"/>


### PR DESCRIPTION
## Summary

- Adds 42 new tests covering state hash, root-span stamping, and instance registry
- Tests cover the reactive on_rendered branch's data-pjx-id/data-pjx-hash stamping
- Verifies state_hash() determinism, collection/nested-model sensitivity, and exclude semantics
- Validates _override_tag matrix (self-closing, override-vs-insert, quote fallback, unrelated attrs)
- Confirms registry writer behavior through real render_level() passes and request scope
- Test-only; no module changes

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)