### PR TITLE
chore(test): declare import-graph edges for the accordion family (#519)

### DIFF
--- a/pyjinhx2/builtins/ui/pjx_accordion/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_accordion/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx2.builtins.ui.pjx_accordion.pjx_accordion import PJXAccordion
+
+__all__ = ["PJXAccordion"]

--- a/pyjinhx2/builtins/ui/pjx_accordion/pjx_accordion.css
+++ b/pyjinhx2/builtins/ui/pjx_accordion/pjx_accordion.css
@@ -1,0 +1,3 @@
+.pjx-accordion {
+  border-radius: var(--pjx-accordion-radius, 0);
+}

--- a/pyjinhx2/builtins/ui/pjx_accordion/pjx_accordion.pjx
+++ b/pyjinhx2/builtins/ui/pjx_accordion/pjx_accordion.pjx
@@ -1,0 +1,1 @@
+<details id="{{ id }}" class="pjx-accordion{% if class_name %} {{ class_name }}{% endif %}"{% if open %} open{% endif %}{% if group %} name="{{ group }}"{% endif %}>{{ content }}</details>

--- a/pyjinhx2/builtins/ui/pjx_accordion/pjx_accordion.py
+++ b/pyjinhx2/builtins/ui/pjx_accordion/pjx_accordion.py
@@ -1,0 +1,10 @@
+from pyjinhx2.component import AttrValue, BaseComponent, Slot
+
+
+class PJXAccordion(BaseComponent):
+    """The <details> shell of one accordion item; the summary and body come from PJXAccordionTrigger/Content."""
+
+    open: bool = True
+    group: str | None = None
+    class_name: AttrValue = ""
+    content: Slot = ""

--- a/pyjinhx2/builtins/ui/pjx_accordion_content/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_accordion_content/__init__.py
@@ -1,0 +1,5 @@
+from pyjinhx2.builtins.ui.pjx_accordion_content.pjx_accordion_content import (
+    PJXAccordionContent,
+)
+
+__all__ = ["PJXAccordionContent"]

--- a/pyjinhx2/builtins/ui/pjx_accordion_content/pjx_accordion_content.pjx
+++ b/pyjinhx2/builtins/ui/pjx_accordion_content/pjx_accordion_content.pjx
@@ -1,0 +1,1 @@
+<div id="{{ id }}" class="pjx-accordion__content{% if class_name %} {{ class_name }}{% endif %}">{{ content }}</div>

--- a/pyjinhx2/builtins/ui/pjx_accordion_content/pjx_accordion_content.py
+++ b/pyjinhx2/builtins/ui/pjx_accordion_content/pjx_accordion_content.py
@@ -1,0 +1,8 @@
+from pyjinhx2.component import AttrValue, BaseComponent, Slot
+
+
+class PJXAccordionContent(BaseComponent):
+    """The body region revealed when its parent PJXAccordion is open."""
+
+    class_name: AttrValue = ""
+    content: Slot = ""

--- a/pyjinhx2/builtins/ui/pjx_accordion_group/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_accordion_group/__init__.py
@@ -1,0 +1,5 @@
+from pyjinhx2.builtins.ui.pjx_accordion_group.pjx_accordion_group import (
+    PJXAccordionGroup,
+)
+
+__all__ = ["PJXAccordionGroup"]

--- a/pyjinhx2/builtins/ui/pjx_accordion_group/pjx_accordion_group.css
+++ b/pyjinhx2/builtins/ui/pjx_accordion_group/pjx_accordion_group.css
@@ -1,0 +1,5 @@
+.pjx-accordion-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pjx-accordion-group-gap, 0);
+}

