### PR TITLE
feat: add BaseComponent.render() convenience wrapper

### DIFF
--- a/pyjinhx2/component.py
+++ b/pyjinhx2/component.py
@@ -3,9 +3,11 @@
 All components reject undeclared kwargs at construction time. This keeps the core
 lightweight and lets the renderer avoid walking arbitrary instance attributes.
 
-Imports pydantic and ClassDescriptor from descriptor.py (sole sanctioned import
-from a higher-level module). The import graph is enforced statically by
-tests/pyjinhx2/test_import_graph.py.
+Imports pydantic and ClassDescriptor from descriptor.py at module scope. The
+render() convenience method also reaches upward into render.py and session.py,
+but only from inside the method body — a module-level edge to render.py would
+be a circular import, since render.py imports BaseComponent at import time. The
+import graph is enforced statically by tests/pyjinhx2/test_import_graph.py.
 """
 
 import itertools
@@ -15,7 +17,7 @@ import sys
 import types
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Annotated, Any, ClassVar, Union, get_args, get_origin
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Union, get_args, get_origin
 
 from pydantic import (
     AfterValidator,
@@ -27,6 +29,11 @@ from pydantic import (
 )
 
 from pyjinhx2.descriptor import ClassDescriptor
+
+if TYPE_CHECKING:
+    # Type-only: the runtime import lives inside render() to avoid the cycle
+    # with render.py.
+    from pyjinhx2.session import RenderSession
 
 _auto_id_counter = itertools.count(1)
 
@@ -499,6 +506,25 @@ class BaseComponent(BaseModel):
             else:
                 props[name] = value
         return props
+
+    def render(self, session: "RenderSession | None" = None) -> str:
+        """Render this component to a finished HTML string.
+
+        Args:
+            session: RenderSession to render under. Defaults to the session
+                bound by the active request_scope(), or — outside any scope —
+                to the fresh RenderSession the free render() builds.
+
+        Returns:
+            The component's rendered markup.
+        """
+        # Imported here, not at module scope: render.py imports BaseComponent at
+        # import time, so a module-level edge back into it is a real circular
+        # import. session.py carries no cycle, but stays local for symmetry.
+        from pyjinhx2.render import render as _render
+        from pyjinhx2.session import current_session
+
+        return _render(self, session or current_session())
 
     def pjx_mount(self) -> None:
         """Fire once, on this instance, right before its recursive render.

--- a/tests/pyjinhx2/test_component.py
+++ b/tests/pyjinhx2/test_component.py
@@ -427,8 +427,6 @@ class TestReservedNameCollisions:
 
 
 FORBIDDEN_IMPORTS = (
-    "pyjinhx2.render",
-    "pyjinhx2.session",
     "pyjinhx2.reactive",
     "pyjinhx",
 )
