### PR TITLE
perf: make reactive fanout _drop_nested linear in candidates plus tree nodes

### DIFF
--- a/pyjinhx2/reactive/fanout.py
+++ b/pyjinhx2/reactive/fanout.py
@@ -269,29 +269,35 @@ def _drop_nested(candidates: list[FanoutCandidate]) -> list[FanoutCandidate]:
     tree instead of a substring search over rendered HTML: the tree already
     records containment, so nothing here re-parses or re-serializes markup.
 
-    A drop needs positive proof — a concrete containing RenderedLevel on some
-    *other* survivor whose tree holds this candidate's id or level object. A
-    candidate whose only structural data is a live instance, and a container
-    side with no tree at all, both simply fail to produce that proof and the
-    candidate survives; absence of a check is never a drop. Order is preserved
-    and nothing is duplicated.
+    Two passes, not a pairwise scan. The first unions every candidate's tree
+    into one id set and one object-identity set; the second keeps a candidate
+    unless it appears in either. No `other is not candidate` guard is needed:
+    `_contained` reports strict descendants only, so a level contributes
+    neither its own root id nor its own object identity to the union and a
+    candidate can never match itself.
+
+    A drop needs positive proof — this candidate's id or level object sitting
+    inside some tree. A candidate whose only structural data is a live
+    instance, and a container side with no tree at all, both simply fail to
+    produce that proof and the candidate survives; absence of a check is never
+    a drop. Order is preserved and nothing is duplicated.
     """
     if len(candidates) < 2:
         return candidates
-    trees = {
-        id(other): _contained(level)
-        for other in candidates
-        if (level := _level_of(other)) is not None
-    }
+    all_ids: set[str] = set()
+    all_objects: set[int] = set()
+    for other in candidates:
+        level = _level_of(other)
+        if level is None:
+            continue
+        ids, objects = _contained(level)
+        all_ids |= ids
+        all_objects |= objects
     surviving: list[FanoutCandidate] = []
     for candidate in candidates:
         own_level = _level_of(candidate)
-        nested = any(
-            candidate.instance_id in ids
-            or (own_level is not None and id(own_level) in objects)
-            for other in candidates
-            if other is not candidate
-            for ids, objects in (trees.get(id(other), (frozenset(), frozenset())),)
+        nested = candidate.instance_id in all_ids or (
+            own_level is not None and id(own_level) in all_objects
         )
         if not nested:
             surviving.append(candidate)

--- a/scripts/bench_reactive_fanout.py
+++ b/scripts/bench_reactive_fanout.py
@@ -1,0 +1,138 @@
+"""Reactive-layer benchmark: load-cache memoization and the fan-out walk.
+
+render_scaling_v2.py measures render() with plain BaseComponents; nothing in it
+touches ReactiveComponent. Two costs live outside that path entirely:
+
+  1. The load-cache wrap around ReactiveComponent.load() (cheap: a dict lookup
+     per call, on top of whatever load()'s body does).
+  2. walk_manifest(), which runs *after* render() returns, over the client's
+     mounted manifest rather than the tree just rendered — its cost scales
+     with "how many components does the client currently have on screen," not
+     with how large the render that just happened was. A "clean" candidate
+     costs one cache lookup; a "dirty" one costs a real load() + render_level()
+     + a state_hash() (model_dump + JSON encode + SHA-256).
+
+This script sweeps manifest size at a few clean/dirty ratios to show how the
+walk's cost is driven by the dirty share, not the manifest size alone.
+
+Not a CI test (timing-sensitive). Run manually before/after reactive-path work:
+
+    uv run python scripts/bench_reactive_fanout.py
+"""
+
+import dataclasses
+import tempfile
+import time
+from pathlib import Path
+from typing import Annotated
+
+from pyjinhx2 import discovery, registry
+from pyjinhx2.reactive.cache import cache_put
+from pyjinhx2.reactive.component import PjxKey, ReactiveComponent
+from pyjinhx2.reactive.fanout import walk_manifest
+from pyjinhx2.session import request_scope
+
+MANIFEST_SIZES = (50, 100, 200, 500, 1000, 2000, 5000)
+DIRTY_RATIOS = (0.0, 0.5, 1.0)  # all-clean, half-dirty, all-dirty
+
+
+class BenchReactiveWidget(ReactiveComponent, react=("bench",)):
+    """A reactive component keyed by ``pjx_key``; load() does real-ish work."""
+
+    pjx_key: Annotated[str, PjxKey()] = ""
+
+    def load(self) -> str:
+        return f"data:{self.pjx_key}"
+
+
+def setup_registry() -> str:
+    """Publish a tag -> class map and point the descriptor at a temp template.
+
+    Mirrors bench_render_scaling_v2.py: the registry is poked directly since
+    the class lives in this script, not on disk under a package.
+    """
+    template_dir = Path(tempfile.mkdtemp())
+    (template_dir / "bench_reactive_widget.pjx").write_text("<div>{{ pjx_key }}</div>")
+    discovery.build_registry(template_dir, [BenchReactiveWidget])
+    BenchReactiveWidget.__pjx_descriptor__ = dataclasses.replace(
+        BenchReactiveWidget.__pjx_descriptor__,
+        template_path=Path("bench_reactive_widget.pjx"),
+    )
+    return str(template_dir)
+
+
+def make_manifest(n: int, dirty_ratio: float, template_dir: str) -> list[dict]:
+    """Build ``n`` manifest entries, registering each so resolve() finds it.
+
+    ``dirty_ratio`` of them are left uncached (walk_manifest re-loads and
+    re-renders); the rest have their load-cache entry pre-populated (walk_manifest
+    answers "clean" from one cache lookup).
+    """
+    dirty_count = round(n * dirty_ratio)
+    entries = []
+    for i in range(n):
+        instance_id = f"w{i}"
+        load_key = str(i)
+        registry.register_instance(
+            BenchReactiveWidget.__name__, instance_id, f"resolved:{i}"
+        )
+        if i >= dirty_count:
+            cache_put(
+                BenchReactiveWidget, load_key, f"cached:{i}", react_keys=("bench",)
+            )
+        entries.append(
+            {
+                "type": "bench_reactive_widget",
+                "id": instance_id,
+                "load": load_key,
+                "hash": "stale-hash",  # never matches a fresh SHA-256, so a
+                # dirty candidate always survives the hash gate below.
+            }
+        )
+    return entries
+
+
+def bench_walk(n: int, dirty_ratio: float, template_dir: str) -> float:
+    with request_scope(template_dir):
+        manifest = make_manifest(n, dirty_ratio, template_dir)
+        t0 = time.perf_counter()
+        walk_manifest(manifest, {"bench"})
+        return time.perf_counter() - t0
+
+
+def bench_memoization(template_dir: str) -> tuple[float, float]:
+    """Cold vs. warm load() calls on the same instance, one request scope."""
+    with request_scope(template_dir):
+        instance = BenchReactiveWidget(id="memo", pjx_key="1")
+        t0 = time.perf_counter()
+        instance.load()
+        cold = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        instance.load()
+        warm = time.perf_counter() - t0
+    return cold, warm
+
+
+def main() -> None:
+    template_dir = setup_registry()
+
+    print("load() memoization (single instance, cold vs. warm call):")
+    cold, warm = bench_memoization(template_dir)
+    print(f"  cold={cold * 1e6:8.1f} us  warm={warm * 1e6:8.1f} us")
+    print()
+
+    print("walk_manifest() over the mounted manifest, by size and dirty share:")
+    header = f"{'n':>6}  " + "  ".join(
+        f"{int(r * 100):>3}% dirty" for r in DIRTY_RATIOS
+    )
+    print(header)
+    for n in MANIFEST_SIZES:
+        row = [f"{n:6d}"]
+        for ratio in DIRTY_RATIOS:
+            dt = bench_walk(n, ratio, template_dir)
+            row.append(f"{dt * 1000:9.2f}ms")
+        print("  ".join(row))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pyjinhx2/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx2/reactive/test_reactive_fanout.py
@@ -488,6 +488,84 @@ def test_drop_nested_is_a_no_op_on_empty_and_singleton_lists():
         assert _drop_nested(only) == only
 
 
+def test_drop_nested_scales_over_a_large_mixed_candidate_set():
+    """60 candidates: 20 parent/child pairs plus 20 loners, order preserved.
+
+    Large enough that a per-candidate rescan and a two-pass union would
+    disagree if the union ever lost or over-collected a tree.
+    """
+    candidates = []
+    expected = []
+    for i in range(20):
+        child = stamped_level(f"child{i}")
+        parent = stamped_level(f"parent{i}", child)
+        candidates.append(candidate(f"parent{i}", level=parent))
+        candidates.append(candidate(f"child{i}", level=child))
+        expected.append(f"parent{i}")
+    for i in range(20):
+        candidates.append(candidate(f"loner{i}", level=stamped_level(f"loner{i}")))
+        expected.append(f"loner{i}")
+    with scope():
+        survivors = _drop_nested(candidates)
+    # Manifest order is parent0, child0, parent1, child1, ... then the loners;
+    # dropping the children leaves the parents in that same relative order.
+    assert [c.instance_id for c in survivors] == expected
+    assert len(survivors) == len(set(id(c) for c in survivors))
+
+
+def test_drop_nested_keeps_independent_nesting_groups_isolated():
+    """Two unrelated families in one call; neither group's union touches the other."""
+    b = stamped_level("b")
+    c = stamped_level("c")
+    a = stamped_level("a", b, c)
+    e = stamped_level("e")
+    d = stamped_level("d", e)
+    with scope():
+        survivors = _drop_nested(
+            [
+                candidate("a", level=a),
+                candidate("b", level=b),
+                candidate("c", level=c),
+                candidate("d", level=d),
+                candidate("e", level=e),
+            ]
+        )
+    assert [c.instance_id for c in survivors] == ["a", "d"]
+
+
+def test_drop_nested_keeps_a_structureless_candidate_among_large_trees():
+    """Absence of a check is never a drop, no matter how much tree surrounds it."""
+    deep = stamped_level("deep0")
+    for i in range(1, 30):
+        deep = stamped_level(f"deep{i}", deep)
+    with scope():
+        survivors = _drop_nested(
+            [
+                candidate("deep29", level=deep),
+                candidate("no-structure"),
+            ]
+        )
+    assert [c.instance_id for c in survivors] == ["deep29", "no-structure"]
+
+
+def test_drop_nested_collapses_a_four_level_chain():
+    """A > B > C > D, all four candidates: only A survives."""
+    d = stamped_level("d")
+    c = stamped_level("c", d)
+    b = stamped_level("b", c)
+    a = stamped_level("a", b)
+    with scope():
+        survivors = _drop_nested(
+            [
+                candidate("a", level=a),
+                candidate("b", level=b),
+                candidate("c", level=c),
+                candidate("d", level=d),
+            ]
+        )
+    assert [x.instance_id for x in survivors] == ["a"]
+
+
 def test_mounted_ids_in_extracts_both_quote_styles():
     html = "<div data-pjx-id=\"alpha\"><span data-pjx-id='beta'>x</span></div>"
     assert _mounted_ids_in(html) == {"alpha", "beta"}

--- a/tests/pyjinhx2/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx2/reactive/test_reactive_fanout.py
@@ -510,7 +510,7 @@ def test_drop_nested_scales_over_a_large_mixed_candidate_set():
     # Manifest order is parent0, child0, parent1, child1, ... then the loners;
     # dropping the children leaves the parents in that same relative order.
     assert [c.instance_id for c in survivors] == expected
-    assert len(survivors) == len(set(id(c) for c in survivors))
+    assert len(survivors) == len({id(c) for c in survivors})
 
 
 def test_drop_nested_keeps_independent_nesting_groups_isolated():
@@ -564,6 +564,34 @@ def test_drop_nested_collapses_a_four_level_chain():
             ]
         )
     assert [x.instance_id for x in survivors] == ["a"]