--- a/pyjinhx2/builtins/ui/pjx_accordion_group/pjx_accordion_group.js
+++ b/pyjinhx2/builtins/ui/pjx_accordion_group/pjx_accordion_group.js
@@ -1,0 +1,51 @@
+(function () {
+  "use strict";
+  window.pjx = window.pjx || {};
+  if (pjx._accordionGroupWired) return;
+  pjx._accordionGroupWired = true;
+
+  function applyDefaultOpen(el) {
+    var spec = el.dataset.defaultOpen;
+    if (!spec || spec === "none") return;
+    var items = el.querySelectorAll(":scope > details");
+    if (spec === "first") {
+      if (items.length) items[0].open = true;
+    } else if (spec === "all") {
+      items.forEach(function (d) { d.open = true; });
+    }
+  }
+
+  function initGroup(el) {
+    if (el.dataset.pjxGroupInit) return;
+    el.dataset.pjxGroupInit = "1";
+
+    applyDefaultOpen(el);
+
+    if (el.dataset.mode !== "exclusive") return;
+    el.addEventListener("toggle", function (e) {
+      if (!e.target.matches("details") || !e.target.open) return;
+      el.querySelectorAll("details[open]").forEach(function (d) {
+        if (d !== e.target) d.removeAttribute("open");
+      });
+    }, true);
+  }
+
+  function init() {
+    document
+      .querySelectorAll("[data-pjx-accordion-group]")
+      .forEach(initGroup);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  document.addEventListener("htmx:afterSettle", function (e) {
+    var root = (e.detail && e.detail.elt) || document;
+    if (root.querySelectorAll) {
+      root.querySelectorAll("[data-pjx-accordion-group]").forEach(initGroup);
+    }
+  });
+})();

--- a/pyjinhx2/builtins/ui/pjx_accordion_group/pjx_accordion_group.pjx
+++ b/pyjinhx2/builtins/ui/pjx_accordion_group/pjx_accordion_group.pjx
@@ -1,0 +1,1 @@
+<div id="{{ id }}" class="pjx-accordion-group{% if class_name %} {{ class_name }}{% endif %}" data-pjx-accordion-group data-mode="{{ mode }}"{% if default_open != "none" %} data-default-open="{{ default_open }}"{% endif %} style="--pjx-accordion-group-gap: {{ gap }}">{{ content }}</div>

--- a/pyjinhx2/builtins/ui/pjx_accordion_group/pjx_accordion_group.py
+++ b/pyjinhx2/builtins/ui/pjx_accordion_group/pjx_accordion_group.py
@@ -1,0 +1,13 @@
+from typing import Literal
+
+from pyjinhx2.component import AttrValue, BaseComponent, Slot
+
+
+class PJXAccordionGroup(BaseComponent):
+    """The wrapper that scopes exclusive/multi open behavior over the PJXAccordion items inside it."""
+
+    mode: Literal["exclusive", "multi"] = "multi"
+    gap: str = "0"
+    default_open: Literal["none", "first", "all"] = "none"
+    class_name: AttrValue = ""
+    content: Slot = ""

--- a/pyjinhx2/builtins/ui/pjx_accordion_trigger/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_accordion_trigger/__init__.py
@@ -1,0 +1,5 @@
+from pyjinhx2.builtins.ui.pjx_accordion_trigger.pjx_accordion_trigger import (
+    PJXAccordionTrigger,
+)
+
+__all__ = ["PJXAccordionTrigger"]

--- a/pyjinhx2/builtins/ui/pjx_accordion_trigger/pjx_accordion_trigger.css
+++ b/pyjinhx2/builtins/ui/pjx_accordion_trigger/pjx_accordion_trigger.css
@@ -1,0 +1,49 @@
+.pjx-accordion__trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  list-style: none;
+  cursor: pointer;
+  padding: var(--pjx-accordion-trigger-padding, 0.5rem 0.75rem);
+  background: var(--pjx-accordion-trigger-bg, transparent);
+  color: var(--pjx-accordion-trigger-color, inherit);
+  font-size: var(--pjx-accordion-trigger-font-size, inherit);
+  font-weight: var(--pjx-accordion-trigger-font-weight, 500);
+}
+
+.pjx-accordion__trigger::-webkit-details-marker {
+  display: none;
+}
+
+.pjx-accordion__trigger:hover {
+  background: var(--pjx-accordion-trigger-bg-hover, var(--pjx-accordion-trigger-bg, transparent));
+}
+
+.pjx-accordion__chevron {
+  width: var(--pjx-accordion-chevron-size, 1em);
+  height: var(--pjx-accordion-chevron-size, 1em);
+  transition: transform 0.15s ease;
+}
+
+.pjx-accordion[open] > .pjx-accordion__trigger .pjx-accordion__chevron {
+  transform: rotate(90deg);
+}
+
+.pjx-accordion__trigger[aria-disabled="true"] {
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.pjx-accordion__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--pjx-accordion-actions-gap, 0.25rem);
+  margin-left: auto;
+  /* Clicks are stopped by the trigger JS so the summary does not toggle. */
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pjx-accordion__chevron {
+    transition: none;
+  }
+}

