### PR TITLE
feat(v2): port PJXBreadcrumb to pyjinhx2

### DIFF
--- a/pyjinhx2/builtins/ui/pjx_breadcrumb/__init__.py
+++ b/pyjinhx2/builtins/ui/pjx_breadcrumb/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx2.builtins.ui.pjx_breadcrumb.pjx_breadcrumb import PJXBreadcrumb
+
+__all__ = ["PJXBreadcrumb"]

--- a/pyjinhx2/builtins/ui/pjx_breadcrumb/pjx_breadcrumb.css
+++ b/pyjinhx2/builtins/ui/pjx_breadcrumb/pjx_breadcrumb.css
@@ -1,0 +1,47 @@
+:where(:root) {
+  --pjx-breadcrumb-gap: 0.35rem;
+  --pjx-breadcrumb-sep: "/";
+  --pjx-breadcrumb-sep-color: var(--text-muted);
+  --pjx-breadcrumb-link-color: var(--brand);
+  --pjx-breadcrumb-current-color: var(--text);
+  --pjx-breadcrumb-font-size: var(--font-size-sm);
+}
+
+.pjx-breadcrumb__list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: var(--pjx-breadcrumb-font-size);
+}
+
+.pjx-breadcrumb__item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pjx-breadcrumb-gap);
+}
+
+.pjx-breadcrumb__item:not(:last-child)::after {
+  content: var(--pjx-breadcrumb-sep);
+  color: var(--pjx-breadcrumb-sep-color);
+  margin-left: var(--pjx-breadcrumb-gap);
+  user-select: none;
+  pointer-events: none;
+}
+
+.pjx-breadcrumb__link {
+  color: var(--pjx-breadcrumb-link-color);
+  text-decoration: none;
+}
+
+.pjx-breadcrumb__link:hover {
+  text-decoration: underline;
+}
+
+.pjx-breadcrumb__current {
+  color: var(--pjx-breadcrumb-current-color);
+  font-weight: 500;
+}

--- a/pyjinhx2/builtins/ui/pjx_breadcrumb/pjx_breadcrumb.pjx
+++ b/pyjinhx2/builtins/ui/pjx_breadcrumb/pjx_breadcrumb.pjx
@@ -1,0 +1,13 @@
+<nav id="{{ id }}" class="pjx-breadcrumb{% if class_name %} {{ class_name }}{% endif %}" aria-label="{{ aria_label }}">
+  <ol class="pjx-breadcrumb__list">
+    {% for label, href in items %}
+    <li class="pjx-breadcrumb__item">
+      {% if href %}
+      <a class="pjx-breadcrumb__link" href="{{ href }}">{{ label }}</a>
+      {% else %}
+      <span class="pjx-breadcrumb__current" aria-current="page">{{ label }}</span>
+      {% endif %}
+    </li>
+    {% endfor %}
+  </ol>
+</nav>

--- a/pyjinhx2/builtins/ui/pjx_breadcrumb/pjx_breadcrumb.py
+++ b/pyjinhx2/builtins/ui/pjx_breadcrumb/pjx_breadcrumb.py
@@ -1,0 +1,11 @@
+from pydantic import Field
+
+from pyjinhx2.component import AttrValue, BaseComponent
+
+
+class PJXBreadcrumb(BaseComponent):
+    """A navigation trail of (label, href) crumbs where a null href marks the current page."""
+
+    items: list[tuple[str, str | None]] = Field(default_factory=list)
+    aria_label: str = "Breadcrumb"
+    class_name: AttrValue = ""

