### PR TITLE
feat: port PJXAvatar and PJXAvatarStack to v2 (#502)

### DIFF
--- a/pyjinhx2/builtins/ui/pjx_avatar/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_avatar/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx2.builtins.ui.pjx_avatar.pjx_avatar import PJXAvatar
+
+__all__ = ["PJXAvatar"]

--- a/pyjinhx2/builtins/ui/pjx_avatar/pjx_avatar.css
+++ b/pyjinhx2/builtins/ui/pjx_avatar/pjx_avatar.css
@@ -1,0 +1,55 @@
+:where(:root) {
+  --pjx-avatar-sm: 2rem;
+  --pjx-avatar-md: 2.5rem;
+  --pjx-avatar-lg: 3.25rem;
+  --pjx-avatar-bg: var(--surface-alt);
+  --pjx-avatar-fg: var(--text-muted);
+  --pjx-avatar-border: var(--border);
+  --pjx-avatar-font-size-sm: var(--font-size-xs);
+  --pjx-avatar-font-size-md: var(--font-size-sm);
+  --pjx-avatar-font-size-lg: var(--font-size-md);
+}
+
+.pjx-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: var(--radius-full, 9999px);
+  overflow: hidden;
+  background: var(--pjx-avatar-bg);
+  border: 1px solid var(--pjx-avatar-border);
+  font-weight: 600;
+  color: var(--pjx-avatar-fg);
+}
+
+.pjx-avatar--sm {
+  width: var(--pjx-avatar-sm);
+  height: var(--pjx-avatar-sm);
+  font-size: var(--pjx-avatar-font-size-sm);
+}
+
+.pjx-avatar--md {
+  width: var(--pjx-avatar-md);
+  height: var(--pjx-avatar-md);
+  font-size: var(--pjx-avatar-font-size-md);
+}
+
+.pjx-avatar--lg {
+  width: var(--pjx-avatar-lg);
+  height: var(--pjx-avatar-lg);
+  font-size: var(--pjx-avatar-font-size-lg);
+}
+
+.pjx-avatar__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.pjx-avatar__initials {
+  line-height: 1;
+  text-transform: uppercase;
+  user-select: none;
+}

--- a/pyjinhx2/builtins/ui/pjx_avatar/pjx_avatar.pjx
+++ b/pyjinhx2/builtins/ui/pjx_avatar/pjx_avatar.pjx
@@ -1,0 +1,8 @@
+<div id="{{ id }}"
+     class="pjx-avatar{% if size_is_token %} pjx-avatar--{{ size }}{% endif %}{% if class_name %} {{ class_name }}{% endif %}"{% if not size_is_token %} style="width:{{ size_css }};height:{{ size_css }};{% if color %}background:{{ color }};{% endif %}"{% elif color %} style="background:{{ color }};"{% endif %}>
+  {% if src %}
+  <img class="pjx-avatar__img" src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" />
+  {% else %}
+  <span class="pjx-avatar__initials" {% if alt %}title="{{ alt }}"{% endif %}>{{ initials or "?" }}</span>
+  {% endif %}
+</div>

--- a/pyjinhx2/builtins/ui/pjx_avatar/pjx_avatar.py
+++ b/pyjinhx2/builtins/ui/pjx_avatar/pjx_avatar.py
@@ -1,0 +1,41 @@
+from pydantic import computed_field, field_validator
+
+from pyjinhx2.component import AttrValue, BaseComponent
+
+_NAMED_SIZES = {"sm", "md", "lg"}
+
+
+class PJXAvatar(BaseComponent):
+    """A circular avatar showing an image when ``src`` is set, initials otherwise."""
+
+    src: str = ""
+    alt: str = ""
+    initials: str = ""
+    # Named tokens ("sm", "md", "lg") emit a BEM modifier class.
+    # An int (px) or any other CSS length string (e.g. "36px", "2.5rem")
+    # renders inline width/height instead and omits the modifier class.
+    size: str | int = "md"
+    class_name: AttrValue = ""
+    color: AttrValue = ""
+
+    @field_validator("initials", mode="before")
+    @classmethod
+    def cap_initials(cls, value: str) -> str:
+        if not value:
+            return ""
+        text = str(value).strip()
+        return text[:2] if len(text) > 2 else text
+
+    @computed_field
+    @property
+    def size_is_token(self) -> bool:
+        return str(self.size) in _NAMED_SIZES
+
+    @computed_field
+    @property
+    def size_css(self) -> str:
+        """CSS length string for inline style when size is not a named token."""
+        val = self.size
+        if isinstance(val, int):
+            return f"{val}px"
+        return str(val)

