### PR TITLE
feat: add ReactiveResponse composing primary render with OOB fragments

### DIFF
--- a/pyjinhx2/reactive/response.py
+++ b/pyjinhx2/reactive/response.py
@@ -1,0 +1,67 @@
+"""One reactive HTTP body: the primary render output plus the OOB fan-out fragments."""
+
+from markupsafe import Markup
+
+from pyjinhx2.client.inject import MountedManifest
+from pyjinhx2.reactive.fanout import FanoutCandidate, oob_swaps, walk_manifest
+from pyjinhx2.session import current_session, get_dirtied
+
+
+class ReactiveResponse:
+    """The composed body for one reactive request.
+
+    Holds the primary render output and the client's raw mounted manifest, and
+    answers the single body that goes on the wire: the primary markup followed by
+    one OOB fragment per region this request's dirtied keys invalidated.
+
+    Body only. Response headers, htmx redirect adaptation and framework glue are
+    each owned elsewhere, so this object stays usable by all of them.
+    """
+
+    def __init__(self, primary: object = None, mounted: object = None) -> None:
+        """Store the two inputs; nothing is walked or rendered until ``body`` is read.
+
+        Args:
+            primary: This request's already-serialized primary render output, or
+                None/empty for a handler that renders nothing directly.
+            mounted: The raw ``X-PJX-Mounted`` header value, a pre-parsed entry
+                list, a request-like object, or None.
+        """
+        self.primary = primary
+        self.mounted = mounted
+
+    def candidates(self) -> list[FanoutCandidate]:
+        """The fan-out candidates this request's dirtied keys make of the manifest.
+
+        Returns:
+            ``walk_manifest`` output, in manifest order. Empty when nothing is
+            mounted, nothing is dirtied, or the header was unreadable.
+        """
+        # primary_html is passed so a region the primary body already carries is not
+        # also swapped OOB: fan-out runs after the primary serialize, and without
+        # this the client would swap that region twice in one response.
+        return walk_manifest(
+            MountedManifest.parse(self.mounted),
+            get_dirtied(),
+            session=current_session(),
+            primary_html=self.primary,
+        )
+
+    @property
+    def body(self) -> Markup:
+        """The whole response body: primary markup, then the OOB fragments.
+
+        Returns:
+            ``Markup(primary or "") + oob_swaps(candidates)``. Concatenation only —
+            the fragments were already stamped by splicing at recorded offsets, so
+            nothing here re-parses either side.
+        """
+        return Markup(self.primary or "") + oob_swaps(self.candidates())
+
+    def __html__(self) -> Markup:
+        """Return the composed body, so templates interpolate it without escaping."""
+        return self.body
+
+    def __str__(self) -> str:
+        """Return the composed body as a plain string."""
+        return str(self.body)

