### PR TITLE
feat: port PJXRegionLoader to the v2 engine

### DIFF
--- a/pyjinhx2/builtins/pjx_region_loader/__init__.py
+++ b/pyjinhx2/builtins/pjx_region_loader/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx2.builtins.pjx_region_loader.pjx_region_loader import PJXRegionLoader
+
+__all__ = ["PJXRegionLoader"]

--- a/pyjinhx2/builtins/pjx_region_loader/pjx_region_loader.css
+++ b/pyjinhx2/builtins/pjx_region_loader/pjx_region_loader.css
@@ -1,0 +1,73 @@
+/* ── PJXRegionLoader tokens ──────────────────────────────────── */
+:where(:root) {
+  --pjx-region-loader-bg:            color-mix(in srgb, var(--text) 55%, transparent);
+  --pjx-region-loader-backdrop:      blur(2px);
+  --pjx-region-loader-z:             100;
+  --pjx-region-loader-spinner-size:  2.5rem;
+  --pjx-region-loader-spinner-width: 3px;
+  --pjx-region-loader-spinner-color: var(--brand);
+  --pjx-region-loader-spinner-track: color-mix(in srgb, var(--text) 12%, transparent);
+}
+
+/* ── Overlay ────────────────────────────────────────────────── */
+/* Parent must have position: relative (or any non-static position). */
+.pjx-region-loader {
+  display: none;
+  position: absolute;
+  inset: 0;
+  z-index: var(--pjx-region-loader-z);
+  align-items: center;
+  justify-content: center;
+  background: var(--pjx-region-loader-bg);
+  backdrop-filter: var(--pjx-region-loader-backdrop);
+  border-radius: inherit;
+}
+
+.pjx-region-loader--visible {
+  display: flex;
+  animation: region-loader-in 150ms ease forwards;
+}
+
+.pjx-region-loader.htmx-request {
+  display: flex;
+  animation: region-loader-in 150ms ease forwards;
+}
+
+.pjx-region-loader--hiding {
+  display: flex;
+  animation: region-loader-out 150ms ease forwards;
+}
+
+/* ── PJXSpinner ────────────────────────────────────────────────── */
+.pjx-region-loader__spinner {
+  width: var(--pjx-region-loader-spinner-size);
+  height: var(--pjx-region-loader-spinner-size);
+  border: var(--pjx-region-loader-spinner-width) solid var(--pjx-region-loader-spinner-track);
+  border-top-color: var(--pjx-region-loader-spinner-color);
+  border-radius: var(--radius-full);
+  animation: region-loader-spin 600ms linear infinite;
+  flex-shrink: 0;
+}
+
+/* ── Animations ────────────────────────────────────────────── */
+@keyframes region-loader-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes region-loader-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+@keyframes region-loader-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pjx-region-loader--visible,
+  .pjx-region-loader.htmx-request,
+  .pjx-region-loader--hiding {
+    animation-duration: 0.01ms !important;
+  }
+}

