### PR TITLE
fix: add type: ignore comments for CountingSet attribute access

### DIFF
--- a/pyjinhx2/reactive/cache.py
+++ b/pyjinhx2/reactive/cache.py
@@ -10,17 +10,19 @@ would be indistinguishable from - ``cache_has()`` is the way to tell the two
 apart, and the reason a private sentinel does the lookup internally rather than
 a plain ``.get()``.
 
-``cache_put()`` is the only mutator, and the only writer of the reverse index -
+``cache_put()`` is the only mutator, and the only writer of the two indexes -
 the ``reactive key -> {(cls, key)}`` map ``session.get_cache_reverse()`` hands
 out, which ``invalidate()`` reads to evict exactly the entries a dirtied key
-touched. Outside a request scope every function is a no-op: ``get_cache_store()``
-and ``get_cache_reverse()`` answer throwaway containers, so writes vanish and
-reads miss. A cache that does nothing is a correct cache, so nothing raises.
+touched, and its mirror ``session.get_cache_forward()``, which names the keys a
+single entry sits under so un-indexing costs that entry's own key count instead
+of a walk over every bucket. Outside a request scope every function is a no-op:
+the session getters answer throwaway containers, so writes vanish and reads
+miss. A cache that does nothing is a correct cache, so nothing raises.
 """
 
 from collections.abc import Iterable
 
-from pyjinhx2.session import get_cache_reverse, get_cache_store
+from pyjinhx2.session import get_cache_forward, get_cache_reverse, get_cache_store
 
 # Distinguishes "no entry" from an entry whose value happens to be None.
 _MISS = object()
@@ -90,11 +92,13 @@ def cache_put(
     """
     cache_key = make_key(cls, key)
     reverse = get_cache_reverse()
+    forward = get_cache_forward()
     # A re-put may depend on a different set of keys than the entry it replaces,
     # so drop every old membership before re-indexing rather than adding to it.
-    _unindex(reverse, cache_key)
+    _unindex(reverse, forward, cache_key)
     for react_key in react_keys:
         reverse.setdefault(react_key, set()).add(cache_key)
+        forward.setdefault(cache_key, set()).add(react_key)
     get_cache_store()[cache_key] = value
 
 
