### PR TITLE
feat(reactive): add delete_swap for a plain instance id

### DIFF
--- a/pyjinhx2/reactive/fanout.py
+++ b/pyjinhx2/reactive/fanout.py
@@ -112,8 +112,8 @@ def _resolve_registry_entry(
     The one place the snake_case tag name is traded for the PascalCase class
     name the registry is keyed by. A LookupError is caught rather than allowed
     out: one region the client still shows but the server no longer knows about
-    must not take the whole walk down — it becomes a "missing" candidate, which
-    is #470's hook point for a delete swap.
+    must not take the whole walk down — it becomes a "missing" candidate,
+    which ``delete_swap()`` turns into a delete swap.
     """
     try:
         return registry.resolve(cls.__name__, instance_id), True
@@ -306,9 +306,9 @@ def walk_manifest(
         survivor's region is dropped: the parent's swap already carries it, and
         so is one whose id the primary response already carries.
 
-    Deliberately not done here, each owned by the next subtask in L3.5: turning
-    a ``"missing"`` candidate into a delete swap (#470); splicing
-    ``hx-swap-oob`` at a level's root_span (#471).
+    Turning a ``"missing"`` candidate into a delete swap is ``delete_swap()``
+    below; assembling those fragments with the real swaps into one response
+    body is #471's, and is deliberately not done here.
     """
     dirty = set(dirtied_keys)
     excluded = _mounted_ids_in(primary_html)

--- a/pyjinhx2/reactive/fanout.py
+++ b/pyjinhx2/reactive/fanout.py
@@ -25,6 +25,8 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from markupsafe import Markup
+
 from pyjinhx2 import discovery, registry
 from pyjinhx2.reactive.cache import cache_get, cache_has
 from pyjinhx2.reactive.component import ReactiveComponent
@@ -369,6 +371,48 @@ def walk_manifest(
             )
         )
     return _drop_nested(candidates)
+
+
+def _css_attr_value(value: str) -> str:
+    """Escape a string for use inside a single-quoted CSS attribute selector.
+
+    Backslash first, then quote: escaping the quote first would leave the
+    backslash pass turning its own escape into a literal backslash and letting
+    the quote out of the selector.
+    """
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def delete_swap(candidate: FanoutCandidate) -> Markup:
+    """The OOB fragment that removes a gone region from the client's DOM.
+
+    A region whose instance the registry no longer knows about cannot be
+    re-rendered — there is nothing left to render. htmx's ``delete`` swap takes
+    the element out instead, so the client stops reporting it in the next
+    manifest and the pair converges.
+
+    The id is the one the *client* reported, verbatim from the manifest: the
+    server has no record of this instance, so there is nothing to re-derive it
+    from, and a lookup would only fail again.
+
+    Args:
+        candidate: A ``"missing"`` candidate from ``walk_manifest``.
+
+    Returns:
+        ``<div hx-swap-oob="delete:[data-pjx-id='ID']"></div>`` — content-free,
+        because the swap is the whole instruction.
+
+    Raises:
+        ValueError: The candidate is not ``"missing"``. Rendering real content
+            for a clean or dirty candidate belongs to #471; answering an empty
+            string here would hide that caller bug.
+    """
+    if candidate.status != "missing":
+        raise ValueError(
+            f"delete_swap expects a 'missing' candidate, got {candidate.status!r}"
+        )
+    selector = f"delete:[data-pjx-id='{_css_attr_value(candidate.instance_id)}']"
+    return Markup(f'<div hx-swap-oob="{selector}"></div>')
 
 
 # TODO(#449): registry.register_rendered_instance is exported but subscribed by

--- a/tests/pyjinhx2/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx2/reactive/test_reactive_fanout.py
@@ -548,6 +548,21 @@ def test_delete_swap_escapes_a_backslash_before_a_quote_without_unescaping_it():
     assert "delete:[data-pjx-id='a\\\\\\'b']" in fragment
 
 
+@pytest.mark.parametrize("status", ["clean", "dirty"])
+def test_delete_swap_rejects_a_non_missing_candidate(status):
+    with pytest.raises(ValueError, match=status):
+        delete_swap(missing_candidate("a", status=status))
+
+
+def test_delete_swap_of_an_empty_id_is_still_a_fragment():
+    # walk_manifest coerces an entry with no id to "", and that is not this
+    # function's problem to diagnose — it emits the selector it was given.
+    assert (
+        delete_swap(missing_candidate(""))
+        == "<div hx-swap-oob=\"delete:[data-pjx-id='']\"></div>"
+    )
+
+
 def test_walk_manifest_runs_the_nesting_dedup_on_its_survivors(monkeypatch):
     """The pass is wired into the walk, not just importable."""
     seen_calls: list[int] = []