--- a/pyjinhx2/builtins/ui/pjx_accordion_trigger/pjx_accordion_trigger.js
+++ b/pyjinhx2/builtins/ui/pjx_accordion_trigger/pjx_accordion_trigger.js
@@ -1,0 +1,23 @@
+(function () {
+    window.pjx = window.pjx || {};
+    if (pjx._accordionWired) return;
+    pjx._accordionWired = true;
+
+    // Stop clicks inside .pjx-accordion__actions from toggling the native
+    // details element. The summary's toggle is the click's *default action*,
+    // so preventDefault() in the capture phase cancels it before the browser
+    // acts. We deliberately do NOT stopPropagation(), so the action element's
+    // own htmx/Alpine/click handlers (which run in the bubble phase) still fire.
+    document.addEventListener('click', function (e) {
+        var actions = e.target.closest('.pjx-accordion__actions');
+        if (!actions) return;
+        e.preventDefault();
+    }, true); // capture phase: runs before the summary's default toggle
+
+    // aria-disabled doesn't stop a <summary>'s native toggle; cancel it too.
+    document.addEventListener('click', function (e) {
+        var trigger = e.target.closest('.pjx-accordion__trigger[aria-disabled="true"]');
+        if (!trigger) return;
+        e.preventDefault();
+    }, true);
+})();

--- a/pyjinhx2/builtins/ui/pjx_accordion_trigger/pjx_accordion_trigger.pjx
+++ b/pyjinhx2/builtins/ui/pjx_accordion_trigger/pjx_accordion_trigger.pjx
@@ -1,0 +1,1 @@
+<summary id="{{ id }}" class="pjx-accordion__trigger{% if class_name %} {{ class_name }}{% endif %}"{% if disabled %} aria-disabled="true" tabindex="-1"{% endif %}><PJXIcon name="chevron-right" class_name="pjx-accordion__chevron"/>{{ content }}</summary>

--- a/pyjinhx2/builtins/ui/pjx_accordion_trigger/pjx_accordion_trigger.py
+++ b/pyjinhx2/builtins/ui/pjx_accordion_trigger/pjx_accordion_trigger.py
@@ -1,0 +1,9 @@
+from pyjinhx2.component import AttrValue, BaseComponent, Slot
+
+
+class PJXAccordionTrigger(BaseComponent):
+    """The <summary> row that toggles its parent PJXAccordion, with the chevron affordance."""
+
+    disabled: bool = False
+    class_name: AttrValue = ""
+    content: Slot = ""

