### PR TITLE
chore(builtins): wire pjx_popover family into import graph and pyright

### DIFF
--- a/pyjinhx2/builtins/ui/pjx_popover/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_popover/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx2.builtins.ui.pjx_popover.pjx_popover import PJXPopover
+
+__all__ = ["PJXPopover"]

--- a/pyjinhx2/builtins/ui/pjx_popover/pjx_popover.css
+++ b/pyjinhx2/builtins/ui/pjx_popover/pjx_popover.css
@@ -1,0 +1,51 @@
+:where(:root) {
+  --pjx-popover-bg:      var(--surface-alt);
+  --pjx-popover-border:  var(--border);
+  --pjx-popover-radius:  var(--radius-md);
+  --pjx-popover-shadow:  var(--shadow-md);
+  --pjx-popover-min-w:   12rem;
+  --pjx-popover-z:       300;
+  --pjx-popover-padding: var(--space-3, 0.75rem);
+}
+
+.pjx-popover {
+  position: relative;
+  display: inline-block;
+}
+
+.pjx-popover__trigger {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.pjx-popover__trigger:focus-visible {
+  outline: 2px solid var(--border-focus, var(--border));
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.pjx-popover__panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: var(--pjx-popover-z);
+  min-width: var(--pjx-popover-min-w);
+  padding: var(--pjx-popover-padding);
+  background: var(--pjx-popover-bg);
+  border: 1px solid var(--pjx-popover-border);
+  border-radius: var(--pjx-popover-radius);
+  box-shadow: var(--pjx-popover-shadow);
+}
+
+.pjx-popover--align-end .pjx-popover__panel {
+  left: auto;
+  right: 0;
+}
+
+.pjx-popover__panel[hidden] {
+  display: none !important;
+}

--- a/pyjinhx2/builtins/ui/pjx_popover/pjx_popover.js
+++ b/pyjinhx2/builtins/ui/pjx_popover/pjx_popover.js
@@ -1,0 +1,106 @@
+(function () {
+    window.pjx = window.pjx || {};
+    if (pjx.popover) return;
+
+    const DISMISSIBLE = '.pjx-notification, .pjx-alert, dialog.pjx-modal, dialog.pjx-drawer, [data-pjx-popover-panel]';
+
+    function fire(el, name, detail, cancelable) {
+        return el.dispatchEvent(new CustomEvent(name, {
+            bubbles: true, cancelable: Boolean(cancelable), detail: detail || {},
+        }));
+    }
+
+    function rootOf(panel) {
+        return panel.closest('[data-pjx-popover]') || panel;
+    }
+
+    function triggerFor(panel) {
+        const root = panel.closest('[data-pjx-popover]');
+        return root ? root.querySelector('[data-pjx-toggle]') : null;
+    }
+
+    function resolvePanel(idOrEl) {
+        if (typeof idOrEl === 'string') return document.getElementById(idOrEl);
+        return idOrEl;
+    }
+
+    function open(idOrEl, reason, trigger) {
+        const panel = resolvePanel(idOrEl);
+        if (!panel || !panel.hidden) return false;
+        const target = rootOf(panel);
+        const detail = { reason: reason || 'api', trigger: trigger || null };
+        if (!fire(target, 'pjx:popover:before-open', detail, true)) return false;
+        panel.hidden = false;
+        const t = trigger || triggerFor(panel);
+        if (t) t.setAttribute('aria-expanded', 'true');
+        fire(target, 'pjx:popover:open', detail);
+        return true;
+    }
+
+    function close(idOrEl, reason, trigger) {
+        const panel = resolvePanel(idOrEl);
+        if (!panel || panel.hidden) return false;
+        const target = rootOf(panel);
+        const detail = { reason: reason || 'api', trigger: trigger || null };
+        if (!fire(target, 'pjx:popover:before-close', detail, true)) return false;
+        panel.hidden = true;
+        const t = trigger || triggerFor(panel);
+        if (t) t.setAttribute('aria-expanded', 'false');
+        fire(target, 'pjx:popover:close', detail);
+        return true;
+    }
+
+    function toggle(idOrEl, reason, trigger) {
+        const panel = resolvePanel(idOrEl);
+        if (!panel) return false;
+        return panel.hidden ? open(panel, reason, trigger) : close(panel, reason, trigger);
+    }
+
+    function panelForToggle(toggleEl) {
+        const explicit = toggleEl.getAttribute('data-pjx-toggle');
+        if (explicit) return document.getElementById(explicit);
+        const root = toggleEl.closest('[data-pjx-popover]');
+        return root ? root.querySelector('[data-pjx-popover-panel]') : null;
+    }
+
+    document.addEventListener('click', (e) => {
+        const closer = e.target.closest('[data-pjx-close]');
+        if (closer) {
+            const dismissible = closer.closest(DISMISSIBLE);
+            if (dismissible && dismissible.hasAttribute && dismissible.hasAttribute('data-pjx-popover-panel')) {
+                close(dismissible, 'trigger', closer);
+                return;
+            }
+            // Nearest dismissible is another kind (modal, drawer, alert, notification) —
+            // fall through to the outside-close loop WITHOUT toggling; no open popover
+            // panel would have the click inside its root anyway.
+        }
+        const toggleEl = e.target.closest('[data-pjx-toggle]');
+        const targetPanel = toggleEl ? panelForToggle(toggleEl) : null;
+        // Close every open panel whose root doesn't contain the click —
+        // also when clicking a trigger (so opening B closes A; nested popovers survive).
+        document.querySelectorAll('[data-pjx-popover-panel]:not([hidden])').forEach((panel) => {
+            if (panel === targetPanel) return;
+            if (!rootOf(panel).contains(e.target)) close(panel, 'backdrop', null);
+        });
+        if (toggleEl && targetPanel) toggle(targetPanel, 'trigger', toggleEl);
+    });
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            const toggleEl = e.target.closest('div[data-pjx-toggle][role="button"]');
+            if (toggleEl) {
+                e.preventDefault();
+                const panel = panelForToggle(toggleEl);
+                if (panel) toggle(panel, 'trigger', toggleEl);
+                return;
+            }
+        }
+        if (e.key !== 'Escape') return;
+        document.querySelectorAll('[data-pjx-popover-panel]:not([hidden])').forEach((panel) => {
+            close(panel, 'escape', null);
+        });
+    });
+
+    pjx.popover = { open: open, close: close, toggle: toggle };
+}());

