### PR TITLE
docs: correct architecture-overview.md's asset-delta source

### DIFF
--- a/docs/superpowers/rebuild/architecture-overview.md
+++ b/docs/superpowers/rebuild/architecture-overview.md
@@ -91,8 +91,7 @@ graph LR
     InstReg -- "resolve name+id;<br/>cached render if clean" --> Fanout
     Hash -- "fresh hash vs<br/>manifest hash: gate" --> Fanout
     Fanout -- "OOB swaps<br/>(stamped at root_span)" --> Pjx
-    Session -. "missing assets<br/>(X-PJX-Assets dedup)" .-> Fanout
-    Fanout -. "swap-in assets" .-> Pjx
+    Fanout -. "missing assets<br/>(candidates' descriptors vs<br/>X-PJX-Assets dedup)" .-> Pjx
 ```
 
 Edge semantics, restated for this map: **solid** — the consumer cannot produce its output without this input (`Parse` cannot exist without Jinja's string). **Dotted** — keyed lookup or hook; a miss is a defined, non-error path (`Expand` on an unknown tag passes it through verbatim; a non-reactive component never touches `InstReg`). **Thick** — single-writer ownership (`Discovery` is the only writer of `ClassReg`; `Load` is the only writer of `InstReg` entries; `Expand` is the only caller that splices children).
@@ -163,7 +162,7 @@ All 60+ components. Pure consumers of everything above — no engine edges of th
 
 **Root span is written twice, parsed never.** The stamp mechanism splices pass-through attrs at render time; fan-out splices `hx-swap-oob` at response time. Same offset, same splice primitive, two moments. In v0.36 each of these was a separate document parse.
 
-**Assets flow through two doors.** Cold render: RenderSession → inline tags at serialize. Reactive swap: fan-out compares session accumulation against `X-PJX-Assets` and ships only the delta as OOB fragments. Same accumulator, two emission paths — which is why RenderSession lives in L2 but has a dotted edge into L3.
+**Assets flow through two doors.** Cold render: RenderSession → inline tags at serialize. Reactive swap (#490): fan-out compares the surviving candidates' frozen class descriptors — not session accumulation — against `X-PJX-Assets` and ships only the delta as OOB fragments (`pyjinhx2/reactive/assets.py`). Nothing subscribes `accumulate_assets` onto the fan-out render's session, so that accumulator is empty on the dirty path; descriptors are already frozen, already carry the paths, and cover clean candidates too (a clean region still needs its CSS if the client never got it). INLINE mode only today — LINK-mode delivery and cold-render `data-pjx-asset` stamping are open follow-ups (`TODO(#490 follow-up)` in `assets.py`).
 
 **Discovery and `{#def#}` are the only writers at import time; everything per-request is ContextVar.** The full mutable-state census (invariant 4): class registry + descriptors (built-then-swap, import/registration time), instance registry + RenderSession + dirtied keys + LoadCache request store + LoadCache reverse index (ContextVar, reset by `request_scope`). Nothing else. A mechanism needing mutable state not in this census amends this census first.
 

--- a/pyjinhx2/assets.py
+++ b/pyjinhx2/assets.py
@@ -1,6 +1,7 @@
 """L2.2 assets — delivery modes, emission, and the manifest of a request's assets."""
 
 import hashlib
+import os
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import Enum
@@ -175,6 +176,20 @@ def hashed_filename(path: Path, *, hash_len: int = 8) -> str:
     result = f"{path.stem}.{digest}{path.suffix}"
     _hash_filename_cache[key] = result
     return result
+
+
+def asset_token(path: Path) -> str:
+    """Return the opaque dedup token the client reports for this asset.
+
+    The identity the ``data-pjx-asset`` attribute carries and ``X-PJX-Assets``
+    reports back, so the server can tell an asset the browser already has from
+    one it does not. Derived from the normalized path rather than the file's
+    contents: an edited asset must keep the same identity, or every reactive
+    response after an edit would append a second copy to the head instead of
+    recognizing the one already there.
+    """
+    normalized = os.path.normpath(str(path)).replace("\\", "/")
+    return hashlib.sha1(normalized.encode("utf-8")).hexdigest()[:16]
 
 
 def resolver_with_hash(base_url: str, root: str) -> Callable[[Path], str]:

--- a/pyjinhx2/reactive/assets.py
+++ b/pyjinhx2/reactive/assets.py
@@ -1,0 +1,108 @@
+"""The asset delta: which of a fan-out's assets the client does not have yet.
+
+An OOB region swap carries markup only. A region that is being swapped in for
+the first time in this page's life still needs its stylesheet and its script,
+and the client tells the server which ones it already has in ``X-PJX-Assets``.
+This module answers the difference, as head-targeted OOB fragments pjx.js
+relocates on arrival (``pyjinhx2/client/pjx.js`` reads ``data-pjx-asset``).
+
+Ported from v0.x's ``render_missing_assets_oob`` (``pyjinhx/assets.py``), with
+one deliberate difference: the required paths come from the candidates' frozen
+class descriptors rather than from a shared RenderSession's accumulator, since
+nothing in v2 subscribes ``accumulate_assets`` onto the fan-out render's
+session and that accumulator would therefore always be empty.
+"""
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from pyjinhx2.assets import AssetMode, asset_token
+from pyjinhx2.reactive.fanout import FanoutCandidate
+from pyjinhx2.session import RenderSession
+
+# TODO(#490 follow-up): LINK mode needs a URL resolver to build <link href>/
+# <script src> tags, and ReactiveResponse has no resolver to hand down, so a
+# LINK-mode app delivers no swap-in assets today. Same for cold renders:
+# emit_assets() does not stamp data-pjx-asset yet, so a freshly loaded page
+# reports an empty token set and pays one redundant re-delivery on its first
+# reactive response.
+
+
+def required_asset_paths(
+    candidates: Iterable[FanoutCandidate],
+) -> tuple[set[Path], set[Path]]:
+    """The CSS and JS paths every rendering candidate in this walk needs.
+
+    A ``"missing"`` candidate is skipped: its region is being deleted from the
+    client, so there is nothing left for an asset to style or drive. Clean
+    candidates are included — a region the client already shows correctly can
+    still be a region whose stylesheet never arrived.
+
+    Args:
+        candidates: ``walk_manifest()`` output.
+
+    Returns:
+        The CSS paths and the JS paths, deduped across candidates.
+    """
+    css: set[Path] = set()
+    js: set[Path] = set()
+    for candidate in candidates:
+        if candidate.status == "missing":
+            continue
+        # A class that never went through descriptor resolution contributes
+        # nothing rather than taking the whole response down over an asset.
+        descriptor: Any = getattr(candidate.component_class, "__pjx_descriptor__", None)
+        if descriptor is None:
+            continue
+        css.update(descriptor.css_paths)
+        js.update(descriptor.js_paths)
+    return css, js
+
+
+def _inline_fragments(
+    paths: set[Path], loaded: frozenset[str], open_tag: str, close_tag: str
+) -> list[str]:
+    """One head-targeted OOB fragment per path the client does not report.
+
+    Path-sorted for the same reason ``emit_assets`` sorts: the store is a set,
+    and two identical responses must be byte-identical.
+    """
+    fragments: list[str] = []
+    for path in sorted(paths, key=str):
+        token = asset_token(path)
+        if token in loaded:
+            continue
+        fragments.append(
+            f'{open_tag} data-pjx-asset="{token}" hx-swap-oob="beforeend:head">'
+            f"{path.read_text()}{close_tag}"
+        )
+    return fragments
+
+
+def missing_asset_oob(
+    candidates: Iterable[FanoutCandidate],
+    loaded: frozenset[str],
+    session: RenderSession,
+) -> str:
+    """The OOB fragments delivering assets this walk needs and the client lacks.
+
+    Args:
+        candidates: ``walk_manifest()`` output for this request.
+        loaded: ``LoadedAssets.parse()`` output — the tokens the browser
+            reports. An unreadable header parses to an empty set, which means
+            every required asset is delivered rather than none.
+        session: The RenderSession whose css_mode/js_mode decide delivery.
+
+    Returns:
+        CSS fragments then JS fragments, newline-joined, or ``""`` when the
+        client already has everything, no candidate declares an asset, or the
+        session delivers that kind some other way.
+    """
+    css_paths, js_paths = required_asset_paths(candidates)
+    fragments: list[str] = []
+    if session.css_mode is AssetMode.INLINE:
+        fragments += _inline_fragments(css_paths, loaded, "<style", "</style>")
+    if session.js_mode is AssetMode.INLINE:
+        fragments += _inline_fragments(js_paths, loaded, "<script", "</script>")
+    return "\n".join(fragments)

--- a/pyjinhx2/reactive/response.py
+++ b/pyjinhx2/reactive/response.py
@@ -4,10 +4,11 @@ from typing import Literal
 
 from markupsafe import Markup
 
-from pyjinhx2.client.inject import MountedManifest
+from pyjinhx2.client.inject import LoadedAssets, MountedManifest
+from pyjinhx2.reactive.assets import missing_asset_oob
 from pyjinhx2.reactive.cache import invalidate
 from pyjinhx2.reactive.fanout import FanoutCandidate, oob_swaps, walk_manifest
-from pyjinhx2.session import current_session, get_dirtied
+from pyjinhx2.session import RenderSession, current_session, get_dirtied
 
 
 class ReactiveResponse:
@@ -28,6 +29,7 @@ class ReactiveResponse:
         mounted: object = None,
         redirect: str | None = None,
         redirect_mode: Literal["redirect", "location"] = "redirect",
+        assets: object = None,
     ) -> None:
         """Store the inputs; nothing is walked or rendered until ``body`` is read.
 
@@ -40,6 +42,12 @@ class ReactiveResponse:
             redirect_mode: ``"redirect"`` for a full browser navigation
                 (``HX-Redirect``), ``"location"`` for htmx's client-side ajax
                 navigation (``HX-Location``). Ignored when ``redirect`` is None.
+            assets: The raw ``X-PJX-Assets`` header value, a pre-parsed token
+                list, a request-like object, or None. None falls back to
+                ``mounted`` when that is itself a request-like object, so a
+                handler passing ``mounted=request`` gets both headers for free;
+                anything unreadable means "the client has nothing", and every
+                required asset is delivered.
 
         Raises:
             ValueError: If ``redirect`` is given as an empty string.
@@ -52,6 +60,7 @@ class ReactiveResponse:
         self.mounted = mounted
         self.redirect = redirect
         self.redirect_mode: Literal["redirect", "location"] = redirect_mode
+        self.assets = assets
 
     def candidates(self) -> list[FanoutCandidate]:
         """The fan-out candidates this request's dirtied keys make of the manifest.