--- a/pyjinhx2/builtins/ui/pjx_avatar_stack/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_avatar_stack/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx2.builtins.ui.pjx_avatar_stack.pjx_avatar_stack import PJXAvatarStack
+
+__all__ = ["PJXAvatarStack"]

--- a/pyjinhx2/builtins/ui/pjx_avatar_stack/pjx_avatar_stack.css
+++ b/pyjinhx2/builtins/ui/pjx_avatar_stack/pjx_avatar_stack.css
@@ -1,0 +1,57 @@
+:where(:root) {
+  --pjx-avatar-stack-overlap: -0.5rem;
+  --pjx-avatar-stack-ring:    var(--surface);
+}
+
+.pjx-avatar-stack {
+  display: inline-flex;
+  align-items: center;
+}
+
+.pjx-avatar-stack > .pjx-avatar,
+.pjx-avatar-stack > .pjx-avatar-stack__pill,
+.pjx-avatar-stack > .pjx-avatar-stack__more {
+  box-shadow: 0 0 0 2px var(--pjx-avatar-stack-ring);
+}
+
+.pjx-avatar-stack__pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: var(--pjx-avatar-sm, 2rem);
+  height: var(--pjx-avatar-sm, 2rem);
+  border-radius: var(--radius-full, 9999px);
+  overflow: hidden;
+  background: var(--pjx-avatar-bg, var(--surface-alt));
+  border: 1px solid var(--pjx-avatar-border, var(--border));
+  font-size: var(--pjx-avatar-font-size-sm, var(--font-size-xs));
+  font-weight: 600;
+  color: var(--pjx-avatar-fg, var(--text-muted));
+  text-transform: uppercase;
+  user-select: none;
+  line-height: 1;
+}
+
+.pjx-avatar-stack > * + * {
+  margin-left: var(--pjx-avatar-stack-overlap);
+}
+
+.pjx-avatar-stack__more {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  height: 2rem;
+  padding: 0 0.3rem;
+  border-radius: 50%;
+  background: var(--surface-alt);
+  color: var(--text-muted);
+  font-size: var(--font-size-sm, 0.85rem);
+  font-weight: 600;
+}
+
+.pjx-avatar-stack__empty {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm, 0.85rem);
+}

--- a/pyjinhx2/builtins/ui/pjx_avatar_stack/pjx_avatar_stack.pjx
+++ b/pyjinhx2/builtins/ui/pjx_avatar_stack/pjx_avatar_stack.pjx
@@ -1,0 +1,5 @@
+<div id="{{ id }}" class="pjx-avatar-stack{% if class_name %} {{ class_name }}{% endif %}">
+  {% for avatar in avatars %}{% if avatar is mapping %}{% set tooltip = avatar.alt or avatar.name or "" %}<span class="pjx-avatar pjx-avatar-stack__pill"{% if avatar.color %} style="background:{{ avatar.color }};"{% endif %}{% if tooltip %} title="{{ tooltip }}" aria-label="{{ tooltip }}"{% endif %}>{{ (avatar.initials or "?")[:2] }}</span>{% else %}{{ avatar }}{% endif %}{% endfor %}
+  {% if extra_count > 0 %}<span class="pjx-avatar-stack__more" aria-label="{{ extra_count }} more">+{{ extra_count }}</span>{% endif %}
+  {% if not avatars and empty_label %}<span class="pjx-avatar-stack__empty">{{ empty_label }}</span>{% endif %}
+</div>

--- a/pyjinhx2/builtins/ui/pjx_avatar_stack/pjx_avatar_stack.py
+++ b/pyjinhx2/builtins/ui/pjx_avatar_stack/pjx_avatar_stack.py
@@ -1,0 +1,30 @@
+from typing import Annotated, Any
+
+from pydantic import Field
+
+from pyjinhx2.component import AttrValue, BaseComponent, PjxSlot
+
+
+class PJXAvatarStack(BaseComponent):
+    """A row of overlapping avatar pills with an optional "+N" overflow badge."""
+
+    # Items to render.  Two accepted shapes:
+    #   - Structured dict: keys initials, color, alt, name
+    #       - initials (str): text shown in the pill (escaped)
+    #       - color    (str, optional): inline background color
+    #       - alt      (str, optional): tooltip/title on the pill (escaped)
+    #       - name     (str, optional): alias for alt; alt takes precedence if both given
+    #   - BaseComponent instance: rendered raw via __html__
+    #
+    # Note: plain HTML *strings* are now escaped (autoescape is on).
+    # Pass a BaseComponent for raw markup instead of a string.
+    #
+    # The PjxSlot marker is what keeps the second shape working on v2:
+    # build_context() serializes non-slot fields through model_dump(), which
+    # would turn a component into a plain dict and route it down the
+    # "is mapping" pill branch. Marking the field slot re-reads the live list
+    # and wraps each component as an opaque node instead.
+    avatars: Annotated[list[Any], PjxSlot()] = Field(default_factory=list)
+    extra_count: int = 0
+    empty_label: str = ""
+    class_name: AttrValue = ""