--- a/tests/pyjinhx2/reactive/test_reactive_response.py
+++ b/tests/pyjinhx2/reactive/test_reactive_response.py
@@ -1,0 +1,114 @@
+"""Composition tests: ReactiveResponse joins the primary body with OOB fragments."""
+
+import dataclasses
+from pathlib import Path
+from typing import Annotated
+
+import pytest
+from markupsafe import Markup
+
+from pyjinhx2 import discovery, registry
+from pyjinhx2.reactive.component import PjxKey, ReactiveComponent
+from pyjinhx2.reactive.response import ReactiveResponse
+from pyjinhx2.session import add_dirtied, request_scope
+
+
+class ResponseWidget(ReactiveComponent, react=("todos",)):
+    """A reactive component keyed by ``pjx_key``, dirtied by the ``todos`` key."""
+
+    pjx_key: Annotated[str, PjxKey()] = ""
+
+    def load(self) -> str:
+        return f"data:{self.pjx_key}"
+
+
+_TEMPLATE_DIR = "templates"
+"""Set by `_publish_registry` to this test's tmp_path.
+
+`RenderSession(template_dir="templates")` (the class default) does not exist relative to
+the test process's cwd, so every test must enter `scope()` rather than bare
+`request_scope()` or the dirty path's `render_level()` raises TemplateNotFound instead of
+exercising the code under test.
+"""
+
+
+@pytest.fixture(autouse=True)
+def _publish_registry(tmp_path, monkeypatch):
+    """Publish a tag -> class map for ResponseWidget and point it at a real template."""
+    global _TEMPLATE_DIR
+    template = tmp_path / "response_widget.pjx"
+    template.write_text("<div>{{ pjx_key }}</div>")
+    discovery.build_registry(tmp_path, [ResponseWidget])
+    # `_resolve_template_path` probes the class's defining module directory, not the
+    # dir passed to build_registry; repoint the descriptor at the tmp_path file, using
+    # the bare filename because RenderSession's FileSystemLoader joins names under
+    # template_dir and would never open an absolute path.
+    ResponseWidget.__pjx_descriptor__ = dataclasses.replace(
+        ResponseWidget.__pjx_descriptor__, template_path=Path(template.name)
+    )
+    _TEMPLATE_DIR = str(tmp_path)
+    yield
+
+
+def scope():
+    """`request_scope()` bound to this test's tmp_path template dir."""
+    return request_scope(_TEMPLATE_DIR)
+
+
+def entry(instance_id: str, load: object = None, hash_: str = "stale") -> dict:
+    """Build one synthetic X-PJX-Mounted manifest entry for ResponseWidget."""
+    return {
+        "type": "response_widget",
+        "id": instance_id,
+        "load": load,
+        "hash": hash_,
+    }
+
+
+def test_no_dirtied_and_no_mounted_leaves_primary_untouched():
+    with scope():
+        response = ReactiveResponse(primary=Markup("<p>hello</p>"))
+        assert response.body == Markup("<p>hello</p>")
+        assert str(response) == "<p>hello</p>"
+        assert response.__html__() == Markup("<p>hello</p>")
+
+
+def test_dirty_mounted_region_appends_an_oob_fragment_after_the_primary():
+    with scope():
+        registry.register_instance(ResponseWidget.__name__, "a", "resolved-entry")
+        add_dirtied(["todos"])
+        response = ReactiveResponse(
+            primary=Markup("<p>hello</p>"), mounted=[entry("a", load="todo-1")]
+        )
+        body = str(response)
+        assert body.startswith("<p>hello</p>")
+        assert "hx-swap-oob=\"outerHTML:[data-pjx-id='a']\"" in body
+
+
+def test_absent_primary_yields_oob_fragments_only():
+    with scope():
+        registry.register_instance(ResponseWidget.__name__, "a", "resolved-entry")
+        add_dirtied(["todos"])
+        response = ReactiveResponse(primary=None, mounted=[entry("a", load="todo-1")])
+        body = str(response)
+        assert body.startswith("<div")
+        assert "hx-swap-oob=\"outerHTML:[data-pjx-id='a']\"" in body
+
+
+def test_region_already_in_the_primary_is_not_swapped_again():
+    with scope():
+        registry.register_instance(ResponseWidget.__name__, "a", "resolved-entry")
+        add_dirtied(["todos"])
+        primary = Markup('<div data-pjx-id="a">fresh</div>')
+        response = ReactiveResponse(
+            primary=primary, mounted=[entry("a", load="todo-1")]
+        )
+        assert response.body == primary
+        assert "hx-swap-oob" not in str(response)
+
+
+def test_malformed_mounted_header_degrades_to_primary_only():
+    with scope():
+        add_dirtied(["todos"])
+        response = ReactiveResponse(primary=Markup("<p>hello</p>"), mounted="{not json")
+        assert response.body == Markup("<p>hello</p>")

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -87,6 +87,17 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # mutations.py records dirtied keys through session's public writer; it owns
     # no ContextVar of its own and never reaches sideways into cache.py.
     "reactive.mutations": frozenset({"pyjinhx2.session", "pyjinhx2.reactive.keys"}),
+    # ReactiveResponse (L3.6.1) composes one body out of the primary render and
+    # fanout.py's OOB candidates; it reads the manifest parser, the fanout walk
+    # and session's request-scoped dirtied-key/session accessors, and nothing
+    # else. No registry edge (ADR 0009): fanout.py already owns registry reads.
+    "reactive.response": frozenset(
+        {
+            "pyjinhx2.client.inject",
+            "pyjinhx2.reactive.fanout",
+            "pyjinhx2.session",
+        }
+    ),
     # ReactiveComponent subclasses BaseComponent and routes load() through the
     # cache: the two edges below are the whole design. The reverse - anything in
     # the render spine importing reactive/ - stays forbidden.


### PR DESCRIPTION
## Summary
- Adds `pyjinhx2/reactive/response.py` with new `ReactiveResponse` class that composes one reactive HTTP body from the primary render output plus OOB fan-out fragments
- Passes `primary_html=` to avoid double-swapping already-present regions
- Declares module edges in the import-graph edge table (#473)

## Test count
- 114 new lines of test code in `test_reactive_response.py`
- Updates to `test_import_graph.py`

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)