--- a/pyjinhx2/builtins/ui/pjx_popover/pjx_popover.pjx
+++ b/pyjinhx2/builtins/ui/pjx_popover/pjx_popover.pjx
@@ -1,0 +1,1 @@
+<div id="{{ id }}" class="pjx-popover{% if align == "end" %} pjx-popover--align-end{% endif %}{% if class_name %} {{ class_name }}{% endif %}" data-pjx-popover>{{ content }}</div>

--- a/pyjinhx2/builtins/ui/pjx_popover/pjx_popover.py
+++ b/pyjinhx2/builtins/ui/pjx_popover/pjx_popover.py
@@ -1,0 +1,11 @@
+from typing import Literal
+
+from pyjinhx2.component import AttrValue, BaseComponent, Slot
+
+
+class PJXPopover(BaseComponent):
+    """The positioned root shell that anchors a trigger to its panel; the JS finds both through data-pjx-popover (port of v0.x pyjinhx/builtins/ui/pjx_popover/pjx_popover.py)."""
+
+    align: Literal["start", "end"] = "start"
+    class_name: AttrValue = ""
+    content: Slot = ""

--- a/pyjinhx2/builtins/ui/pjx_popover_panel/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_popover_panel/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx2.builtins.ui.pjx_popover_panel.pjx_popover_panel import PJXPopoverPanel
+
+__all__ = ["PJXPopoverPanel"]

--- a/pyjinhx2/builtins/ui/pjx_popover_panel/pjx_popover_panel.pjx
+++ b/pyjinhx2/builtins/ui/pjx_popover_panel/pjx_popover_panel.pjx
@@ -1,0 +1,2 @@
+{% set _tag = "form" if as_form else "div" -%}
+<{{ _tag }} id="{{ id }}" class="pjx-popover__panel{% if class_name %} {{ class_name }}{% endif %}" data-pjx-popover-panel hidden{% if role %} role="{{ role }}"{% endif %}>{{ content }}</{{ _tag }}>