--- a/pyjinhx2/builtins/pjx_region_loader/pjx_region_loader.js
+++ b/pyjinhx2/builtins/pjx_region_loader/pjx_region_loader.js
@@ -1,0 +1,118 @@
+(function () {
+    window.pjx = window.pjx || {};
+    pjx.loader = pjx.loader || {};
+    if (pjx.loader.region) return;
+
+    const VISIBLE = 'pjx-region-loader--visible';
+    const HIDING = 'pjx-region-loader--hiding';
+    const counts = new Map();
+    const hideTimers = new Map();
+
+    function fire(el, name) {
+        el.dispatchEvent(new CustomEvent(name, { bubbles: true, detail: {} }));
+    }
+
+    function clearHideTimer(id) {
+        clearTimeout(hideTimers.get(id));
+        hideTimers.delete(id);
+    }
+
+    // Idempotent: runs once per hide via the HIDING guard, whether reached
+    // from animationend or the fallback timer. A resurrecting show() strips
+    // HIDING first, turning any stale finalize into a no-op.
+    function finalizeHide(overlay, id) {
+        clearHideTimer(id);
+        if (!overlay.classList.contains(HIDING)) return;
+        overlay.classList.remove(VISIBLE, HIDING);
+        fire(overlay, 'pjx:region-loader:hide');
+    }
+
+    function onAnimationEnd(e) {
+        if (!e.target.classList || !e.target.classList.contains(HIDING)) return;
+        finalizeHide(e.target, e.target.id);
+    }
+
+    function show(id) {
+        const overlay = document.getElementById(id);
+        if (!overlay) return;
+        const count = counts.get(id) || 0;
+        counts.set(id, count + 1);
+        const isFresh = !overlay.classList.contains(VISIBLE) && !overlay.classList.contains(HIDING);
+        if (count > 0 && !isFresh) return;
+        clearHideTimer(id);
+        overlay.classList.remove(HIDING);
+        const wasVisible = overlay.classList.contains(VISIBLE);
+        overlay.classList.add(VISIBLE);
+        if (!wasVisible) fire(overlay, 'pjx:region-loader:show');
+    }
+
+    function hide(id) {
+        const overlay = document.getElementById(id);
+        if (!overlay) {
+            // Element gone mid-flight: drop all per-id state so a future
+            // mount with the same id starts clean.
+            counts.delete(id);
+            clearHideTimer(id);
+            return;
+        }
+        const count = counts.get(id) || 0;
+        if (count === 0) return;
+        if (count > 1) {
+            counts.set(id, count - 1);
+            return;
+        }
+        counts.delete(id);
+        if (!overlay.classList.contains(VISIBLE)) {
+            // Same-id node replaced mid-flight: it never showed, so there is
+            // no visibility transition to animate or announce.
+            clearHideTimer(id);
+            return;
+        }
+        overlay.classList.add(HIDING);
+        // Same-function listeners dedupe, so repeated hides never stack.
+        overlay.addEventListener('animationend', onAnimationEnd);
+        // Fallback for animation-less environments (prefers-reduced-motion).
+        // 250ms > the 150ms default out-animation; raw-CSS themes with longer fades get cut to display:none early.
+        hideTimers.set(id, setTimeout(() => finalizeHide(overlay, id), 250));
+    }
+
+    function reset(id) {
+        counts.delete(id);
+        clearHideTimer(id);
+        const overlay = document.getElementById(id);
+        if (!overlay) return;
+        overlay.classList.remove(VISIBLE, HIDING);
+    }
+
+    async function wrap(id, promise) {
+        show(id);
+        try {
+            return await promise;
+        } finally {
+            hide(id);
+        }
+    }
+
+    // A swap can replace the overlay's node while sources are still active
+    // (count > 0). Re-light replacements after htmx settles — same strategy
+    // as the reactive runtime's pjxReapplyLoading. Silent on purpose: the
+    // show event for this loading episode already fired on the old node.
+    function relight() {
+        counts.forEach(function (count, id) {
+            if (count <= 0) return;
+            const overlay = document.getElementById(id);
+            if (!overlay) return;
+            if (overlay.classList.contains(VISIBLE) || overlay.classList.contains(HIDING)) return;
+            overlay.classList.add(VISIBLE);
+        });
+    }
+    if (document.body) {
+        document.body.addEventListener('htmx:afterSettle', relight);
+    } else {
+        document.addEventListener('DOMContentLoaded', function () {
+            document.body.addEventListener('htmx:afterSettle', relight);
+        });
+    }
+
+    pjx.loader.region = { show: show, hide: hide, reset: reset, wrap: wrap };
+}());

--- a/pyjinhx2/builtins/pjx_region_loader/pjx_region_loader.pjx
+++ b/pyjinhx2/builtins/pjx_region_loader/pjx_region_loader.pjx
@@ -1,0 +1,1 @@
+<div class="pjx-region-loader{% if class_name %} {{ class_name }}{% endif %}" id="{{ id }}" role="status" aria-label="{{ aria_label }}" aria-live="polite"{% for name, value in extra_attrs.items() %} {{ name }}="{{ value }}"{% endfor %}><div class="pjx-region-loader__spinner"></div></div>

