### PR TITLE
fix: add pjx_request attribute to RenderSession for type checking

### DIFF
--- a/pyjinhx2/context.py
+++ b/pyjinhx2/context.py
@@ -82,6 +82,26 @@ class PjxContext:
         """This request's reactive-key -> cache-entry index."""
         return get_cache_reverse()
 
+    @property
+    def mounted(self) -> Any:
+        """The MountedManifest the middleware parsed onto this request."""
+        return self._state("pjx_mounted")
+
+    @property
+    def assets(self) -> Any:
+        """The LoadedAssets manifest the middleware parsed onto this request."""
+        return self._state("pjx_assets")
+
+    @property
+    def trigger(self) -> Any:
+        """The TriggerManifest the middleware parsed onto this request."""
+        return self._state("pjx_trigger")
+
+    @property
+    def app_context(self) -> Any:
+        """Whatever the app's configured ``context_factory`` returned, or None."""
+        return self._state("pjx_context")
+
     def _state(self, name: str) -> Any:
         """The named ``request.state`` attribute, or None when unset."""
         if self.request is None:

--- a/pyjinhx2/context.py
+++ b/pyjinhx2/context.py
@@ -1,0 +1,89 @@
+"""PjxContext: the request-scoped, read-only handle onto session and reactive state.
+
+This is deliberately narrower than v0.x's PjxContext: no user-data injection,
+no load()-parameter introspection, no mutation methods. It is a view over
+state that already lives in session.py's ContextVars and on request.state —
+constructed on demand, never itself ContextVar-bound.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from pyjinhx2.session import (
+    NoActiveRequestScope,
+    RenderSession,
+    current_session,
+    get_cache_reverse,
+    get_cache_store,
+    get_dirtied,
+    get_instances,
+)
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+
+@dataclass(frozen=True)
+class PjxContext:
+    """A live view of one request's pyjinhx state.
+
+    Exposes the session bound by ``request_scope()``, the dirtied reactive
+    keys, the instance registry, the two load-cache stores, the pjx header
+    manifests parsed onto ``request.state``, and whatever an app's
+    ``context_factory`` returned. Read-only: dirtying and mutation stay with
+    ``reactive.mutations``.
+    """
+
+    # A facade, not a holder: every accessor re-reads session.py's ContextVars
+    # on each call, so a PjxContext handed to a template cannot go stale and
+    # cannot become a second, competing source of per-request truth. It binds
+    # no ContextVar of its own for the same reason.
+
+    request: Request | None
+
+    @classmethod
+    def current(cls) -> PjxContext:
+        """Build a view over the request bound to the active scope.
+
+        Raises:
+            NoActiveRequestScope: If called outside an active ``request_scope()``.
+        """
+        session = current_session()
+        if session is None:
+            raise NoActiveRequestScope(
+                "PjxContext.current() requires an active request_scope()"
+            )
+        return cls(request=getattr(session, "pjx_request", None))
+
+    @property
+    def session(self) -> RenderSession | None:
+        """The RenderSession bound to this request, or None outside a scope."""
+        return current_session()
+
+    @property
+    def dirtied(self) -> set[str]:
+        """This request's dirtied reactive keys."""
+        return get_dirtied()
+
+    @property
+    def instances(self) -> dict[str, object]:
+        """This request's instance registry."""
+        return get_instances()
+
+    @property
+    def cache_store(self) -> dict[object, object]:
+        """This request's load cache store."""
+        return get_cache_store()
+
+    @property
+    def cache_reverse(self) -> dict[str, set[tuple[type, object]]]:
+        """This request's reactive-key -> cache-entry index."""
+        return get_cache_reverse()
+
+    def _state(self, name: str) -> Any:
+        """The named ``request.state`` attribute, or None when unset."""
+        if self.request is None:
+            return None
+        return getattr(self.request.state, name, None)

--- a/pyjinhx2/session.py
+++ b/pyjinhx2/session.py
@@ -89,6 +89,9 @@ class RenderSession:
         self.on_rendered: list[
             Callable[[BaseComponent, RenderedLevel, RenderSession], None]
         ] = []
