### PR TITLE
feat: port pjx_spinner to pyjinhx2 builtins (#505)

### DIFF
--- a/pyjinhx2/builtins/ui/pjx_spinner/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_spinner/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx2.builtins.ui.pjx_spinner.pjx_spinner import PJXSpinner
+
+__all__ = ["PJXSpinner"]

--- a/pyjinhx2/builtins/ui/pjx_spinner/pjx_spinner.css
+++ b/pyjinhx2/builtins/ui/pjx_spinner/pjx_spinner.css
@@ -1,0 +1,59 @@
+:where(:root) {
+  --pjx-spinner-sm: 1.25rem;
+  --pjx-spinner-md: 2rem;
+  --pjx-spinner-lg: 2.75rem;
+  --pjx-spinner-track: color-mix(in srgb, var(--text-muted) 35%, transparent);
+  --pjx-spinner-accent: var(--brand);
+}
+
+.pjx-spinner {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  vertical-align: middle;
+}
+
+.pjx-spinner__ring {
+  display: inline-block;
+  border-radius: 50%;
+  border-style: solid;
+  border-color: var(--pjx-spinner-track);
+  border-top-color: var(--pjx-spinner-accent);
+  animation: pjx-spinner-rotate 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+.pjx-spinner--sm .pjx-spinner__ring {
+  width: var(--pjx-spinner-sm);
+  height: var(--pjx-spinner-sm);
+  border-width: 2px;
+}
+
+.pjx-spinner--md .pjx-spinner__ring {
+  width: var(--pjx-spinner-md);
+  height: var(--pjx-spinner-md);
+  border-width: 3px;
+}
+
+.pjx-spinner--lg .pjx-spinner__ring {
+  width: var(--pjx-spinner-lg);
+  height: var(--pjx-spinner-lg);
+  border-width: 4px;
+}
+
+.pjx-spinner__label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes pjx-spinner-rotate {
+  to { transform: rotate(360deg); }
+}

--- a/pyjinhx2/builtins/ui/pjx_spinner/pjx_spinner.pjx
+++ b/pyjinhx2/builtins/ui/pjx_spinner/pjx_spinner.pjx
@@ -1,0 +1,8 @@
+<span id="{{ id }}"
+      class="pjx-spinner pjx-spinner--{{ size }}{% if class_name %} {{ class_name }}{% endif %}"
+      role="status"
+      aria-live="polite"
+      aria-busy="true">
+  <span class="pjx-spinner__ring" aria-hidden="true"></span>
+  <span class="pjx-spinner__label">{{ label }}</span>
+</span>

--- a/pyjinhx2/builtins/ui/pjx_spinner/pjx_spinner.py
+++ b/pyjinhx2/builtins/ui/pjx_spinner/pjx_spinner.py
@@ -1,0 +1,11 @@
+from typing import Literal
+
+from pyjinhx2.component import AttrValue, BaseComponent
+
+
+class PJXSpinner(BaseComponent):
+    """A rotating loading indicator with a visually-hidden status label."""
+
+    size: Literal["sm", "md", "lg"] = "md"
+    label: str = "Loading"
+    class_name: AttrValue = ""

--- a/tests/pyjinhx2/builtins/pjx_spinner/test_pjx_spinner.py
+++ b/tests/pyjinhx2/builtins/pjx_spinner/test_pjx_spinner.py
@@ -1,0 +1,70 @@
+"""PJXSpinner renders a loading indicator (port of v0.x pyjinhx/builtins/ui/pjx_spinner)."""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_spinner import PJXSpinner
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def spinner_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve.
+
+    ClassDescriptor.template_path is absolute and render() feeds it straight to
+    the session's FileSystemLoader; Jinja only resolves an absolute path when
+    the loader root is "/". Same fixture shape as tests/pyjinhx2/builtins/pjx_progress.
+    """
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kw) -> str:
+    return render(PJXSpinner(id="s", **kw), session)
+
+
+def test_default_render(spinner_session):
+    html = _html(spinner_session)
+    assert 'id="s"' in html
+    assert 'class="pjx-spinner pjx-spinner--md"' in html
+    assert 'role="status"' in html
+    assert 'aria-live="polite"' in html
+    assert 'aria-busy="true"' in html
+    assert 'class="pjx-spinner__ring" aria-hidden="true"' in html
+    assert '<span class="pjx-spinner__label">Loading</span>' in html
+
+
+@pytest.mark.parametrize("size", ["sm", "md", "lg"])
+def test_size_variants(spinner_session, size):
+    html = _html(spinner_session, size=size)
+    assert f"pjx-spinner--{size}" in html
+
+
+def test_invalid_size_is_rejected():
+    with pytest.raises(ValidationError):
+        PJXSpinner(id="s", size="huge")  # pyright: ignore[reportArgumentType]
+
+
+def test_label_renders_escaped_text(spinner_session):
+    html = _html(spinner_session, label="<script>x</script>")
+    assert "&lt;script&gt;x&lt;/script&gt;" in html
+    assert "<script>" not in html
+
+
+def test_class_name_appended(spinner_session):
+    html = _html(spinner_session, class_name="mine")
+    assert 'class="pjx-spinner pjx-spinner--md mine"' in html
+
+
+def test_empty_class_name_adds_nothing(spinner_session):
+    html = _html(spinner_session, class_name="")
+    assert 'class="pjx-spinner pjx-spinner--md"' in html
+
+
+def test_undeclared_attr_is_rejected():
+    """v2 core is strict (extra="forbid"): v0.x's extra_attrs pass-through is gone.
+
+    Deliberate narrowing of v0.x behavior, matching the #504 precedent.
+    """
+    with pytest.raises(ValidationError):
+        PJXSpinner(id="s", extra_attrs={"data-x": "y"})  # pyright: ignore[reportCallIssue]

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -54,6 +54,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
         {"pyjinhx2.builtins.ui.pjx_progress.pjx_progress"}
     ),
     "builtins.ui.pjx_progress.pjx_progress": frozenset({"pyjinhx2.component"}),
+    "builtins.ui.pjx_spinner.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_spinner.pjx_spinner"}
+    ),
+    "builtins.ui.pjx_spinner.pjx_spinner": frozenset({"pyjinhx2.component"}),
     "builtins.ui.pjx_icon.__init__": frozenset(
         {"pyjinhx2.builtins.ui.pjx_icon.pjx_icon"}
     ),


### PR DESCRIPTION
## Summary
Straight port of v0.x pjx_spinner (rotating loading indicator) onto the v2 component model, mirroring the #504 (Progress) precedent. Extra attributes pass-through is dropped per ADR 0006 (strict core). Also declares the new module's edges in the import-graph guard test.

## Test plan
- Import graph validation passes
- All existing tests continue to pass

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxwB6LvymhekN1iFNoNbqu