### PR TITLE
feat: port PJXBadge to the v2 engine

### DIFF
--- a/pyjinhx2/builtins/ui/pjx_badge/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_badge/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx2.builtins.ui.pjx_badge.pjx_badge import PJXBadge
+
+__all__ = ["PJXBadge"]

--- a/pyjinhx2/builtins/ui/pjx_badge/pjx_badge.pjx
+++ b/pyjinhx2/builtins/ui/pjx_badge/pjx_badge.pjx
@@ -1,0 +1,1 @@
+<span id="{{ id }}" class="pjx-badge pjx-badge--{{ color }} pjx-badge--{{ shape }}{% if class_name %} {{ class_name }}{% endif %}">{{ label }}</span>

--- a/pyjinhx2/builtins/ui/pjx_badge/pjx_badge.py
+++ b/pyjinhx2/builtins/ui/pjx_badge/pjx_badge.py
@@ -1,0 +1,10 @@
+from typing import Literal
+
+from pyjinhx2.component import AttrValue, BaseComponent
+
+
+class PJXBadge(BaseComponent):
+    label: str = ""
+    color: Literal["brand", "error", "neutral", "muted"] = "neutral"
+    shape: Literal["square", "sm", "md", "full"] = "md"
+    class_name: AttrValue = ""

--- a/tests/pyjinhx2/builtins/pjx_badge/test_pjx_badge.py
+++ b/tests/pyjinhx2/builtins/pjx_badge/test_pjx_badge.py
@@ -1,0 +1,75 @@
+"""PJXBadge renders a single-root themeable label span (port of v0.x pyjinhx/builtins/ui/pjx_badge)."""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_badge import PJXBadge
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def badge_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve.
+
+    ClassDescriptor.template_path is absolute and render() feeds it straight to
+    the session's FileSystemLoader; Jinja only resolves an absolute path when
+    the loader root is "/". Same fixture shape as tests/pyjinhx2/builtins/pjx_icon.
+    """
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kw) -> str:
+    return render(PJXBadge(id="b", **kw), session)
+
+
+def test_default_render(badge_session):
+    html = _html(badge_session)
+    assert html.count("<span") == 1
+    assert 'id="b"' in html
+    assert 'class="pjx-badge pjx-badge--neutral pjx-badge--md"' in html
+    assert html.endswith(
+        '--md"></span>'
+    )  # nothing rendered between the tag and </span>: label defaults to ""
+
+
+@pytest.mark.parametrize("color", ["brand", "error", "neutral", "muted"])
+def test_color_variants(badge_session, color):
+    html = _html(badge_session, color=color)
+    assert f"pjx-badge--{color}" in html
+
+
+@pytest.mark.parametrize("shape", ["square", "sm", "md", "full"])
+def test_shape_variants(badge_session, shape):
+    html = _html(badge_session, shape=shape)
+    assert f"pjx-badge--{shape}" in html
+
+
+def test_class_name_appended_space_separated(badge_session):
+    html = _html(badge_session, class_name="mine")
+    assert 'class="pjx-badge pjx-badge--neutral pjx-badge--md mine"' in html
+
+
+def test_empty_class_name_adds_nothing(badge_session):
+    html = _html(badge_session, class_name="")
+    assert 'class="pjx-badge pjx-badge--neutral pjx-badge--md"' in html
+
+
+def test_label_renders_escaped_text(badge_session):
+    html = _html(badge_session, label="<b>New</b>")
+    assert "&lt;b&gt;New&lt;/b&gt;" in html
+    assert "<b>New</b>" not in html
+
+
+def test_invalid_literal_is_rejected():
+    with pytest.raises(ValidationError):
+        PJXBadge(id="b", color="chartreuse")  # pyright: ignore[reportArgumentType]
+
+
+def test_undeclared_attr_is_rejected():
+    """v2 core is strict (extra="forbid"): v0.x's extra_attrs pass-through is gone.
+
+    Deliberate narrowing of v0.x behavior, matching the #500 precedent.
+    """
+    with pytest.raises(ValidationError):
+        PJXBadge(id="b", **{"data-x": "y"})  # pyright: ignore[reportCallIssue, reportArgumentType]

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -237,7 +237,6 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # pjx_table family (#526): each component module imports only the core
     # component surface (AttrValue, BaseComponent, Slot); each __init__ just
     # re-exports its class from its co-located module.
-    "builtins.__init__": frozenset(),
     "builtins.pjx_table.__init__": frozenset({"pyjinhx2.builtins.pjx_table.pjx_table"}),
     "builtins.pjx_table.pjx_table": frozenset({"pyjinhx2.component"}),
     "builtins.pjx_table_head.__init__": frozenset(

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -34,6 +34,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # data module; nothing above the leaf imports back.
     "builtins.__init__": frozenset(),
     "builtins.ui.__init__": frozenset(),
+    "builtins.ui.pjx_badge.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_badge.pjx_badge"}
+    ),
+    "builtins.ui.pjx_badge.pjx_badge": frozenset({"pyjinhx2.component"}),
     "builtins.ui.pjx_icon.__init__": frozenset(
         {"pyjinhx2.builtins.ui.pjx_icon.pjx_icon"}
     ),


### PR DESCRIPTION
## Summary
- Port PJXBadge (leaf display component) to the v2 engine
- Single root `<span>`, no children/slots, not tag-registered
- Follows #500 (PJXIcon) pattern; drops v0.x's extra_attrs since v2 core is strict (extra="forbid")

## Test coverage
- 8 test functions covering default render, color variants, shape variants, class name handling, label escaping, and validation

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)