@@ -109,6 +113,7 @@ def invalidate(dirtied_keys: Iterable[str]) -> None:
             coerce_reactive_keys() and collected by session.add_dirtied().
     """
     reverse = get_cache_reverse()
+    forward = get_cache_forward()
     store = get_cache_store()
     evicted: set[tuple[type, object]] = set()
     for react_key in dirtied_keys:
@@ -120,12 +125,16 @@ def invalidate(dirtied_keys: Iterable[str]) -> None:
         # Clean every key the entry was registered under, not just the dirtied
         # ones that matched: the entry is gone from the store, so any surviving
         # membership would name a cache_key nothing can look up.
-        _unindex(reverse, cache_key)
+        _unindex(reverse, forward, cache_key)
 
 
 def _unindex(
-    reverse: dict[str, set[tuple[type, object]]], cache_key: tuple[type, object]
+    reverse: dict[str, set[tuple[type, object]]],
+    forward: dict[tuple[type, object], set[str]],
+    cache_key: tuple[type, object],
 ) -> None:
     """Remove a cache key from every reverse-index set that holds it."""
-    for entries in reverse.values():
-        entries.discard(cache_key)
+    # The forward index names exactly the buckets this entry sits in, so the
+    # cost is the entry's own key count rather than the whole reverse index.
+    for react_key in forward.pop(cache_key, ()):
+        reverse[react_key].discard(cache_key)

--- a/pyjinhx2/session.py
+++ b/pyjinhx2/session.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from pyjinhx2.component import BaseComponent
     from pyjinhx2.segments import RenderedLevel
 
-# The five pieces of per-request mutable state. They live here rather than beside
+# The six pieces of per-request mutable state. They live here rather than beside
 # their eventual consumers because the import rule runs one way only: reactive/
 # imports session, never the reverse. Each defaults to None so that reading one
 # outside a request is a miss, not a LookupError.
@@ -33,6 +33,9 @@ _cache_store: ContextVar[dict[object, object] | None] = ContextVar(
 )
 _cache_reverse: ContextVar[dict[str, set[tuple[type, object]]] | None] = ContextVar(
     "pjx_cache_reverse", default=None
+)
+_cache_forward: ContextVar[dict[tuple[type, object], set[str]] | None] = ContextVar(
+    "pjx_cache_forward", default=None
 )
 
 
@@ -190,6 +193,19 @@ def get_cache_reverse() -> dict[str, set[tuple[type, object]]]:
     return reverse
 
 
+def get_cache_forward() -> dict[tuple[type, object], set[str]]:
+    """Return this request's cache-entry -> reactive-key index, empty outside a scope.
+
+    The mirror of get_cache_reverse(): maps a ``(cls, key)`` cache entry to the
+    set of reactive keys it was registered under, so un-indexing an entry can go
+    straight to the buckets that hold it instead of scanning every bucket.
+    """
+    forward = _cache_forward.get()
+    if forward is None:
+        return {}
+    return forward
+
+
 @contextmanager
 def request_scope(
     template_dir: str = "templates", session: "RenderSession | None" = None
@@ -214,11 +230,13 @@ def request_scope(
     dirtied_token = _dirtied.set(set())
     cache_token = _cache_store.set({})
     cache_reverse_token = _cache_reverse.set({})
+    cache_forward_token = _cache_forward.set({})
     try:
         yield session
     finally:
         # Reset by token rather than assigning None: a nested scope must hand the
         # outer scope its own state back, not clear the variable outright.
+        _cache_forward.reset(cache_forward_token)
         _cache_reverse.reset(cache_reverse_token)
         _cache_store.reset(cache_token)
         _dirtied.reset(dirtied_token)

--- a/scripts/bench_reactive_cache.py
+++ b/scripts/bench_reactive_cache.py
@@ -1,0 +1,79 @@
+"""Load-cache benchmark: the cost of indexing and evicting cache entries.
+
+bench_reactive_fanout.py measures walk_manifest() and the memoization wrapper;
+neither exercises the index bookkeeping that cache_put() and invalidate() do
+underneath. Two costs live there:
+
+  1. cache_put(), which un-indexes whatever entry it replaces and then writes
+     the entry into one reverse bucket and one forward bucket per reactive key.
+  2. invalidate(), which collects the entries a dirtied key names and un-indexes
+     each of them - the step that used to walk every bucket in the reverse index
+     per entry, making a full eviction quadratic in the number of cached entries.
+
+This script sweeps the number of cached entries so the two should trace straight
+lines: doubling N should roughly double each column, not quadruple it.
+
+Not a CI test (timing-sensitive). Run manually before/after load-cache work:
+
+    uv run python scripts/bench_reactive_cache.py
+"""
+
+import time
+
+from pyjinhx2.reactive.cache import cache_put, invalidate
+from pyjinhx2.session import request_scope
+
+ENTRY_COUNTS = (500, 1000, 2000, 4000, 8000)
+# Every entry also carries a shared key, so one invalidate() evicts all of them.
+SHARED_KEY = "all"
+
+
+class BenchWidget:
+    """Stand-in component class; cache keys only need a hashable type."""
+
+
+def bench_puts(n: int) -> float:
+    """Time filling an empty cache with ``n`` entries, two reactive keys each."""
+    with request_scope():
+        t0 = time.perf_counter()
+        for i in range(n):
+            cache_put(BenchWidget, i, f"value {i}", react_keys=(f"key:{i}", SHARED_KEY))
+        return time.perf_counter() - t0
+
+
+def bench_repurs(n: int) -> float:
+    """Time re-putting every entry, which un-indexes each one before rewriting."""
+    with request_scope():
+        for i in range(n):
+            cache_put(BenchWidget, i, f"value {i}", react_keys=(f"key:{i}", SHARED_KEY))
+        t0 = time.perf_counter()
+        for i in range(n):
+            cache_put(BenchWidget, i, f"redone {i}", react_keys=(f"key:{i}", SHARED_KEY))
+        return time.perf_counter() - t0
+
+
+def bench_invalidate_all(n: int) -> float:
+    """Time evicting every entry at once through the shared reactive key."""
+    with request_scope():
+        for i in range(n):
+            cache_put(BenchWidget, i, f"value {i}", react_keys=(f"key:{i}", SHARED_KEY))
+        t0 = time.perf_counter()
+        invalidate([SHARED_KEY])
+        return time.perf_counter() - t0
+
+
+def main() -> None:
+    print("load-cache indexing cost by number of cached entries:")
+    print(f"{'n':>6}  {'put':>12}  {'re-put':>12}  {'invalidate all':>16}")
+    for n in ENTRY_COUNTS:
+        put = bench_puts(n)
+        reput = bench_repurs(n)
+        evict = bench_invalidate_all(n)
+        print(
+            f"{n:6d}  {put * 1000:10.2f}ms  {reput * 1000:10.2f}ms  "
+            f"{evict * 1000:14.2f}ms"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_reactive_cache.py
+++ b/scripts/bench_reactive_cache.py
@@ -48,7 +48,9 @@ def bench_repurs(n: int) -> float:
             cache_put(BenchWidget, i, f"value {i}", react_keys=(f"key:{i}", SHARED_KEY))
         t0 = time.perf_counter()
         for i in range(n):
-            cache_put(BenchWidget, i, f"redone {i}", react_keys=(f"key:{i}", SHARED_KEY))
+            cache_put(
+                BenchWidget, i, f"redone {i}", react_keys=(f"key:{i}", SHARED_KEY)
+            )
         return time.perf_counter() - t0
 
 

--- a/tests/pyjinhx2/reactive/test_reactive_cache.py
+++ b/tests/pyjinhx2/reactive/test_reactive_cache.py
@@ -196,3 +196,30 @@ def test_the_forward_index_does_not_leak_across_requests():
 def test_the_forward_index_is_a_throwaway_dict_outside_a_request_scope():
     get_cache_forward()[(Widget, "todos")] = {"todos"}
     assert get_cache_forward() == {}
+
+
+def test_put_records_the_entrys_reactive_keys_in_the_forward_index():
+    with request_scope():
+        cache_put(Widget, "todos", "loaded", react_keys={"todos", "users"})
+        assert get_cache_forward() == {(Widget, "todos"): {"todos", "users"}}
+
+
+def test_re_putting_replaces_the_forward_entry_rather_than_growing_it():
+    with request_scope():
+        cache_put(Widget, "todos", "first", react_keys=["todos"])
+        cache_put(Widget, "todos", "second", react_keys=["users"])
+        assert get_cache_forward() == {(Widget, "todos"): {"users"}}
+
+
+def test_eviction_drops_the_entry_from_the_forward_index():
+    with request_scope():
+        cache_put(Widget, "todos", "loaded", react_keys={"todos", "users"})
+        invalidate(["users"])
+        assert get_cache_forward() == {}
+
+
+def test_putting_an_entry_with_no_reactive_keys_leaves_both_indexes_empty():
+    with request_scope():
+        cache_put(Widget, "todos", "memoized")
+        assert get_cache_forward() == {}
+        assert get_cache_reverse() == {}

--- a/tests/pyjinhx2/reactive/test_reactive_cache.py
+++ b/tests/pyjinhx2/reactive/test_reactive_cache.py
@@ -243,14 +243,14 @@ def test_eviction_only_touches_the_buckets_that_held_the_entry():
             cache_put(Widget, i, f"value {i}", react_keys={f"key:{i}"})
         reverse = get_cache_reverse()
         for react_key, entries in reverse.items():
-            reverse[react_key] = CountingSet(entries)
+            reverse[react_key] = CountingSet(entries)  # type: ignore[assignment]
 
         invalidate(["key:7"])
 
         touched = {
             react_key
             for react_key, entries in reverse.items()
-            if entries.discard_calls > 0
+            if entries.discard_calls > 0  # type: ignore[attr-defined]
         }
         assert touched == {"key:7"}
 
@@ -264,11 +264,11 @@ def test_eviction_work_does_not_grow_with_the_number_of_unrelated_entries():
                 cache_put(Widget, i, f"value {i}", react_keys={f"key:{i}", "all"})
             reverse = get_cache_reverse()
             for react_key, entries in reverse.items():
-                reverse[react_key] = CountingSet(entries)
+                reverse[react_key] = CountingSet(entries)  # type: ignore[assignment]
 
             invalidate(["key:3"])
 
-            return sum(entries.discard_calls for entries in reverse.values())
+            return sum(entries.discard_calls for entries in reverse.values())  # type: ignore[attr-defined]
 
     # The evicted entry sits in exactly two buckets ("key:3" and "all"), whatever
     # N is; a scan over reverse.values() would answer N + 1 instead.

--- a/tests/pyjinhx2/reactive/test_reactive_cache.py
+++ b/tests/pyjinhx2/reactive/test_reactive_cache.py
@@ -223,3 +223,54 @@ def test_putting_an_entry_with_no_reactive_keys_leaves_both_indexes_empty():
         cache_put(Widget, "todos", "memoized")
         assert get_cache_forward() == {}
         assert get_cache_reverse() == {}
+
+
+class CountingSet(set):
+    """A set that records how many times discard() was called on it."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.discard_calls = 0
+
+    def discard(self, value):
+        self.discard_calls += 1
+        super().discard(value)
+
+
+def test_eviction_only_touches_the_buckets_that_held_the_entry():
+    with request_scope():
+        for i in range(500):
+            cache_put(Widget, i, f"value {i}", react_keys={f"key:{i}"})
+        reverse = get_cache_reverse()
+        for react_key, entries in reverse.items():
+            reverse[react_key] = CountingSet(entries)
+
+        invalidate(["key:7"])
+
+        touched = {
+            react_key
+            for react_key, entries in reverse.items()
+            if entries.discard_calls > 0
+        }
+        assert touched == {"key:7"}
+
+
+def test_eviction_work_does_not_grow_with_the_number_of_unrelated_entries():
+    """A quadratic _unindex would scale total discard() calls with N."""
+
+    def total_discards(n: int) -> int:
+        with request_scope():
+            for i in range(n):
+                cache_put(Widget, i, f"value {i}", react_keys={f"key:{i}", "all"})
+            reverse = get_cache_reverse()
+            for react_key, entries in reverse.items():
+                reverse[react_key] = CountingSet(entries)
+
+            invalidate(["key:3"])
+
+            return sum(entries.discard_calls for entries in reverse.values())
+
+    # The evicted entry sits in exactly two buckets ("key:3" and "all"), whatever
+    # N is; a scan over reverse.values() would answer N + 1 instead.
+    assert total_discards(100) == 2
+    assert total_discards(1000) == 2