+        # The Starlette request object for this render, set by middleware and
+        # read by PjxContext to expose request.state manifests and app context.
+        self.pjx_request: Any = None
 
     def emit_rendered(self, component: "BaseComponent", level: "RenderedLevel") -> None:
         """Notify subscribers that ``component``'s subtree finished rendering.

--- a/tests/pyjinhx2/test_context.py
+++ b/tests/pyjinhx2/test_context.py
@@ -55,3 +55,48 @@ def test_current_outside_a_request_scope_raises_no_active_request_scope():
     assert current_session() is None
     with pytest.raises(NoActiveRequestScope):
         PjxContext.current()
+
+
+def test_manifest_accessors_read_request_state():
+    request = FakeRequest(
+        pjx_mounted="mounted-manifest",
+        pjx_assets="loaded-assets",
+        pjx_trigger="trigger-manifest",
+        pjx_context=None,
+    )
+    with request_scope() as session:
+        session.pjx_request = request
+        ctx = PjxContext.current()
+        assert ctx.request is request
+        assert ctx.mounted == "mounted-manifest"
+        assert ctx.assets == "loaded-assets"
+        assert ctx.trigger == "trigger-manifest"
+
+
+def test_manifest_accessors_are_none_without_a_request():
+    with request_scope():
+        ctx = PjxContext.current()
+        assert ctx.request is None
+        assert ctx.mounted is None
+        assert ctx.assets is None
+        assert ctx.trigger is None
+
+
+def test_app_context_is_none_when_no_factory_was_configured():
+    request = FakeRequest(pjx_context=None)
+    with request_scope() as session:
+        session.pjx_request = request
+        assert PjxContext.current().app_context is None
+
+
+def test_app_context_is_the_factory_result_when_one_was_configured():
+    sentinel = object()
+    request = FakeRequest(pjx_context=sentinel)
+    with request_scope() as session:
+        session.pjx_request = request
+        assert PjxContext.current().app_context is sentinel
+
+
+def test_app_context_is_none_without_a_request():
+    with request_scope():
+        assert PjxContext.current().app_context is None

--- a/tests/pyjinhx2/test_context.py
+++ b/tests/pyjinhx2/test_context.py
@@ -1,0 +1,57 @@
+"""PjxContext is a live view: every accessor re-reads session.py, nothing caches."""
+
+import pytest
+
+from pyjinhx2.context import PjxContext
+from pyjinhx2.session import (
+    NoActiveRequestScope,
+    add_dirtied,
+    current_session,
+    get_cache_reverse,
+    get_cache_store,
+    get_dirtied,
+    get_instances,
+    request_scope,
+)
+
+
+class FakeState:
+    """Stand-in for ``request.state``, populated the way PjxScopeMiddleware does."""
+
+    def __init__(self, **values: object) -> None:
+        self.__dict__.update(values)
+
+
+class FakeRequest:
+    """Stand-in for a Starlette Request carrying only the pjx state attributes."""
+
+    def __init__(self, **values: object) -> None:
+        self.state = FakeState(**values)
+
+
+def test_session_accessor_is_the_bound_session():
+    with request_scope() as session:
+        assert PjxContext.current().session is session
+
+
+def test_dirtied_instances_and_cache_accessors_are_identity_stable():
+    with request_scope():
+        ctx = PjxContext.current()
+        assert ctx.dirtied is get_dirtied()
+        assert ctx.instances is get_instances()
+        assert ctx.cache_store is get_cache_store()
+        assert ctx.cache_reverse is get_cache_reverse()
+
+
+def test_dirtied_reflects_later_mutations_without_staleness():
+    with request_scope():
+        ctx = PjxContext.current()
+        add_dirtied(["Widget:1"])
+        assert "Widget:1" in ctx.dirtied
+        assert ctx.dirtied is get_dirtied()
+
+
+def test_current_outside_a_request_scope_raises_no_active_request_scope():
+    assert current_session() is None
+    with pytest.raises(NoActiveRequestScope):
+        PjxContext.current()

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -67,6 +67,12 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
             "pyjinhx2.integrations.fastapi",
         }
     ),
+    # context sits above the spine with config and integrations.fastapi: it is a
+    # read-only view over session's ContextVars plus the pjx state the FastAPI
+    # middleware parsed onto the request. Request is typed from starlette, never
+    # imported from integrations.fastapi, so the adapter keeps zero importers
+    # below it. Nothing in the spine may import context back.
+    "context": frozenset({"pyjinhx2.session"}),
     "descriptor": frozenset(),
     # discovery keys the registry by each class's own resolved tag, so it reads
     # component.py's snake-case helper rather than inventing a second naming
@@ -284,6 +290,18 @@ def test_nothing_below_config_imports_config():
         if "pyjinhx2.config" in internal_imports(path)
     }
     assert importers == {"integrations.fastapi"}
+
+
+def test_nothing_imports_context():
+    """context.py is a leaf consumer. The spine, reactive/ and client/ expose
+    state through session.py's accessors; importing the facade back would make
+    the view a dependency of the thing it views."""
+    importers = {
+        module_name(path)
+        for path in module_paths()
+        if "pyjinhx2.context" in internal_imports(path)
+    }
+    assert importers == set()
 
 
 def test_no_render_spine_module_declares_a_reactive_import():


### PR DESCRIPTION
## Summary

Adds the `pjx_request` attribute to the RenderSession class to support type checking. The attribute was being accessed in tests and context.py but was not defined, causing type checking errors.

Implements:
- PjxContext session/dirtied/instance/cache accessors
- PjxContext manifest and app_context accessors
- Import graph edge declarations and guards

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)