### PR TITLE
feat(reactive): drop fan-out candidates whose fresh hash matches the manifest

### DIFF
--- a/pyjinhx2/reactive/fanout.py
+++ b/pyjinhx2/reactive/fanout.py
@@ -63,6 +63,13 @@ class FanoutCandidate:
     instance: ReactiveComponent | None = None
     """The instance built on the dirty path, else None."""
 
+    fresh_hash: str | None = None
+    """The dirty path's freshly computed state hash; None on clean/missing.
+
+    #471 stamps this back onto the swapped region's ``data-pjx-hash``, so the
+    next manifest reports the hash the client is actually showing.
+    """
+
 
 def _candidate_class(
     entry: dict[str, Any], dirtied_keys: set[str]
@@ -129,6 +136,18 @@ def _build_dirty(
     return instance, render_level(instance, session)
 
 
+def _hash_gate_drops(fresh_hash: str, entry: dict[str, Any]) -> bool:
+    """Whether this re-rendered instance is byte-identical to what the client shows.
+
+    A dirtied key only says the *data* may have moved, never that the *output*
+    did. When the fresh state hash equals the one the client reported for this
+    region, the swap would replace the region with itself, so it is dropped.
+    A manifest entry with no ``hash`` at all can never match a real digest and
+    therefore always survives — an unstamped region is refreshed, not skipped.
+    """
+    return fresh_hash == entry.get("hash")
+
+
 def walk_manifest(
     manifest_entries: Sequence[dict[str, Any]],
     dirtied_keys: Iterable[str],
@@ -148,12 +167,14 @@ def walk_manifest(
         An entry naming an unknown tag, or a class no dirtied key touches, is
         dropped silently — it is not this request's concern. A candidate's
         ``status`` is one of ``"clean"``, ``"dirty"``, or ``"missing"``.
+        A dirty entry whose freshly rendered state hash equals the hash the
+        client reported is dropped too: the region changed keys but not output.
 
     Deliberately not done here, each owned by the next subtask in L3.5:
-    the ``entry["hash"]`` vs fresh ``state_hash()`` gate (#467); structural
-    nesting dedup of survivors (#468); excluding regions already inside the
-    primary response (#469); turning a ``"missing"`` candidate into a delete
-    swap (#470); splicing ``hx-swap-oob`` at a level's root_span (#471).
+    structural nesting dedup of survivors (#468); excluding regions already
+    inside the primary response (#469); turning a ``"missing"`` candidate into
+    a delete swap (#470); splicing ``hx-swap-oob`` at a level's root_span
+    (#471).
     """
     dirty = set(dirtied_keys)
     seen: set[tuple[str, str | None]] = set()
@@ -172,11 +193,11 @@ def walk_manifest(
         load = entry.get("load")
         resolved, found = _resolve_registry_entry(cls, instance_id)
         if not found:
-            status, instance, level = "missing", None, None
+            status, instance, level, fresh_hash = "missing", None, None, None
         elif cache_has(cls, dedup_key[1]):
             # E13: the clean answer comes from the load cache's own key space,
             # never from the registry key that resolved above.
-            status, instance, level = "clean", None, None
+            status, instance, level, fresh_hash = "clean", None, None, None
             resolved = (
                 resolved if resolved is not None else cache_get(cls, dedup_key[1])
             )
@@ -188,6 +209,12 @@ def walk_manifest(
             # its dirty-path render silently point at the wrong template dir.
             render_session = session or current_session() or RenderSession()
             instance, level = _build_dirty(cls, instance_id, load, render_session)
+            fresh_hash = instance.state_hash()
+            if _hash_gate_drops(fresh_hash, entry):
+                # The dedup slot above is deliberately kept: a later duplicate
+                # of this (type, load-key) pair would gate out identically, so
+                # dropping here must not buy it a second load/render.
+                continue
             status = "dirty"
         candidates.append(
             FanoutCandidate(
@@ -200,6 +227,7 @@ def walk_manifest(
                 resolved=resolved,
                 level=level,
                 instance=instance,
+                fresh_hash=fresh_hash,
             )
         )
     return candidates

--- a/tests/pyjinhx2/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx2/reactive/test_reactive_fanout.py
@@ -180,6 +180,122 @@ def test_the_walk_never_writes_to_the_instance_registry(monkeypatch):
         assert calls == []
 
 
+def fresh_hash_for(load: object) -> str:
+    """The state hash `walk_manifest`'s dirty path will compute for this load arg.
+
+    Built from an instance shaped exactly like `_build_dirty` builds one, so a
+    test can seed a manifest entry with the *matching* hash without hardcoding
+    a digest that changes whenever the model's fields do.
+    """
+    return FanoutWidget(id="probe", pjx_key=str(load)).state_hash()
+
+
+def test_dirty_candidate_whose_fresh_hash_matches_the_manifest_hash_is_dropped():
+    with scope():
+        registry.register_instance(FanoutWidget.__name__, "a", "resolved-entry")
+        manifest = [
+            entry("fanout_widget", "a", load="todo-1", hash_=fresh_hash_for("todo-1"))
+        ]
+        assert walk_manifest(manifest, {"todos"}) == []
+
+
+def test_dirty_candidate_whose_fresh_hash_differs_survives_carrying_that_hash():
+    with scope():
+        registry.register_instance(FanoutWidget.__name__, "a", "resolved-entry")
+        manifest = [entry("fanout_widget", "a", load="todo-1", hash_="stale-hash")]
+        [candidate] = walk_manifest(manifest, {"todos"})
+        assert candidate.status == "dirty"
+        assert candidate.fresh_hash == fresh_hash_for("todo-1")
+        assert candidate.fresh_hash != "stale-hash"
+
+
+def test_dirty_candidate_whose_manifest_entry_has_no_hash_key_survives():
+    with scope():
+        registry.register_instance(FanoutWidget.__name__, "a", "resolved-entry")
+        # A manifest entry that never carried a `hash` field — `entry.get("hash")`
+        # answers None, which must read as "unknown", never as "unchanged".
+        manifest = [{"type": "fanout_widget", "id": "a", "load": "todo-1"}]
+        [candidate] = walk_manifest(manifest, {"todos"})
+        assert candidate.status == "dirty"
+        assert candidate.fresh_hash == fresh_hash_for("todo-1")
+
+
+def test_clean_candidate_is_not_hash_gated_and_carries_no_fresh_hash(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(
+        FanoutWidget,
+        "state_hash",
+        lambda self: calls.append(self.id) or "computed",
+        raising=False,
+    )
+    with scope():
+        cache_put(FanoutWidget, "todo-1", "cached-payload", react_keys=("todos",))
+        registry.register_instance(FanoutWidget.__name__, "a", "resolved-entry")
+        # The manifest reports the very hash the patched state_hash() would
+        # answer: a clean candidate must survive anyway, because no fresh
+        # render exists for the gate to compare against.
+        manifest = [entry("fanout_widget", "a", load="todo-1", hash_="computed")]
+        [candidate] = walk_manifest(manifest, {"todos"})
+        assert candidate.status == "clean"
+        assert candidate.fresh_hash is None
+        assert calls == []
+
+
+def test_missing_candidate_is_not_hash_gated_and_carries_no_fresh_hash():
+    with scope():
+        # Nothing registered under this id, so registry.resolve() raises and the
+        # entry is "missing" — #470's delete-swap input, which this gate must
+        # not consume even when the reported hash is the matching one.
+        manifest = [
+            entry(
+                "fanout_widget", "gone", load="todo-1", hash_=fresh_hash_for("todo-1")
+            )
+        ]
+        [candidate] = walk_manifest(manifest, {"todos"})
+        assert candidate.status == "missing"
+        assert candidate.fresh_hash is None
+
+
+def test_mixed_manifest_gates_only_the_dirty_entries():
+    with scope():
+        cache_put(FanoutWidget, "todo-1", "cached-payload", react_keys=("todos",))
+        registry.register_instance(FanoutWidget.__name__, "a", "level-a")
+        registry.register_instance(FanoutWidget.__name__, "same", "level-same")
+        registry.register_instance(FanoutWidget.__name__, "moved", "level-moved")
+        manifest = [
+            # clean: cached, reports the hash its own fresh render would have
+            entry("fanout_widget", "a", load="todo-1", hash_=fresh_hash_for("todo-1")),
+            # dirty + gated out: fresh hash equals the reported one
+            entry(
+                "fanout_widget", "same", load="todo-2", hash_=fresh_hash_for("todo-2")
+            ),
+            # dirty + survives: reported hash is stale
+            entry("fanout_widget", "moved", load="todo-3", hash_="stale"),
+            # missing: never resolved, gate must not touch it
+            entry(
+                "fanout_widget", "gone", load="todo-4", hash_=fresh_hash_for("todo-4")
+            ),
+        ]
+        candidates = walk_manifest(manifest, {"todos"})
+        assert [(c.instance_id, c.status) for c in candidates] == [
+            ("a", "clean"),
+            ("moved", "dirty"),
+            ("gone", "missing"),
+        ]
+        assert [c.fresh_hash for c in candidates] == [
+            None,
+            fresh_hash_for("todo-3"),
+            None,
+        ]
+        # The gated-out entry still ran its load — the gate decides *after* the
+        # re-render, which is the whole point: it compares fresh output, not
+        # a guess about the data. The "gone" entry never loads: in
+        # `walk_manifest`, `_resolve_registry_entry`'s LookupError sets
+        # status="missing" before `_build_dirty` (and therefore `load()`) is
+        # ever reached, so only the two dirty entries appear here.
+        assert LOAD_CALLS == ["todo-2", "todo-3"]
+
+
 def test_mixed_manifest_produces_the_expected_ordered_candidate_list():
     with scope():
         cache_put(FanoutWidget, "todo-1", "cached-payload", react_keys=("todos",))


### PR DESCRIPTION
## Summary

A dirtied reactive key says the data may have moved, not that the rendered output did. The dirty branch now compares the re-rendered instance's state_hash() to the hash the client reported for that region and drops the candidate when they match, so an unchanged region never costs a swap. The surviving candidate carries its fresh hash for #471 to stamp back.

## Test Coverage

Added 116 lines of exhaustive test cases for the fan-out mechanism in `test_reactive_fanout.py`.

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)