### PR TITLE
fix: replace name-membership cycle guard with bounded-repeat check

### DIFF
--- a/pyjinhx2/render.py
+++ b/pyjinhx2/render.py
@@ -19,6 +19,12 @@ from pyjinhx2.render_context import build_context
 from pyjinhx2.segments import ChildRef, RenderedLevel, VerbatimParser, serialize
 from pyjinhx2.session import RenderSession
 
+# How many times one class may appear on a single nesting path before the path
+# is treated as a cycle. A terminating design reuses a class a handful of times
+# at most; a component that re-instantiates itself with no base case blows past
+# this, and does so well inside Python's recursion limit.
+MAX_CHAIN_REPEATS = 32
+
 
 def _passthrough_markup(ref: ChildRef) -> str:
     """Markup for a ChildRef whose tag no component class claims.
@@ -161,15 +167,19 @@ def render_level(
         component: A valid BaseComponent instance (construction-time validation passed).
         session: RenderSession providing Jinja environment and hooks.
         chain: Class names of the components already being rendered on this
-            call path, outermost first. Passed by value down the recursion so
-            each branch sees its own ancestors and nothing else.
+            call path, outermost first, one entry per level (a class may appear
+            more than once). Passed by value down the recursion so each branch
+            sees its own ancestors and nothing else.
 
     Returns:
         RenderedLevel with segments (str | ChildRef), root_span, descriptor.
 
     Raises:
         ValueError: If template renders zero or 2+ root elements.
-        ValueError: If a component re-enters its own render chain (cycle).
+        ValueError: If one class recurs MAX_CHAIN_REPEATS times on a single
+            call path — a path that has stopped making progress. Reusing a
+            class at a shallower and a deeper level of the same path is not a
+            cycle and does not raise.
         jinja2.TemplateNotFound: If template file missing.
         jinja2.TemplateAssertionError: If Jinja evaluation fails.
         Exception: Whatever a session.on_rendered subscriber raises; the hook
@@ -191,13 +201,19 @@ def render_level(
     jinja_env = session.jinja_env
     prefix = f"{component.__class__.__name__} (template: {descriptor.template_path}): "
 
-    # A component whose subtree instantiates itself or an ancestor would recurse
-    # forever; the chain is the current call path only, so the same class on two
-    # sibling branches is fine (ADR 0004: nesting/load chains are the only cycle
-    # vector left in v2).
+    # A class may legitimately reappear deeper on the same path — Card > Row >
+    # Card terminates — so mere presence in the chain proves nothing. What a
+    # real cycle looks like is a path that stops making progress: the same class
+    # recurring over and over. The chain is the current call path only, so the
+    # same class on two sibling branches is still fine (ADR 0004: nesting/load
+    # chains are the only cycle vector left in v2).
     name = component.__class__.__name__
-    if name in chain:
-        cycle = chain[chain.index(name) :]
+    if chain.count(name) >= MAX_CHAIN_REPEATS:
+        # `chain` is a tuple (no .rindex()); walk from the end to find the most
+        # recent occurrence, so the message names one turn of the loop rather
+        # than every repetition of it.
+        last = len(chain) - 1 - chain[::-1].index(name)
+        cycle = chain[last:]
         raise ValueError(f"{prefix}cycle detected: {' -> '.join((*cycle, name))}")
     chain = (*chain, name)
 

--- a/tests/pyjinhx2/test_direct_nesting.py
+++ b/tests/pyjinhx2/test_direct_nesting.py
@@ -181,7 +181,11 @@ class TestNestedOfNested:
 
 
 class TestCycle:
-    def test_assigning_an_instance_of_the_same_class_raises(self):
+    def test_assigning_an_instance_of_the_same_class_terminates_and_renders(self):
+        # Reusing a class at a shallower and a deeper level of the same path is
+        # not a cycle by itself — this path terminates at Leaf, so it must
+        # render rather than raise (#645: same-class-anywhere was a false
+        # positive; only a path that stops making progress is a cycle).
         class Recur(BaseComponent):
             content: Slot = ""
 
@@ -189,8 +193,10 @@ class TestCycle:
             "nest_content.html", frozenset({"content"}), "content"
         )
 
-        with pytest.raises(ValueError, match="cycle detected"):
-            render(Recur(content=Recur(content=Leaf(text="z"))), session())
+        assert render(Recur(content=Recur(content=Leaf(text="z"))), session()) == (
+            '<div class="card"><div class="card">'
+            '<span class="leaf">z</span></div></div>'
+        )
 
 
 class TestBoundaries:

--- a/tests/pyjinhx2/test_render_cycle_guard.py
+++ b/tests/pyjinhx2/test_render_cycle_guard.py
@@ -68,6 +68,14 @@ class PJXPassthroughCycle(BaseComponent):
     pass
 
 
+class PJXCardL2(BaseComponent):
+    depth: str = ""
+
+
+class PJXRowL2(BaseComponent):
+    depth: str = ""
+
+
 TEMPLATES = {
     PJXCycleSelf: "cycle_self.html",
     PJXCycleA: "cycle_a.html",
@@ -80,6 +88,8 @@ TEMPLATES = {
     PJXAcyclicC: "cycle_acyclic_c.html",
     PJXDiamond: "cycle_diamond.html",
     PJXPassthroughCycle: "cycle_passthrough.html",
+    PJXCardL2: "cycle_card_l2.html",
+    PJXRowL2: "cycle_row_l2.html",
 }
 
 for _cls, _template in TEMPLATES.items():
@@ -144,4 +154,17 @@ def test_same_component_on_two_sibling_paths_is_not_a_cycle(session):
 def test_passthrough_sibling_does_not_mask_the_cycle(session):
     with pytest.raises(ValueError) as err:
         render(PJXPassthroughCycle(), session)
+    assert "cycle detected: PJXCycleSelf -> PJXCycleSelf" in str(err.value)
+
+
+def test_same_class_at_two_depths_on_one_path_is_not_a_cycle(session):
+    assert render(PJXCardL2(depth="1"), session) == (
+        '<div class="card"><div class="row"><div class="card"></div></div></div>'
+    )
+
+
+def test_unbounded_self_nesting_raises_before_the_recursion_limit(session):
+    # RecursionError is not a ValueError, so a stack blowup fails this outright.
+    with pytest.raises(ValueError) as err:
+        render(PJXCycleSelf(), session)
     assert "cycle detected: PJXCycleSelf -> PJXCycleSelf" in str(err.value)

--- a/tests/templates/cycle_card_l2.html
+++ b/tests/templates/cycle_card_l2.html
@@ -1,0 +1,1 @@
+<div class="card">{% if depth %}<PJXRowL2 depth=""/>{% endif %}</div>

--- a/tests/templates/cycle_row_l2.html
+++ b/tests/templates/cycle_row_l2.html
@@ -1,0 +1,1 @@
+<div class="row"><PJXCardL2 depth=""/></div>


### PR DESCRIPTION
## Summary

Fixes the cycle guard in render_level() that was falsely flagging legitimate component reuse patterns like Card > Row > Card. The guard now only fires when a class recurs 32+ times on a single path, while still catching direct self-cycles and indirect cycles well before Python's recursion limit.

## Changes

- Updated cycle detection logic with bounded-repeat check
- Updated test_assigning_an_instance_of_the_same_class_raises to assert correct render output
- Added new render_cycle_guard test coverage
- Added template fixtures for cycle test scenarios

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)