--- a/tests/pyjinhx2/builtins/pjx_avatar/test_pjx_avatar.py
+++ b/tests/pyjinhx2/builtins/pjx_avatar/test_pjx_avatar.py
@@ -119,3 +119,16 @@ def test_undeclared_attr_is_rejected():
     """
     with pytest.raises(ValidationError):
         PJXAvatar(id="a", **{"data-x": "y"})  # pyright: ignore[reportCallIssue, reportArgumentType]
+
+
+def test_stylesheet_is_auto_discovered_by_snake_case_filename():
+    """The descriptor probes "<snake_case class name>.css" next to the module,
+    so the v0.x kebab-case filename had to be renamed on the way in.
+
+    ``ClassDescriptor.css_paths`` is a tuple (0 or 1 entries — one probe per
+    class, per ADR 0007), not a singular ``css_path``; see descriptor.py.
+    """
+    css_paths = PJXAvatar.__pjx_descriptor__.css_paths
+    assert len(css_paths) == 1
+    assert css_paths[0].name == "pjx_avatar.css"
+    assert ".pjx-avatar__initials" in css_paths[0].read_text(encoding="utf-8")

--- a/tests/pyjinhx2/builtins/pjx_avatar/test_pjx_avatar.py
+++ b/tests/pyjinhx2/builtins/pjx_avatar/test_pjx_avatar.py
@@ -1,0 +1,121 @@
+"""PJXAvatar renders an image-or-initials circle (port of v0.x pyjinhx/builtins/ui/pjx_avatar)."""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_avatar import PJXAvatar
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def avatar_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve.
+
+    ClassDescriptor.template_path is absolute and render() feeds it straight to
+    the session's FileSystemLoader; Jinja only resolves an absolute path when
+    the loader root is "/". Same fixture shape as tests/pyjinhx2/builtins/pjx_badge.
+    """
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kw) -> str:
+    return render(PJXAvatar(id="a", **kw), session)
+
+
+def test_default_render_is_a_single_div_with_initials_fallback(avatar_session):
+    html = _html(avatar_session)
+    assert html.count("<div") == 1
+    assert 'id="a"' in html
+    assert 'class="pjx-avatar pjx-avatar--md"' in html
+    assert ">?<" in html
+    assert "<img" not in html
+
+
+def test_src_renders_img_and_no_initials(avatar_session):
+    html = _html(avatar_session, src="/u/1.png", alt="Ada")
+    assert '<img class="pjx-avatar__img"' in html
+    assert 'src="/u/1.png"' in html
+    assert 'alt="Ada"' in html
+    assert 'loading="lazy"' in html
+    assert 'decoding="async"' in html
+    assert "pjx-avatar__initials" not in html
+
+
+def test_initials_render_when_no_src(avatar_session):
+    html = _html(avatar_session, initials="AL")
+    assert '<span class="pjx-avatar__initials"' in html
+    assert ">AL<" in html
+
+
+def test_initials_longer_than_two_chars_are_capped(avatar_session):
+    assert PJXAvatar(id="a", initials="Ada Lovelace").initials == "Ad"
+    html = _html(avatar_session, initials="Ada Lovelace")
+    assert ">Ad<" in html
+
+
+def test_initials_are_stripped_before_capping():
+    assert PJXAvatar(id="a", initials="  AL  ").initials == "AL"
+
+
+def test_empty_initials_stay_empty():
+    assert PJXAvatar(id="a", initials="").initials == ""
+
+
+@pytest.mark.parametrize("size", ["sm", "md", "lg"])
+def test_token_sizes_emit_modifier_class_and_no_inline_size(avatar_session, size):
+    html = _html(avatar_session, size=size)
+    assert f"pjx-avatar--{size}" in html
+    assert "width:" not in html
+
+
+def test_int_size_omits_modifier_and_emits_inline_pixels(avatar_session):
+    html = _html(avatar_session, size=36)
+    assert "pjx-avatar--" not in html
+    assert 'style="width:36px;height:36px;"' in html
+
+
+def test_css_length_size_omits_modifier_and_emits_inline_length(avatar_session):
+    html = _html(avatar_session, size="2.5rem")
+    assert "pjx-avatar--" not in html
+    assert 'style="width:2.5rem;height:2.5rem;"' in html
+
+
+def test_color_adds_background_on_token_size(avatar_session):
+    html = _html(avatar_session, color="#f00")
+    assert "pjx-avatar--md" in html
+    assert 'style="background:#f00;"' in html
+
+
+def test_color_adds_background_on_non_token_size(avatar_session):
+    html = _html(avatar_session, size=36, color="#f00")
+    assert 'style="width:36px;height:36px;background:#f00;"' in html
+
+
+def test_class_name_appended_space_separated(avatar_session):
+    html = _html(avatar_session, class_name="mine")
+    assert 'class="pjx-avatar pjx-avatar--md mine"' in html
+
+
+def test_empty_class_name_adds_nothing(avatar_session):
+    html = _html(avatar_session, class_name="")
+    assert 'class="pjx-avatar pjx-avatar--md"' in html
+
+
+def test_alt_adds_title_on_initials_span(avatar_session):
+    html = _html(avatar_session, alt="Ada", initials="AL")
+    assert 'title="Ada"' in html
+
+
+def test_no_alt_omits_title_on_initials_span(avatar_session):
+    html = _html(avatar_session, initials="AL")
+    assert "title=" not in html
+
+
+def test_undeclared_attr_is_rejected():
+    """v2 core is strict (extra="forbid"): v0.x's extra_attrs pass-through is gone.
+
+    Deliberate narrowing of v0.x behavior, matching the #500/#501 precedent.
+    """
+    with pytest.raises(ValidationError):
+        PJXAvatar(id="a", **{"data-x": "y"})  # pyright: ignore[reportCallIssue, reportArgumentType]