--- a/tests/pyjinhx2/builtins/pjx_accordion/test_pjx_accordion.py
+++ b/tests/pyjinhx2/builtins/pjx_accordion/test_pjx_accordion.py
@@ -1,0 +1,93 @@
+"""PJXAccordion renders the single-root <details> shell of the accordion family (port of v0.x pyjinhx/builtins/ui/pjx_accordion)."""
+
+import dataclasses
+
+import pytest
+
+from pyjinhx2.builtins.ui.pjx_accordion import PJXAccordion
+from pyjinhx2.component import BaseComponent, Slot
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def accordion_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve."""
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kw) -> str:
+    return render(PJXAccordion(id="a", **kw), session)
+
+
+def test_default_render_is_a_single_open_details(accordion_session):
+    assert (
+        _html(accordion_session)
+        == '<details id="a" class="pjx-accordion" open></details>'
+    )
+
+
+def test_open_false_omits_the_open_attribute(accordion_session):
+    assert _html(accordion_session, open=False) == (
+        '<details id="a" class="pjx-accordion"></details>'
+    )
+
+
+def test_group_renders_the_name_attribute(accordion_session):
+    assert 'name="g"' in _html(accordion_session, group="g")
+
+
+def test_group_default_omits_the_name_attribute(accordion_session):
+    assert "name=" not in _html(accordion_session)
+
+
+def test_class_name_appended_to_root(accordion_session):
+    assert 'class="pjx-accordion mine"' in _html(accordion_session, class_name="mine")
+
+
+def test_empty_class_name_adds_nothing(accordion_session):
+    assert 'class="pjx-accordion"' in _html(accordion_session, class_name="")
+
+
+def test_string_content_renders_escaped_inside_root(accordion_session):
+    """v2 narrowing of v0.x: a plain str in a Slot is escaped; only components emit markup."""
+    html = _html(accordion_session, content="<p>raw</p>")
+    assert html.count("<details") == 1
+    assert "&lt;p&gt;raw&lt;/p&gt;" in html
+    assert "<p>raw</p>" not in html
+
+
+class AccordionChild(BaseComponent):
+    """A minimal component child, to prove a nested component renders inside <details>."""
+
+    content: Slot = ""
+
+
+@pytest.fixture
+def accordion_child_template(tmp_path):
+    """Give AccordionChild a real template on disk and repoint its descriptor at it.
+
+    A class defined ad hoc in a test module resolves a template candidate
+    co-located with the test file, which does not exist.
+    """
+    path = tmp_path / "accordion_child.pjx"
+    path.write_text('<span id="{{ id }}" class="child">{{ content }}</span>')
+    AccordionChild.__pjx_descriptor__ = dataclasses.replace(
+        AccordionChild.__pjx_descriptor__, template_path=path
+    )
+    yield path
+
+
+def test_component_content_renders_inside_details(
+    accordion_session, accordion_child_template
+):
+    html = _html(accordion_session, content=AccordionChild(id="c", content="hi"))
+    assert html.count("<details") == 1
+    assert '<span id="c" class="child">hi</span>' in html
+
+
+def test_assets_are_discovered_from_the_component_directory():
+    """CSS sits next to the module and is picked up by the descriptor, with no manual wiring."""
+    descriptor = PJXAccordion.__pjx_descriptor__
+    assert descriptor.css_paths
+    assert any(p.name == "pjx_accordion.css" for p in descriptor.css_paths)

--- a/tests/pyjinhx2/builtins/pjx_accordion_content/test_pjx_accordion_content.py
+++ b/tests/pyjinhx2/builtins/pjx_accordion_content/test_pjx_accordion_content.py
@@ -1,0 +1,63 @@
+"""PJXAccordionContent renders the accordion body region (port of v0.x pyjinhx/builtins/ui/pjx_accordion_content)."""
+
+import dataclasses
+
+import pytest
+
+from pyjinhx2.builtins.ui.pjx_accordion_content import PJXAccordionContent
+from pyjinhx2.component import BaseComponent, Slot
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def content_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve."""
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kw) -> str:
+    return render(PJXAccordionContent(id="c", **kw), session)
+
+
+def test_default_render_is_a_single_empty_div(content_session):
+    assert _html(content_session) == '<div id="c" class="pjx-accordion__content"></div>'
+
+
+def test_class_name_appended_to_root(content_session):
+    assert 'class="pjx-accordion__content mine"' in _html(
+        content_session, class_name="mine"
+    )
+
+
+def test_empty_class_name_adds_nothing(content_session):
+    assert 'class="pjx-accordion__content"' in _html(content_session, class_name="")
+
+
+def test_string_content_renders_escaped_inside_root(content_session):
+    html = _html(content_session, content="<p>raw</p>")
+    assert "&lt;p&gt;raw&lt;/p&gt;" in html
+    assert "<p>raw</p>" not in html
+
+
+class ContentChild(BaseComponent):
+    """A minimal component child, to prove a nested component renders inside the region."""
+
+    content: Slot = ""
+
+
+@pytest.fixture
+def content_child_template(tmp_path):
+    """Give ContentChild a real template on disk and repoint its descriptor at it."""
+    path = tmp_path / "content_child.pjx"
+    path.write_text('<span id="{{ id }}" class="child">{{ content }}</span>')
+    ContentChild.__pjx_descriptor__ = dataclasses.replace(
+        ContentChild.__pjx_descriptor__, template_path=path
+    )
+    yield path
+
+
+def test_component_content_renders_inside_root(content_session, content_child_template):
+    html = _html(content_session, content=ContentChild(id="k", content="body"))
+    assert html.count("<div") == 1
+    assert '<span id="k" class="child">body</span>' in html

