### PR TITLE
test: declare config's edges in the pyjinhx2 import-graph table

### DIFF
--- a/pyjinhx2/config.py
+++ b/pyjinhx2/config.py
@@ -1,0 +1,196 @@
+"""App-level configuration for pyjinhx2: the settings object and the setup() entrypoint.
+
+config sits above the render spine and may read from it; nothing in the spine,
+in reactive/ or in client/ may import this module back. Siblings that do not
+exist yet (dev, integrations.fastapi) are imported lazily inside functions so
+importing this module never depends on them.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass, fields, replace
+from pathlib import Path
+from typing import Any
+
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.discovery import build_registry
+
+# Sentinel distinguishing "argument omitted" from None or a real value, so
+# setup()'s pass-through keywords never clobber an explicit settings object.
+_UNSET: Any = object()
+
+_TRUE = {"1", "true", "yes", "on"}
+_FALSE = {"0", "false", "no", "off"}
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    """``name``'s value as a bool, or ``default`` when it is unset or empty."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    lowered = raw.strip().lower()
+    if lowered in _TRUE:
+        return True
+    if lowered in _FALSE:
+        return False
+    raise ValueError(
+        f"{name}={raw!r} is not a boolean; use one of {sorted(_TRUE | _FALSE)}."
+    )
+
+
+def _env_path(name: str) -> Path | None:
+    raw = os.environ.get(name)
+    return Path(raw) if raw else None
+
+
+@dataclass(frozen=True)
+class PjxSettings:
+    """The app-level knobs pyjinhx2 reads once at startup.
+
+    ``inject_htmx`` is stored only; how it maps onto the session's asset modes
+    is pending design.
+    """
+
+    reactive_dev: bool = False
+    inject_htmx: bool = True
+    components_root: Path | str | None = None
+    static_root: Path | str | None = None
+
+    @classmethod
+    def from_env(cls) -> PjxSettings:
+        """Settings read from the ``PJX_*`` environment variables."""
+        return cls(
+            reactive_dev=_env_bool("PJX_REACTIVE_DEV", False),
+            inject_htmx=_env_bool("PJX_INJECT_HTMX", True),
+            components_root=_env_path("PJX_COMPONENTS_ROOT"),
+            static_root=_env_path("PJX_STATIC_ROOT"),
+        )
+
+    def merge(self, **overrides: Any) -> PjxSettings:
+        """A copy of these settings with ``overrides`` applied.
+
+        Keywords carrying the ``_UNSET`` sentinel are dropped, so a caller can
+        pass every field through unconditionally and still say nothing about
+        the ones it was never given. ``None`` is a real value and does override.
+        """
+        known = {field.name for field in fields(self)}
+        unknown = sorted(set(overrides) - known)
+        if unknown:
+            raise TypeError(f"unknown pyjinhx settings: {unknown}")
+        applied = {
+            key: value for key, value in overrides.items() if value is not _UNSET
+        }
+        return replace(self, **applied)
+
+
+_current = PjxSettings()
+
+
+def current_settings() -> PjxSettings:
+    """The settings the last ``configure_pyjinhx`` published for this process."""
+    return _current
+
+
+def _apply_reactive_dev(enabled: bool) -> None:
+    """Turn dev mode on or off, if the dev module is importable.
+
+    The import is deferred and its absence is not an error: configuration must
+    still succeed in an install where dev tooling is not present, with the flag
+    recorded for whoever reads it later.
+    """
+    try:
+        from pyjinhx2 import dev  # pyright: ignore[reportAttributeAccessIssue]
+    except ImportError:
+        return
+    if dev is None:
+        return
+    if enabled:
+        dev.enable_reactive_dev()
+    else:
+        dev.disable_reactive_dev()
+
+
+def configure_pyjinhx(settings: PjxSettings) -> PjxSettings:
+    """Publish ``settings`` as this process's configuration and apply its effects."""
+    global _current
+    _current = settings
+    _apply_reactive_dev(settings.reactive_dev)
+    return settings
+
+
+def shutdown_pyjinhx() -> None:
+    """Reset the process back to default settings and undo what config applied."""
+    global _current
+    _current = PjxSettings()
+    _apply_reactive_dev(False)
+
+
+def setup(
+    app: object | None = None,
+    *,
+    settings: PjxSettings | None = None,
+    context_factory: Callable[[Any], object | None] | None = None,
+    components_root: Path | str | None = _UNSET,
+    static_root: Path | str | None = _UNSET,
+    **kwargs: Any,
+) -> PjxSettings:
+    """Configure pyjinhx2 for this process, and optionally wire it into an app.
+
+    Resolution order: an explicit ``settings`` object replaces the environment
+    as the base, and explicit keywords override whichever base was used.
+    ``components_root`` also triggers component discovery. With ``app=None``
+    only process configuration runs, which is what tests and scripts want.
+    """
+    base = settings if settings is not None else PjxSettings.from_env()
+    resolved = base.merge(
+        components_root=components_root,
+        static_root=static_root,
+        **kwargs,
+    )
+    if resolved.components_root is not None:
+        _register_components(resolved.components_root)
+    configure_pyjinhx(resolved)
+    if app is None:
+        return resolved
+    if not _is_asgi_app(app):
+        raise TypeError(
+            "setup(app=...) needs a Starlette/FastAPI-like app with "
+            "add_middleware and router attributes."
+        )
+    from pyjinhx2.integrations.fastapi import (  # pyright: ignore[reportMissingImports]
+        apply_setup,
+    )
+
+    apply_setup(app, resolved, context_factory=context_factory)
+    return resolved
+
+
+def _is_asgi_app(app: object) -> bool:
+    """Whether ``app`` looks like a Starlette/FastAPI application.
+
+    Duck-typed rather than isinstance-checked so pyjinhx2 never imports
+    Starlette to answer a question about an object the caller already built.
+    """
+    return hasattr(app, "add_middleware") and hasattr(app, "router")
+
+
+def _register_components(components_root: Path | str) -> None:
+    """Walk ``components_root`` and publish the tag -> class registry.
+
+    Every declared component class is offered to the walk; discovery is what
+    decides which of them a template on disk actually claims.
+    """
+    build_registry(components_root, _all_component_classes())
+
+
+def _all_component_classes() -> list[type]:
+    """Every declared BaseComponent subclass, nested ones included."""
+    found: list[type] = []
+    stack = list(BaseComponent.__subclasses__())
+    while stack:
+        cls = stack.pop()
+        found.append(cls)
+        stack.extend(cls.__subclasses__())
+    return found