--- a/tests/pyjinhx2/builtins/pjx_avatar_stack/test_pjx_avatar_stack.py
+++ b/tests/pyjinhx2/builtins/pjx_avatar_stack/test_pjx_avatar_stack.py
@@ -1,0 +1,138 @@
+"""PJXAvatarStack renders overlapping avatar pills (port of v0.x pyjinhx/builtins/ui/pjx_avatar_stack)."""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_avatar_stack import PJXAvatarStack
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def stack_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve.
+
+    Same fixture shape as tests/pyjinhx2/builtins/pjx_badge.
+    """
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kw) -> str:
+    return render(PJXAvatarStack(id="s", **kw), session)
+
+
+def test_empty_stack_with_empty_label_shows_empty_state(stack_session):
+    html = _html(stack_session, empty_label="No one yet")
+    assert '<span class="pjx-avatar-stack__empty">No one yet</span>' in html
+
+
+def test_empty_stack_without_empty_label_shows_nothing(stack_session):
+    html = _html(stack_session)
+    assert "pjx-avatar-stack__empty" not in html
+    assert "pjx-avatar-stack__pill" not in html
+
+
+def test_empty_label_is_suppressed_once_there_are_avatars(stack_session):
+    html = _html(stack_session, avatars=[{"initials": "AL"}], empty_label="No one yet")
+    assert "pjx-avatar-stack__empty" not in html
+
+
+def test_mapping_avatar_renders_a_pill(stack_session):
+    html = _html(stack_session, avatars=[{"initials": "AL", "color": "#f00"}])
+    assert '<span class="pjx-avatar pjx-avatar-stack__pill"' in html
+    assert 'style="background:#f00;"' in html
+    assert ">AL<" in html
+
+
+def test_mapping_avatar_without_initials_falls_back_to_question_mark(stack_session):
+    html = _html(stack_session, avatars=[{}])
+    assert ">?<" in html
+
+
+def test_mapping_avatar_initials_are_sliced_to_two_in_the_template(stack_session):
+    html = _html(stack_session, avatars=[{"initials": "ABCD"}])
+    assert ">AB<" in html
+    assert "ABCD" not in html
+
+
+def test_alt_becomes_tooltip_and_aria_label(stack_session):
+    html = _html(stack_session, avatars=[{"initials": "AL", "alt": "Ada"}])
+    assert 'title="Ada"' in html
+    assert 'aria-label="Ada"' in html
+
+
+def test_name_is_the_tooltip_fallback(stack_session):
+    html = _html(stack_session, avatars=[{"initials": "AL", "name": "Ada"}])
+    assert 'title="Ada"' in html
+
+
+def test_alt_takes_precedence_over_name(stack_session):
+    html = _html(
+        stack_session, avatars=[{"initials": "AL", "alt": "Ada", "name": "Grace"}]
+    )
+    assert 'title="Ada"' in html
+    assert "Grace" not in html
+
+
+def test_no_tooltip_when_neither_alt_nor_name(stack_session):
+    html = _html(stack_session, avatars=[{"initials": "AL"}])
+    assert "title=" not in html
+    assert "aria-label=" not in html
+
+
+def test_plain_string_avatar_is_escaped(stack_session):
+    """Invariant 6 regression guard: autoescape is on, so an HTML *string* is
+    escaped. Raw markup must come in as a BaseComponent instead."""
+    html = _html(stack_session, avatars=["<b>raw</b>"])
+    assert "&lt;b&gt;raw&lt;/b&gt;" in html
+    assert "<b>raw</b>" not in html
+
+
+def test_extra_count_renders_overflow_badge(stack_session):
+    html = _html(stack_session, extra_count=3)
+    assert '<span class="pjx-avatar-stack__more" aria-label="3 more">+3</span>' in html
+
+
+def test_zero_extra_count_omits_overflow_badge(stack_session):
+    html = _html(stack_session, extra_count=0)
+    assert "pjx-avatar-stack__more" not in html
+
+
+def test_class_name_appended_space_separated(stack_session):
+    html = _html(stack_session, class_name="mine")
+    assert 'class="pjx-avatar-stack mine"' in html
+
+
+def test_empty_class_name_adds_nothing(stack_session):
+    html = _html(stack_session, class_name="")
+    assert 'class="pjx-avatar-stack"' in html
+
+
+def test_undeclared_attr_is_rejected():
+    """v2 core is strict (extra="forbid"): v0.x's extra_attrs pass-through is gone."""
+    with pytest.raises(ValidationError):
+        PJXAvatarStack(id="s", **{"data-x": "y"})  # pyright: ignore[reportCallIssue, reportArgumentType]
+
+
+def test_stylesheet_is_auto_discovered_by_snake_case_filename():
+    css_paths = PJXAvatarStack.__pjx_descriptor__.css_paths
+    assert len(css_paths) == 1
+    assert css_paths[0].name == "pjx_avatar_stack.css"
+    assert ".pjx-avatar-stack__pill" in css_paths[0].read_text(encoding="utf-8")
+
+
+def test_base_component_avatar_renders_raw(stack_session):
+    """A component in the list is the sanctioned way to get raw markup in.
+
+    build_context() starts from model_dump(), which would flatten a component
+    into a plain dict and send it down the "is mapping" pill branch, so
+    `avatars` is marked as a slot field — that is what makes build_context
+    re-read the live value and hand the template a ComponentNode.
+    """
+    from pyjinhx2.builtins.ui.pjx_avatar import PJXAvatar
+
+    html = _html(stack_session, avatars=[PJXAvatar(id="inner", initials="AL")])
+    assert 'id="inner"' in html
+    assert 'class="pjx-avatar pjx-avatar--md"' in html
+    assert "pjx-avatar-stack__pill" not in html
+    assert "&lt;div" not in html

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -38,6 +38,14 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
         {"pyjinhx2.builtins.ui.pjx_badge.pjx_badge"}
     ),
     "builtins.ui.pjx_badge.pjx_badge": frozenset({"pyjinhx2.component"}),
+    "builtins.ui.pjx_avatar.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_avatar.pjx_avatar"}
+    ),
+    "builtins.ui.pjx_avatar.pjx_avatar": frozenset({"pyjinhx2.component"}),
+    "builtins.ui.pjx_avatar_stack.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_avatar_stack.pjx_avatar_stack"}
+    ),
+    "builtins.ui.pjx_avatar_stack.pjx_avatar_stack": frozenset({"pyjinhx2.component"}),
     "builtins.ui.pjx_icon.__init__": frozenset(
         {"pyjinhx2.builtins.ui.pjx_icon.pjx_icon"}
     ),


### PR DESCRIPTION
## Summary
Port PJXAvatar and PJXAvatarStack components to the pyjinhx2 engine, completing their migration to v2. Includes full test coverage and CSS auto-discovery integration.

## Changes
- Add PJXAvatar component with styling
- Add PJXAvatarStack component with styling
- Register both components in the import graph for auto-discovery
- Add 35 test cases covering functionality and CSS conventions

## Test plan
- [x] All 35 new tests pass
- [x] Import graph discovery works for both components
- [x] CSS auto-discovery convention enforced via tests
- [x] Ruff lint and format checks pass

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)