--- a/tests/pyjinhx2/builtins/pjx_breadcrumb/test_pjx_breadcrumb.py
+++ b/tests/pyjinhx2/builtins/pjx_breadcrumb/test_pjx_breadcrumb.py
@@ -1,0 +1,91 @@
+"""PJXBreadcrumb renders the single-root <nav> trail of linked and current crumbs (port of v0.x pyjinhx/builtins/ui/pjx_breadcrumb)."""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx2.builtins.ui.pjx_breadcrumb import PJXBreadcrumb
+from pyjinhx2.render import render
+from pyjinhx2.session import RenderSession
+
+
+@pytest.fixture
+def breadcrumb_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve."""
+    return RenderSession(template_dir="/")
+
+
+def _html(session, **kw) -> str:
+    return render(PJXBreadcrumb(id="bc", **kw), session)
+
+
+def test_default_render_is_empty_list_inside_nav(breadcrumb_session):
+    """Missing items renders the shell with an empty <ol>: no error, no crumbs."""
+    html = _html(breadcrumb_session)
+    assert '<nav id="bc"' in html
+    assert 'class="pjx-breadcrumb"' in html
+    assert 'aria-label="Breadcrumb"' in html
+    assert '<ol class="pjx-breadcrumb__list">' in html
+    assert "<li" not in html
+    assert "<a " not in html
+
+
+def test_linked_item_renders_anchor(breadcrumb_session):
+    html = _html(breadcrumb_session, items=[("Home", "/")])
+    assert '<li class="pjx-breadcrumb__item">' in html
+    assert '<a class="pjx-breadcrumb__link" href="/">Home</a>' in html
+    assert "aria-current" not in html
+
+
+def test_current_item_renders_span(breadcrumb_session):
+    """A crumb with href=None is the current page: a span, never an anchor."""
+    html = _html(breadcrumb_session, items=[("Settings", None)])
+    assert (
+        '<span class="pjx-breadcrumb__current" aria-current="page">Settings</span>'
+        in html
+    )
+    assert "<a " not in html
+
+
+def test_mixed_items_render_in_order(breadcrumb_session):
+    html = _html(
+        breadcrumb_session,
+        items=[("Home", "/"), ("Reports", "/reports"), ("Q3", None)],
+    )
+    assert html.count("<li") == 3
+    assert html.index("Home") < html.index("Reports") < html.index("Q3")
+    assert 'href="/reports"' in html
+    assert 'aria-current="page">Q3</span>' in html
+
+
+def test_class_name_appended_to_root(breadcrumb_session):
+    assert 'class="pjx-breadcrumb mine"' in _html(breadcrumb_session, class_name="mine")
+
+
+def test_empty_class_name_adds_nothing(breadcrumb_session):
+    assert 'class="pjx-breadcrumb"' in _html(breadcrumb_session, class_name="")
+
+
+def test_aria_label_defaults_and_is_overridable(breadcrumb_session):
+    assert PJXBreadcrumb.model_fields["aria_label"].default == "Breadcrumb"
+    assert 'aria-label="You are here"' in _html(
+        breadcrumb_session, aria_label="You are here"
+    )
+
+
+def test_clean_break_no_extra_attrs_field():
+    """v2 core is strict (extra="forbid"): v0.x's extra_attrs pass-through is gone."""
+    assert "extra_attrs" not in PJXBreadcrumb.model_fields
+
+
+def test_undeclared_attr_is_rejected():
+    with pytest.raises(ValidationError):
+        PJXBreadcrumb(id="bc", extra_attrs={"data-x": "y"})  # pyright: ignore[reportCallIssue]
+
+
+def test_json_string_items_still_coerced_by_core_hook():
+    """The component-local _coerce_breadcrumb_items BeforeValidator is gone, but
+    BaseComponent._coerce_json_string_attrs (generic, applies to every strict
+    list-typed field) still parses a JSON-looking string before Pydantic sees
+    it — so this is NOT a behavior change from v0.x, just a different hook."""
+    bc = PJXBreadcrumb(id="bc", items='[["Home", "/"]]')  # pyright: ignore[reportArgumentType]
+    assert bc.items == [("Home", "/")]

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -237,6 +237,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
         {"pyjinhx2.builtins.ui.pjx_dropdown.pjx_dropdown"}
     ),
     "builtins.ui.pjx_dropdown.pjx_dropdown": frozenset({"pyjinhx2.component"}),
+    "builtins.ui.pjx_breadcrumb.__init__": frozenset(
+        {"pyjinhx2.builtins.ui.pjx_breadcrumb.pjx_breadcrumb"}
+    ),
+    "builtins.ui.pjx_breadcrumb.pjx_breadcrumb": frozenset({"pyjinhx2.component"}),
     "builtins.ui.pjx_tooltip_content.__init__": frozenset(
         {"pyjinhx2.builtins.ui.pjx_tooltip_content.pjx_tooltip_content"}
     ),


### PR DESCRIPTION
## Summary

Ports `pyjinhx/builtins/ui/pjx_breadcrumb` to pyjinhx2 following the sibling ports of story #496:
- `.pjx` template for markup structure
- Module-name-matched CSS for styling
- Re-export-only `__init__.py` pattern

Behavior narrowed from v0.x: `extra_attrs` is dropped (v2 core is strict with `extra="forbid"`). The `items` field still accepts JSON strings via the generic `BaseComponent._coerce_json_string_attrs` hook, so this is not a behavior change.

Also registers the new module in `test_import_graph.py`'s declared edge table.

## Test Coverage

10 new tests covering:
- Default render behavior (empty list inside nav shell)
- Linked items rendering anchors
- Current item rendering spans with `aria-current`
- Mixed items render in order
- Class name and aria label customization
- JSON string coercion via core hook

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)