### PR TITLE
test: port the PJXChipInput unit tests to v2

### DIFF
--- a/pyjinhx2/builtins/ui/pjx_chip_input/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_chip_input/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx2.builtins.ui.pjx_chip_input.pjx_chip_input import PJXChipInput
+
+__all__ = ["PJXChipInput"]

--- a/pyjinhx2/builtins/ui/pjx_chip_input/pjx_chip_input.css
+++ b/pyjinhx2/builtins/ui/pjx_chip_input/pjx_chip_input.css
@@ -1,0 +1,82 @@
+/* ── PJXChipInput tokens ──────────────────────────────────────────────────────── */
+:where(:root) {
+  --pjx-chip-input-gap:        0.375rem;
+  --pjx-chip-input-chip-bg:    var(--surface-alt);
+  --pjx-chip-input-chip-fg:    var(--text);
+  --pjx-chip-input-chip-radius: var(--radius-full);
+  --pjx-chip-input-border:     var(--border);
+  --pjx-chip-input-focus:      var(--border-focus, var(--border));
+  --pjx-chip-input-radius:     var(--radius-md);
+  --pjx-chip-input-padding:    0.375rem 0.5rem;
+}
+
+.pjx-chip-input {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--pjx-chip-input-gap);
+  padding: var(--pjx-chip-input-padding);
+  border: 1px solid var(--pjx-chip-input-border);
+  border-radius: var(--pjx-chip-input-radius);
+  background: var(--surface, #fff);
+  cursor: text;
+}
+
+.pjx-chip-input:focus-within {
+  outline: 2px solid var(--pjx-chip-input-focus);
+  outline-offset: -1px;
+}
+
+.pjx-chip-input__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  background: var(--pjx-chip-input-chip-bg);
+  color: var(--pjx-chip-input-chip-fg);
+  border-radius: var(--pjx-chip-input-chip-radius);
+  border: 1px solid var(--pjx-chip-input-border);
+  font-size: 0.875em;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+
+.pjx-chip-input__label {
+  max-width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pjx-chip-input__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.75em;
+  line-height: 1;
+  opacity: 0.7;
+  transition: opacity var(--transition, 0.15s ease);
+}
+
+.pjx-chip-input__remove:hover {
+  opacity: 1;
+}
+
+.pjx-chip-input__field {
+  flex: 1;
+  min-width: 6rem;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text, inherit);
+  font: inherit;
+  padding: 0;
+}