--- a/tests/pyjinhx2/builtins/pjx_accordion_group/test_pjx_accordion_group.py
+++ b/tests/pyjinhx2/builtins/pjx_accordion_group/test_pjx_accordion_group.py
@@ -1,0 +1,92 @@
+"""PJXAccordionGroup renders the wrapper that scopes exclusive/multi behavior (port of v0.x pyjinhx/builtins/ui/pjx_accordion_group)."""
+
+import dataclasses
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_accordion_group import PJXAccordionGroup
+from pyjinhx2.component import BaseComponent, Slot
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def group_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve."""
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kw) -> str:
+    return render(PJXAccordionGroup(id="g", **kw), session)
+
+
+def test_default_render_matches_v0x_markup(group_session):
+    assert _html(group_session) == (
+        '<div id="g" class="pjx-accordion-group" data-pjx-accordion-group'
+        ' data-mode="multi" style="--pjx-accordion-group-gap: 0"></div>'
+    )
+
+
+def test_exclusive_mode_reflected_in_data_mode(group_session):
+    assert 'data-mode="exclusive"' in _html(group_session, mode="exclusive")
+
+
+def test_default_open_none_omits_the_data_attribute(group_session):
+    assert "data-default-open" not in _html(group_session)
+
+
+def test_default_open_first_emits_the_data_attribute(group_session):
+    assert 'data-default-open="first"' in _html(group_session, default_open="first")
+
+
+def test_gap_lands_in_the_custom_property(group_session):
+    assert "--pjx-accordion-group-gap: 1rem" in _html(group_session, gap="1rem")
+
+
+def test_class_name_appended_to_root(group_session):
+    assert 'class="pjx-accordion-group mine"' in _html(group_session, class_name="mine")
+
+
+def test_empty_class_name_adds_nothing(group_session):
+    assert 'class="pjx-accordion-group"' in _html(group_session, class_name="")
+
+
+def test_mode_outside_the_literal_is_rejected():
+    with pytest.raises(ValidationError):
+        PJXAccordionGroup(id="g", mode="nope")  # pyright: ignore[reportArgumentType]
+
+
+def test_default_open_outside_the_literal_is_rejected():
+    with pytest.raises(ValidationError):
+        PJXAccordionGroup(id="g", default_open="some")  # pyright: ignore[reportArgumentType]
+
+
+class GroupChild(BaseComponent):
+    """A minimal component child, to prove a nested component renders inside the group."""
+
+    content: Slot = ""
+
+
+@pytest.fixture
+def group_child_template(tmp_path):
+    """Give GroupChild a real template on disk and repoint its descriptor at it."""
+    path = tmp_path / "group_child.pjx"
+    path.write_text('<span id="{{ id }}" class="child">{{ content }}</span>')
+    GroupChild.__pjx_descriptor__ = dataclasses.replace(
+        GroupChild.__pjx_descriptor__, template_path=path
+    )
+    yield path
+
+
+def test_component_content_renders_inside_root(group_session, group_child_template):
+    html = _html(group_session, content=GroupChild(id="i", content="item"))
+    assert html.count("<div") == 1
+    assert '<span id="i" class="child">item</span>' in html
+
+
+def test_assets_are_discovered_from_the_component_directory():
+    """JS sits next to the module and is picked up by the descriptor, with no manual wiring."""
+    descriptor = PJXAccordionGroup.__pjx_descriptor__
+    assert descriptor.js_paths
+    assert any(p.name == "pjx_accordion_group.js" for p in descriptor.js_paths)

--- a/tests/pyjinhx2/builtins/pjx_accordion_trigger/test_pjx_accordion_trigger.py
+++ b/tests/pyjinhx2/builtins/pjx_accordion_trigger/test_pjx_accordion_trigger.py
@@ -1,0 +1,103 @@
+"""PJXAccordionTrigger renders the <summary> row with its chevron icon (port of v0.x pyjinhx/builtins/ui/pjx_accordion_trigger)."""
+
+import dataclasses
+
+import pytest
+
+from pyjinhx2 import discovery
+from pyjinhx2.builtins.ui.pjx_accordion_trigger import PJXAccordionTrigger
+from pyjinhx2.builtins.ui.pjx_icon import PJXIcon
+from pyjinhx2.component import BaseComponent, Slot
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def trigger_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve."""
+    return RenderSession(template_dir="/")
+
+
+@pytest.fixture
+def icon_registered():
+    """Publish the ``pjx_icon`` tag for this test only.
+
+    ``<PJXIcon/>`` in the trigger template is resolved at render time through
+    discovery's tag map, not through a Python import; an unclaimed tag is
+    emitted verbatim instead. The map is process-global, so it is snapshotted
+    and restored.
+    """
+    before = discovery._registry.mapping
+    discovery.register_class("pjx_icon", PJXIcon)
+    yield
+    discovery._registry.mapping = before
+
+
+def _html(session, **kw) -> str:
+    return render(PJXAccordionTrigger(id="t", **kw), session)
+
+
+def test_default_render_is_a_single_summary(trigger_session, icon_registered):
+    html = _html(trigger_session)
+    assert html.count("<summary") == 1
+    assert html.startswith('<summary id="t" class="pjx-accordion__trigger">')
+    assert html.endswith("</summary>")
+
+
+def test_chevron_icon_tag_expands_to_svg_markup(trigger_session, icon_registered):
+    html = _html(trigger_session)
+    assert "<PJXIcon" not in html
+    assert "<svg" in html
+    assert 'class="pjx-icon pjx-accordion__chevron"' in html
+
+
+def test_disabled_emits_aria_disabled(trigger_session, icon_registered):
+    html = _html(trigger_session, disabled=True)
+    assert 'aria-disabled="true"' in html
+    assert 'tabindex="-1"' in html
+
+
+def test_disabled_default_omits_aria_disabled(trigger_session, icon_registered):
+    assert "aria-disabled" not in _html(trigger_session, disabled=False)
+
+
+def test_class_name_appended_to_root(trigger_session, icon_registered):
+    assert 'class="pjx-accordion__trigger mine"' in _html(
+        trigger_session, class_name="mine"
+    )
+
+
+def test_empty_class_name_adds_nothing(trigger_session, icon_registered):
+    assert 'class="pjx-accordion__trigger"' in _html(trigger_session, class_name="")
+
+
+class TriggerChild(BaseComponent):
+    """A minimal component child, to prove a nested component renders inside the summary."""
+
+    content: Slot = ""
+
+
+@pytest.fixture
+def trigger_child_template(tmp_path):
+    """Give TriggerChild a real template on disk and repoint its descriptor at it."""
+    path = tmp_path / "trigger_child.pjx"
+    path.write_text('<span id="{{ id }}" class="child">{{ content }}</span>')
+    TriggerChild.__pjx_descriptor__ = dataclasses.replace(
+        TriggerChild.__pjx_descriptor__, template_path=path
+    )
+    yield path
+
+
+def test_component_content_renders_after_the_icon(
+    trigger_session, icon_registered, trigger_child_template
+):
+    html = _html(trigger_session, content=TriggerChild(id="l", content="Label"))
+    assert html.index("pjx-accordion__chevron") < html.index('id="l"')
+    assert "Label" in html
+
+
+def test_assets_are_discovered_from_the_component_directory():
+    """JS sits next to the module and is picked up by the descriptor, with no manual wiring."""
+    descriptor = PJXAccordionTrigger.__pjx_descriptor__
+    assert descriptor.js_paths
+    assert any(p.name == "pjx_accordion_trigger.js" for p in descriptor.js_paths)

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -143,6 +143,32 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "builtins.ui.pjx_drawer_footer.pjx_drawer_footer": frozenset(
         {"pyjinhx2.component"}
     ),
