### PR TITLE
feat: port pjx_progress to pyjinhx2 builtins (#504)

### DIFF
--- a/pyjinhx2/builtins/ui/pjx_progress/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_progress/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx2.builtins.ui.pjx_progress.pjx_progress import PJXProgress
+
+__all__ = ["PJXProgress"]

--- a/pyjinhx2/builtins/ui/pjx_progress/pjx_progress.css
+++ b/pyjinhx2/builtins/ui/pjx_progress/pjx_progress.css
@@ -1,0 +1,60 @@
+:where(:root) {
+  --pjx-progress-height:     0.5rem;
+  --pjx-progress-radius:     var(--radius-full);
+  --pjx-progress-track:      var(--surface-alt);
+  --pjx-progress-fill:       var(--brand);
+  --pjx-progress-indeterminate-speed: 1.2s;
+}
+
+.pjx-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  width: 100%;
+  max-width: 24rem;
+}
+
+.pjx-progress__label {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+.pjx-progress__bar {
+  width: 100%;
+  height: var(--pjx-progress-height);
+  border-radius: var(--pjx-progress-radius);
+  border: 1px solid var(--border);
+  background: var(--pjx-progress-track);
+  overflow: hidden;
+}
+
+.pjx-progress__bar::-webkit-progress-bar {
+  background: var(--pjx-progress-track);
+  border-radius: var(--pjx-progress-radius);
+}
+
+.pjx-progress__bar::-webkit-progress-value {
+  background: var(--pjx-progress-fill);
+  border-radius: var(--pjx-progress-radius);
+}
+
+.pjx-progress__bar::-moz-progress-bar {
+  background: var(--pjx-progress-fill);
+  border-radius: var(--pjx-progress-radius);
+}
+
+.pjx-progress__bar:indeterminate {
+  background: linear-gradient(
+    90deg,
+    var(--pjx-progress-track) 0%,
+    var(--pjx-progress-fill) 50%,
+    var(--pjx-progress-track) 100%
+  );
+  background-size: 200% 100%;
+  animation: pjx-progress-indeterminate var(--pjx-progress-indeterminate-speed) ease infinite;
+}
+
+@keyframes pjx-progress-indeterminate {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}

--- a/pyjinhx2/builtins/ui/pjx_progress/pjx_progress.pjx
+++ b/pyjinhx2/builtins/ui/pjx_progress/pjx_progress.pjx
@@ -1,0 +1,18 @@
+<div id="{{ id }}" class="pjx-progress{% if class_name %} {{ class_name }}{% endif %}">
+  {% if label %}
+  <span class="pjx-progress__label" id="{{ id }}-label">{{ label }}</span>
+  {% endif %}
+  {% if value is none %}
+  <progress class="pjx-progress__bar"
+            max="{{ max }}"
+            {% if label %}aria-labelledby="{{ id }}-label"{% else %}aria-label="{{ loading_label }}"{% endif %}></progress>
+  {% else %}
+  <progress class="pjx-progress__bar"
+            max="{{ max }}"
+            value="{{ value }}"
+            aria-valuenow="{{ value }}"
+            aria-valuemin="0"
+            aria-valuemax="{{ max }}"
+            {% if label %}aria-labelledby="{{ id }}-label"{% endif %}></progress>
+  {% endif %}
+</div>

--- a/pyjinhx2/builtins/ui/pjx_progress/pjx_progress.py
+++ b/pyjinhx2/builtins/ui/pjx_progress/pjx_progress.py
@@ -1,0 +1,11 @@
+from pyjinhx2.component import AttrValue, BaseComponent
+
+
+class PJXProgress(BaseComponent):
+    """A progress bar, or an indeterminate loading indicator when no value is given."""
+
+    value: float | None = None
+    max: float = 100
+    label: str = ""
+    loading_label: str = "Loading"
+    class_name: AttrValue = ""

--- a/tests/pyjinhx2/builtins/pjx_progress/test_pjx_progress.py
+++ b/tests/pyjinhx2/builtins/pjx_progress/test_pjx_progress.py
@@ -1,0 +1,89 @@
+"""PJXProgress renders a progress bar / loading indicator (port of v0.x pyjinhx/builtins/ui/pjx_progress)."""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_progress import PJXProgress
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def progress_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve.
+
+    ClassDescriptor.template_path is absolute and render() feeds it straight to
+    the session's FileSystemLoader; Jinja only resolves an absolute path when
+    the loader root is "/". Same fixture shape as tests/pyjinhx2/builtins/pjx_divider.
+    """
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kw) -> str:
+    return render(PJXProgress(id="p", **kw), session)
+
+
+def test_default_render_is_indeterminate(progress_session):
+    html = _html(progress_session)
+    assert html.count("<div") == 1
+    assert html.count("<progress") == 1
+    assert 'value="' not in html
+    assert "aria-valuenow" not in html
+    assert 'aria-label="Loading"' in html
+    assert 'class="pjx-progress"' in html
+    assert 'id="p"' in html
+
+
+def test_valued_render_sets_aria_and_value(progress_session):
+    html = _html(progress_session, value=40, max=80)
+    assert 'value="40.0"' in html
+    assert 'aria-valuenow="40.0"' in html
+    assert 'aria-valuemin="0"' in html
+    assert 'aria-valuemax="80.0"' in html
+
+
+def test_label_renders_span_and_aria_labelledby(progress_session):
+    html = _html(progress_session, label="Uploading")
+    assert 'id="p-label"' in html
+    assert 'class="pjx-progress__label"' in html
+    assert ">Uploading<" in html
+    assert 'aria-labelledby="p-label"' in html
+    assert "aria-label=" not in html
+
+
+def test_loading_label_used_only_without_label_and_value(progress_session):
+    html = _html(progress_session, loading_label="Please wait")
+    assert 'aria-label="Please wait"' in html
+
+    labeled = _html(progress_session, loading_label="Please wait", label="Uploading")
+    assert "Please wait" not in labeled
+
+
+def test_class_name_appended(progress_session):
+    html = _html(progress_session, class_name="mine")
+    assert 'class="pjx-progress mine"' in html
+
+
+def test_empty_class_name_adds_nothing(progress_session):
+    html = _html(progress_session, class_name="")
+    assert 'class="pjx-progress"' in html
+
+
+def test_label_renders_escaped_text(progress_session):
+    html = _html(progress_session, label="<script>x</script>")
+    assert "&lt;script&gt;x&lt;/script&gt;" in html
+    assert "<script>" not in html
+
+
+def test_invalid_value_type_is_rejected():
+    with pytest.raises(ValidationError):
+        PJXProgress(id="p", value="not-a-number")  # pyright: ignore[reportArgumentType]
+
+
+def test_undeclared_attr_is_rejected():
+    """v2 core is strict (extra="forbid"): v0.x's extra_attrs pass-through is gone.
+
+    Deliberate narrowing of v0.x behavior, matching the #500 precedent.
+    """
+    with pytest.raises(ValidationError):
+        PJXProgress(id="p", extra_attrs={"data-x": "y"})  # pyright: ignore[reportCallIssue]

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -50,6 +50,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
         {"pyjinhx2.builtins.ui.pjx_divider.pjx_divider"}
     ),
     "builtins.ui.pjx_divider.pjx_divider": frozenset({"pyjinhx2.component"}),
+    "builtins.ui.pjx_progress.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_progress.pjx_progress"}
+    ),
+    "builtins.ui.pjx_progress.pjx_progress": frozenset({"pyjinhx2.component"}),
     "builtins.ui.pjx_icon.__init__": frozenset(
         {"pyjinhx2.builtins.ui.pjx_icon.pjx_icon"}
     ),


### PR DESCRIPTION
## Summary
- Port of v0.x pjx_progress, dropping extra_attrs pass-through per v2's strict BaseComponent (ADR 0006)
- Registers the new module pair in the import-graph edge table required by test_import_graph.py
- 9 tests added covering default rendering, valued rendering, labeling, class names, and validation

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code