--- a/pyjinhx2/builtins/ui/pjx_popover_panel/pjx_popover_panel.py
+++ b/pyjinhx2/builtins/ui/pjx_popover_panel/pjx_popover_panel.py
@@ -1,0 +1,12 @@
+from typing import Literal
+
+from pyjinhx2.component import AttrValue, BaseComponent, Slot
+
+
+class PJXPopoverPanel(BaseComponent):
+    """The hidden-by-default floating panel a trigger reveals, optionally a <form> so it can submit on its own (port of v0.x pyjinhx/builtins/ui/pjx_popover/pjx_popover_panel.html)."""
+
+    as_form: bool = False
+    role: Literal["", "menu", "listbox", "dialog"] = ""
+    class_name: AttrValue = ""
+    content: Slot = ""

--- a/pyjinhx2/builtins/ui/pjx_popover_trigger/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_popover_trigger/__init__.py
@@ -1,0 +1,5 @@
+from pyjinhx2.builtins.ui.pjx_popover_trigger.pjx_popover_trigger import (
+    PJXPopoverTrigger,
+)
+
+__all__ = ["PJXPopoverTrigger"]

--- a/pyjinhx2/builtins/ui/pjx_popover_trigger/pjx_popover_trigger.pjx
+++ b/pyjinhx2/builtins/ui/pjx_popover_trigger/pjx_popover_trigger.pjx
@@ -1,0 +1,1 @@
+<{{ tag }} id="{{ id }}" class="pjx-popover__trigger{% if class_name %} {{ class_name }}{% endif %}"{% if tag == "button" %} type="button"{% else %} role="button" tabindex="0"{% endif %} data-pjx-toggle aria-expanded="false"{% if role %} aria-haspopup="{{ role }}"{% endif %}>{{ content }}</{{ tag }}>

--- a/pyjinhx2/builtins/ui/pjx_popover_trigger/pjx_popover_trigger.py
+++ b/pyjinhx2/builtins/ui/pjx_popover_trigger/pjx_popover_trigger.py
@@ -1,0 +1,12 @@
+from typing import Literal
+
+from pyjinhx2.component import AttrValue, BaseComponent, Slot
+
+
+class PJXPopoverTrigger(BaseComponent):
+    """The clickable element that toggles its popover panel; a div variant carries button semantics by hand (port of v0.x pyjinhx/builtins/ui/pjx_popover/pjx_popover_trigger.html)."""
+
+    tag: Literal["button", "div"] = "button"
+    role: Literal["", "menu", "listbox", "dialog"] = ""
+    class_name: AttrValue = ""
+    content: Slot = ""

