### PR TITLE
feat: register PJXSegmentedControl in the import graph

### DIFF
--- a/pyjinhx2/builtins/ui/pjx_segmented_control/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_segmented_control/__init__.py
@@ -1,0 +1,5 @@
+from pyjinhx2.builtins.ui.pjx_segmented_control.pjx_segmented_control import (
+    PJXSegmentedControl,
+)
+
+__all__ = ["PJXSegmentedControl"]

--- a/pyjinhx2/builtins/ui/pjx_segmented_control/pjx_segmented_control.css
+++ b/pyjinhx2/builtins/ui/pjx_segmented_control/pjx_segmented_control.css
@@ -1,0 +1,74 @@
+/* ── PJXSegmentedControl tokens ──────────────────────────────────────────────── */
+:where(:root) {
+  --pjx-segmented-control-bg:        var(--surface-alt, #f0f0f0);
+  --pjx-segmented-control-border:    var(--border, #ddd);
+  --pjx-segmented-control-radius:    var(--radius-full, 9999px);
+  --pjx-segmented-control-gap:       0.25rem;
+  --pjx-segmented-control-padding:   0.25rem;
+  --pjx-segmented-control-active-bg: var(--surface, #fff);
+  --pjx-segmented-control-active-fg: var(--text, inherit);
+  --pjx-segmented-control-active-shadow: 0 1px 3px rgb(0 0 0 / 0.12);
+  --pjx-segmented-control-fg:        var(--text-muted, #666);
+  --pjx-segmented-control-focus:     var(--border-focus, var(--brand, #0d6efd));
+}
+
+.pjx-segmented-control {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pjx-segmented-control-gap);
+  padding: var(--pjx-segmented-control-padding);
+  background: var(--pjx-segmented-control-bg);
+  border: 1px solid var(--pjx-segmented-control-border);
+  border-radius: var(--pjx-segmented-control-radius);
+}
+
+.pjx-segmented-control__segment {
+  display: inline-flex;
+  position: relative;
+  cursor: pointer;
+}
+
+/* Visually-hidden radio — same clip-path technique as PJXToggleSwitch */
+.pjx-segmented-control__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.pjx-segmented-control__text {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: calc(var(--pjx-segmented-control-radius) - var(--pjx-segmented-control-padding));
+  font-size: 0.875em;
+  font-weight: 500;
+  color: var(--pjx-segmented-control-fg);
+  transition: background var(--transition, 0.15s ease), color var(--transition, 0.15s ease);
+  white-space: nowrap;
+  user-select: none;
+}
+
+/* Active segment */
+.pjx-segmented-control__input:checked + .pjx-segmented-control__text {
+  background: var(--pjx-segmented-control-active-bg);
+  color: var(--pjx-segmented-control-active-fg);
+  box-shadow: var(--pjx-segmented-control-active-shadow);
+}
+
+/* Focus-visible ring on the text pill */
+.pjx-segmented-control__input:focus-visible + .pjx-segmented-control__text {
+  outline: 2px solid var(--pjx-segmented-control-focus);
+  outline-offset: 1px;
+}
+
+/* Disabled */
+.pjx-segmented-control__input:disabled + .pjx-segmented-control__text {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/pyjinhx2/builtins/ui/pjx_segmented_control/pjx_segmented_control.pjx
+++ b/pyjinhx2/builtins/ui/pjx_segmented_control/pjx_segmented_control.pjx
@@ -1,0 +1,8 @@
+<div id="{{ id }}" class="pjx-segmented-control{% if class_name %} {{ class_name }}{% endif %}" role="radiogroup"{% for name_, value_ in extra_attrs.items() %} {{ name_ }}="{{ value_ }}"{% endfor %}>
+  {% for value, label in options %}
+  <label class="pjx-segmented-control__segment">
+    <input type="radio" class="pjx-segmented-control__input" name="{{ name }}" value="{{ value }}"{% if value == selected %} checked{% endif %}{% if disabled %} disabled{% endif %}>
+    <span class="pjx-segmented-control__text">{{ label }}</span>
+  </label>
+  {% endfor %}
+</div>

--- a/pyjinhx2/builtins/ui/pjx_segmented_control/pjx_segmented_control.py
+++ b/pyjinhx2/builtins/ui/pjx_segmented_control/pjx_segmented_control.py
@@ -1,0 +1,21 @@
+from pydantic import Field
+
+from pyjinhx2.component import AttrValue, BaseComponent, ExtraAttrs
+
+
+class PJXSegmentedControl(BaseComponent):
+    """A radiogroup rendered as a row of mutually exclusive segments.
+
+    Each ``options`` entry is a ``(value, label)`` pair; ``selected`` names the
+    value whose radio carries ``checked``. A JSON-string ``options`` (the
+    inline-attr path) is decoded by the core's generic
+    ``BaseComponent._coerce_json_string_attrs`` — no component-local coercion
+    needed here.
+    """
+
+    name: str
+    options: list[tuple[str, str]] = Field(default_factory=list)
+    selected: str = ""
+    disabled: bool = False
+    class_name: AttrValue = ""
+    extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/tests/pyjinhx2/builtins/pjx_segmented_control/test_pjx_segmented_control.py
+++ b/tests/pyjinhx2/builtins/pjx_segmented_control/test_pjx_segmented_control.py
@@ -11,6 +11,31 @@ import pytest
 from pydantic import ValidationError
 
 from pyjinhx2.builtins.ui.pjx_segmented_control import PJXSegmentedControl
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+OPTIONS = [("a", "Alpha"), ("b", "Beta"), ("c", "Gamma")]
+
+
+@pytest.fixture
+def session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve.
+
+    ClassDescriptor.template_path is absolute and render() feeds it straight to
+    the session's FileSystemLoader; Jinja only resolves an absolute path when
+    the loader root is "/". Same fixture shape as the sibling builtin tests.
+    """
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kwargs) -> str:
+    base = {"id": "sc", "name": "plan", "options": OPTIONS}
+    base.update(kwargs)
+    return render(PJXSegmentedControl(**base), session)  # type: ignore[arg-type]
+
+
+def _root(html: str) -> str:
+    return html[: html.index(">")]
 
 
 class TestFields:
@@ -43,3 +68,64 @@ class TestFields:
             id="sc", name="plan", options='[["a","A"],["b","B"]]'
         )
         assert control.options == [("a", "A"), ("b", "B")]
+
+
+class TestRender:
+    def test_single_root_div(self, session):
+        html = _html(session).strip()
+        assert html.startswith('<div id="sc"')
+        assert html.endswith("</div>")
+        assert 'role="radiogroup"' in _root(html)
+
+    def test_renders_one_segment_per_option(self, session):
+        html = _html(session)
+        assert html.count("pjx-segmented-control__segment") == 3
+        assert html.count('type="radio"') == 3
+
+    def test_radio_name_matches_field_name(self, session):
+        assert _html(session).count('name="plan"') == 3
+
+    def test_selected_option_is_checked(self, session):
+        html = _html(session, selected="b")
+        assert html.count(" checked") == 1
+        assert 'value="b" checked' in html
+
+    def test_no_option_checked_when_selected_is_empty_or_unmatched(self, session):
+        assert " checked" not in _html(session)
+        assert " checked" not in _html(session, selected="zzz")
+
+    def test_disabled_adds_disabled_to_every_input(self, session):
+        assert _html(session, disabled=True).count(" disabled") == 3
+
+    def test_not_disabled_by_default(self, session):
+        assert " disabled" not in _html(session)
+
+    def test_text_labels_render_in_span(self, session):
+        html = _html(session)
+        assert html.count("pjx-segmented-control__text") == 3
+        assert ">Alpha</span>" in html
+
+    def test_label_text_renders_escaped(self, session):
+        html = _html(session, options=[("x", "<script>x</script>")])
+        assert "&lt;script&gt;x&lt;/script&gt;" in html
+        assert "<script>" not in html
+
+    def test_class_name_is_appended_without_clobbering_base_classes(self, session):
+        assert 'class="pjx-segmented-control my-sc"' in _html(session, class_name="my-sc")
+
+    def test_empty_class_name_adds_nothing(self, session):
+        assert 'class="pjx-segmented-control"' in _html(session)
+
+    def test_extra_attrs_surface_on_the_root(self, session):
+        assert 'data-test="1"' in _root(_html(session, extra_attrs={"data-test": "1"}))
+
+
+class TestAssets:
+    def test_stylesheet_is_frozen_on_the_descriptor(self):
+        css = PJXSegmentedControl.__pjx_descriptor__.css_paths
+        assert len(css) == 1
+        assert css[0].name == "pjx_segmented_control.css"
+        assert css[0].is_file()
+
+    def test_no_script_asset(self):
+        assert PJXSegmentedControl.__pjx_descriptor__.js_paths == ()

--- a/tests/pyjinhx2/builtins/pjx_segmented_control/test_pjx_segmented_control.py
+++ b/tests/pyjinhx2/builtins/pjx_segmented_control/test_pjx_segmented_control.py
@@ -1,0 +1,45 @@
+"""PJXSegmentedControl — v0.x field/markup parity on the v2 engine.
+
+Partial port of tests/unit/test_toggle_segmented.py: only the
+``test_segmented_control_*`` cases carry over here. The PJXToggleSwitch cases in
+that same file belong to #514. v0.x's golden-snapshot comparison does not carry
+over either — v2 builtins assert on rendered substrings, like every sibling
+port.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_segmented_control import PJXSegmentedControl
+
+
+class TestFields:
+    def test_defaults(self):
+        control = PJXSegmentedControl(id="sc", name="plan")
+        assert control.name == "plan"
+        assert control.options == []
+        assert control.selected == ""
+        assert control.disabled is False
+        assert control.class_name == ""
+        assert control.extra_attrs == {}
+
+    def test_undeclared_kwarg_raises(self):
+        with pytest.raises(ValidationError):
+            PJXSegmentedControl(id="sc", name="plan", bogus="x")  # type: ignore[call-arg]
+
+    def test_inline_attr_kwargs_no_longer_pass_through(self):
+        """v0.x accepted ``PJXSegmentedControl(..., **{"data-test": "1"})``.
+
+        v2 core is strict (extra="forbid"), so a bare inline attr kwarg is now a
+        ValidationError. The behavior it replaces is not dropped: pass-through
+        moved to the declared ``extra_attrs`` mapping, covered by
+        TestRender.test_extra_attrs_surface_on_the_root.
+        """
+        with pytest.raises(ValidationError):
+            PJXSegmentedControl(id="sc", name="plan", **{"data-test": "1"})  # type: ignore[arg-type]
+
+    def test_json_string_options_coercion(self):
+        control = PJXSegmentedControl(
+            id="sc", name="plan", options='[["a","A"],["b","B"]]'
+        )
+        assert control.options == [("a", "A"), ("b", "B")]

--- a/tests/pyjinhx2/builtins/pjx_segmented_control/test_pjx_segmented_control.py
+++ b/tests/pyjinhx2/builtins/pjx_segmented_control/test_pjx_segmented_control.py
@@ -65,7 +65,9 @@ class TestFields:
 
     def test_json_string_options_coercion(self):
         control = PJXSegmentedControl(
-            id="sc", name="plan", options='[["a","A"],["b","B"]]'
+            id="sc",
+            name="plan",
+            options='[["a","A"],["b","B"]]',  # type: ignore[arg-type]
         )
         assert control.options == [("a", "A"), ("b", "B")]
 
@@ -111,7 +113,9 @@ class TestRender:
         assert "<script>" not in html
 
     def test_class_name_is_appended_without_clobbering_base_classes(self, session):
-        assert 'class="pjx-segmented-control my-sc"' in _html(session, class_name="my-sc")
+        assert 'class="pjx-segmented-control my-sc"' in _html(
+            session, class_name="my-sc"
+        )
 
     def test_empty_class_name_adds_nothing(self, session):
         assert 'class="pjx-segmented-control"' in _html(session)

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -72,6 +72,12 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "builtins.ui.pjx_password_input.pjx_password_input": frozenset(
         {"pyjinhx2.component"}
     ),
+    "builtins.ui.pjx_segmented_control.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_segmented_control.pjx_segmented_control"}
+    ),
+    "builtins.ui.pjx_segmented_control.pjx_segmented_control": frozenset(
+        {"pyjinhx2.component"}
+    ),
     "builtins.ui.pjx_spinner.__init__": frozenset(
         {"pyjinhx2.builtins.ui.pjx_spinner.pjx_spinner"}
     ),


### PR DESCRIPTION
## Summary
Completes the pyjinhx2 port of PJXSegmentedControl with three focused commits:

- **Port model + markup**: Model, template, and stylesheet ported from pyjinhx/builtins/ui to pyjinhx2's strict-model engine. Options coercion relies on the core's generic `_coerce_json_string_attrs`.
- **Add render + asset coverage**: Tests cover markup shape (radiogroup, segments, checked/disabled state, escaping, class_name/extra_attrs) and CSS descriptor lifecycle.
- **Wire import graph**: Declares leaf edges (__init__ → module → component) so the whole-package guard recognizes the new builtin.

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)