--- a/pyjinhx2/builtins/pjx_region_loader/pjx_region_loader.py
+++ b/pyjinhx2/builtins/pjx_region_loader/pjx_region_loader.py
@@ -1,0 +1,15 @@
+from pydantic import Field
+
+from pyjinhx2.component import AttrValue, BaseComponent, ExtraAttrs
+
+
+class PJXRegionLoader(BaseComponent):
+    """An overlay spinner that covers its nearest positioned ancestor.
+
+    The parent must be non-statically positioned for the overlay to cover it.
+    Visibility is driven from the client by ``pjx.loader.region``.
+    """
+
+    aria_label: str = "Loading"
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/tests/pyjinhx2/builtins/test_pjx_region_loader.py
+++ b/tests/pyjinhx2/builtins/test_pjx_region_loader.py
@@ -1,0 +1,80 @@
+"""PJXRegionLoader — v0.x field/markup parity on the v2 engine."""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.pjx_region_loader import PJXRegionLoader
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+class TestFields:
+    def test_defaults(self):
+        loader = PJXRegionLoader(id="rl")
+        assert loader.aria_label == "Loading"
+        assert loader.class_name == ""
+        assert loader.extra_attrs == {}
+
+    def test_undeclared_kwarg_raises(self):
+        with pytest.raises(ValidationError):
+            PJXRegionLoader(id="rl", bogus="x")  # type: ignore[call-arg]
+
+
+@pytest.fixture
+def session():
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kwargs) -> str:
+    base = {"id": "rl"}
+    base.update(kwargs)
+    return render(PJXRegionLoader(**base), session)  # type: ignore[arg-type]
+
+
+class TestRender:
+    def test_root_is_a_single_status_div(self, session):
+        html = _html(session)
+        assert html.startswith('<div class="pjx-region-loader" id="rl"')
+        assert 'role="status"' in html
+        assert 'aria-label="Loading"' in html
+        assert 'aria-live="polite"' in html
+        assert html.rstrip().endswith("</div>")
+
+    def test_spinner_child_is_present(self, session):
+        assert '<div class="pjx-region-loader__spinner"></div>' in _html(session)
+
+    def test_custom_aria_label(self, session):
+        assert 'aria-label="Saving"' in _html(session, aria_label="Saving")
+
+    def test_class_name_is_appended_to_the_root_class(self, session):
+        assert 'class="pjx-region-loader compact"' in _html(
+            session, class_name="compact"
+        )
+
+    def test_extra_attrs_surface_on_the_root(self, session):
+        html = _html(session, extra_attrs={"data-k": "v"})
+        assert 'data-k="v"' in html[: html.index(">")]
+
+
+class TestAssets:
+    def test_stylesheet_is_frozen_on_the_descriptor(self):
+        css = PJXRegionLoader.__pjx_descriptor__.css_paths
+        assert len(css) == 1
+        assert css[0].name == "pjx_region_loader.css"
+        assert css[0].is_file()
+
+    def test_script_is_frozen_on_the_descriptor(self):
+        js = PJXRegionLoader.__pjx_descriptor__.js_paths
+        assert len(js) == 1
+        assert js[0].name == "pjx_region_loader.js"
+        assert js[0].is_file()
+
+    def test_render_accumulates_both_assets_into_the_session(self, session):
+        # RenderSession does not auto-subscribe accumulate_assets — the same
+        # explicit wiring test_pjx_lazy_load.py uses.
+        from pyjinhx2.session import accumulate_assets
+
+        session.on_rendered.append(accumulate_assets)
+        _html(session)
+        assert {p.name for p in session.css_assets} == {"pjx_region_loader.css"}
+        assert {p.name for p in session.js_assets} == {"pjx_region_loader.js"}

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -281,6 +281,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
         {"pyjinhx2.builtins.pjx_lazy_load.pjx_lazy_load"}
     ),
     "builtins.pjx_lazy_load.pjx_lazy_load": frozenset({"pyjinhx2.component"}),
+    "builtins.pjx_region_loader.__init__": frozenset(
+        {"pyjinhx2.builtins.pjx_region_loader.pjx_region_loader"}
+    ),
+    "builtins.pjx_region_loader.pjx_region_loader": frozenset({"pyjinhx2.component"}),
 }
 
 

--- a/tests/unit/golden/button_loading.html
+++ b/tests/unit/golden/button_loading.html
@@ -1,3 +1,1 @@
-<button id="g" type="button" class="pjx-button pjx-button--primary" aria-busy="true">Save<div class="pjx-region-loader" id="pjx-AUTO" role="status" aria-label="Loading" aria-live="polite">
-    <div class="pjx-region-loader__spinner"></div>
-</div></button>
+<button id="g" type="button" class="pjx-button pjx-button--primary" aria-busy="true">Save<div class="pjx-region-loader" id="pjx-AUTO" role="status" aria-label="Loading" aria-live="polite"><div class="pjx-region-loader__spinner"></div></div></button>


### PR DESCRIPTION
## Summary

Ports PJXRegionLoader to the v2 engine. A straight port of the v0.x overlay loader: fields, template, CSS and the ref-counted pjx.loader.region script carry over unchanged. extra_attrs gains the root-tag loop every v2 builtin renders explicitly, since the v2 engine does not splice it.

## Test plan

- All existing tests pass
- Golden snapshot updated for button_loading with new PJXRegionLoader rendering

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)