+    # pjx_accordion family (#519): the details/summary shell plus its
+    # group/trigger/content parts. Same shape as the modal/drawer families —
+    # each component module reaches down into component.py only; each
+    # __init__ just re-exports its class from its co-located module.
+    "builtins.ui.pjx_accordion.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_accordion.pjx_accordion"}
+    ),
+    "builtins.ui.pjx_accordion.pjx_accordion": frozenset({"pyjinhx2.component"}),
+    "builtins.ui.pjx_accordion_content.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_accordion_content.pjx_accordion_content"}
+    ),
+    "builtins.ui.pjx_accordion_content.pjx_accordion_content": frozenset(
+        {"pyjinhx2.component"}
+    ),
+    "builtins.ui.pjx_accordion_group.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_accordion_group.pjx_accordion_group"}
+    ),
+    "builtins.ui.pjx_accordion_group.pjx_accordion_group": frozenset(
+        {"pyjinhx2.component"}
+    ),
+    "builtins.ui.pjx_accordion_trigger.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_accordion_trigger.pjx_accordion_trigger"}
+    ),
+    "builtins.ui.pjx_accordion_trigger.pjx_accordion_trigger": frozenset(
+        {"pyjinhx2.component"}
+    ),
     "builtins.ui.pjx_notification.__init__": frozenset(
         {"pyjinhx2.builtins.ui.pjx_notification.pjx_notification"}
     ),


### PR DESCRIPTION
## Summary

Ports the accordion component family (PJXAccordion, PJXAccordionContent, PJXAccordionGroup, PJXAccordionTrigger) to pyjinhx v2. Declares import-graph edges for the accordion modules as required by the whole-package import-direction guard.

## Changes

- Port PJXAccordion to v2
- Port PJXAccordionContent to v2
- Port PJXAccordionGroup to v2
- Port PJXAccordionTrigger to v2
- Declare import-graph edges for the accordion family

5 commits, tests pass.

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)