--- a/tests/pyjinhx2/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx2/reactive/test_reactive_fanout.py
@@ -528,6 +528,26 @@ def test_delete_swap_for_a_plain_id_is_a_bare_oob_delete_div():
     )
 
 
+def test_delete_swap_escapes_a_single_quote_in_the_id():
+    fragment = delete_swap(missing_candidate("it's-here"))
+    assert "delete:[data-pjx-id='it\\'s-here']" in fragment
+    # The selector's quoting stays balanced: exactly the opening and closing
+    # quote are unescaped, so nothing after the id leaks into the selector.
+    assert fragment.count("'") - fragment.count("\\'") == 2
+
+
+def test_delete_swap_escapes_a_backslash_in_the_id():
+    fragment = delete_swap(missing_candidate("back\\slash"))
+    assert "delete:[data-pjx-id='back\\\\slash']" in fragment
+
+
+def test_delete_swap_escapes_a_backslash_before_a_quote_without_unescaping_it():
+    # The order-sensitive case: "\\'" must become "\\\\\\'", never "\\\\'",
+    # which would end the selector's quoted value early.
+    fragment = delete_swap(missing_candidate("a\\'b"))
+    assert "delete:[data-pjx-id='a\\\\\\'b']" in fragment
+
+
 def test_walk_manifest_runs_the_nesting_dedup_on_its_survivors(monkeypatch):
     """The pass is wired into the walk, not just importable."""
     seen_calls: list[int] = []

--- a/tests/pyjinhx2/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx2/reactive/test_reactive_fanout.py
@@ -13,6 +13,7 @@ from pyjinhx2.reactive.fanout import (
     FanoutCandidate,
     _drop_nested,
     _mounted_ids_in,
+    delete_swap,
     walk_manifest,
 )
 from pyjinhx2.segments import ChildRef, RenderedLevel
@@ -506,6 +507,25 @@ def test_primary_exclusion_and_nesting_dedup_compose_in_one_walk(monkeypatch):
             primary_html='<section data-pjx-id="in-primary"></section>',
         )
     assert [c.instance_id for c in candidates] == ["parent"]
+
+
+def missing_candidate(instance_id: str, status: str = "missing") -> FanoutCandidate:
+    """A FanoutCandidate shaped exactly as walk_manifest builds one for a gone region."""
+    return FanoutCandidate(
+        type_name="fanout_widget",
+        component_class=FanoutWidget,
+        instance_id=instance_id,
+        load="todo-1",
+        status=status,
+        entry=entry("fanout_widget", instance_id, load="todo-1"),
+    )
+
+
+def test_delete_swap_for_a_plain_id_is_a_bare_oob_delete_div():
+    assert (
+        delete_swap(missing_candidate("todo-list"))
+        == "<div hx-swap-oob=\"delete:[data-pjx-id='todo-list']\"></div>"
+    )
 
 
 def test_walk_manifest_runs_the_nesting_dedup_on_its_survivors(monkeypatch):

--- a/tests/pyjinhx2/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx2/reactive/test_reactive_fanout.py
@@ -563,6 +563,29 @@ def test_delete_swap_of_an_empty_id_is_still_a_fragment():
     )
 
 
+def test_a_gone_region_walks_to_a_delete_fragment_without_loading_anything(
+    monkeypatch,
+):
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        registry, "register_instance", lambda *a, **kw: calls.append((a, kw))
+    )
+    with scope():
+        [candidate_] = walk_manifest(
+            [entry("fanout_widget", "gone-1", load="todo-1")], {"todos"}
+        )
+    assert candidate_.status == "missing"
+    assert (
+        delete_swap(candidate_)
+        == "<div hx-swap-oob=\"delete:[data-pjx-id='gone-1']\"></div>"
+    )
+    # A missing region costs no load, no render and no registry write on the
+    # whole path from manifest entry to delete fragment.
+    assert LOAD_CALLS == []
+    assert candidate_.level is None
+    assert calls == []
+
+
 def test_walk_manifest_runs_the_nesting_dedup_on_its_survivors(monkeypatch):
     """The pass is wired into the walk, not just importable."""
     seen_calls: list[int] = []


### PR DESCRIPTION
## Summary
- Adds `delete_swap()` to turn a missing FanoutCandidate into the OOB delete fragment that htmx uses to remove gone regions' mounted elements from the DOM
- Includes comprehensive tests covering escape ordering, status validation, and end-to-end integration with walk_manifest
- Updates docstrings to reference the newly shipped implementation

## Test Plan
- 6 new tests added covering delete_swap functionality
- All 37 tests in test_reactive_fanout.py pass

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)