--- a/tests/pyjinhx2/test_config_v2.py
+++ b/tests/pyjinhx2/test_config_v2.py
@@ -1,0 +1,229 @@
+"""Unit tests for pyjinhx2/config.py — PjxSettings, setup() and the process-wide holder."""
+
+import dataclasses
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyjinhx2.config import PjxSettings
+
+
+@pytest.fixture(autouse=True)
+def _reset_process_settings():
+    yield
+    from pyjinhx2.config import shutdown_pyjinhx
+
+    shutdown_pyjinhx()
+
+
+def test_defaults():
+    settings = PjxSettings()
+    assert settings.reactive_dev is False
+    assert settings.inject_htmx is True
+    assert settings.components_root is None
+    assert settings.static_root is None
+
+
+def test_settings_are_frozen():
+    settings = PjxSettings()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        settings.reactive_dev = True  # type: ignore[misc]
+
+
+def test_from_env_reads_every_var(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PJX_REACTIVE_DEV", "true")
+    monkeypatch.setenv("PJX_INJECT_HTMX", "0")
+    monkeypatch.setenv("PJX_COMPONENTS_ROOT", "/srv/components")
+    monkeypatch.setenv("PJX_STATIC_ROOT", "/srv/static")
+    settings = PjxSettings.from_env()
+    assert settings.reactive_dev is True
+    assert settings.inject_htmx is False
+    assert settings.components_root == Path("/srv/components")
+    assert settings.static_root == Path("/srv/static")
+
+
+def test_from_env_falls_back_to_defaults(monkeypatch: pytest.MonkeyPatch):
+    for name in (
+        "PJX_REACTIVE_DEV",
+        "PJX_INJECT_HTMX",
+        "PJX_COMPONENTS_ROOT",
+        "PJX_STATIC_ROOT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    assert PjxSettings.from_env() == PjxSettings()
+
+
+def test_from_env_rejects_a_non_bool_string(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PJX_REACTIVE_DEV", "maybe")
+    with pytest.raises(ValueError, match="PJX_REACTIVE_DEV"):
+        PjxSettings.from_env()
+
+
+def test_merge_with_no_arguments_changes_nothing():
+    settings = PjxSettings(reactive_dev=True, components_root=Path("/a"))
+    assert settings.merge() == settings
+
+
+def test_merge_only_overrides_what_was_passed():
+    settings = PjxSettings(reactive_dev=True, inject_htmx=False)
+    merged = settings.merge(components_root=Path("/a"))
+    assert merged.components_root == Path("/a")
+    assert merged.reactive_dev is True
+    assert merged.inject_htmx is False
+
+
+def test_merge_drops_unset_sentinel_values():
+    from pyjinhx2.config import _UNSET
+
+    settings = PjxSettings(reactive_dev=True)
+    assert settings.merge(reactive_dev=_UNSET, inject_htmx=_UNSET) == settings
+
+
+def test_merge_accepts_none_as_a_real_value():
+    settings = PjxSettings(components_root=Path("/a"))
+    assert settings.merge(components_root=None).components_root is None
+
+
+def test_configure_then_shutdown_round_trip():
+    from pyjinhx2.config import configure_pyjinhx, current_settings, shutdown_pyjinhx
+
+    configure_pyjinhx(PjxSettings(reactive_dev=True, inject_htmx=False))
+    assert current_settings().reactive_dev is True
+    assert current_settings().inject_htmx is False
+    shutdown_pyjinhx()
+    assert current_settings() == PjxSettings()
+
+
+def test_reactive_dev_survives_a_missing_dev_module(monkeypatch: pytest.MonkeyPatch):
+    """pyjinhx2.dev does not exist yet; configure must store the flag anyway."""
+    monkeypatch.setitem(sys.modules, "pyjinhx2.dev", None)
+    from pyjinhx2.config import configure_pyjinhx, current_settings
+
+    configure_pyjinhx(PjxSettings(reactive_dev=True))
+    assert current_settings().reactive_dev is True
+
+
+def test_reactive_dev_calls_the_dev_hooks_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    dev = types.ModuleType("pyjinhx2.dev")
+    dev.enable_reactive_dev = MagicMock()  # type: ignore[attr-defined]
+    dev.disable_reactive_dev = MagicMock()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pyjinhx2.dev", dev)
+    from pyjinhx2.config import configure_pyjinhx, shutdown_pyjinhx
+
+    configure_pyjinhx(PjxSettings(reactive_dev=True))
+    dev.enable_reactive_dev.assert_called_once_with()  # type: ignore[attr-defined]
+    shutdown_pyjinhx()
+    dev.disable_reactive_dev.assert_called_once_with()  # type: ignore[attr-defined]
+
+
+def test_setup_without_an_app_returns_merged_settings():
+    from pyjinhx2.config import setup
+
+    resolved = setup(reactive_dev=True, inject_htmx=False)
+    assert resolved.reactive_dev is True
+    assert resolved.inject_htmx is False
+
+
+def test_setup_publishes_the_resolved_settings():
+    from pyjinhx2.config import current_settings, setup
+
+    resolved = setup(reactive_dev=True)
+    assert current_settings() == resolved
+
+
+def test_explicit_settings_bypasses_the_environment(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PJX_REACTIVE_DEV", "true")
+    monkeypatch.setenv("PJX_INJECT_HTMX", "0")
+    from pyjinhx2.config import setup
+
+    resolved = setup(settings=PjxSettings())
+    assert resolved.reactive_dev is False
+    assert resolved.inject_htmx is True
+
+
+def test_explicit_keywords_win_over_an_explicit_settings_object():
+    """Precedence rule: keywords are the caller's most specific statement, so
+    they override both the environment and a passed-in settings object."""
+    from pyjinhx2.config import setup
+
+    resolved = setup(settings=PjxSettings(reactive_dev=False), reactive_dev=True)
+    assert resolved.reactive_dev is True
+
+
+def test_components_root_builds_the_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from pyjinhx2 import config
+
+    calls: list[tuple[Path | str, list[type]]] = []
+    monkeypatch.setattr(
+        config,
+        "build_registry",
+        lambda template_dir, classes: calls.append((template_dir, list(classes))),
+    )
+    config.setup(components_root=tmp_path)
+    assert len(calls) == 1
+    assert calls[0][0] == tmp_path
+
+
+def test_no_components_root_does_not_build_the_registry(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from pyjinhx2 import config
+
+    calls: list[object] = []
+    monkeypatch.setattr(
+        config, "build_registry", lambda template_dir, classes: calls.append(1)
+    )
+    config.setup()
+    assert calls == []
+
+
+def test_setup_rejects_a_non_asgi_app():
+    from pyjinhx2.config import setup
+
+    class NotAnApp:
+        pass
+
+    with pytest.raises(TypeError, match="add_middleware"):
+        setup(NotAnApp())
+
+
+def test_setup_delegates_an_asgi_app_to_the_fastapi_integration(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """#484 owns integrations.fastapi; config only hands the app over to it."""
+    integration = types.ModuleType("pyjinhx2.integrations.fastapi")
+    integration.apply_setup = MagicMock()  # type: ignore[attr-defined]
+    package = types.ModuleType("pyjinhx2.integrations")
+    package.fastapi = integration  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pyjinhx2.integrations", package)
+    monkeypatch.setitem(sys.modules, "pyjinhx2.integrations.fastapi", integration)
+
+    from pyjinhx2.config import setup
+
+    app = MagicMock(spec=["add_middleware", "router"])
+    factory = MagicMock()
+    resolved = setup(app, context_factory=factory, reactive_dev=True)
+
+    integration.apply_setup.assert_called_once_with(  # type: ignore[attr-defined]
+        app, resolved, context_factory=factory
+    )
+    assert resolved.reactive_dev is True
+
+
+def test_deferred_cache_machinery_is_not_ported():
+    """ADR 0009/0011: no invalidation backend, hub or cache scope in v2."""
+    names = {field.name for field in dataclasses.fields(PjxSettings)}
+    assert names == {"reactive_dev", "inject_htmx", "components_root", "static_root"}
+
+
+def test_static_root_is_stored_on_the_settings(tmp_path: Path):
+    from pyjinhx2.config import setup
+
+    assert setup(static_root=tmp_path).static_root == tmp_path

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -54,6 +54,19 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "component": frozenset(
         {"pyjinhx2.descriptor", "pyjinhx2.props_header"}
     ),  # the stale-header probe needs template_has_props_header
+    # config sits above everything: it may read the spine to register
+    # components and it defers to siblings that own the app wiring and dev
+    # tooling. The reverse edge — any spine, reactive/ or client/ module
+    # importing config — stays forbidden and is asserted below.
+    "config": frozenset(
+        {
+            "pyjinhx2",
+            "pyjinhx2.component",
+            "pyjinhx2.discovery",
+            "pyjinhx2.dev",
+            "pyjinhx2.integrations.fastapi",
+        }
+    ),
     "descriptor": frozenset(),
     # discovery keys the registry by each class's own resolved tag, so it reads
     # component.py's snake-case helper rather than inventing a second naming
@@ -238,6 +251,17 @@ def test_session_never_reaches_into_reactive():
         "pyjinhx2.segments",
         "pyjinhx2.assets",
     }
+
+
+def test_nothing_below_config_imports_config():
+    """config is the top of the stack: it reads the spine, reactive/ and
+    client/, and none of them may reach back up into it."""
+    importers = {
+        module_name(path)
+        for path in module_paths()
+        if "pyjinhx2.config" in internal_imports(path)
+    }
+    assert importers == set()
 
 
 def test_no_render_spine_module_declares_a_reactive_import():


### PR DESCRIPTION
## Summary

Adds PjxSettings, setup(), and process-wide configuration holder to pyjinhx2. PjxSettings is a frozen dataclass supporting environment variable parsing (PJX_* env vars), safe immutable merging, and lifecycle management via configure_pyjinhx()/shutdown_pyjinhx(). The test suite verifies import-graph constraints: config sits above the render spine, cannot be imported by spine/reactive/client modules.

Test coverage: 31 tests (22 config unit tests + 9 import-graph tests)

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)