### PR TITLE
feat(reactive): drop structurally nested fanout candidates via segment containment

### DIFF
--- a/pyjinhx2/reactive/fanout.py
+++ b/pyjinhx2/reactive/fanout.py
@@ -20,6 +20,7 @@ TODO(#446 owner): nothing server-side stamps ``data-pjx-type`` or
 touches L3.4 (#445), which this subtask does not own.
 """
 
+import re
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -29,6 +30,7 @@ from pyjinhx2.reactive.cache import cache_get, cache_has
 from pyjinhx2.reactive.component import ReactiveComponent
 from pyjinhx2.reactive.keys import coerce_load_key_str
 from pyjinhx2.render import render_level
+from pyjinhx2.segments import ChildRef, RenderedLevel
 from pyjinhx2.session import RenderSession, current_session
 
 
@@ -148,6 +150,109 @@ def _hash_gate_drops(fresh_hash: str, entry: dict[str, Any]) -> bool:
     return fresh_hash == entry.get("hash")
 
 
+RE_ROOT_PJX_ID = re.compile(
+    r'data-pjx-id\s*=\s*"([^"]*)"|data-pjx-id\s*=\s*\'([^\']*)\''
+)
+
+
+def _level_of(candidate: FanoutCandidate) -> RenderedLevel | None:
+    """The candidate's own segment tree, from either field, or None.
+
+    A dirty candidate carries a fresh ``level``; a clean one carries only
+    whatever ``registry.resolve()`` handed back, which is a RenderedLevel for a
+    cached region and a live instance otherwise. A live instance has no tree, so
+    it answers None — a side with no tree is never walked and never guessed at.
+    """
+    if isinstance(candidate.level, RenderedLevel):
+        return candidate.level
+    if isinstance(candidate.resolved, RenderedLevel):
+        return candidate.resolved
+    return None
+
+
+def _root_instance_id(level: RenderedLevel) -> str | None:
+    """The ``data-pjx-id`` on this level's root tag, or None if unstamped.
+
+    The exact inverse of ``stamp_root_attrs``: one read of the single tag whose
+    offsets the original parse recorded, never a re-parse and never a scan of
+    the rendered markup. ``_fill_children`` replaces a child's ChildRef with its
+    RenderedLevel and the authored ``id`` attr goes with it, so the stamped root
+    tag is the only place a nested level's instance identity still lives.
+    """
+    root = level.segments[0] if level.segments else ""
+    if not isinstance(root, str):
+        return None
+    start, end = level.root_span
+    match = RE_ROOT_PJX_ID.search(root[start:end])
+    if match is None:
+        return None
+    return match.group(1) if match.group(1) is not None else match.group(2)
+
+
+def _contained(level: RenderedLevel) -> tuple[set[str], set[int]]:
+    """Every id and every level object nested *strictly inside* this level.
+
+    Two identity channels, because a descendant can be either shape: an
+    unfilled ChildRef still carries the authored ``id`` attr, while a filled
+    RenderedLevel carries its stamped root id — plus object identity, which
+    settles the case where a survivor's own level object is literally the node
+    sitting in another survivor's tree.
+    """
+    ids: set[str] = set()
+    objects: set[int] = set()
+    stack: list[object] = list(level.segments)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, ChildRef):
+            nested_id = node.attrs.get("id")
+            if nested_id:
+                ids.add(nested_id)
+        elif isinstance(node, RenderedLevel):
+            objects.add(id(node))
+            nested_id = _root_instance_id(node)
+            if nested_id:
+                ids.add(nested_id)
+            stack.extend(node.segments)
+    return ids, objects
+
+
+def _drop_nested(candidates: list[FanoutCandidate]) -> list[FanoutCandidate]:
+    """Drop every candidate whose region sits inside another survivor's region.
+
+    The v0.x behavior (a parent's swap already carries its children, so a child
+    swap is redundant and would fight the parent's) reached through the segment
+    tree instead of a substring search over rendered HTML: the tree already
+    records containment, so nothing here re-parses or re-serializes markup.
+
+    A drop needs positive proof — a concrete containing RenderedLevel on some
+    *other* survivor whose tree holds this candidate's id or level object. A
+    candidate whose only structural data is a live instance, and a container
+    side with no tree at all, both simply fail to produce that proof and the
+    candidate survives; absence of a check is never a drop. Order is preserved
+    and nothing is duplicated.
+    """
+    if len(candidates) < 2:
+        return candidates
+    trees = {
+        id(other): _contained(level)
+        for other in candidates
+        if (level := _level_of(other)) is not None
+    }
+    surviving: list[FanoutCandidate] = []
+    for candidate in candidates:
+        own_level = _level_of(candidate)
+        nested = any(
+            candidate.instance_id in ids
+            or (own_level is not None and id(own_level) in objects)
+            for other in candidates
+            if other is not candidate
+            for ids, objects in (trees.get(id(other), (frozenset(), frozenset())),)
+        )
+        if not nested:
+            surviving.append(candidate)
+    return surviving
+
+
 def walk_manifest(
     manifest_entries: Sequence[dict[str, Any]],
     dirtied_keys: Iterable[str],
@@ -169,12 +274,13 @@ def walk_manifest(
         ``status`` is one of ``"clean"``, ``"dirty"``, or ``"missing"``.
         A dirty entry whose freshly rendered state hash equals the hash the
         client reported is dropped too: the region changed keys but not output.
+        A candidate whose region is structurally nested inside another
+        survivor's region is dropped: the parent's swap already carries it.
 
     Deliberately not done here, each owned by the next subtask in L3.5:
-    structural nesting dedup of survivors (#468); excluding regions already
-    inside the primary response (#469); turning a ``"missing"`` candidate into
-    a delete swap (#470); splicing ``hx-swap-oob`` at a level's root_span
-    (#471).
+    excluding regions already inside the primary response (#469); turning a
+    ``"missing"`` candidate into a delete swap (#470); splicing
+    ``hx-swap-oob`` at a level's root_span (#471).
     """
     dirty = set(dirtied_keys)
     seen: set[tuple[str, str | None]] = set()
@@ -230,7 +336,7 @@ def walk_manifest(
                 fresh_hash=fresh_hash,
             )
         )
-    return candidates
+    return _drop_nested(candidates)
 
 
 # TODO(#449): registry.register_rendered_instance is exported but subscribed by

--- a/tests/pyjinhx2/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx2/reactive/test_reactive_fanout.py
@@ -9,8 +9,8 @@ import pytest
 from pyjinhx2 import discovery, registry
 from pyjinhx2.reactive.cache import cache_has, cache_put
 from pyjinhx2.reactive.component import PjxKey, ReactiveComponent
-from pyjinhx2.reactive.fanout import walk_manifest
-from pyjinhx2.segments import RenderedLevel
+from pyjinhx2.reactive.fanout import FanoutCandidate, _drop_nested, walk_manifest
+from pyjinhx2.segments import ChildRef, RenderedLevel
 from pyjinhx2.session import request_scope
 
 LOAD_CALLS: list[str | None] = []
@@ -318,3 +318,126 @@ def test_mixed_manifest_produces_the_expected_ordered_candidate_list():
         # Only the dirty candidate ran its body; the clean one was never loaded
         # and the missing one was never built.
         assert LOAD_CALLS == ["todo-2"]
+
+
+def candidate(instance_id: str, level=None, resolved=None, status: str = "dirty"):
+    """Build one FanoutCandidate carrying only the fields _drop_nested reads."""
+    return FanoutCandidate(
+        type_name="fanout_widget",
+        component_class=FanoutWidget,
+        instance_id=instance_id,
+        load=None,
+        status=status,
+        entry=entry("fanout_widget", instance_id),
+        resolved=resolved,
+        level=level,
+    )
+
+
+def stamped_level(instance_id: str, *children) -> RenderedLevel:
+    """A RenderedLevel whose root tag carries data-pjx-id, with children nested."""
+    root = f'<div data-pjx-id="{instance_id}">'
+    return RenderedLevel(
+        segments=[root, *children, "</div>"],
+        root_span=(0, len(root)),
+        descriptor=FanoutWidget.__pjx_descriptor__,
+    )
+
+
+def test_drop_nested_drops_a_child_level_nested_in_a_parent_level():
+    child = stamped_level("child")
+    parent = stamped_level("parent", child)
+    with scope():
+        survivors = _drop_nested(
+            [candidate("parent", level=parent), candidate("child", level=child)]
+        )
+    assert [c.instance_id for c in survivors] == ["parent"]
+
+
+def test_drop_nested_keeps_siblings_that_contain_neither_other():
+    with scope():
+        survivors = _drop_nested(
+            [
+                candidate("a", level=stamped_level("a")),
+                candidate("b", level=stamped_level("b")),
+            ]
+        )
+    assert [c.instance_id for c in survivors] == ["a", "b"]
+
+
+def test_drop_nested_drops_a_clean_child_whose_resolved_is_a_nested_level():
+    child = stamped_level("child")
+    parent = stamped_level("parent", child)
+    with scope():
+        survivors = _drop_nested(
+            [
+                candidate("parent", level=parent),
+                candidate("child", resolved=child, status="clean"),
+            ]
+        )
+    assert [c.instance_id for c in survivors] == ["parent"]
+
+
+def test_drop_nested_keeps_a_live_instance_candidate_not_found_in_any_tree():
+    with scope():
+        survivors = _drop_nested(
+            [
+                candidate("parent", level=stamped_level("parent")),
+                candidate("other", resolved=FanoutWidget(id="other"), status="clean"),
+            ]
+        )
+    assert [c.instance_id for c in survivors] == ["parent", "other"]
+
+
+def test_drop_nested_finds_a_child_declared_as_an_unfilled_child_ref():
+    parent = stamped_level(
+        "parent", ChildRef(tag="FanoutWidget", attrs={"id": "child"}, inner=None)
+    )
+    with scope():
+        survivors = _drop_nested(
+            [candidate("parent", level=parent), candidate("child")]
+        )
+    assert [c.instance_id for c in survivors] == ["parent"]
+
+
+def test_drop_nested_collapses_three_levels_to_the_outermost():
+    child = stamped_level("child")
+    parent = stamped_level("parent", child)
+    grandparent = stamped_level("grandparent", parent)
+    with scope():
+        survivors = _drop_nested(
+            [
+                candidate("grandparent", level=grandparent),
+                candidate("parent", level=parent),
+                candidate("child", level=child),
+            ]
+        )
+    assert [c.instance_id for c in survivors] == ["grandparent"]
+
+
+def test_drop_nested_is_a_no_op_on_empty_and_singleton_lists():
+    only = [candidate("a", level=stamped_level("a"))]
+    with scope():
+        assert _drop_nested([]) == []
+        assert _drop_nested(only) == only
+
+
+def test_walk_manifest_runs_the_nesting_dedup_on_its_survivors(monkeypatch):
+    """The pass is wired into the walk, not just importable."""
+    seen_calls: list[int] = []
+    original = _drop_nested
+
+    def spy(candidates):
+        seen_calls.append(len(candidates))
+        return original(candidates)
+
+    monkeypatch.setattr("pyjinhx2.reactive.fanout._drop_nested", spy)
+    with scope():
+        walk_manifest(
+            [
+                entry("fanout_widget", "a", load="t1"),
+                entry("fanout_widget", "b", load="t2"),
+            ],
+            {"todos"},
+        )
+    assert seen_calls == [2]

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -115,7 +115,9 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # and the load cache (a separate key space, E13). It re-renders a dirty
     # candidate through render_level(), the same primitive root_attrs.py
     # uses, and falls back to current_session() rather than ever building an
-    # unscoped RenderSession with the wrong template_dir.
+    # unscoped RenderSession with the wrong template_dir. #468 adds the
+    # structural nesting dedup pass, which walks segments/ChildRef directly
+    # rather than re-parsing or substring-matching rendered markup.
     "reactive.fanout": frozenset(
         {
             "pyjinhx2",
@@ -125,6 +127,7 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
             "pyjinhx2.reactive.component",
             "pyjinhx2.reactive.keys",
             "pyjinhx2.render",
+            "pyjinhx2.segments",
             "pyjinhx2.session",
         }
     ),


### PR DESCRIPTION
## Summary

- Add `_drop_nested()` to `walk_manifest()`, removing candidates whose region is a descendant of another survivor's region in the segment tree
- Direct v2 replacement for v0.x's `_drop_nested()` (pyjinhx/reactive.py:388-408), using structural tree walking instead of substring matching
- Comprehensive test coverage for segment tree containment logic

## Test plan

- All existing fanout tests pass
- New unit tests for `_drop_nested()` covering nested level containment scenarios
- Import graph and pyright checks satisfied

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)