--- a/pyjinhx2/builtins/ui/pjx_chip_input/pjx_chip_input.js
+++ b/pyjinhx2/builtins/ui/pjx_chip_input/pjx_chip_input.js
@@ -1,0 +1,129 @@
+(function () {
+    window.pjx = window.pjx || {};
+    if (pjx._chipInputWired) return;
+    pjx._chipInputWired = true;
+
+    function fire(el, name, detail, cancelable) {
+        return el.dispatchEvent(new CustomEvent(name, {
+            bubbles: true, cancelable: Boolean(cancelable), detail: detail || {},
+        }));
+    }
+
+    function getRoot(el) {
+        return el.closest('[data-pjx-chip-input]');
+    }
+
+    function isDisabled(root) {
+        return root.hasAttribute('data-disabled');
+    }
+
+    function isDuplicate(root, value) {
+        return Array.from(root.querySelectorAll('input[type="hidden"]'))
+            .some(function (inp) { return inp.value === value; });
+    }
+
+    function getRemoveLabel(root) {
+        const existing = root.querySelector('[data-pjx-chip-remove]');
+        if (existing) return existing.getAttribute('aria-label') || 'Remove';
+        return root.dataset.removeLabel || 'Remove';
+    }
+
+    function buildChip(root, value) {
+        const chip = document.createElement('span');
+        chip.className = 'pjx-chip-input__chip';
+        chip.setAttribute('data-pjx-chip', '');
+
+        const label = document.createElement('span');
+        label.className = 'pjx-chip-input__label';
+        label.textContent = value;
+        chip.appendChild(label);
+
+        const hidden = document.createElement('input');
+        hidden.type = 'hidden';
+        hidden.name = root.dataset.name;
+        hidden.value = value;
+        chip.appendChild(hidden);
+
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'pjx-chip-input__remove';
+        btn.setAttribute('data-pjx-chip-remove', '');
+        btn.setAttribute('aria-label', getRemoveLabel(root));
+        btn.textContent = '✕';
+        chip.appendChild(btn);
+
+        return chip;
+    }
+
+    function commit(root, field) {
+        const value = field.value.trim().replace(/,$/, '');
+        if (!value) return;
+        if (isDuplicate(root, value)) {
+            field.value = '';
+            return;
+        }
+        if (!fire(root, 'pjx:chip-input:before-add', { value: value }, true)) return;
+        const chip = buildChip(root, value);
+        root.insertBefore(chip, field);
+        field.value = '';
+        fire(root, 'pjx:chip-input:add', { value: value });
+    }
+
+    function removeChip(chip) {
+        const root = getRoot(chip);
+        if (!root || isDisabled(root)) return;
+        const hidden = chip.querySelector('input[type="hidden"]');
+        const value = hidden ? hidden.value : '';
+        if (!fire(root, 'pjx:chip-input:before-remove', { value: value }, true)) return;
+        chip.remove();
+        fire(root, 'pjx:chip-input:remove', { value: value });
+    }
+
+    document.addEventListener('keydown', function (e) {
+        if (e.isComposing) return;
+        if (!e.target.classList.contains('pjx-chip-input__field')) return;
+        const root = getRoot(e.target);
+        if (!root || isDisabled(root)) return;
+
+        if (e.key === 'Enter') {
+            if (e.target.value.trim()) {
+                e.preventDefault();
+                commit(root, e.target);
+            }
+        } else if (e.key === ',') {
+            e.preventDefault();
+            commit(root, e.target);
+        } else if (e.key === 'Backspace' && e.target.value === '') {
+            const chips = root.querySelectorAll('[data-pjx-chip]');
+            if (chips.length > 0) {
+                removeChip(chips[chips.length - 1]);
+            }
+        }
+    });
+
+    document.addEventListener('focusout', function (e) {
+        if (!e.target.classList.contains('pjx-chip-input__field')) return;
+        const root = getRoot(e.target);
+        if (!root || isDisabled(root)) return;
+        commit(root, e.target);
+    });
+
+    document.addEventListener('click', function (e) {
+        const btn = e.target.closest('[data-pjx-chip-remove]');
+        if (!btn) return;
+        const chip = btn.closest('[data-pjx-chip]');
+        if (chip) removeChip(chip);
+    });
+
+    // Commit pending text on form submit (Safari never fires focusout on button click).
+    document.addEventListener('submit', function (e) {
+        const form = e.target;
+        if (!form.querySelectorAll) return;
+        form.querySelectorAll('.pjx-chip-input__field').forEach(function (field) {
+            const root = field.closest('[data-pjx-chip-input]');
+            if (root && !root.hasAttribute('data-disabled') && field.value.trim()) {
+                commit(root, field);
+            }
+        });
+    });
+}());

--- a/pyjinhx2/builtins/ui/pjx_chip_input/pjx_chip_input.pjx
+++ b/pyjinhx2/builtins/ui/pjx_chip_input/pjx_chip_input.pjx
@@ -1,0 +1,10 @@
+<div id="{{ id }}" class="pjx-chip-input{% if class_name %} {{ class_name }}{% endif %}" data-pjx-chip-input data-name="{{ name }}" data-remove-label="{{ remove_label }}"{% if disabled %} data-disabled{% endif %}{% for name, value in extra_attrs.items() %} {{ name }}="{{ value }}"{% endfor %}>
+  {% for value in values %}
+  <span class="pjx-chip-input__chip" data-pjx-chip>
+    <span class="pjx-chip-input__label">{{ value }}</span>
+    <input type="hidden" name="{{ name }}" value="{{ value }}">
+    {% if not disabled %}<button type="button" class="pjx-chip-input__remove" data-pjx-chip-remove aria-label="{{ remove_label }}">&#x2715;</button>{% endif %}
+  </span>
+  {% endfor %}
+  {% if not disabled %}<input type="text" class="pjx-chip-input__field" placeholder="{{ placeholder }}" autocomplete="off">{% endif %}
+</div>