--- a/tests/pyjinhx2/builtins/pjx_popover/test_pjx_popover.py
+++ b/tests/pyjinhx2/builtins/pjx_popover/test_pjx_popover.py
@@ -71,19 +71,19 @@ def test_component_content_renders_inside_the_root(
 
 def test_invalid_align_is_rejected():
     with pytest.raises(ValidationError):
-        PJXPopover(id="p", align="middle")
+        PJXPopover(id="p", align="middle")  # type: ignore[arg-type]
 
 
 def test_dropped_behavior_field_is_rejected():
     """`behavior` did not survive the v2 port; extra="forbid" turns it into an error."""
     with pytest.raises(ValidationError):
-        PJXPopover(id="p", behavior=True)
+        PJXPopover(id="p", behavior=True)  # type: ignore[call-arg]
 
 
 def test_dropped_extra_attrs_field_is_rejected():
     """`extra_attrs` did not survive the v2 port either (ADR 0006, strict core)."""
     with pytest.raises(ValidationError):
-        PJXPopover(id="p", extra_attrs={"data-x": "1"})
+        PJXPopover(id="p", extra_attrs={"data-x": "1"})  # type: ignore[call-arg]
 
 
 def test_assets_are_discovered_from_the_component_directory():

--- a/tests/pyjinhx2/builtins/pjx_popover/test_pjx_popover.py
+++ b/tests/pyjinhx2/builtins/pjx_popover/test_pjx_popover.py
@@ -1,0 +1,93 @@
+"""PJXPopover renders the positioned root shell that anchors a trigger and its panel (port of v0.x pyjinhx/builtins/ui/pjx_popover/pjx_popover.py)."""
+
+import dataclasses
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_popover import PJXPopover
+from pyjinhx2.component import BaseComponent, Slot
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def popover_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve."""
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kw) -> str:
+    return render(PJXPopover(id="p", **kw), session)
+
+
+def test_default_render_is_a_single_start_aligned_root(popover_session):
+    assert _html(popover_session) == (
+        '<div id="p" class="pjx-popover" data-pjx-popover></div>'
+    )
+
+
+def test_align_start_matches_the_default(popover_session):
+    assert _html(popover_session, align="start") == _html(popover_session)
+
+
+def test_align_end_adds_the_alignment_modifier(popover_session):
+    assert 'class="pjx-popover pjx-popover--align-end"' in _html(
+        popover_session, align="end"
+    )
+
+
+def test_class_name_appended_to_root(popover_session):
+    assert 'class="pjx-popover mine"' in _html(popover_session, class_name="mine")
+
+
+def test_string_content_is_interpolated(popover_session):
+    assert ">hello</div>" in _html(popover_session, content="hello")
+
+
+class PopoverChild(BaseComponent):
+    """A minimal component child, to prove a nested component renders inside the root."""
+
+    content: Slot = ""
+
+
+@pytest.fixture
+def popover_child_template(tmp_path):
+    """Give PopoverChild a real template on disk and repoint its descriptor at it."""
+    path = tmp_path / "popover_child.pjx"
+    path.write_text('<span id="{{ id }}" class="child">{{ content }}</span>')
+    PopoverChild.__pjx_descriptor__ = dataclasses.replace(
+        PopoverChild.__pjx_descriptor__, template_path=path
+    )
+    yield path
+
+
+def test_component_content_renders_inside_the_root(
+    popover_session, popover_child_template
+):
+    html = _html(popover_session, content=PopoverChild(id="c", content="Inner"))
+    assert '<span id="c" class="child">Inner</span>' in html
+
+
+def test_invalid_align_is_rejected():
+    with pytest.raises(ValidationError):
+        PJXPopover(id="p", align="middle")
+
+
+def test_dropped_behavior_field_is_rejected():
+    """`behavior` did not survive the v2 port; extra="forbid" turns it into an error."""
+    with pytest.raises(ValidationError):
+        PJXPopover(id="p", behavior=True)
+
+
+def test_dropped_extra_attrs_field_is_rejected():
+    """`extra_attrs` did not survive the v2 port either (ADR 0006, strict core)."""
+    with pytest.raises(ValidationError):
+        PJXPopover(id="p", extra_attrs={"data-x": "1"})
+
+
+def test_assets_are_discovered_from_the_component_directory():
+    """CSS and JS sit next to the module and are picked up by the descriptor, with no manual wiring."""
+    descriptor = PJXPopover.__pjx_descriptor__
+    assert any(p.name == "pjx_popover.js" for p in descriptor.js_paths)
+    assert any(p.name == "pjx_popover.css" for p in descriptor.css_paths)

--- a/tests/pyjinhx2/builtins/pjx_popover_panel/test_pjx_popover_panel.py
+++ b/tests/pyjinhx2/builtins/pjx_popover_panel/test_pjx_popover_panel.py
@@ -58,16 +58,16 @@ def test_string_content_is_interpolated(panel_session):
 
 def test_invalid_role_is_rejected():
     with pytest.raises(ValidationError):
-        PJXPopoverPanel(id="pl", role="banner")
+        PJXPopoverPanel(id="pl", role="banner")  # type: ignore[arg-type]
 
 
 def test_dropped_behavior_field_is_rejected():
     """`behavior` did not survive the v2 port; extra="forbid" turns it into an error."""
     with pytest.raises(ValidationError):
-        PJXPopoverPanel(id="pl", behavior=True)
+        PJXPopoverPanel(id="pl", behavior=True)  # type: ignore[call-arg]
 
 
 def test_dropped_extra_attrs_field_is_rejected():
     """`extra_attrs` did not survive the v2 port either (ADR 0006, strict core)."""
     with pytest.raises(ValidationError):
-        PJXPopoverPanel(id="pl", extra_attrs={"data-x": "1"})
+        PJXPopoverPanel(id="pl", extra_attrs={"data-x": "1"})  # type: ignore[call-arg]

--- a/tests/pyjinhx2/builtins/pjx_popover_panel/test_pjx_popover_panel.py
+++ b/tests/pyjinhx2/builtins/pjx_popover_panel/test_pjx_popover_panel.py
@@ -1,0 +1,73 @@
+"""PJXPopoverPanel renders the hidden-by-default floating panel a trigger reveals (port of v0.x pyjinhx/builtins/ui/pjx_popover/pjx_popover_panel.html)."""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_popover_panel import PJXPopoverPanel
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def panel_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve."""
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kw) -> str:
+    return render(PJXPopoverPanel(id="pl", **kw), session)
+
+
+def test_default_render_is_a_hidden_div(panel_session):
+    assert _html(panel_session) == (
+        '<div id="pl" class="pjx-popover__panel" data-pjx-popover-panel hidden></div>'
+    )
+
+
+def test_as_form_false_matches_the_default(panel_session):
+    assert _html(panel_session, as_form=False) == _html(panel_session)
+
+
+def test_as_form_wraps_the_panel_in_a_form(panel_session):
+    """A form panel lets the popover submit without an outer form; the closing tag has to match too."""
+    html = _html(panel_session, as_form=True)
+    assert html.startswith('<form id="pl"')
+    assert html.endswith("</form>")
+    assert "<div" not in html
+
+
+def test_panel_is_hidden_so_the_js_owns_the_open_state(panel_session):
+    assert " hidden>" in _html(panel_session)
+
+
+def test_role_is_applied(panel_session):
+    assert 'role="listbox"' in _html(panel_session, role="listbox")
+
+
+def test_empty_role_omits_the_attribute(panel_session):
+    assert "role=" not in _html(panel_session)
+
+
+def test_class_name_appended_to_panel(panel_session):
+    assert 'class="pjx-popover__panel mine"' in _html(panel_session, class_name="mine")
+
+
+def test_string_content_is_interpolated(panel_session):
+    assert ">body</div>" in _html(panel_session, content="body")
+
+
+def test_invalid_role_is_rejected():
+    with pytest.raises(ValidationError):
+        PJXPopoverPanel(id="pl", role="banner")
+
+
+def test_dropped_behavior_field_is_rejected():
+    """`behavior` did not survive the v2 port; extra="forbid" turns it into an error."""
+    with pytest.raises(ValidationError):
+        PJXPopoverPanel(id="pl", behavior=True)
+
+
+def test_dropped_extra_attrs_field_is_rejected():
+    """`extra_attrs` did not survive the v2 port either (ADR 0006, strict core)."""
+    with pytest.raises(ValidationError):
+        PJXPopoverPanel(id="pl", extra_attrs={"data-x": "1"})

