### PR TITLE
feat(builtins): port PJXPasswordInput to v2, wire import graph

### DIFF
--- a/pyjinhx2/builtins/ui/pjx_password_input/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_password_input/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx2.builtins.ui.pjx_password_input.pjx_password_input import PJXPasswordInput
+
+__all__ = ["PJXPasswordInput"]

--- a/pyjinhx2/builtins/ui/pjx_password_input/pjx_password_input.css
+++ b/pyjinhx2/builtins/ui/pjx_password_input/pjx_password_input.css
@@ -1,0 +1,99 @@
+/* ── PJXPasswordInput tokens ─────────────────────────────────────────────────── */
+:where(:root) {
+  --pjx-password-input-border:       var(--border, #ccc);
+  --pjx-password-input-radius:       var(--radius-md, 0.375rem);
+  --pjx-password-input-focus:        var(--border-focus, var(--brand, #0d6efd));
+  --pjx-password-input-toggle-color: var(--text-muted, #666);
+  --pjx-password-input-eye-size:     1.25rem;
+}
+
+.pjx-password-input {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+  width: 100%;
+  border: 1px solid var(--pjx-password-input-border);
+  border-radius: var(--pjx-password-input-radius);
+  background: var(--surface, #fff);
+}
+
+.pjx-password-input:focus-within {
+  outline: 2px solid var(--pjx-password-input-focus);
+  outline-offset: -1px;
+}
+
+.pjx-password-input__field {
+  flex: 1;
+  min-width: 0;
+  padding: 0.5rem 2.75rem 0.5rem 0.75rem;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text, inherit);
+  font: inherit;
+  border-radius: inherit;
+}
+
+/* Suppress Edge's built-in password-reveal button (would double up with our toggle). */
+.pjx-password-input__field::-ms-reveal {
+  display: none;
+}
+
+.pjx-password-input__toggle {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  border: none;
+  background: transparent;
+  color: var(--pjx-password-input-toggle-color);
+  cursor: pointer;
+  border-radius: 0 var(--pjx-password-input-radius) var(--pjx-password-input-radius) 0;
+  transition: color var(--transition, 0.15s ease);
+}
+
+.pjx-password-input__toggle:hover {
+  color: var(--text, inherit);
+}
+
+.pjx-password-input__toggle:focus-visible {
+  outline: 2px solid var(--pjx-password-input-focus);
+  outline-offset: 2px;
+}
+
+/* Eye glyph — bordered circle with a diagonal slash via ::after when active */
+.pjx-password-input__eye {
+  display: inline-block;
+  position: relative;
+  width: var(--pjx-password-input-eye-size);
+  height: var(--pjx-password-input-eye-size);
+}
+
+.pjx-password-input__eye::before {
+  content: '';
+  position: absolute;
+  inset: 15% 10%;
+  border: 2px solid currentColor;
+  border-radius: 50% 50% 50% 50% / 40% 40% 60% 60%;
+}
+
+.pjx-password-input__eye::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2px;
+  height: 0;
+  background: currentColor;
+  transform: translate(-50%, -50%) rotate(45deg);
+  transition: height var(--transition, 0.15s ease);
+}
+
+/* Slash visible when password is revealed (toggle--on) */
+.pjx-password-input__toggle--on .pjx-password-input__eye::after {
+  height: 130%;
+}

--- a/pyjinhx2/builtins/ui/pjx_password_input/pjx_password_input.js
+++ b/pyjinhx2/builtins/ui/pjx_password_input/pjx_password_input.js
@@ -1,0 +1,23 @@
+(function () {
+    window.pjx = window.pjx || {};
+    if (pjx._passwordWired) return;
+    pjx._passwordWired = true;
+
+    document.addEventListener('click', function (e) {
+        const btn = e.target.closest('[data-pjx-password-toggle]');
+        if (!btn) return;
+
+        const root = btn.closest('[data-pjx-password]');
+        if (!root) return;
+
+        const field = root.querySelector('.pjx-password-input__field');
+        if (!field) return;
+
+        const isShowing = field.type === 'text';
+        field.type = isShowing ? 'password' : 'text';
+
+        // single ARIA signal: static label + aria-pressed (ARIA APG toggle-button pattern)
+        btn.setAttribute('aria-pressed', String(!isShowing));
+        btn.classList.toggle('pjx-password-input__toggle--on', !isShowing);
+    });
+}());

--- a/pyjinhx2/builtins/ui/pjx_password_input/pjx_password_input.pjx
+++ b/pyjinhx2/builtins/ui/pjx_password_input/pjx_password_input.pjx
@@ -1,0 +1,4 @@
+<div id="{{ id }}" class="pjx-password-input{% if class_name %} {{ class_name }}{% endif %}" data-pjx-password{% for attr, value in extra_attrs.items() %} {{ attr }}="{{ value }}"{% endfor %}>
+  <input type="password" class="pjx-password-input__field" id="{{ id }}-field" name="{{ name }}"{% if placeholder %} placeholder="{{ placeholder }}"{% endif %}{% if autocomplete %} autocomplete="{{ autocomplete }}"{% endif %}{% if required %} required{% endif %}>
+  <button type="button" class="pjx-password-input__toggle" data-pjx-password-toggle aria-label="{{ show_label }}" aria-pressed="false"><span class="pjx-password-input__eye" aria-hidden="true"></span></button>
+</div>

--- a/pyjinhx2/builtins/ui/pjx_password_input/pjx_password_input.py
+++ b/pyjinhx2/builtins/ui/pjx_password_input/pjx_password_input.py
@@ -1,0 +1,20 @@
+from pydantic import Field
+
+from pyjinhx2.component import AttrValue, BaseComponent, ExtraAttrs
+
+
+class PJXPasswordInput(BaseComponent):
+    """A password field with a show/hide toggle button.
+
+    The toggle flips the field between ``type="password"`` and ``type="text"``
+    client-side and reports state through ``aria-pressed`` on a static label,
+    following the ARIA APG toggle-button pattern.
+    """
+
+    name: str = "password"
+    placeholder: str = ""
+    autocomplete: str = "current-password"
+    required: bool = False
+    show_label: str = "Show password"
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/tests/pyjinhx2/builtins/pjx_password_input/test_pjx_password_input.py
+++ b/tests/pyjinhx2/builtins/pjx_password_input/test_pjx_password_input.py
@@ -1,0 +1,133 @@
+"""PJXPasswordInput — v0.x field/markup parity on the v2 engine.
+
+Port of tests/unit/test_password_input.py. v0.x's golden snapshot
+(tests/unit/golden/password_input.html) does not carry over: v2 builtins assert
+on rendered substrings, like every sibling port. The template composes no child
+component tags — only div/input/button/span — so there is no child-tag render
+coverage here and no registry fixture.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_password_input import PJXPasswordInput
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+class TestFields:
+    def test_defaults(self):
+        field = PJXPasswordInput(id="p")
+        assert field.name == "password"
+        assert field.placeholder == ""
+        assert field.autocomplete == "current-password"
+        assert field.required is False
+        assert field.show_label == "Show password"
+        assert field.class_name == ""
+        assert field.extra_attrs == {}
+
+    def test_undeclared_kwarg_raises(self):
+        with pytest.raises(ValidationError):
+            PJXPasswordInput(id="p", bogus="x")  # type: ignore[call-arg]
+
+    def test_inline_attr_kwargs_no_longer_pass_through(self):
+        """v0.x accepted ``PJXPasswordInput(id="p", **{"data-test": "yes"})``.
+
+        v2 core is strict (extra="forbid"), so a bare inline attr kwarg is now a
+        ValidationError. The behavior it replaces is not dropped: pass-through
+        moved to the declared ``extra_attrs`` mapping, covered by
+        TestRender.test_extra_attrs_surface_on_the_root.
+        """
+        with pytest.raises(ValidationError):
+            PJXPasswordInput(id="p", **{"data-test": "yes"})  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve.
+
+    ClassDescriptor.template_path is absolute and render() feeds it straight to
+    the session's FileSystemLoader; Jinja only resolves an absolute path when
+    the loader root is "/". Same fixture shape as the sibling builtin tests.
+    """
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kwargs) -> str:
+    base = {"id": "p"}
+    base.update(kwargs)
+    return render(PJXPasswordInput(**base), session)  # type: ignore[arg-type]
+
+
+class TestRender:
+    def test_single_root_div(self, session):
+        html = _html(session).strip()
+        assert html.count("data-pjx-password ") + html.count("data-pjx-password>") == 1
+        assert html.startswith('<div id="p"')
+        assert html.endswith("</div>")
+
+    def test_field_is_a_password_input(self, session):
+        html = _html(session)
+        assert '<input type="password"' in html
+        assert 'id="p-field"' in html
+        assert 'name="password"' in html
+
+    def test_name_reaches_the_field(self, session):
+        assert 'name="pwd1"' in _html(session, name="pwd1")
+
+    def test_placeholder_only_renders_when_set(self, session):
+        assert "placeholder=" not in _html(session)
+        assert 'placeholder="Your password"' in _html(
+            session, placeholder="Your password"
+        )
+
+    def test_autocomplete_renders_by_default_and_can_be_dropped(self, session):
+        assert 'autocomplete="current-password"' in _html(session)
+        assert "autocomplete=" not in _html(session, autocomplete="")
+
+    def test_required_only_renders_when_true(self, session):
+        assert " required" not in _html(session)
+        assert " required" in _html(session, required=True)
+
+    def test_toggle_button_markup_is_present(self, session):
+        html = _html(session)
+        assert "data-pjx-password-toggle" in html
+        assert 'type="button"' in html
+        assert 'class="pjx-password-input__eye"' in html
+
+    def test_toggle_aria_label_comes_from_show_label(self, session):
+        assert 'aria-label="Show password"' in _html(session)
+        assert 'aria-label="Reveal"' in _html(session, show_label="Reveal")
+
+    def test_toggle_defaults_to_unpressed(self, session):
+        assert 'aria-pressed="false"' in _html(session)
+
+    def test_class_name_is_appended_without_clobbering_base_classes(self, session):
+        assert 'class="pjx-password-input my-pw"' in _html(session, class_name="my-pw")
+
+    def test_empty_class_name_adds_nothing(self, session):
+        assert 'class="pjx-password-input"' in _html(session)
+
+    def test_extra_attrs_surface_on_the_root(self, session):
+        html = _html(session, extra_attrs={"data-test": "yes"})
+        assert 'data-test="yes"' in html[: html.index(">")]
+
+    def test_user_supplied_values_are_escaped(self, session):
+        html = _html(session, show_label="<script>x</script>", placeholder='"quoted"')
+        assert "&lt;script&gt;x&lt;/script&gt;" in html
+        assert "<script>" not in html
+        assert "&#34;quoted&#34;" in html or "&quot;quoted&quot;" in html
+
+
+class TestAssets:
+    def test_stylesheet_is_frozen_on_the_descriptor(self):
+        css = PJXPasswordInput.__pjx_descriptor__.css_paths
+        assert len(css) == 1
+        assert css[0].name == "pjx_password_input.css"
+        assert css[0].is_file()
+
+    def test_script_is_frozen_on_the_descriptor(self):
+        js = PJXPasswordInput.__pjx_descriptor__.js_paths
+        assert len(js) == 1
+        assert js[0].name == "pjx_password_input.js"
+        assert js[0].is_file()

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -66,6 +66,12 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
         {"pyjinhx2.builtins.ui.pjx_form_field.pjx_form_field"}
     ),
     "builtins.ui.pjx_form_field.pjx_form_field": frozenset({"pyjinhx2.component"}),
+    "builtins.ui.pjx_password_input.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_password_input.pjx_password_input"}
+    ),
+    "builtins.ui.pjx_password_input.pjx_password_input": frozenset(
+        {"pyjinhx2.component"}
+    ),
     "builtins.ui.pjx_spinner.__init__": frozenset(
         {"pyjinhx2.builtins.ui.pjx_spinner.pjx_spinner"}
     ),


### PR DESCRIPTION
## Summary

Port PJXPasswordInput from v0 to v2, following the pjx_chip_input pattern as a Pydantic BaseComponent subclass with a single .pjx template. Carries over snake_case CSS/JS assets byte-identical and adds extra_attrs expansion on the root since v0's inline **kwargs pass-through no longer works under v2's extra="forbid" core. Wire import-graph gate for the new leaf modules. Composition with FormField and other controls is deferred to #515.

- 1 commit, 6 files changed (+288 lines)
- 1 new test module with 133 test lines covering PJXPasswordInput functionality

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)