### PR TITLE
test: L3.9.1 core reactive parity — cover dirty() with no keys (#488)

### DIFF
--- a/tests/pyjinhx2/reactive/test_reactive_mutations.py
+++ b/tests/pyjinhx2/reactive/test_reactive_mutations.py
@@ -129,6 +129,13 @@ def test_dirty_and_mutates_accumulate_across_calls_in_one_scope():
         assert get_dirtied() == {"todos", "user", "todos:7"}
 
 
+def test_dirty_with_no_keys_leaves_the_dirtied_set_untouched():
+    with request_scope():
+        dirty(Keys.TODOS)
+        dirty()
+        assert get_dirtied() == {"todos"}
+
+
 def test_get_dirtied_outside_a_scope_is_empty():
     assert get_dirtied() == set()
 


### PR DESCRIPTION
Closes #488.

## Parity diff (v0.x core reactive unit tests -> tests/pyjinhx2/reactive/)

Scope: `pyjinhx2/reactive/{keys,mutations,cache}.py` + `ReactiveComponent.state_hash()`. Fan-out/OOB and the hash-gate decision are #489; the demo is #490; suite sign-off is #491.

**Genuine gap found and closed (1):**
- `test_mutations.py::test_dirty_without_args_is_noop` -> added as `test_dirty_with_no_keys_leaves_the_dirtied_set_untouched` in `test_reactive_mutations.py`.

**Already covered on master (no action):**
- `test_mutations.py`: `test_mutates_accumulates_pending_dirtied`, `test_request_scope_isolates_mutations`, `test_dirty_records_multiple_keys`, `test_dirty_rejects_bare_strings`, `test_dirty_accepts_reactive_key`, `test_mutates_accepts_reactive_key`, `test_mutates_key_kwarg_derives_from_call_args`, `test_mutates_key_kwarg_reflects_each_call`, `test_mutates_key_kwarg_applies_to_every_key`.
- `test_load_cache.py`: `test_load_result_is_cached`, `test_invalidate_evicts_matching_dependency`, `test_invalidate_unrelated_key_keeps_cache`, `test_invalidate_empty_set_is_noop`, `test_invalidate_cleans_reverse_index_across_keys`.
- `test_reactive_keys_helpers.py` / `test_keys.py`: enum coercion, `reactive_key()` formatting and pass-through.
- `test_hash_gating.py` hash-computation scenarios -> `test_reactive_state_hash.py` (28 tests, incl. exclude-inheritance).

**Intentionally dropped (no v2 surface / owned elsewhere):**
1. `test_load_cache_scope.py` (all) + `test_cache_default.py` — ADR 0011: v2 cache is request-scope only, no scope config exists.
2. `test_load_cache.py::test_load_returns_independent_copies` — v2 `cache_put()` stores values as-is by design; no copy semantics to test.
3. `test_load_cache.py::test_invalidate_is_exported` — redundant with `test_import_graph.py`.
4. `test_instance_key_cache.py`, `test_dynamic_reactive_keys.py` — `ReactiveComponent` keyed-instance wiring, owned by #444; their cache-mechanism content is covered generically in `test_reactive_cache.py`.
5. `test_reactive_keys_and_enum_load.py` — class-definition-time wiring (`component.py`) and OOB matching (`fanout.py`, #489); the coercion it depends on is covered in `test_reactive_keys.py`.

Note for #489: `invalidate()` has no production caller in v2 yet — wiring dirtied keys to cache eviction lands with fan-out.

## Verification
- `uv run pytest tests/ -q`: 2854 passed, 5 skipped
- `uvx basedpyright pyjinhx2/ tests/pyjinhx2/`: 0 errors
- `uvx ruff@0.16.0 check .` / `format --check .`: clean