--- a/tests/pyjinhx2/builtins/pjx_popover_trigger/test_pjx_popover_trigger.py
+++ b/tests/pyjinhx2/builtins/pjx_popover_trigger/test_pjx_popover_trigger.py
@@ -55,21 +55,21 @@ def test_string_content_is_interpolated(trigger_session):
 
 def test_invalid_tag_is_rejected():
     with pytest.raises(ValidationError):
-        PJXPopoverTrigger(id="t", tag="span")
+        PJXPopoverTrigger(id="t", tag="span")  # type: ignore[arg-type]
 
 
 def test_invalid_role_is_rejected():
     with pytest.raises(ValidationError):
-        PJXPopoverTrigger(id="t", role="banner")
+        PJXPopoverTrigger(id="t", role="banner")  # type: ignore[arg-type]
 
 
 def test_dropped_behavior_field_is_rejected():
     """`behavior` did not survive the v2 port; extra="forbid" turns it into an error."""
     with pytest.raises(ValidationError):
-        PJXPopoverTrigger(id="t", behavior=True)
+        PJXPopoverTrigger(id="t", behavior=True)  # type: ignore[call-arg]
 
 
 def test_dropped_extra_attrs_field_is_rejected():
     """`extra_attrs` did not survive the v2 port either (ADR 0006, strict core)."""
     with pytest.raises(ValidationError):
-        PJXPopoverTrigger(id="t", extra_attrs={"data-x": "1"})
+        PJXPopoverTrigger(id="t", extra_attrs={"data-x": "1"})  # type: ignore[call-arg]