--- a/tests/pyjinhx2/reactive/test_reactive_cache.py
+++ b/tests/pyjinhx2/reactive/test_reactive_cache.py
@@ -5,7 +5,12 @@ from pyjinhx2.reactive.cache import (
     invalidate,
     make_key,
 )
-from pyjinhx2.session import get_cache_reverse, get_cache_store, request_scope
+from pyjinhx2.session import (
+    get_cache_forward,
+    get_cache_reverse,
+    get_cache_store,
+    request_scope,
+)
 
 
 class Widget:
@@ -174,3 +179,20 @@ def test_an_entry_with_no_reactive_keys_survives_any_invalidation():
         invalidate(["users", "anything-else"])
         assert cache_get(Widget, "todos") == "memoized"
         assert get_cache_reverse() == {}
+
+
+def test_the_forward_index_starts_empty_inside_a_fresh_request_scope():
+    with request_scope():
+        assert get_cache_forward() == {}
+
+
+def test_the_forward_index_does_not_leak_across_requests():
+    with request_scope():
+        get_cache_forward()[(Widget, "todos")] = {"todos"}
+    with request_scope():
+        assert get_cache_forward() == {}
+
+
+def test_the_forward_index_is_a_throwaway_dict_outside_a_request_scope():
+    get_cache_forward()[(Widget, "todos")] = {"todos"}
+    assert get_cache_forward() == {}


### PR DESCRIPTION
## Summary

- Fix type checking issues by adding type: ignore comments for CountingSet attribute access in test utilities
- Add request-scoped forward index optimization for load-cache entries
- Implement un-indexing through the forward index for better performance
- Add manual load-cache indexing benchmark for performance tracking
- Pin load-cache un-indexing to the entry's own reactive keys

## Changes

6 commits addressing type checker inference issues and load-cache performance optimizations.

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)