@@ -76,16 +85,47 @@ class ReactiveResponse:
             primary_html=self.primary,
         )
 
+    def _loaded_assets(self) -> frozenset[str]:
+        """The asset tokens the client reports, from whichever input carries them.
+
+        ``mounted`` is only consulted when it is a request-like object: a raw
+        manifest string or list holds region entries, and handing those to the
+        asset parser would invent tokens out of region ids.
+        """
+        if self.assets is not None:
+            return LoadedAssets.parse(self.assets)
+        if isinstance(self.mounted, (str, list)) or self.mounted is None:
+            return frozenset()
+        return LoadedAssets.parse(self.mounted)
+
     @property
     def body(self) -> Markup:
-        """The whole response body: primary markup, then the OOB fragments.
+        """The whole response body: primary markup, OOB fragments, missing assets.
 
         Returns:
-            ``Markup(primary or "") + oob_swaps(candidates)``. Concatenation only —
-            the fragments were already stamped by splicing at recorded offsets, so
+            The primary markup, then one OOB fragment per surviving candidate,
+            then the head-targeted fragments for assets those candidates need
+            and the client did not report. Concatenation only — the region
+            fragments were already stamped by splicing at recorded offsets, so
             nothing here re-parses either side.
         """
-        return Markup(self.primary or "") + oob_swaps(self.candidates())
+        # One walk, not two: candidates() re-renders every dirty region, so
+        # asking it again for the asset leg would double every load() and every
+        # render this response pays for.
+        candidates = self.candidates()
+        session = current_session() or RenderSession()
+        # Markup(self.primary or "") first, not str(self.primary or ""): a
+        # handler-supplied primary can be an object exposing only __html__
+        # (never __str__), and Markup() is what adopts that protocol without
+        # escaping. str()-ing the raw object first would silently fall through
+        # to object.__str__ and ship a Python repr instead of the markup
+        # (caught by test_primary_with_dunder_html_is_used_as_markup).
+        parts = [
+            str(Markup(self.primary or "")),
+            str(oob_swaps(candidates)),
+            missing_asset_oob(candidates, self._loaded_assets(), session),
+        ]
+        return Markup("\n".join(part for part in parts if part))
 
     @property
     def headers(self) -> dict[str, str]:

--- a/tests/pyjinhx2/integrations/test_reactive_request_cycle.py
+++ b/tests/pyjinhx2/integrations/test_reactive_request_cycle.py
@@ -17,6 +17,7 @@ from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from pyjinhx2 import discovery, registry
+from pyjinhx2.assets import asset_token
 from pyjinhx2.config import PjxSettings
 from pyjinhx2.context import PjxContext
 from pyjinhx2.dev import warn_unconsumed_mutations
@@ -63,6 +64,19 @@ class CycleCard(ReactiveComponent, react=(Keys.CYCLE,)):
         return STORE.get(self.pjx_key, 0)
 
 
+class CycleBadge(ReactiveComponent, react=(Keys.CYCLE,)):
+    """A second reactive region, this one carrying CSS and JS assets."""
+
+    pjx_key: Annotated[str, PjxKey()] = ""
+
+    def load(self) -> int:
+        LOAD_CALLS.append(f"badge:{self.pjx_key}")
+        return STORE.get(self.pjx_key, 0)
+
+
+ASSET_DIR = Path(__file__).parent.parent.parent / "templates"
+
+
 class Counter:
     """An app object whose mutation method dirties the ``cycle`` key."""
 
@@ -77,13 +91,19 @@ def _publish_registry():
     STORE.clear()
     LOAD_CALLS.clear()
     template_dir = Path(__file__).parent.parent.parent / "templates"
-    discovery.build_registry(template_dir, [CycleCard])
+    discovery.build_registry(template_dir, [CycleCard, CycleBadge])
     # `_resolve_template_path` probes the class's *defining module* directory
     # (this test file's), not the dir handed to build_registry, so the
     # descriptor is repointed at the bare template name the middleware's
     # FileSystemLoader will join under tests/templates.
     CycleCard.__pjx_descriptor__ = dataclasses.replace(
         CycleCard.__pjx_descriptor__, template_path=Path("cycle_card.pjx")
+    )
+    CycleBadge.__pjx_descriptor__ = dataclasses.replace(
+        CycleBadge.__pjx_descriptor__,
+        template_path=Path("cycle_badge.pjx"),
+        css_paths=(ASSET_DIR / "cycle_badge.css",),
+        js_paths=(ASSET_DIR / "cycle_badge.js",),
     )
     yield
 
@@ -98,6 +118,11 @@ def make_app(**settings_kwargs) -> FastAPI:
 def entry(instance_id: str, load: object, hash_: str = "stale") -> dict:
     """One synthetic X-PJX-Mounted entry naming a mounted CycleCard region."""
     return {"type": "cycle_card", "id": instance_id, "load": load, "hash": hash_}
+
+
+def badge_entry(instance_id: str, load: object, hash_: str = "stale") -> dict:
+    """One synthetic X-PJX-Mounted entry naming a mounted CycleBadge region."""
+    return {"type": "cycle_badge", "id": instance_id, "load": load, "hash": hash_}
 
 
 def test_apply_setup_idempotent_on_repeat_calls():
@@ -241,6 +266,116 @@ def test_unchanged_region_is_gated_out_of_the_oob_swap():
     # Dirty says the data may have moved; the hash says this region's output
     # did not, so the swap that would replace it with itself is dropped.
     assert "hx-swap-oob" not in response.text
+
+
+def test_mutation_round_trip_demo_swaps_dirty_regions_and_ships_missing_assets():
+    """One request through every leg: dirty -> evict -> fan-out -> gate -> assets."""
+    app = make_app()
+    STORE["card-1"] = 0
+    STORE["card-2"] = 41
+    unchanged_hash = CycleCard(id="b", pjx_key="card-2").state_hash()
+
+    @app.post("/bump")
+    def bump(request: Request):
+        for instance_id, cls, key in (
+            ("a", CycleCard, "card-1"),
+            ("b", CycleCard, "card-2"),
+            ("c", CycleBadge, "card-1"),
+        ):
+            registry.register_instance(
+                cls.__name__, instance_id, cls(id=instance_id, pjx_key=key)
+            )
+        Counter().bump("card-1")
+        return ReactiveResponse(primary="", mounted=request, assets=request)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/bump",
+            headers={
+                "X-PJX-Mounted": json.dumps(
+                    [
+                        entry("a", load="card-1"),
+                        entry("b", load="card-2", hash_=unchanged_hash),
+                        badge_entry("c", load="card-1"),
+                        # A region the registry no longer knows about: gone.
+                        badge_entry("gone", load="card-9"),
+                    ]
+                ),
+                "X-PJX-Assets": "[]",
+            },
+        )
+
+    body = response.text
+    # 1-3: the mutation moved the store, eviction let the swap re-read it.
+    assert STORE["card-1"] == 1
+    # 4a: the dirty+changed region swaps.
+    assert "hx-swap-oob=\"outerHTML:[data-pjx-id='a']\"" in body
+    # 4b: dirty but byte-identical output — gated out.
+    assert "[data-pjx-id='b']" not in body
+    # 4c: a region the registry lost is deleted rather than re-rendered.
+    assert "hx-swap-oob=\"delete:[data-pjx-id='gone']\"" in body
+    # 5: the asset-bearing region's CSS and JS ride along, head-targeted.
+    css_token = asset_token(ASSET_DIR / "cycle_badge.css")
+    js_token = asset_token(ASSET_DIR / "cycle_badge.js")
+    assert f'<style data-pjx-asset="{css_token}" hx-swap-oob="beforeend:head">' in body
+    assert f'<script data-pjx-asset="{js_token}" hx-swap-oob="beforeend:head">' in body
+    # 6: nothing for htmx's default swap to place.
+    assert response.headers["HX-Reswap"] == "none"
+
+
+def test_round_trip_does_not_resend_assets_the_client_already_reports():
+    app = make_app()
+    STORE["card-1"] = 0
+    css_token = asset_token(ASSET_DIR / "cycle_badge.css")
+    js_token = asset_token(ASSET_DIR / "cycle_badge.js")
+
+    @app.post("/bump")
+    def bump(request: Request):
+        registry.register_instance(
+            CycleBadge.__name__, "c", CycleBadge(id="c", pjx_key="card-1")
+        )
+        Counter().bump("card-1")
+        return ReactiveResponse(primary="", mounted=request, assets=request)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/bump",
+            headers={
+                "X-PJX-Mounted": json.dumps([badge_entry("c", load="card-1")]),
+                "X-PJX-Assets": json.dumps([css_token, js_token]),
+            },
+        )
+
+    assert "hx-swap-oob=\"outerHTML:[data-pjx-id='c']\"" in response.text
+    assert "data-pjx-asset" not in response.text
+
+
+def test_a_malformed_assets_header_means_the_client_has_nothing():
+    app = make_app()
+    STORE["card-1"] = 0
+
+    @app.post("/bump")
+    def bump(request: Request):
+        registry.register_instance(
+            CycleBadge.__name__, "c", CycleBadge(id="c", pjx_key="card-1")
+        )
+        Counter().bump("card-1")
+        return ReactiveResponse(primary="", mounted=request, assets=request)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/bump",
+            headers={
+                "X-PJX-Mounted": json.dumps([badge_entry("c", load="card-1")]),
+                "X-PJX-Assets": "{not json",
+            },
+        )
+
+    # An unreadable browser-supplied header re-delivers rather than raising.
+    assert (
+        f'data-pjx-asset="{asset_token(ASSET_DIR / "cycle_badge.css")}"'
+        in response.text
+    )
 
 
 def test_pjx_context_current_populated_inside_live_handler():

--- a/tests/pyjinhx2/reactive/test_fanout_assets.py
+++ b/tests/pyjinhx2/reactive/test_fanout_assets.py
@@ -1,0 +1,113 @@
+"""The asset-delta leg of fan-out: which required assets the client is missing."""
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from pyjinhx2.assets import AssetMode, asset_token
+from pyjinhx2.reactive.assets import missing_asset_oob, required_asset_paths
+from pyjinhx2.reactive.component import ReactiveComponent
+from pyjinhx2.reactive.fanout import FanoutCandidate
+from pyjinhx2.reactive.keys import MutationKey
+from pyjinhx2.session import RenderSession
+
+
+class Keys(MutationKey):
+    WIDGET = "widget"
+
+
+class AssetWidget(ReactiveComponent, react=(Keys.WIDGET,)):
+    """A reactive component whose descriptor is repointed at real asset files."""
+
+    def load(self) -> int:
+        return 0
+
+
+@pytest.fixture
+def asset_files(tmp_path: Path) -> tuple[Path, Path]:
+    css = tmp_path / "widget.css"
+    css.write_text(".widget{color:red}")
+    js = tmp_path / "widget.js"
+    js.write_text("window.widget=1;")
+    AssetWidget.__pjx_descriptor__ = dataclasses.replace(
+        AssetWidget.__pjx_descriptor__, css_paths=(css,), js_paths=(js,)
+    )
+    return css, js
+
+
+def candidate(status: str = "dirty") -> FanoutCandidate:
+    return FanoutCandidate(
+        type_name="asset_widget",
+        component_class=AssetWidget,
+        instance_id="w1",
+        load=None,
+        status=status,
+        entry={"id": "w1", "type": "asset_widget"},
+    )
+
+
+def test_required_asset_paths_reads_the_candidate_classes_descriptors(asset_files):
+    css, js = asset_files
+    assert required_asset_paths([candidate()]) == ({css}, {js})
+
+
+def test_a_missing_candidate_requires_nothing(asset_files):
+    assert required_asset_paths([candidate(status="missing")]) == (set(), set())
+
+
+def test_missing_asset_oob_emits_only_the_tokens_the_client_lacks(asset_files):
+    css, js = asset_files
+    session = RenderSession()
+    fragment = missing_asset_oob(
+        [candidate()], frozenset({asset_token(css)}), session
+    )
+
+    assert asset_token(css) not in fragment
+    assert (
+        f'<script data-pjx-asset="{asset_token(js)}" '
+        'hx-swap-oob="beforeend:head">window.widget=1;</script>' in fragment
+    )
+
+
+def test_missing_asset_oob_emits_both_kinds_when_the_client_has_nothing(asset_files):
+    css, js = asset_files
+    fragment = missing_asset_oob([candidate()], frozenset(), RenderSession())
+
+    assert f'<style data-pjx-asset="{asset_token(css)}"' in fragment
+    assert f'<script data-pjx-asset="{asset_token(js)}"' in fragment
+    # CSS before JS, so a script that measures layout sees the styled DOM.
+    assert fragment.index("<style") < fragment.index("<script")
+
+
+def test_missing_asset_oob_is_empty_when_the_client_has_everything(asset_files):
+    css, js = asset_files
+    loaded = frozenset({asset_token(css), asset_token(js)})
+
+    assert missing_asset_oob([candidate()], loaded, RenderSession()) == ""
+
+
+def test_garbage_tokens_are_treated_as_having_nothing(asset_files):
+    css, _ = asset_files
+    fragment = missing_asset_oob(
+        [candidate()], frozenset({"not-a-real-token"}), RenderSession()
+    )
+
+    assert asset_token(css) in fragment
+
+
+def test_a_class_with_no_assets_is_a_no_op_not_an_error():
+    class Bare(ReactiveComponent, react=(Keys.WIDGET,)):
+        def load(self) -> int:
+            return 0
+
+    bare = dataclasses.replace(candidate(), component_class=Bare)
+    assert missing_asset_oob([bare], frozenset(), RenderSession()) == ""
+
+
+def test_non_inline_modes_emit_nothing(asset_files):
+    session = RenderSession()
+    session.css_mode = AssetMode.NONE
+    session.js_mode = AssetMode.LINK
+
+    assert missing_asset_oob([candidate()], frozenset(), session) == ""

--- a/tests/pyjinhx2/reactive/test_fanout_assets.py
+++ b/tests/pyjinhx2/reactive/test_fanout_assets.py
@@ -111,3 +111,55 @@ def test_non_inline_modes_emit_nothing(asset_files):
     session.js_mode = AssetMode.LINK
 
     assert missing_asset_oob([candidate()], frozenset(), session) == ""
+
+
+def test_reactive_response_appends_the_asset_fragment_after_the_swaps(
+    asset_files, monkeypatch
+):
+    from pyjinhx2.reactive import response as response_module
+
+    css, _ = asset_files
+    # status="clean": a "dirty" FanoutCandidate must carry a real RenderedLevel
+    # or oob_swaps() asserts (walk_manifest's contract), and this test only
+    # exercises the asset leg, not the swap markup.
+    monkeypatch.setattr(
+        response_module.ReactiveResponse, "candidates", lambda self: [candidate("clean")]
+    )
+    body = str(
+        response_module.ReactiveResponse(
+            primary="", mounted=None, assets='["nope"]'
+        ).body
+    )
+
+    assert asset_token(css) in body
+
+
+def test_reactive_response_omits_the_asset_fragment_when_the_client_has_it(
+    asset_files, monkeypatch
+):
+    from pyjinhx2.reactive import response as response_module
+
+    css, js = asset_files
+    monkeypatch.setattr(
+        response_module.ReactiveResponse, "candidates", lambda self: [candidate("clean")]
+    )
+    loaded = [asset_token(css), asset_token(js)]
+    body = str(
+        response_module.ReactiveResponse(
+            primary="", mounted=None, assets=loaded
+        ).body
+    )
+
+    assert "data-pjx-asset" not in body
+
+
+def test_an_assets_only_body_still_says_do_not_swap(asset_files, monkeypatch):
+    from pyjinhx2.reactive import response as response_module
+
+    monkeypatch.setattr(
+        response_module.ReactiveResponse, "candidates", lambda self: [candidate("clean")]
+    )
+    reactive = response_module.ReactiveResponse(primary="", mounted=None, assets=None)
+
+    assert "data-pjx-asset" in str(reactive.body)
+    assert reactive.headers["HX-Reswap"] == "none"

--- a/tests/pyjinhx2/reactive/test_fanout_assets.py
+++ b/tests/pyjinhx2/reactive/test_fanout_assets.py
@@ -59,9 +59,7 @@ def test_a_missing_candidate_requires_nothing(asset_files):
 def test_missing_asset_oob_emits_only_the_tokens_the_client_lacks(asset_files):
     css, js = asset_files
     session = RenderSession()
-    fragment = missing_asset_oob(
-        [candidate()], frozenset({asset_token(css)}), session
-    )
+    fragment = missing_asset_oob([candidate()], frozenset({asset_token(css)}), session)
 
     assert asset_token(css) not in fragment
     assert (
@@ -123,7 +121,9 @@ def test_reactive_response_appends_the_asset_fragment_after_the_swaps(
     # or oob_swaps() asserts (walk_manifest's contract), and this test only
     # exercises the asset leg, not the swap markup.
     monkeypatch.setattr(
-        response_module.ReactiveResponse, "candidates", lambda self: [candidate("clean")]
+        response_module.ReactiveResponse,
+        "candidates",
+        lambda self: [candidate("clean")],
     )
     body = str(
         response_module.ReactiveResponse(
@@ -141,13 +141,13 @@ def test_reactive_response_omits_the_asset_fragment_when_the_client_has_it(
 
     css, js = asset_files
     monkeypatch.setattr(
-        response_module.ReactiveResponse, "candidates", lambda self: [candidate("clean")]
+        response_module.ReactiveResponse,
+        "candidates",
+        lambda self: [candidate("clean")],
     )
     loaded = [asset_token(css), asset_token(js)]
     body = str(
-        response_module.ReactiveResponse(
-            primary="", mounted=None, assets=loaded
-        ).body
+        response_module.ReactiveResponse(primary="", mounted=None, assets=loaded).body
     )
 
     assert "data-pjx-asset" not in body
@@ -157,7 +157,9 @@ def test_an_assets_only_body_still_says_do_not_swap(asset_files, monkeypatch):
     from pyjinhx2.reactive import response as response_module
 
     monkeypatch.setattr(
-        response_module.ReactiveResponse, "candidates", lambda self: [candidate("clean")]
+        response_module.ReactiveResponse,
+        "candidates",
+        lambda self: [candidate("clean")],
     )
     reactive = response_module.ReactiveResponse(primary="", mounted=None, assets=None)
 

--- a/tests/pyjinhx2/test_assets.py
+++ b/tests/pyjinhx2/test_assets.py
@@ -260,3 +260,18 @@ def test_all_assets_returns_paths_not_strings():
     css, js = all_assets()
     assert all(isinstance(path, Path) for path in css)
     assert all(isinstance(path, Path) for path in js)
+
+
+def test_asset_token_is_a_stable_short_digest_of_the_normalized_path():
+    from pyjinhx2.assets import asset_token
+
+    token = asset_token(Path("a/../a/style.css"))
+    assert token == asset_token(Path("a/style.css"))
+    assert len(token) == 16
+    assert token.isalnum()
+
+
+def test_asset_token_differs_per_path():
+    from pyjinhx2.assets import asset_token
+
+    assert asset_token(Path("a/style.css")) != asset_token(Path("b/style.css"))

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -133,10 +133,23 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # #489/#488: `candidates()` also evicts the load cache for this request's
     # dirtied keys before walking, so cache.py's `invalidate()` is a direct edge
     # too, not just fanout.py's own transitive one.
+    # #490: the asset-delta leg reads assets.py's fragment builder alongside
+    # everything the region-swap leg already reads.
     "reactive.response": frozenset(
         {
             "pyjinhx2.client.inject",
+            "pyjinhx2.reactive.assets",
             "pyjinhx2.reactive.cache",
+            "pyjinhx2.reactive.fanout",
+            "pyjinhx2.session",
+        }
+    ),
+    # #490: which of a fan-out's required assets the client is missing, read
+    # from the candidates' frozen descriptors (not session accumulation - see
+    # the module docstring) and diffed against asset_token()'s identity.
+    "reactive.assets": frozenset(
+        {
+            "pyjinhx2.assets",
             "pyjinhx2.reactive.fanout",
             "pyjinhx2.session",
         }

--- a/tests/templates/cycle_badge.css
+++ b/tests/templates/cycle_badge.css
@@ -1,0 +1,1 @@
+.badge{color:blue}

--- a/tests/templates/cycle_badge.js
+++ b/tests/templates/cycle_badge.js
@@ -1,0 +1,1 @@
+window.badge=1;

--- a/tests/templates/cycle_badge.pjx
+++ b/tests/templates/cycle_badge.pjx
@@ -1,0 +1,1 @@
+<span>badge {{ pjx_key }}</span>


### PR DESCRIPTION
## Summary
- Add asset_token() for stable path-derived asset identity
- Compute the fan-out asset delta and its OOB fragments
- Wire the asset delta into ReactiveResponse.body
- Demo the full mutation round trip through dirty->evict->fanout->gate->assets
- Correct architecture-overview.md's asset-delta source

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)