@@ -436,11 +434,14 @@ FORBIDDEN_IMPORTS = (
 
 def test_component_module_does_not_import_above_itself():
     """component.py sits below descriptor/render in the import graph, so it must
-    not reach up into them (nor into session.py, reactive/, or v0.x pyjinhx) —
-    except the one sanctioned edge #271 adds: importing ``ClassDescriptor`` from
-    descriptor.py to build and attach it in ``__pydantic_init_subclass__``.
-    tests/pyjinhx2/test_import_graph.py is the whole-package view that enforces
-    component.py is the *only* module allowed that edge."""
+    not reach up into them (nor into reactive/ or v0.x pyjinhx) — except the two
+    sanctioned edges: importing ``ClassDescriptor`` from descriptor.py (#271) to
+    build and attach it in ``__pydantic_init_subclass__``, and the local,
+    method-body-only imports of render.py/session.py inside
+    ``BaseComponent.render()`` (#643), which exist because render.py imports
+    BaseComponent at module scope and a module-level edge back would be a real
+    cycle. tests/pyjinhx2/test_import_graph.py is the whole-package view that
+    enforces component.py is the *only* module allowed those edges."""
     tree = ast.parse(inspect.getsource(pyjinhx2.component))
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -1,8 +1,11 @@
 """The declared import direction for pyjinhx2, enforced statically.
 
-component.py sits below descriptor.py and render.py and must never reach up into
-them for anything but the one sanctioned edge: the ClassDescriptor it builds and
-attaches in __pydantic_init_subclass__ (#271). descriptor.py and segments.py are
+component.py sits below descriptor.py and must never reach up into it for
+anything but the one sanctioned edge: the ClassDescriptor it builds and attaches
+in __pydantic_init_subclass__ (#271). It also reaches up into render.py and
+session.py, but only from inside BaseComponent.render()'s method body — never at
+module scope, since render.py imports BaseComponent at import time and a
+module-level edge back would be a real cycle (#643). descriptor.py and segments.py are
 import-pure — stdlib only. Per-module purity is also asserted in
 test_descriptor.py and test_segments.py; this file is the whole-package view, so
 a new module cannot quietly add an edge nobody declared.
@@ -317,9 +320,19 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "client.inject": frozenset(
         {"pyjinhx2.assets", "pyjinhx2.client", "pyjinhx2.session"}
     ),
+    # descriptor/props_header are ordinary upward reads. render and session are
+    # the reverse edges behind BaseComponent.render(): both are imported inside
+    # the method body, never at module scope, because render.py imports
+    # BaseComponent at import time and a module-level edge back would be a real
+    # cycle — the same local-import escape hatch assets.py already uses.
     "component": frozenset(
-        {"pyjinhx2.descriptor", "pyjinhx2.props_header"}
-    ),  # the stale-header probe needs template_has_props_header
+        {
+            "pyjinhx2.descriptor",
+            "pyjinhx2.props_header",
+            "pyjinhx2.render",
+            "pyjinhx2.session",
+        }
+    ),
     # config sits above everything: it may read the spine to register
     # components and it defers to siblings that own the app wiring and dev
     # tooling. The reverse edge — any spine, reactive/ or client/ module

--- a/tests/pyjinhx2/test_import_graph.py
+++ b/tests/pyjinhx2/test_import_graph.py
@@ -648,6 +648,38 @@ def test_nothing_imports_context():
     assert importers == set()
 
 
+def module_level_internal_imports(path: Path) -> set[str]:
+    """Every ``pyjinhx2.*`` module name imported at module scope by ``path`` —
+    i.e. only the file's top-level statements, never descending into a
+    function or class body. This is what distinguishes a real module-scope
+    edge (which can create an import cycle) from the local-import escape
+    hatch component.py uses for render.py/session.py inside render()'s body."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            names = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names = [node.module or ""]
+        else:
+            continue
+        found.update(n for n in names if n == "pyjinhx2" or n.startswith("pyjinhx2."))
+    return found
+
+
+def test_component_only_imports_render_and_session_inside_a_method_body():
+    """The docstring above and the ALLOWED_INTERNAL_IMPORTS comment on
+    "component" both claim render.py/session.py are reached only from inside
+    BaseComponent.render()'s method body, never at module scope — because
+    render.py imports BaseComponent at import time, so a module-level edge
+    back would be a real cycle (#643). Assert that claim directly: the whole
+    file's edge table above passes even if the import moves to module scope,
+    since it doesn't distinguish where in the file the import lives."""
+    module_level = module_level_internal_imports(PACKAGE_ROOT / "component.py")
+    assert "pyjinhx2.render" not in module_level
+    assert "pyjinhx2.session" not in module_level
+
+
 def test_no_render_spine_module_declares_a_reactive_import():
     """FORBIDDEN per architecture-overview.md: anything in the render spine
     importing reactive/. pyjinhx2/reactive/ doesn't exist yet (#288), so this

--- a/tests/pyjinhx2/test_render_public.py
+++ b/tests/pyjinhx2/test_render_public.py
@@ -12,7 +12,7 @@ import pytest
 from pyjinhx2.component import BaseComponent
 from pyjinhx2.descriptor import ClassDescriptor
 from pyjinhx2.render import render
-from pyjinhx2.session import RenderSession
+from pyjinhx2.session import RenderSession, request_scope
 
 
 def _make_component(template_path: str):
@@ -171,3 +171,39 @@ def test_render_zeroroot_raises(render_session):
 
     with pytest.raises(ValueError, match="must render exactly one root element"):
         render(component, render_session)
+
+
+# Test: component.render(session=...) delegates to the free render() with that
+# exact session, ambient context or not.
+def test_component_render_with_explicit_session(render_session):
+    """component.render(session=s) matches render(component, s)."""
+    DivComp = _make_component("div.html")
+
+    assert DivComp().render(session=render_session) == render(
+        DivComp(), render_session
+    )
+
+
+# Test: no-arg component.render() inside a request_scope picks the ambient
+# session up off the ContextVar.
+def test_component_render_uses_ambient_session(tmp_path):
+    """Inside request_scope(), no-arg render() uses the scope's session."""
+    template_dir = str(Path(__file__).parent.parent / "templates")
+    DivComp = _make_component("div.html")
+
+    with request_scope(template_dir=template_dir) as session:
+        ambient = DivComp().render()
+
+    assert ambient == render(DivComp(), RenderSession(template_dir=template_dir))
+    assert ambient == render(DivComp(), session)
+
+
+# Test: outside any request_scope, no-arg render() behaves exactly like passing
+# session=None to the free function — a fresh default RenderSession, whose
+# loader is the cwd-relative "templates" dir.
+def test_component_render_without_session(monkeypatch):
+    """Outside a scope, no-arg render() matches render(component, None)."""
+    monkeypatch.chdir(Path(__file__).parent.parent)  # tests/, so "templates" resolves
+    DivComp = _make_component("div.html")
+
+    assert DivComp().render() == render(DivComp(), None)

--- a/tests/pyjinhx2/test_render_public.py
+++ b/tests/pyjinhx2/test_render_public.py
@@ -179,9 +179,7 @@ def test_component_render_with_explicit_session(render_session):
     """component.render(session=s) matches render(component, s)."""
     DivComp = _make_component("div.html")
 
-    assert DivComp().render(session=render_session) == render(
-        DivComp(), render_session
-    )
+    assert DivComp().render(session=render_session) == render(DivComp(), render_session)
 
 
 # Test: no-arg component.render() inside a request_scope picks the ambient


### PR DESCRIPTION
## Summary

- Add BaseComponent.render() convenience wrapper that delegates to the free render() function
- Resolver session from ambient contextvar (current_session()) when none is passed
- Both render and session imports are local to method body to avoid circular import
- Add comprehensive test coverage including regression tests and import graph validation
- Reconcile legacy import guard with new sanctioned render()/session() local imports

## Tests

Added 4 test blocks/cases across test_render_public.py and test_import_graph.py to validate the new BaseComponent.render() API and verify import graph constraints remain enforced.

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)