--- a/pyjinhx2/builtins/ui/pjx_chip_input/pjx_chip_input.py
+++ b/pyjinhx2/builtins/ui/pjx_chip_input/pjx_chip_input.py
@@ -1,0 +1,20 @@
+from pydantic import Field
+
+from pyjinhx2.component import AttrValue, BaseComponent, ExtraAttrs
+
+
+class PJXChipInput(BaseComponent):
+    """A multi-value text field that renders each committed value as a chip.
+
+    Every value also renders a hidden input under ``name``, so the chips post
+    as a repeated form field. ``disabled`` drops both the text field and the
+    per-chip remove buttons while keeping the hidden inputs.
+    """
+
+    name: str
+    values: list[str] = Field(default_factory=list)
+    placeholder: str = "Add…"
+    remove_label: str = "Remove"
+    disabled: bool = False
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/tests/pyjinhx2/builtins/pjx_chip_input/test_pjx_chip_input.py
+++ b/tests/pyjinhx2/builtins/pjx_chip_input/test_pjx_chip_input.py
@@ -1,0 +1,144 @@
+"""PJXChipInput — v0.x field/markup parity on the v2 engine.
+
+Port of tests/unit/test_chip_input.py. v0.x's golden snapshot
+(tests/unit/golden/chip_input.html) does not carry over: v2 builtins assert on
+rendered substrings, like every sibling port. The template composes no child
+component tags — only div/span/input/button — so there is no child-tag render
+coverage here and no registry fixture, unlike PJXButton's region-loader leg.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_chip_input import PJXChipInput
+
+
+class TestFields:
+    def test_defaults(self):
+        chips = PJXChipInput(id="c", name="tags")
+        assert chips.values == []
+        assert chips.placeholder == "Add…"
+        assert chips.remove_label == "Remove"
+        assert chips.disabled is False
+        assert chips.class_name == ""
+        assert chips.extra_attrs == {}
+
+    def test_name_is_required(self):
+        with pytest.raises(ValidationError):
+            PJXChipInput(id="c")  # type: ignore[call-arg]
+
+    def test_undeclared_kwarg_raises(self):
+        with pytest.raises(ValidationError):
+            PJXChipInput(id="c", name="tags", bogus="x")  # type: ignore[call-arg]
+
+    def test_inline_attr_kwargs_no_longer_pass_through(self):
+        """v0.x accepted ``PJXChipInput(id="c", **{"data-test": "yes"})``.
+
+        v2 core is strict (extra="forbid"), so a bare inline attr kwarg is now a
+        ValidationError. The behavior it replaces is not dropped: pass-through
+        moved to the declared ``extra_attrs`` mapping, covered by
+        TestRender.test_extra_attrs_surface_on_the_root.
+        """
+        with pytest.raises(ValidationError):
+            PJXChipInput(id="c", name="tags", **{"data-test": "yes"})  # type: ignore[arg-type]
+
+
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve.
+
+    ClassDescriptor.template_path is absolute and render() feeds it straight to
+    the session's FileSystemLoader; Jinja only resolves an absolute path when
+    the loader root is "/". Same fixture shape as the sibling builtin tests.
+    """
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kwargs) -> str:
+    base = {"id": "c", "name": "tags"}
+    base.update(kwargs)
+    return render(PJXChipInput(**base), session)  # type: ignore[arg-type]
+
+
+class TestRender:
+    def test_single_root_div(self, session):
+        html = _html(session, values=["a"]).strip()
+        assert html.count("data-pjx-chip-input") == 1
+        assert html.startswith('<div id="c"')
+        assert html.endswith("</div>")
+
+    def test_one_chip_and_one_hidden_input_per_value_in_order(self, session):
+        html = _html(session, values=["c", "a", "b"])
+        assert html.count("data-pjx-chip>") == 3
+        assert html.count('<input type="hidden"') == 3
+        positions = [html.find(f'value="{v}"') for v in ("c", "a", "b")]
+        assert positions == sorted(positions)
+
+    def test_hidden_input_name_matches_the_name_field(self, session):
+        html = _html(session, name="keywords", values=["x", "y"])
+        assert html.count('<input type="hidden" name="keywords"') == 2
+
+    def test_remove_buttons_carry_the_remove_label(self, session):
+        html = _html(session, values=["x", "y"], remove_label="Remove chip")
+        assert html.count('aria-label="Remove chip"') == 2
+        assert html.count("data-pjx-chip-remove") == 2
+
+    def test_disabled_drops_the_text_field_and_remove_buttons(self, session):
+        html = _html(session, values=["x"], disabled=True)
+        assert 'type="text"' not in html
+        assert "data-pjx-chip-remove" not in html
+
+    def test_disabled_keeps_the_hidden_inputs(self, session):
+        html = _html(session, values=["x", "y"], disabled=True)
+        assert html.count('<input type="hidden" name="tags"') == 2
+
+    def test_root_data_attrs(self, session):
+        head = _html(session, name="skills", remove_label="Delete")
+        head = head[: head.index(">")]
+        assert 'data-name="skills"' in head
+        assert 'data-remove-label="Delete"' in head
+
+    def test_data_disabled_only_when_disabled(self, session):
+        assert "data-disabled" not in _html(session)[: _html(session).index(">")]
+        head = _html(session, disabled=True)
+        assert "data-disabled" in head[: head.index(">")]
+
+    def test_class_name_is_appended_without_clobbering_base_classes(self, session):
+        assert 'class="pjx-chip-input my-chips"' in _html(
+            session, class_name="my-chips"
+        )
+
+    def test_empty_class_name_adds_nothing(self, session):
+        assert 'class="pjx-chip-input"' in _html(session)
+
+    def test_extra_attrs_surface_on_the_root(self, session):
+        html = _html(session, extra_attrs={"data-test": "yes"})
+        assert 'data-test="yes"' in html[: html.index(">")]
+
+    def test_placeholder_renders_on_the_text_field(self, session):
+        html = _html(session, placeholder="Type here…")
+        assert 'placeholder="Type here…"' in html
+        assert 'type="text"' in html
+
+    def test_chip_value_is_escaped(self, session):
+        html = _html(session, values=["<script>x</script>"])
+        assert "&lt;script&gt;x&lt;/script&gt;" in html
+        assert "<script>" not in html
+
+
+class TestAssets:
+    def test_stylesheet_is_frozen_on_the_descriptor(self):
+        css = PJXChipInput.__pjx_descriptor__.css_paths
+        assert len(css) == 1
+        assert css[0].name == "pjx_chip_input.css"
+        assert css[0].is_file()
+
+    def test_script_is_frozen_on_the_descriptor(self):
+        js = PJXChipInput.__pjx_descriptor__.js_paths
+        assert len(js) == 1
+        assert js[0].name == "pjx_chip_input.js"
+        assert js[0].is_file()

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -58,6 +58,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
         {"pyjinhx2.builtins.ui.pjx_button.pjx_button"}
     ),
     "builtins.ui.pjx_button.pjx_button": frozenset({"pyjinhx2.component"}),
+    "builtins.ui.pjx_chip_input.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_chip_input.pjx_chip_input"}
+    ),
+    "builtins.ui.pjx_chip_input.pjx_chip_input": frozenset({"pyjinhx2.component"}),
     "builtins.ui.pjx_spinner.__init__": frozenset(
         {"pyjinhx2.builtins.ui.pjx_spinner.pjx_spinner"}
     ),


### PR DESCRIPTION
## Summary
- Port PJXChipInput functionality to pyjinhx2 engine
- Add comprehensive unit tests for the v2 implementation

## Test plan
- Full test suite for PJXChipInput ported to v2
- All existing functionality preserved

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)