--- a/tests/pyjinhx2/builtins/pjx_popover_trigger/test_pjx_popover_trigger.py
+++ b/tests/pyjinhx2/builtins/pjx_popover_trigger/test_pjx_popover_trigger.py
@@ -1,0 +1,75 @@
+"""PJXPopoverTrigger renders the clickable element that toggles its popover panel (port of v0.x pyjinhx/builtins/ui/pjx_popover/pjx_popover_trigger.html)."""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_popover_trigger import PJXPopoverTrigger
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def trigger_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve."""
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kw) -> str:
+    return render(PJXPopoverTrigger(id="t", **kw), session)
+
+
+def test_default_render_is_a_collapsed_button(trigger_session):
+    assert _html(trigger_session) == (
+        '<button id="t" class="pjx-popover__trigger" type="button"'
+        ' data-pjx-toggle aria-expanded="false"></button>'
+    )
+
+
+def test_div_tag_gets_button_semantics_by_hand(trigger_session):
+    """A div trigger has to carry role/tabindex itself; the JS keyboard handler keys off exactly this shape."""
+    html = _html(trigger_session, tag="div")
+    assert html.startswith('<div id="t"')
+    assert 'role="button"' in html
+    assert 'tabindex="0"' in html
+    assert "type=" not in html
+    assert html.endswith("</div>")
+
+
+def test_role_becomes_aria_haspopup(trigger_session):
+    assert 'aria-haspopup="menu"' in _html(trigger_session, role="menu")
+
+
+def test_empty_role_omits_aria_haspopup(trigger_session):
+    assert "aria-haspopup" not in _html(trigger_session)
+
+
+def test_class_name_appended_to_trigger(trigger_session):
+    assert 'class="pjx-popover__trigger mine"' in _html(
+        trigger_session, class_name="mine"
+    )
+
+
+def test_string_content_is_interpolated(trigger_session):
+    assert ">Open</button>" in _html(trigger_session, content="Open")
+
+
+def test_invalid_tag_is_rejected():
+    with pytest.raises(ValidationError):
+        PJXPopoverTrigger(id="t", tag="span")
+
+
+def test_invalid_role_is_rejected():
+    with pytest.raises(ValidationError):
+        PJXPopoverTrigger(id="t", role="banner")
+
+
+def test_dropped_behavior_field_is_rejected():
+    """`behavior` did not survive the v2 port; extra="forbid" turns it into an error."""
+    with pytest.raises(ValidationError):
+        PJXPopoverTrigger(id="t", behavior=True)
+
+
+def test_dropped_extra_attrs_field_is_rejected():
+    """`extra_attrs` did not survive the v2 port either (ADR 0006, strict core)."""
+    with pytest.raises(ValidationError):
+        PJXPopoverTrigger(id="t", extra_attrs={"data-x": "1"})

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -199,6 +199,25 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
         {"pyjinhx2.builtins.ui.pjx_tab_panel.pjx_tab_panel"}
     ),
     "builtins.ui.pjx_tab_panel.pjx_tab_panel": frozenset({"pyjinhx2.component"}),
+    # pjx_popover family (#521): the positioned root shell, its trigger, and
+    # the panel it reveals. JS/CSS live only on the root; each leaf reaches
+    # component.py only.
+    "builtins.ui.pjx_popover.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_popover.pjx_popover"}
+    ),
+    "builtins.ui.pjx_popover.pjx_popover": frozenset({"pyjinhx2.component"}),
+    "builtins.ui.pjx_popover_trigger.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_popover_trigger.pjx_popover_trigger"}
+    ),
+    "builtins.ui.pjx_popover_trigger.pjx_popover_trigger": frozenset(
+        {"pyjinhx2.component"}
+    ),
+    "builtins.ui.pjx_popover_panel.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_popover_panel.pjx_popover_panel"}
+    ),
+    "builtins.ui.pjx_popover_panel.pjx_popover_panel": frozenset(
+        {"pyjinhx2.component"}
+    ),
     "builtins.ui.pjx_notification.__init__": frozenset(
         {"pyjinhx2.builtins.ui.pjx_notification.pjx_notification"}
     ),


### PR DESCRIPTION
## Summary

- Port PJXPopover root shell, PJXPopoverTrigger, and PJXPopoverPanel from v0.x to v2 conventions
- Update assets naming (pjx-popover.* → pjx_popover.* per v2 module-name discovery)
- Wire popover family into import graph and add type: ignore markers for guard tests
- 4 test files updated across popover component family

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)