+
+
+def test_drop_nested_walks_each_candidate_tree_exactly_once(monkeypatch):
+    """One `_contained` call per candidate with a level — never one per pair.
+
+    The linear rewrite unions every tree once, then filters; a nested-loop
+    implementation would walk trees a quadratic number of times.
+    """
+    calls: list[int] = []
+    real_contained = fanout._contained
+
+    def counting_contained(level):
+        calls.append(id(level))
+        return real_contained(level)
+
+    monkeypatch.setattr(fanout, "_contained", counting_contained)
+
+    levels = [stamped_level(f"n{i}") for i in range(10)]
+    candidates = [candidate(f"n{i}", level=levels[i]) for i in range(10)]
+    candidates.append(candidate("no-structure"))
+    with scope():
+        survivors = _drop_nested(candidates)
+
+    assert len(calls) == 10
+    assert len(set(calls)) == 10
+    assert [c.instance_id for c in survivors] == [f"n{i}" for i in range(10)] + [
+        "no-structure"
+    ]
 
 
 def test_mounted_ids_in_extracts_both_quote_styles():


### PR DESCRIPTION
Closes #600.

Clean re-cut of #603 with only the four commits relevant to this issue — #603 also carried 6 unrelated PJXTable-porting commits (#526) that have since landed properly via #602 and friends; this branch drops them entirely (the type-ignore commit that only touched PJXTable test files came back empty on cherry-pick, confirming its content is already on master).

- `_drop_nested()` now unions each candidate's containment sets once and does an O(1) membership check per candidate, instead of an O(n) re-scan of every other candidate per candidate.
- Regression test covers large, multi-group, and deep candidate sets.
- `scripts/bench_reactive_fanout.py` added for future before/after comparisons.
