### PR TITLE
docs+test: pin the table-cell raw-HTML Slot escaping gap (bench fixture)

### DIFF
--- a/docs/superpowers/rebuild/roadmap.md
+++ b/docs/superpowers/rebuild/roadmap.md
@@ -106,7 +106,29 @@ Port order — dependency- and risk-sorted, tests ported alongside each family:
 - [ ] **5. JS-heavy tail** — Notification, ToastHost, Alert, Carousel, Resizable families.
 - [ ] **6. Release train** — bench comparison on the builtin-heavy page (G2: never slower), migration guide written from the port list's mods/drops (G5), rename `pyjinhx2` → `pyjinhx`, publish 1.0, freeze v0.x to critical fixes.
 
-Bench comparison: _(record here)_
+Bench comparison — v0.36.4 vs v2, same builtin-heavy page
+(`tests/fixtures/bench_builtin_heavy.py`, issue #537), reproduced by
+`uv run python scripts/bench_v0_vs_v2.py`. Median/mean of 20 iterations after
+one warmup, rows=200. v0.36 side: `pyjinhx/` was not byte-identical to the
+`v0.36.4` tag at the time of this run, so it was measured from a separate
+`git worktree add /tmp/pyjinhx-v0364 v0.36.4` checkout (see the script's
+docstring). Excluded from both sides (not ported to v2): PJXConfirmDialog,
+PJXPromptDialog.
+
+| case | v0.36 med (ms) | v2 med (ms) | delta (ms) | delta (%) |
+| --- | --- | --- | --- | --- |
+| full page | 103.20 | 41.32 | -61.89 | -60.0% |
+| table rows=200 | 89.73 | 36.51 | -53.22 | -59.3% |
+| shells only | 4.22 | 1.58 | -2.65 | -62.7% |
+
+**G2:** no case regressed — v2 is faster than v0.36 on every bench case
+(~59-65% lower median render time). One apparent regression surfaced and was
+fixed during script development, not left as a finding: an early version of
+the script built a fresh v2 `RenderSession` per timed render call, and its
+Jinja-`Environment` construction cost — paid once per call, never amortized —
+made the cheapest case ("shells only") look ~360% slower than v0. Reusing one
+session per case (mirroring v0's renderer reuse) removed that artifact; see
+the `scripts/bench_v0_vs_v2.py` commit for detail.
 
 ---
 

--- a/scripts/bench_v0_vs_v2.py
+++ b/scripts/bench_v0_vs_v2.py
@@ -1,0 +1,201 @@
+"""v0.36.4 vs v2 comparison on the same builtin-heavy page (issue #537, PRD G2).
+
+Not a CI test (timing-sensitive). Run manually:
+
+    uv run python scripts/bench_v0_vs_v2.py
+    uv run python scripts/bench_v0_vs_v2.py --profile
+
+v0.36 side: the in-tree ``pyjinhx/`` package. It is *not* byte-identical to
+the ``v0.36.4`` tag on this branch (`git diff --stat v0.36.4..origin/master --
+pyjinhx/` is non-empty at the time this was written), so the recorded run
+was taken from a separate worktree checked out at the tag itself
+(`git worktree add /tmp/pyjinhx-v0364 v0.36.4`) with that path prepended to
+``sys.path`` ahead of the in-tree ``pyjinhx/`` package. ``pyjinhx/`` is
+deleted by #540, so the numbers this prints get captured into
+docs/superpowers/rebuild/roadmap.md rather than re-derived later.
+
+v2 side: the fixture page is a real ``pyjinhx2`` component instance tree
+(not a markup string) — see ``tests/fixtures/bench_builtin_heavy.py``'s
+module docstring for why a plain nested-tag markup string does not expand
+past one custom-tag boundary on this side.
+"""
+
+import cProfile
+import importlib
+import io
+import logging
+import pkgutil
+import pstats
+import statistics
+import sys
+import tempfile
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+_V0364_WORKTREE = Path("/tmp/pyjinhx-v0364")
+if _V0364_WORKTREE.is_dir():
+    sys.path.insert(0, str(_V0364_WORKTREE))
+
+import pyjinhx.builtins.ui  # noqa: F401 — registers v0 builtins (import side effect)
+import pyjinhx2.builtins
+from pyjinhx import Renderer as V0Renderer
+from pyjinhx.registry import Registry as V0Registry
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.discovery import build_registry
+from pyjinhx2.render import render as v2_render
+from pyjinhx2.session import RenderSession
+from tests.fixtures.bench_builtin_heavy import (
+    build_v0_page,
+    build_v0_shells,
+    build_v0_table,
+    build_v2_page,
+    build_v2_shells,
+    build_v2_table,
+)
+
+logging.getLogger("pyjinhx").setLevel(logging.ERROR)
+logging.getLogger("pyjinhx2").setLevel(logging.ERROR)
+
+ROWS = 200
+ITERATIONS = 20
+
+
+def _import_all_v2_builtins() -> None:
+    """Import every module under pyjinhx2.builtins so their classes exist to
+    be found by ``__subclasses__()`` — ``import pyjinhx2.builtins`` alone only
+    imports the (empty) package ``__init__``, not each builtin submodule."""
+    for module_info in pkgutil.walk_packages(
+        pyjinhx2.builtins.__path__, prefix="pyjinhx2.builtins."
+    ):
+        importlib.import_module(module_info.name)
+
+
+def _v2_all_classes() -> list[type]:
+    """Every declared BaseComponent subclass (mirrors config.py:_all_component_classes)."""
+    found: list[type] = []
+    stack = list(BaseComponent.__subclasses__())
+    while stack:
+        cls = stack.pop()
+        found.append(cls)
+        stack.extend(cls.__subclasses__())
+    return found
+
+
+def _v0_renderer() -> V0Renderer:
+    V0Renderer.set_default_environment(tempfile.mkdtemp())
+    return V0Renderer.get_default_renderer()
+
+
+def _v0_render(renderer: V0Renderer, source: str) -> str:
+    with V0Registry.request_scope():
+        return renderer.render(source)
+
+
+def _v2_render(session: RenderSession, component: BaseComponent) -> str:
+    return v2_render(component, session)
+
+
+def _sanity(label: str, v0_html: str, v2_html: str) -> None:
+    """Fail fast, before any timing, if the two sides are not comparable."""
+    if not v0_html.strip():
+        raise SystemExit(f"[{label}] v0.36 render produced empty output")
+    if not v2_html.strip():
+        raise SystemExit(f"[{label}] v2 render produced empty output")
+    for marker in ('id="r0"', 'id="r1"', 'id="bench-table"'):
+        if (marker in v0_html) != (marker in v2_html):
+            raise SystemExit(
+                f"[{label}] marker {marker} present on only one side — pages are not comparable"
+            )
+    v0_rows = v0_html.count('id="r')
+    v2_rows = v2_html.count('id="r')
+    if v0_rows != v2_rows:
+        raise SystemExit(
+            f"[{label}] row-marker counts differ: v0={v0_rows} v2={v2_rows}"
+        )
+
+
+def _time(fn: Callable[[], str]) -> list[float]:
+    """One warmup call, then ITERATIONS timed calls; per-iteration milliseconds."""
+    fn()
+    times: list[float] = []
+    for _ in range(ITERATIONS):
+        t0 = time.perf_counter()
+        fn()
+        times.append((time.perf_counter() - t0) * 1000.0)
+    return times
+
+
+CASES: tuple[tuple[str, Callable[[], str], Callable[[], str]], ...] = (
+    ("full page", lambda: build_v0_page(ROWS), lambda: build_v2_page(ROWS)),
+    ("table rows=200", lambda: build_v0_table(ROWS), lambda: build_v2_table(ROWS)),
+    ("shells only", build_v0_shells, build_v2_shells),
+)
+
+
+def main() -> None:
+    _import_all_v2_builtins()
+    build_registry("pyjinhx2/builtins", _v2_all_classes())
+
+    print(
+        f"{'case':<20} {'v0 med':>9} {'v2 med':>9} {'v0 mean':>9} {'v2 mean':>9} "
+        f"{'delta ms':>9} {'delta %':>8}"
+    )
+    v0_renderer = _v0_renderer()
+    any_regression = False
+    for label, v0_build, v2_build in CASES:
+        # One session per case, reused across every iteration of that case's
+        # timed loop — matches v0_renderer's reuse below, so neither side pays
+        # per-iteration environment-construction cost the other doesn't.
+        v2_session = RenderSession(template_dir="/")
+        v0_html = _v0_render(v0_renderer, v0_build())
+        v2_html = _v2_render(v2_session, v2_build())
+        _sanity(label, v0_html, v2_html)
+
+        v0_times = _time(lambda v0_build=v0_build: _v0_render(v0_renderer, v0_build()))
+        v2_times = _time(
+            lambda v2_session=v2_session, v2_build=v2_build: _v2_render(
+                v2_session, v2_build()
+            )
+        )
+        v0_med, v2_med = statistics.median(v0_times), statistics.median(v2_times)
+        v0_mean, v2_mean = statistics.mean(v0_times), statistics.mean(v2_times)
+        d_ms = v2_med - v0_med
+        d_pct = (d_ms / v0_med) * 100.0
+        regressed = d_pct > 0.0
+        any_regression |= regressed
+        print(
+            f"{label:<20} {v0_med:9.2f} {v2_med:9.2f} {v0_mean:9.2f} {v2_mean:9.2f} "
+            f"{d_ms:+9.2f} {d_pct:+7.1f}%"
+        )
+
+    print()
+    print(
+        "G2: no case regressed"
+        if not any_regression
+        else "G2: REGRESSION — see rows with positive delta"
+    )
+
+    if "--profile" in sys.argv:
+        v0_source = build_v0_page(ROWS)
+        v2_component = build_v2_page(ROWS)
+        profile_session = RenderSession(template_dir="/")
+        for side_label, fn in (
+            ("v0.36", lambda: _v0_render(v0_renderer, v0_source)),
+            ("v2", lambda: _v2_render(profile_session, v2_component)),
+        ):
+            print(f"=== {side_label} ===")
+            profiler = cProfile.Profile()
+            profiler.enable()
+            fn()
+            profiler.disable()
+            for sort_key in ("cumulative", "tottime"):
+                stream = io.StringIO()
+                pstats.Stats(profiler, stream=stream).sort_stats(sort_key).print_stats(
+                    25
+                )
+                print(stream.getvalue())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_v0_vs_v2.py
+++ b/scripts/bench_v0_vs_v2.py
@@ -115,7 +115,7 @@ def _sanity(label: str, v0_html: str, v2_html: str) -> None:
         )
 
 
-def _time(fn: Callable[[], str]) -> list[float]:
+def _time(fn: Callable[[], object]) -> list[float]:
     """One warmup call, then ITERATIONS timed calls; per-iteration milliseconds."""
     fn()
     times: list[float] = []
@@ -126,7 +126,7 @@ def _time(fn: Callable[[], str]) -> list[float]:
     return times
 
 
-CASES: tuple[tuple[str, Callable[[], str], Callable[[], str]], ...] = (
+CASES: tuple[tuple[str, Callable[[], str], Callable[[], BaseComponent]], ...] = (
     ("full page", lambda: build_v0_page(ROWS), lambda: build_v2_page(ROWS)),
     ("table rows=200", lambda: build_v0_table(ROWS), lambda: build_v2_table(ROWS)),
     ("shells only", build_v0_shells, build_v2_shells),

--- a/tests/fixtures/bench_builtin_heavy.py
+++ b/tests/fixtures/bench_builtin_heavy.py
@@ -1,0 +1,357 @@
+"""Shared "builtin-heavy page" used by scripts/bench_v0_vs_v2.py (issue #537).
+
+One composition covering all five L4 builtin families, expressed twice —
+once against pyjinhx v0.36.4 tags, once against pyjinhx2 tags — so the two
+renderers are timed on the same page. Both packages happen to spell every
+shared builtin's tag identically (PascalCase class name, e.g. ``PJXTable``),
+so ``TAGS`` maps every logical name to the *same* string on both sides today;
+the mapping still exists so a future rename during the port stays visible in
+one place instead of silently skewing the bench.
+
+Excluded builtins (present in v0.36.4 but not ported to v2, so dropped from
+BOTH sides to keep the comparison 1:1 — confirmed via
+``diff <(ls pyjinhx/builtins/ui) <(ls pyjinhx2/builtins/ui)`` against the
+v0.36.4 tag, issue #537 Task 0): see EXCLUDED_FROM_BOTH below.
+
+v2 also splits ``PJXPopover`` into a trigger/panel pair
+(``PJXPopoverTrigger``/``PJXPopoverPanel``) that v0.36.4 does not have; this
+fixture uses only the bare, self-closing ``PJXPopover`` root on both sides so
+the page stays expressible identically without inventing v0-side children
+that were never ported.
+"""
+
+EXCLUDED_FROM_BOTH = (
+    "PJXConfirmDialog",
+    "PJXPromptDialog",
+)
+
+# Logical name -> (v0.36 tag, v2 tag). Identical today; the mapping exists so
+# a rename during the port stays visible instead of silently skewing the bench.
+TAGS: dict[str, tuple[str, str]] = {
+    # Display primitives (L4.1)
+    "icon": ("PJXIcon", "PJXIcon"),
+    "badge": ("PJXBadge", "PJXBadge"),
+    "avatar": ("PJXAvatar", "PJXAvatar"),
+    "avatar_stack": ("PJXAvatarStack", "PJXAvatarStack"),
+    "divider": ("PJXDivider", "PJXDivider"),
+    "progress": ("PJXProgress", "PJXProgress"),
+    "skeleton": ("PJXSkeleton", "PJXSkeleton"),
+    "spinner": ("PJXSpinner", "PJXSpinner"),
+    "breadcrumb": ("PJXBreadcrumb", "PJXBreadcrumb"),
+    # Forms (L4.2)
+    "button": ("PJXButton", "PJXButton"),
+    "form_field": ("PJXFormField", "PJXFormField"),
+    "password_input": ("PJXPasswordInput", "PJXPasswordInput"),
+    "chip_input": ("PJXChipInput", "PJXChipInput"),
+    "segmented_control": ("PJXSegmentedControl", "PJXSegmentedControl"),
+    "toggle_switch": ("PJXToggleSwitch", "PJXToggleSwitch"),
+    # Composed shells (L4.3)
+    "card": ("PJXCard", "PJXCard"),
+    "card_header": ("PJXCardHeader", "PJXCardHeader"),
+    "card_body": ("PJXCardBody", "PJXCardBody"),
+    "card_footer": ("PJXCardFooter", "PJXCardFooter"),
+    "modal": ("PJXModal", "PJXModal"),
+    "modal_header": ("PJXModalHeader", "PJXModalHeader"),
+    "modal_body": ("PJXModalBody", "PJXModalBody"),
+    "modal_footer": ("PJXModalFooter", "PJXModalFooter"),
+    "drawer": ("PJXDrawer", "PJXDrawer"),
+    "drawer_header": ("PJXDrawerHeader", "PJXDrawerHeader"),
+    "drawer_body": ("PJXDrawerBody", "PJXDrawerBody"),
+    "drawer_footer": ("PJXDrawerFooter", "PJXDrawerFooter"),
+    "accordion": ("PJXAccordion", "PJXAccordion"),
+    "accordion_group": ("PJXAccordionGroup", "PJXAccordionGroup"),
+    "accordion_trigger": ("PJXAccordionTrigger", "PJXAccordionTrigger"),
+    "accordion_content": ("PJXAccordionContent", "PJXAccordionContent"),
+    "tab": ("PJXTab", "PJXTab"),
+    "tab_group": ("PJXTabGroup", "PJXTabGroup"),
+    "tab_list": ("PJXTabList", "PJXTabList"),
+    "tab_panel": ("PJXTabPanel", "PJXTabPanel"),
+    "popover": ("PJXPopover", "PJXPopover"),
+    "dropdown": ("PJXDropdown", "PJXDropdown"),
+    "tooltip": ("PJXTooltip", "PJXTooltip"),
+    "tooltip_trigger": ("PJXTooltipTrigger", "PJXTooltipTrigger"),
+    "tooltip_content": ("PJXTooltipContent", "PJXTooltipContent"),
+    # Table / paginator / loaders (L4.4)
+    "table": ("PJXTable", "PJXTable"),
+    "table_body": ("PJXTableBody", "PJXTableBody"),
+    "table_head": ("PJXTableHead", "PJXTableHead"),
+    "table_header_cell": ("PJXTableHeaderCell", "PJXTableHeaderCell"),
+    "table_row": ("PJXTableRow", "PJXTableRow"),
+    "table_cell": ("PJXTableCell", "PJXTableCell"),
+    "paginator": ("PJXPaginator", "PJXPaginator"),
+    "region_loader": ("PJXRegionLoader", "PJXRegionLoader"),
+    "page_loader": ("PJXPageLoader", "PJXPageLoader"),
+    "lazy_load": ("PJXLazyLoad", "PJXLazyLoad"),
+    # JS-heavy tail (L4.5)
+    "carousel": ("PJXCarousel", "PJXCarousel"),
+    "carousel_slide": ("PJXCarouselSlide", "PJXCarouselSlide"),
+    "notification": ("PJXNotification", "PJXNotification"),
+    "toast_host": ("PJXToastHost", "PJXToastHost"),
+    "alert": ("PJXAlert", "PJXAlert"),
+    "resizable_group": ("PJXResizableGroup", "PJXResizableGroup"),
+    "resizable_handle": ("PJXResizableHandle", "PJXResizableHandle"),
+    "resizable_panel": ("PJXResizablePanel", "PJXResizablePanel"),
+}
+
+V0_MANIFEST = [v0 for v0, _ in TAGS.values()]
+V2_MANIFEST = [v2 for _, v2 in TAGS.values()]
+
+V0_SIDE = 0
+V2_SIDE = 1
+
+
+def _tag(logical: str, side: int) -> str:
+    return TAGS[logical][side]
+
+
+def _display_primitives(side: int) -> str:
+    return (
+        f'<{_tag("icon", side)} id="p-icon" name="gear"/>'
+        f'<{_tag("badge", side)} id="p-badge" label="new" color="brand"/>'
+        f'<{_tag("avatar", side)} id="p-avatar" initials="AB"/>'
+        f'<{_tag("avatar_stack", side)} id="p-avatar-stack"/>'
+        f'<{_tag("divider", side)} id="p-divider"/>'
+        f'<{_tag("progress", side)} id="p-progress" value="42"/>'
+        f'<{_tag("skeleton", side)} id="p-skeleton"/>'
+        f'<{_tag("spinner", side)} id="p-spinner"/>'
+        f'<{_tag("breadcrumb", side)} id="p-breadcrumb"/>'
+    )
+
+
+def _form_block(side: int) -> str:
+    ff, pw, chip, seg, tog, btn = (
+        _tag("form_field", side),
+        _tag("password_input", side),
+        _tag("chip_input", side),
+        _tag("segmented_control", side),
+        _tag("toggle_switch", side),
+        _tag("button", side),
+    )
+    return (
+        f'<{ff} id="f-password"><{pw} id="pw-input" name="password"/></{ff}>'
+        f'<{ff} id="f-chip"><{chip} id="chip-input" name="tags"/></{ff}>'
+        f'<{seg} id="f-segmented" name="mode"/>'
+        f'<{tog} id="f-toggle" name="opt-in"/>'
+        f'<{btn} id="f-submit" type="submit">Save</{btn}>'
+    )
+
+
+def _table(rows: int, side: int) -> str:
+    t, tb, th, thc, tr, td = (
+        _tag("table", side),
+        _tag("table_body", side),
+        _tag("table_head", side),
+        _tag("table_header_cell", side),
+        _tag("table_row", side),
+        _tag("table_cell", side),
+    )
+    parts = [
+        f'<{t} id="bench-table">'
+        f'<{th} id="bench-thead"><{tr} id="head-row">'
+        f'<{thc} id="hc-name">Name</{thc}>'
+        f'<{thc} id="hc-value">Value</{thc}>'
+        f'<{thc} id="hc-score">Score</{thc}>'
+        f"</{tr}></{th}>"
+        f'<{tb} id="bench-tbody">'
+    ]
+    for r in range(rows):
+        parts.append(
+            f'<{tr} id="r{r}">'
+            f'<{td} id="c{r}a">name {r}</{td}>'
+            f'<{td} id="c{r}b"><input type="text" value="v{r}"/></{td}>'
+            f'<{td} id="c{r}c">{r * 3}</{td}>'
+            f"</{tr}>"
+        )
+    parts.append(f"</{tb}></{t}>")
+    return "".join(parts)
+
+
+def _shells(inner: str, side: int) -> str:
+    """Modal -> Accordion -> TabGroup shell nest, wrapping ``inner``."""
+    (
+        modal,
+        modal_header,
+        modal_body,
+        modal_footer,
+        acc_group,
+        acc,
+        acc_trigger,
+        acc_content,
+        tab_group,
+        tab_list,
+        tab,
+        tab_panel,
+    ) = (
+        _tag("modal", side),
+        _tag("modal_header", side),
+        _tag("modal_body", side),
+        _tag("modal_footer", side),
+        _tag("accordion_group", side),
+        _tag("accordion", side),
+        _tag("accordion_trigger", side),
+        _tag("accordion_content", side),
+        _tag("tab_group", side),
+        _tag("tab_list", side),
+        _tag("tab", side),
+        _tag("tab_panel", side),
+    )
+    return (
+        f'<{modal} id="bench-modal">'
+        f'<{modal_header} id="bench-modal-header">Details</{modal_header}>'
+        f'<{modal_body} id="bench-modal-body">'
+        f'<{acc_group} id="bench-acc-group">'
+        f'<{acc} id="bench-acc">'
+        f'<{acc_trigger} id="bench-acc-trigger">Details</{acc_trigger}>'
+        f'<{acc_content} id="bench-acc-content">'
+        f'<{tab_group} id="bench-tabs">'
+        f'<{tab_list} id="bench-tab-list">'
+        f'<{tab} id="bench-tab-1" panel="bench-tab-panel-1">Data</{tab}>'
+        f"</{tab_list}>"
+        f'<{tab_panel} id="bench-tab-panel-1">{inner}</{tab_panel}>'
+        f"</{tab_group}>"
+        f"</{acc_content}>"
+        f"</{acc}>"
+        f"</{acc_group}>"
+        f"</{modal_body}>"
+        f'<{modal_footer} id="bench-modal-footer">Close</{modal_footer}>'
+        f"</{modal}>"
+    )
+
+
+def _cards_dropdown_popover_tooltip(side: int) -> str:
+    (
+        card,
+        card_header,
+        card_body,
+        card_footer,
+        drawer,
+        drawer_header,
+        drawer_body,
+        drawer_footer,
+        popover,
+        dropdown,
+        tooltip,
+        tooltip_trigger,
+        tooltip_content,
+    ) = (
+        _tag("card", side),
+        _tag("card_header", side),
+        _tag("card_body", side),
+        _tag("card_footer", side),
+        _tag("drawer", side),
+        _tag("drawer_header", side),
+        _tag("drawer_body", side),
+        _tag("drawer_footer", side),
+        _tag("popover", side),
+        _tag("dropdown", side),
+        _tag("tooltip", side),
+        _tag("tooltip_trigger", side),
+        _tag("tooltip_content", side),
+    )
+    return (
+        f'<{card} id="bench-card">'
+        f'<{card_header} id="bench-card-header">Overview</{card_header}>'
+        f'<{card_body} id="bench-card-body">Summary text.</{card_body}>'
+        f'<{card_footer} id="bench-card-footer">'
+        f'<{popover} id="bench-popover"/>'
+        f'<{dropdown} id="bench-dropdown" trigger="More"/>'
+        f'<{tooltip} id="bench-tooltip">'
+        f'<{tooltip_trigger} id="bench-tooltip-trigger">?</{tooltip_trigger}>'
+        f'<{tooltip_content} id="bench-tooltip-content">Help text</{tooltip_content}>'
+        f"</{tooltip}>"
+        f"</{card_footer}>"
+        f"</{card}>"
+        f'<{drawer} id="bench-drawer">'
+        f'<{drawer_header} id="bench-drawer-header">Filters</{drawer_header}>'
+        f'<{drawer_body} id="bench-drawer-body">Body</{drawer_body}>'
+        f'<{drawer_footer} id="bench-drawer-footer">Close</{drawer_footer}>'
+        f"</{drawer}>"
+    )
+
+
+def _data_nav(side: int) -> str:
+    pag, region, page, lazy = (
+        _tag("paginator", side),
+        _tag("region_loader", side),
+        _tag("page_loader", side),
+        _tag("lazy_load", side),
+    )
+    return (
+        f'<{pag} id="bench-paginator" page="2" total_pages="10" url="/bench"/>'
+        f'<{region} id="bench-region-loader"/>'
+        f'<{page} id="bench-page-loader"/>'
+        f'<{lazy} id="bench-lazy-load" url="/bench/more"/>'
+    )
+
+
+def _js_heavy_tail(side: int) -> str:
+    (
+        carousel,
+        slide,
+        notification,
+        toast_host,
+        alert,
+        resizable_group,
+        resizable_handle,
+        resizable_panel,
+    ) = (
+        _tag("carousel", side),
+        _tag("carousel_slide", side),
+        _tag("notification", side),
+        _tag("toast_host", side),
+        _tag("alert", side),
+        _tag("resizable_group", side),
+        _tag("resizable_handle", side),
+        _tag("resizable_panel", side),
+    )
+    return (
+        f'<{carousel} id="bench-carousel">'
+        f'<{slide} id="bench-slide-1">One</{slide}>'
+        f'<{slide} id="bench-slide-2">Two</{slide}>'
+        f"</{carousel}>"
+        f'<{notification} id="bench-notification">Saved</{notification}>'
+        f'<{toast_host} id="bench-toast-host"/>'
+        f'<{alert} id="bench-alert">Heads up</{alert}>'
+        f'<{resizable_group} id="bench-resizable">'
+        f'<{resizable_panel} id="bench-resizable-panel-1">Left</{resizable_panel}>'
+        f'<{resizable_handle} id="bench-resizable-handle"/>'
+        f'<{resizable_panel} id="bench-resizable-panel-2">Right</{resizable_panel}>'
+        f"</{resizable_group}>"
+    )
+
+
+def _page(rows: int, side: int) -> str:
+    """The full builtin-heavy page: one composition spanning all five L4 families."""
+    table_and_data = _table(rows, side) + _data_nav(side)
+    body = (
+        _display_primitives(side)
+        + _form_block(side)
+        + _shells(table_and_data, side)
+        + _cards_dropdown_popover_tooltip(side)
+        + _js_heavy_tail(side)
+    )
+    return f'<div id="bench-root">{body}</div>'
+
+
+def build_v0_page(rows: int) -> str:
+    return _page(rows, V0_SIDE)
+
+
+def build_v2_page(rows: int) -> str:
+    return _page(rows, V2_SIDE)
+
+
+def build_v0_table(rows: int) -> str:
+    return _table(rows, V0_SIDE) + _data_nav(V0_SIDE)
+
+
+def build_v2_table(rows: int) -> str:
+    return _table(rows, V2_SIDE) + _data_nav(V2_SIDE)
+
+
+def build_v0_shells() -> str:
+    return _shells(_cards_dropdown_popover_tooltip(V0_SIDE), V0_SIDE)
+
+
+def build_v2_shells() -> str:
+    return _shells(_cards_dropdown_popover_tooltip(V2_SIDE), V2_SIDE)

--- a/tests/fixtures/bench_builtin_heavy.py
+++ b/tests/fixtures/bench_builtin_heavy.py
@@ -26,6 +26,19 @@ Jinja's `autoescape=True` unescaped, so a markup string nested more than one
 custom tag deep silently renders as escaped text on the v2 side — a
 pre-existing renderer gap, not something #537 is scoped to fix (its
 non-goals explicitly rule out changing either renderer to fix a finding).
+The same gap also bites a *single* Slot passed a raw-HTML string directly
+with no custom-tag nesting at all — `PJXTableCell.content` in `_v2_table`
+below is given a literal `<input .../>` string, which v0's markup-string
+page renders as a real `<input>` element but v2 renders as escaped text
+(`&lt;input .../&gt;`). Wrapping the value in `markupsafe.Markup` does
+*not* fix it: `PJXTableCell.content` is a plain-`str`-typed Slot field, and
+pydantic's `str` coercion strips `Markup`'s `__html__` protocol back down to
+a plain `str` on assignment (confirmed by direct construction), so the
+value re-enters the same unescaped-str code path either way. Same
+pre-existing, out-of-scope-for-#537 renderer gap as above; the two table
+cells at `c{r}b` are therefore not byte-identical across sides even though
+this doesn't affect timing (no markers or row counts depend on this cell's
+content, so `_sanity()` doesn't need to and does not check it).
 So: `build_v0_page`/`build_v0_table`/`build_v0_shells` return **markup
 strings** (v0's native shape); `build_v2_page`/`build_v2_table`/
 `build_v2_shells` return a **component instance tree** built by nesting real

--- a/tests/fixtures/bench_builtin_heavy.py
+++ b/tests/fixtures/bench_builtin_heavy.py
@@ -35,6 +35,8 @@ composition, and the one that actually renders every builtin instead of
 escaping it into inert text.
 """
 
+from collections.abc import Sequence
+
 from pyjinhx2.builtins.pjx_lazy_load import PJXLazyLoad
 from pyjinhx2.builtins.pjx_page_loader import PJXPageLoader
 from pyjinhx2.builtins.pjx_paginator import PJXPaginator
@@ -362,9 +364,9 @@ class BenchMulti(BaseComponent):
     items: Slot = ""
 
 
-def _multi(id_: str, items: list[BaseComponent]) -> BaseComponent:
+def _multi(id_: str, items: "Sequence[BaseComponent]") -> BaseComponent:
     """``items[0]`` unwrapped when there is only one, else a BenchMulti host."""
-    return items[0] if len(items) == 1 else BenchMulti(id=id_, items=items)
+    return items[0] if len(items) == 1 else BenchMulti(id=id_, items=list(items))
 
 
 def _v2_display_primitives() -> list[BaseComponent]:

--- a/tests/fixtures/bench_builtin_heavy.py
+++ b/tests/fixtures/bench_builtin_heavy.py
@@ -1,357 +1,597 @@
 """Shared "builtin-heavy page" used by scripts/bench_v0_vs_v2.py (issue #537).
 
-One composition covering all five L4 builtin families, expressed twice —
-once against pyjinhx v0.36.4 tags, once against pyjinhx2 tags — so the two
-renderers are timed on the same page. Both packages happen to spell every
-shared builtin's tag identically (PascalCase class name, e.g. ``PJXTable``),
-so ``TAGS`` maps every logical name to the *same* string on both sides today;
-the mapping still exists so a future rename during the port stays visible in
-one place instead of silently skewing the bench.
+One composition covering all five L4 builtin families, expressed twice — once
+against pyjinhx v0.36.4, once against pyjinhx2 — so the two renderers are
+timed on the same logical page.
 
 Excluded builtins (present in v0.36.4 but not ported to v2, so dropped from
-BOTH sides to keep the comparison 1:1 — confirmed via
-``diff <(ls pyjinhx/builtins/ui) <(ls pyjinhx2/builtins/ui)`` against the
-v0.36.4 tag, issue #537 Task 0): see EXCLUDED_FROM_BOTH below.
+BOTH sides to keep the comparison 1:1 — confirmed via a v0.36.4-tag vs
+pyjinhx2/builtins/ui diff, issue #537 Task 0): PJXConfirmDialog,
+PJXPromptDialog. v2 also splits PJXPopover into a trigger/panel pair that
+v0.36.4 does not have; this fixture uses only the bare, self-closing
+PJXPopover root on both sides.
 
-v2 also splits ``PJXPopover`` into a trigger/panel pair
-(``PJXPopoverTrigger``/``PJXPopoverPanel``) that v0.36.4 does not have; this
-fixture uses only the bare, self-closing ``PJXPopover`` root on both sides so
-the page stays expressible identically without inventing v0-side children
-that were never ported.
+**Why the two sides are built differently (deviation from the plan's original
+single-markup-string design):** v0.36 (`pyjinhx.Renderer.render(source: str)`)
+expands PascalCase tags recursively at any nesting depth from one markup
+string — a flat string works for the whole page. pyjinhx2's tag scanner
+(`segments.VerbatimParser`) deliberately cuts only the *outermost* open
+component tag per parse and leaves what is nested inside it verbatim "for a
+later level's parse to deal with" (see `segments.py`); that later level's
+parse only sees the nested tags if the string carrying them survives into the
+child's own template unescaped. As verified with a throwaway two-line
+repro (`<PJXCard><PJXCardBody>...` one level deep, run outside this fixture
+during Task 3's exploration) plain `str`-typed Slot content does *not* survive
+Jinja's `autoescape=True` unescaped, so a markup string nested more than one
+custom tag deep silently renders as escaped text on the v2 side — a
+pre-existing renderer gap, not something #537 is scoped to fix (its
+non-goals explicitly rule out changing either renderer to fix a finding).
+So: `build_v0_page`/`build_v0_table`/`build_v0_shells` return **markup
+strings** (v0's native shape); `build_v2_page`/`build_v2_table`/
+`build_v2_shells` return a **component instance tree** built by nesting real
+`pyjinhx2.builtins` classes directly in Python — the shape v2's own test
+suite (e.g. `test_family_composed_shells_sweep.py`) uses for multi-level
+composition, and the one that actually renders every builtin instead of
+escaping it into inert text.
 """
+
+from pyjinhx2.builtins.pjx_lazy_load import PJXLazyLoad
+from pyjinhx2.builtins.pjx_page_loader import PJXPageLoader
+from pyjinhx2.builtins.pjx_paginator import PJXPaginator
+from pyjinhx2.builtins.pjx_region_loader import PJXRegionLoader
+from pyjinhx2.builtins.pjx_table import PJXTable
+from pyjinhx2.builtins.pjx_table_body import PJXTableBody
+from pyjinhx2.builtins.pjx_table_cell import PJXTableCell
+from pyjinhx2.builtins.pjx_table_head import PJXTableHead
+from pyjinhx2.builtins.pjx_table_header_cell import PJXTableHeaderCell
+from pyjinhx2.builtins.pjx_table_row import PJXTableRow
+from pyjinhx2.builtins.ui.pjx_accordion import PJXAccordion
+from pyjinhx2.builtins.ui.pjx_accordion_content import PJXAccordionContent
+from pyjinhx2.builtins.ui.pjx_accordion_group import PJXAccordionGroup
+from pyjinhx2.builtins.ui.pjx_accordion_trigger import PJXAccordionTrigger
+from pyjinhx2.builtins.ui.pjx_alert import PJXAlert
+from pyjinhx2.builtins.ui.pjx_avatar import PJXAvatar
+from pyjinhx2.builtins.ui.pjx_avatar_stack import PJXAvatarStack
+from pyjinhx2.builtins.ui.pjx_badge import PJXBadge
+from pyjinhx2.builtins.ui.pjx_breadcrumb import PJXBreadcrumb
+from pyjinhx2.builtins.ui.pjx_button import PJXButton
+from pyjinhx2.builtins.ui.pjx_card import PJXCard
+from pyjinhx2.builtins.ui.pjx_card_body import PJXCardBody
+from pyjinhx2.builtins.ui.pjx_card_footer import PJXCardFooter
+from pyjinhx2.builtins.ui.pjx_card_header import PJXCardHeader
+from pyjinhx2.builtins.ui.pjx_carousel import PJXCarousel
+from pyjinhx2.builtins.ui.pjx_carousel_slide import PJXCarouselSlide
+from pyjinhx2.builtins.ui.pjx_chip_input import PJXChipInput
+from pyjinhx2.builtins.ui.pjx_divider import PJXDivider
+from pyjinhx2.builtins.ui.pjx_drawer import PJXDrawer
+from pyjinhx2.builtins.ui.pjx_drawer_body import PJXDrawerBody
+from pyjinhx2.builtins.ui.pjx_drawer_footer import PJXDrawerFooter
+from pyjinhx2.builtins.ui.pjx_drawer_header import PJXDrawerHeader
+from pyjinhx2.builtins.ui.pjx_dropdown import PJXDropdown
+from pyjinhx2.builtins.ui.pjx_form_field import PJXFormField
+from pyjinhx2.builtins.ui.pjx_icon import PJXIcon
+from pyjinhx2.builtins.ui.pjx_modal import PJXModal
+from pyjinhx2.builtins.ui.pjx_modal_body import PJXModalBody
+from pyjinhx2.builtins.ui.pjx_modal_footer import PJXModalFooter
+from pyjinhx2.builtins.ui.pjx_modal_header import PJXModalHeader
+from pyjinhx2.builtins.ui.pjx_notification import PJXNotification
+from pyjinhx2.builtins.ui.pjx_password_input import PJXPasswordInput
+from pyjinhx2.builtins.ui.pjx_popover import PJXPopover
+from pyjinhx2.builtins.ui.pjx_progress import PJXProgress
+from pyjinhx2.builtins.ui.pjx_resizable_group import PJXResizableGroup
+from pyjinhx2.builtins.ui.pjx_resizable_handle import PJXResizableHandle
+from pyjinhx2.builtins.ui.pjx_resizable_panel import PJXResizablePanel
+from pyjinhx2.builtins.ui.pjx_segmented_control import PJXSegmentedControl
+from pyjinhx2.builtins.ui.pjx_skeleton import PJXSkeleton
+from pyjinhx2.builtins.ui.pjx_spinner import PJXSpinner
+from pyjinhx2.builtins.ui.pjx_tab import PJXTab
+from pyjinhx2.builtins.ui.pjx_tab_group import PJXTabGroup
+from pyjinhx2.builtins.ui.pjx_tab_list import PJXTabList
+from pyjinhx2.builtins.ui.pjx_tab_panel import PJXTabPanel
+from pyjinhx2.builtins.ui.pjx_toast_host import PJXToastHost
+from pyjinhx2.builtins.ui.pjx_toggle_switch import PJXToggleSwitch
+from pyjinhx2.builtins.ui.pjx_tooltip import PJXTooltip
+from pyjinhx2.builtins.ui.pjx_tooltip_content import PJXTooltipContent
+from pyjinhx2.builtins.ui.pjx_tooltip_trigger import PJXTooltipTrigger
+from pyjinhx2.component import BaseComponent, Slot
 
 EXCLUDED_FROM_BOTH = (
     "PJXConfirmDialog",
     "PJXPromptDialog",
 )
 
-# Logical name -> (v0.36 tag, v2 tag). Identical today; the mapping exists so
-# a rename during the port stays visible instead of silently skewing the bench.
-TAGS: dict[str, tuple[str, str]] = {
-    # Display primitives (L4.1)
-    "icon": ("PJXIcon", "PJXIcon"),
-    "badge": ("PJXBadge", "PJXBadge"),
-    "avatar": ("PJXAvatar", "PJXAvatar"),
-    "avatar_stack": ("PJXAvatarStack", "PJXAvatarStack"),
-    "divider": ("PJXDivider", "PJXDivider"),
-    "progress": ("PJXProgress", "PJXProgress"),
-    "skeleton": ("PJXSkeleton", "PJXSkeleton"),
-    "spinner": ("PJXSpinner", "PJXSpinner"),
-    "breadcrumb": ("PJXBreadcrumb", "PJXBreadcrumb"),
-    # Forms (L4.2)
-    "button": ("PJXButton", "PJXButton"),
-    "form_field": ("PJXFormField", "PJXFormField"),
-    "password_input": ("PJXPasswordInput", "PJXPasswordInput"),
-    "chip_input": ("PJXChipInput", "PJXChipInput"),
-    "segmented_control": ("PJXSegmentedControl", "PJXSegmentedControl"),
-    "toggle_switch": ("PJXToggleSwitch", "PJXToggleSwitch"),
-    # Composed shells (L4.3)
-    "card": ("PJXCard", "PJXCard"),
-    "card_header": ("PJXCardHeader", "PJXCardHeader"),
-    "card_body": ("PJXCardBody", "PJXCardBody"),
-    "card_footer": ("PJXCardFooter", "PJXCardFooter"),
-    "modal": ("PJXModal", "PJXModal"),
-    "modal_header": ("PJXModalHeader", "PJXModalHeader"),
-    "modal_body": ("PJXModalBody", "PJXModalBody"),
-    "modal_footer": ("PJXModalFooter", "PJXModalFooter"),
-    "drawer": ("PJXDrawer", "PJXDrawer"),
-    "drawer_header": ("PJXDrawerHeader", "PJXDrawerHeader"),
-    "drawer_body": ("PJXDrawerBody", "PJXDrawerBody"),
-    "drawer_footer": ("PJXDrawerFooter", "PJXDrawerFooter"),
-    "accordion": ("PJXAccordion", "PJXAccordion"),
-    "accordion_group": ("PJXAccordionGroup", "PJXAccordionGroup"),
-    "accordion_trigger": ("PJXAccordionTrigger", "PJXAccordionTrigger"),
-    "accordion_content": ("PJXAccordionContent", "PJXAccordionContent"),
-    "tab": ("PJXTab", "PJXTab"),
-    "tab_group": ("PJXTabGroup", "PJXTabGroup"),
-    "tab_list": ("PJXTabList", "PJXTabList"),
-    "tab_panel": ("PJXTabPanel", "PJXTabPanel"),
-    "popover": ("PJXPopover", "PJXPopover"),
-    "dropdown": ("PJXDropdown", "PJXDropdown"),
-    "tooltip": ("PJXTooltip", "PJXTooltip"),
-    "tooltip_trigger": ("PJXTooltipTrigger", "PJXTooltipTrigger"),
-    "tooltip_content": ("PJXTooltipContent", "PJXTooltipContent"),
-    # Table / paginator / loaders (L4.4)
-    "table": ("PJXTable", "PJXTable"),
-    "table_body": ("PJXTableBody", "PJXTableBody"),
-    "table_head": ("PJXTableHead", "PJXTableHead"),
-    "table_header_cell": ("PJXTableHeaderCell", "PJXTableHeaderCell"),
-    "table_row": ("PJXTableRow", "PJXTableRow"),
-    "table_cell": ("PJXTableCell", "PJXTableCell"),
-    "paginator": ("PJXPaginator", "PJXPaginator"),
-    "region_loader": ("PJXRegionLoader", "PJXRegionLoader"),
-    "page_loader": ("PJXPageLoader", "PJXPageLoader"),
-    "lazy_load": ("PJXLazyLoad", "PJXLazyLoad"),
-    # JS-heavy tail (L4.5)
-    "carousel": ("PJXCarousel", "PJXCarousel"),
-    "carousel_slide": ("PJXCarouselSlide", "PJXCarouselSlide"),
-    "notification": ("PJXNotification", "PJXNotification"),
-    "toast_host": ("PJXToastHost", "PJXToastHost"),
-    "alert": ("PJXAlert", "PJXAlert"),
-    "resizable_group": ("PJXResizableGroup", "PJXResizableGroup"),
-    "resizable_handle": ("PJXResizableHandle", "PJXResizableHandle"),
-    "resizable_panel": ("PJXResizablePanel", "PJXResizablePanel"),
+# Logical name -> v0.36 tag string. v2's manifest (V2_MANIFEST, below) holds
+# the same names as the class __name__ values actually placed in the v2 tree
+# — both lists are the identical set of strings today; the split exists so a
+# future rename during the port stays visible in one place.
+V0_TAGS: dict[str, str] = {
+    "icon": "PJXIcon",
+    "badge": "PJXBadge",
+    "avatar": "PJXAvatar",
+    "avatar_stack": "PJXAvatarStack",
+    "divider": "PJXDivider",
+    "progress": "PJXProgress",
+    "skeleton": "PJXSkeleton",
+    "spinner": "PJXSpinner",
+    "breadcrumb": "PJXBreadcrumb",
+    "button": "PJXButton",
+    "form_field": "PJXFormField",
+    "password_input": "PJXPasswordInput",
+    "chip_input": "PJXChipInput",
+    "segmented_control": "PJXSegmentedControl",
+    "toggle_switch": "PJXToggleSwitch",
+    "card": "PJXCard",
+    "card_header": "PJXCardHeader",
+    "card_body": "PJXCardBody",
+    "card_footer": "PJXCardFooter",
+    "modal": "PJXModal",
+    "modal_header": "PJXModalHeader",
+    "modal_body": "PJXModalBody",
+    "modal_footer": "PJXModalFooter",
+    "drawer": "PJXDrawer",
+    "drawer_header": "PJXDrawerHeader",
+    "drawer_body": "PJXDrawerBody",
+    "drawer_footer": "PJXDrawerFooter",
+    "accordion": "PJXAccordion",
+    "accordion_group": "PJXAccordionGroup",
+    "accordion_trigger": "PJXAccordionTrigger",
+    "accordion_content": "PJXAccordionContent",
+    "tab": "PJXTab",
+    "tab_group": "PJXTabGroup",
+    "tab_list": "PJXTabList",
+    "tab_panel": "PJXTabPanel",
+    "popover": "PJXPopover",
+    "dropdown": "PJXDropdown",
+    "tooltip": "PJXTooltip",
+    "tooltip_trigger": "PJXTooltipTrigger",
+    "tooltip_content": "PJXTooltipContent",
+    "table": "PJXTable",
+    "table_body": "PJXTableBody",
+    "table_head": "PJXTableHead",
+    "table_header_cell": "PJXTableHeaderCell",
+    "table_row": "PJXTableRow",
+    "table_cell": "PJXTableCell",
+    "paginator": "PJXPaginator",
+    "region_loader": "PJXRegionLoader",
+    "page_loader": "PJXPageLoader",
+    "lazy_load": "PJXLazyLoad",
+    "carousel": "PJXCarousel",
+    "carousel_slide": "PJXCarouselSlide",
+    "notification": "PJXNotification",
+    "toast_host": "PJXToastHost",
+    "alert": "PJXAlert",
+    "resizable_group": "PJXResizableGroup",
+    "resizable_handle": "PJXResizableHandle",
+    "resizable_panel": "PJXResizablePanel",
 }
 
-V0_MANIFEST = [v0 for v0, _ in TAGS.values()]
-V2_MANIFEST = [v2 for _, v2 in TAGS.values()]
-
-V0_SIDE = 0
-V2_SIDE = 1
-
-
-def _tag(logical: str, side: int) -> str:
-    return TAGS[logical][side]
+V0_MANIFEST = list(V0_TAGS.values())
+# Same set of names today (see module docstring for why the v2 side is built
+# from real class instances instead of tags parsed out of markup).
+V2_MANIFEST = list(V0_TAGS.values())
 
 
-def _display_primitives(side: int) -> str:
+def component_names(component: BaseComponent) -> set[str]:
+    """Every component class name reachable from ``component``'s Slot fields.
+
+    Walks whatever the descriptor marks as slot fields, recursing into nested
+    components and the items of list/dict slot values. Used by the parity
+    test (and available to the bench script) to confirm the v2 tree actually
+    contains the manifest's components, since v2's tree is built in Python
+    rather than parsed back out of a markup string.
+    """
+    names = {type(component).__name__}
+    descriptor = component.__pjx_descriptor__
+    for field_name in descriptor.slot_fields:
+        value = getattr(component, field_name, None)
+        for item in value if isinstance(value, (list, tuple)) else (value,):
+            if isinstance(item, BaseComponent):
+                names |= component_names(item)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# v0.36 side: markup strings, v0's native shape.
+# ---------------------------------------------------------------------------
+
+
+def _v0_display_primitives() -> str:
     return (
-        f'<{_tag("icon", side)} id="p-icon" name="gear"/>'
-        f'<{_tag("badge", side)} id="p-badge" label="new" color="brand"/>'
-        f'<{_tag("avatar", side)} id="p-avatar" initials="AB"/>'
-        f'<{_tag("avatar_stack", side)} id="p-avatar-stack"/>'
-        f'<{_tag("divider", side)} id="p-divider"/>'
-        f'<{_tag("progress", side)} id="p-progress" value="42"/>'
-        f'<{_tag("skeleton", side)} id="p-skeleton"/>'
-        f'<{_tag("spinner", side)} id="p-spinner"/>'
-        f'<{_tag("breadcrumb", side)} id="p-breadcrumb"/>'
+        '<PJXIcon id="p-icon" name="settings"/>'
+        '<PJXBadge id="p-badge" label="new" color="brand"/>'
+        '<PJXAvatar id="p-avatar" initials="AB"/>'
+        '<PJXAvatarStack id="p-avatar-stack"/>'
+        '<PJXDivider id="p-divider"/>'
+        '<PJXProgress id="p-progress" value="42"/>'
+        '<PJXSkeleton id="p-skeleton"/>'
+        '<PJXSpinner id="p-spinner"/>'
+        '<PJXBreadcrumb id="p-breadcrumb"/>'
     )
 
 
-def _form_block(side: int) -> str:
-    ff, pw, chip, seg, tog, btn = (
-        _tag("form_field", side),
-        _tag("password_input", side),
-        _tag("chip_input", side),
-        _tag("segmented_control", side),
-        _tag("toggle_switch", side),
-        _tag("button", side),
-    )
+def _v0_form_block() -> str:
     return (
-        f'<{ff} id="f-password"><{pw} id="pw-input" name="password"/></{ff}>'
-        f'<{ff} id="f-chip"><{chip} id="chip-input" name="tags"/></{ff}>'
-        f'<{seg} id="f-segmented" name="mode"/>'
-        f'<{tog} id="f-toggle" name="opt-in"/>'
-        f'<{btn} id="f-submit" type="submit">Save</{btn}>'
+        '<PJXFormField id="f-password"><PJXPasswordInput id="pw-input" name="password"/></PJXFormField>'
+        '<PJXFormField id="f-chip"><PJXChipInput id="chip-input" name="tags"/></PJXFormField>'
+        '<PJXSegmentedControl id="f-segmented" name="mode"/>'
+        '<PJXToggleSwitch id="f-toggle" name="opt-in"/>'
+        '<PJXButton id="f-submit" type="submit">Save</PJXButton>'
     )
 
 
-def _table(rows: int, side: int) -> str:
-    t, tb, th, thc, tr, td = (
-        _tag("table", side),
-        _tag("table_body", side),
-        _tag("table_head", side),
-        _tag("table_header_cell", side),
-        _tag("table_row", side),
-        _tag("table_cell", side),
-    )
+def _v0_table(rows: int) -> str:
     parts = [
-        f'<{t} id="bench-table">'
-        f'<{th} id="bench-thead"><{tr} id="head-row">'
-        f'<{thc} id="hc-name">Name</{thc}>'
-        f'<{thc} id="hc-value">Value</{thc}>'
-        f'<{thc} id="hc-score">Score</{thc}>'
-        f"</{tr}></{th}>"
-        f'<{tb} id="bench-tbody">'
+        (
+            '<PJXTable id="bench-table">'
+            '<PJXTableHead id="bench-thead"><PJXTableRow id="head-row">'
+            '<PJXTableHeaderCell id="hc-name">Name</PJXTableHeaderCell>'
+            '<PJXTableHeaderCell id="hc-value">Value</PJXTableHeaderCell>'
+            '<PJXTableHeaderCell id="hc-score">Score</PJXTableHeaderCell>'
+            "</PJXTableRow></PJXTableHead>"
+            '<PJXTableBody id="bench-tbody">'
+        )
     ]
     for r in range(rows):
         parts.append(
-            f'<{tr} id="r{r}">'
-            f'<{td} id="c{r}a">name {r}</{td}>'
-            f'<{td} id="c{r}b"><input type="text" value="v{r}"/></{td}>'
-            f'<{td} id="c{r}c">{r * 3}</{td}>'
-            f"</{tr}>"
+            f'<PJXTableRow id="r{r}">'
+            f'<PJXTableCell id="c{r}a">name {r}</PJXTableCell>'
+            f'<PJXTableCell id="c{r}b"><input type="text" value="v{r}"/></PJXTableCell>'
+            f'<PJXTableCell id="c{r}c">{r * 3}</PJXTableCell>'
+            f"</PJXTableRow>"
         )
-    parts.append(f"</{tb}></{t}>")
+    parts.append("</PJXTableBody></PJXTable>")
     return "".join(parts)
 
 
-def _shells(inner: str, side: int) -> str:
+def _v0_data_nav() -> str:
+    return (
+        '<PJXPaginator id="bench-paginator" page="2" total_pages="10" url="/bench?page={page}"/>'
+        '<PJXRegionLoader id="bench-region-loader"/>'
+        '<PJXPageLoader id="bench-page-loader"/>'
+        '<PJXLazyLoad id="bench-lazy-load" url="/bench/more"/>'
+    )
+
+
+def _v0_shells(inner: str) -> str:
     """Modal -> Accordion -> TabGroup shell nest, wrapping ``inner``."""
-    (
-        modal,
-        modal_header,
-        modal_body,
-        modal_footer,
-        acc_group,
-        acc,
-        acc_trigger,
-        acc_content,
-        tab_group,
-        tab_list,
-        tab,
-        tab_panel,
-    ) = (
-        _tag("modal", side),
-        _tag("modal_header", side),
-        _tag("modal_body", side),
-        _tag("modal_footer", side),
-        _tag("accordion_group", side),
-        _tag("accordion", side),
-        _tag("accordion_trigger", side),
-        _tag("accordion_content", side),
-        _tag("tab_group", side),
-        _tag("tab_list", side),
-        _tag("tab", side),
-        _tag("tab_panel", side),
-    )
     return (
-        f'<{modal} id="bench-modal">'
-        f'<{modal_header} id="bench-modal-header">Details</{modal_header}>'
-        f'<{modal_body} id="bench-modal-body">'
-        f'<{acc_group} id="bench-acc-group">'
-        f'<{acc} id="bench-acc">'
-        f'<{acc_trigger} id="bench-acc-trigger">Details</{acc_trigger}>'
-        f'<{acc_content} id="bench-acc-content">'
-        f'<{tab_group} id="bench-tabs">'
-        f'<{tab_list} id="bench-tab-list">'
-        f'<{tab} id="bench-tab-1" panel="bench-tab-panel-1">Data</{tab}>'
-        f"</{tab_list}>"
-        f'<{tab_panel} id="bench-tab-panel-1">{inner}</{tab_panel}>'
-        f"</{tab_group}>"
-        f"</{acc_content}>"
-        f"</{acc}>"
-        f"</{acc_group}>"
-        f"</{modal_body}>"
-        f'<{modal_footer} id="bench-modal-footer">Close</{modal_footer}>'
-        f"</{modal}>"
+        '<PJXModal id="bench-modal">'
+        '<PJXModalHeader id="bench-modal-header">Details</PJXModalHeader>'
+        '<PJXModalBody id="bench-modal-body">'
+        '<PJXAccordionGroup id="bench-acc-group">'
+        '<PJXAccordion id="bench-acc">'
+        '<PJXAccordionTrigger id="bench-acc-trigger">Details</PJXAccordionTrigger>'
+        '<PJXAccordionContent id="bench-acc-content">'
+        '<PJXTabGroup id="bench-tabs">'
+        '<PJXTabList id="bench-tab-list">'
+        '<PJXTab id="bench-tab-1" panel="bench-tab-panel-1">Data</PJXTab>'
+        "</PJXTabList>"
+        f'<PJXTabPanel id="bench-tab-panel-1">{inner}</PJXTabPanel>'
+        "</PJXTabGroup>"
+        "</PJXAccordionContent>"
+        "</PJXAccordion>"
+        "</PJXAccordionGroup>"
+        "</PJXModalBody>"
+        '<PJXModalFooter id="bench-modal-footer">Close</PJXModalFooter>'
+        "</PJXModal>"
     )
 
 
-def _cards_dropdown_popover_tooltip(side: int) -> str:
-    (
-        card,
-        card_header,
-        card_body,
-        card_footer,
-        drawer,
-        drawer_header,
-        drawer_body,
-        drawer_footer,
-        popover,
-        dropdown,
-        tooltip,
-        tooltip_trigger,
-        tooltip_content,
-    ) = (
-        _tag("card", side),
-        _tag("card_header", side),
-        _tag("card_body", side),
-        _tag("card_footer", side),
-        _tag("drawer", side),
-        _tag("drawer_header", side),
-        _tag("drawer_body", side),
-        _tag("drawer_footer", side),
-        _tag("popover", side),
-        _tag("dropdown", side),
-        _tag("tooltip", side),
-        _tag("tooltip_trigger", side),
-        _tag("tooltip_content", side),
-    )
+def _v0_cards_dropdown_popover_tooltip() -> str:
     return (
-        f'<{card} id="bench-card">'
-        f'<{card_header} id="bench-card-header">Overview</{card_header}>'
-        f'<{card_body} id="bench-card-body">Summary text.</{card_body}>'
-        f'<{card_footer} id="bench-card-footer">'
-        f'<{popover} id="bench-popover"/>'
-        f'<{dropdown} id="bench-dropdown" trigger="More"/>'
-        f'<{tooltip} id="bench-tooltip">'
-        f'<{tooltip_trigger} id="bench-tooltip-trigger">?</{tooltip_trigger}>'
-        f'<{tooltip_content} id="bench-tooltip-content">Help text</{tooltip_content}>'
-        f"</{tooltip}>"
-        f"</{card_footer}>"
-        f"</{card}>"
-        f'<{drawer} id="bench-drawer">'
-        f'<{drawer_header} id="bench-drawer-header">Filters</{drawer_header}>'
-        f'<{drawer_body} id="bench-drawer-body">Body</{drawer_body}>'
-        f'<{drawer_footer} id="bench-drawer-footer">Close</{drawer_footer}>'
-        f"</{drawer}>"
+        '<PJXCard id="bench-card">'
+        '<PJXCardHeader id="bench-card-header">Overview</PJXCardHeader>'
+        '<PJXCardBody id="bench-card-body">Summary text.</PJXCardBody>'
+        '<PJXCardFooter id="bench-card-footer">'
+        '<PJXPopover id="bench-popover"/>'
+        '<PJXDropdown id="bench-dropdown" trigger="More"/>'
+        '<PJXTooltip id="bench-tooltip">'
+        '<PJXTooltipTrigger id="bench-tooltip-trigger">?</PJXTooltipTrigger>'
+        '<PJXTooltipContent id="bench-tooltip-content">Help text</PJXTooltipContent>'
+        "</PJXTooltip>"
+        "</PJXCardFooter>"
+        "</PJXCard>"
+        '<PJXDrawer id="bench-drawer">'
+        '<PJXDrawerHeader id="bench-drawer-header">Filters</PJXDrawerHeader>'
+        '<PJXDrawerBody id="bench-drawer-body">Body</PJXDrawerBody>'
+        '<PJXDrawerFooter id="bench-drawer-footer">Close</PJXDrawerFooter>'
+        "</PJXDrawer>"
     )
 
 
-def _data_nav(side: int) -> str:
-    pag, region, page, lazy = (
-        _tag("paginator", side),
-        _tag("region_loader", side),
-        _tag("page_loader", side),
-        _tag("lazy_load", side),
-    )
+def _v0_js_heavy_tail() -> str:
     return (
-        f'<{pag} id="bench-paginator" page="2" total_pages="10" url="/bench"/>'
-        f'<{region} id="bench-region-loader"/>'
-        f'<{page} id="bench-page-loader"/>'
-        f'<{lazy} id="bench-lazy-load" url="/bench/more"/>'
+        '<PJXCarousel id="bench-carousel">'
+        '<PJXCarouselSlide id="bench-slide-1">One</PJXCarouselSlide>'
+        '<PJXCarouselSlide id="bench-slide-2">Two</PJXCarouselSlide>'
+        "</PJXCarousel>"
+        '<PJXNotification id="bench-notification">Saved</PJXNotification>'
+        '<PJXToastHost id="bench-toast-host"/>'
+        '<PJXAlert id="bench-alert">Heads up</PJXAlert>'
+        '<PJXResizableGroup id="bench-resizable">'
+        '<PJXResizablePanel id="bench-resizable-panel-1">Left</PJXResizablePanel>'
+        '<PJXResizableHandle id="bench-resizable-handle"/>'
+        '<PJXResizablePanel id="bench-resizable-panel-2">Right</PJXResizablePanel>'
+        "</PJXResizableGroup>"
     )
 
 
-def _js_heavy_tail(side: int) -> str:
-    (
-        carousel,
-        slide,
-        notification,
-        toast_host,
-        alert,
-        resizable_group,
-        resizable_handle,
-        resizable_panel,
-    ) = (
-        _tag("carousel", side),
-        _tag("carousel_slide", side),
-        _tag("notification", side),
-        _tag("toast_host", side),
-        _tag("alert", side),
-        _tag("resizable_group", side),
-        _tag("resizable_handle", side),
-        _tag("resizable_panel", side),
-    )
-    return (
-        f'<{carousel} id="bench-carousel">'
-        f'<{slide} id="bench-slide-1">One</{slide}>'
-        f'<{slide} id="bench-slide-2">Two</{slide}>'
-        f"</{carousel}>"
-        f'<{notification} id="bench-notification">Saved</{notification}>'
-        f'<{toast_host} id="bench-toast-host"/>'
-        f'<{alert} id="bench-alert">Heads up</{alert}>'
-        f'<{resizable_group} id="bench-resizable">'
-        f'<{resizable_panel} id="bench-resizable-panel-1">Left</{resizable_panel}>'
-        f'<{resizable_handle} id="bench-resizable-handle"/>'
-        f'<{resizable_panel} id="bench-resizable-panel-2">Right</{resizable_panel}>'
-        f"</{resizable_group}>"
-    )
-
-
-def _page(rows: int, side: int) -> str:
-    """The full builtin-heavy page: one composition spanning all five L4 families."""
-    table_and_data = _table(rows, side) + _data_nav(side)
+def build_v0_page(rows: int) -> str:
+    """The full builtin-heavy page (v0.36 markup string)."""
+    table_and_data = _v0_table(rows) + _v0_data_nav()
     body = (
-        _display_primitives(side)
-        + _form_block(side)
-        + _shells(table_and_data, side)
-        + _cards_dropdown_popover_tooltip(side)
-        + _js_heavy_tail(side)
+        _v0_display_primitives()
+        + _v0_form_block()
+        + _v0_shells(table_and_data)
+        + _v0_cards_dropdown_popover_tooltip()
+        + _v0_js_heavy_tail()
     )
     return f'<div id="bench-root">{body}</div>'
 
 
-def build_v0_page(rows: int) -> str:
-    return _page(rows, V0_SIDE)
-
-
-def build_v2_page(rows: int) -> str:
-    return _page(rows, V2_SIDE)
-
-
 def build_v0_table(rows: int) -> str:
-    return _table(rows, V0_SIDE) + _data_nav(V0_SIDE)
-
-
-def build_v2_table(rows: int) -> str:
-    return _table(rows, V2_SIDE) + _data_nav(V2_SIDE)
+    return _v0_table(rows) + _v0_data_nav()
 
 
 def build_v0_shells() -> str:
-    return _shells(_cards_dropdown_popover_tooltip(V0_SIDE), V0_SIDE)
+    return _v0_shells(_v0_cards_dropdown_popover_tooltip())
 
 
-def build_v2_shells() -> str:
-    return _shells(_cards_dropdown_popover_tooltip(V2_SIDE), V2_SIDE)
+# ---------------------------------------------------------------------------
+# v2 side: real component instances nested in Python (see module docstring).
+# ---------------------------------------------------------------------------
+
+
+class BenchPage(BaseComponent):
+    """Root wrapper for the v2 side. ``content`` carries the whole subtree."""
+
+    content: Slot = ""
+
+
+class BenchMulti(BaseComponent):
+    """Sibling-list wrapper for a real builtin whose own template does a bare
+    ``{{ content }}`` (no ``{% for %}``) — e.g. PJXCard's regions come from
+    PJXCardHeader/Body/Footer rendered as one field's value (see
+    pjx_card.py's own docstring), and the real test suite reaches for an
+    ad hoc multi-slot host in exactly this situation
+    (test_pjx_card.py's ``CardHost`` fixture). This is that host, generic and
+    reused everywhere this fixture needs more than one sibling under a field
+    whose template does not iterate its slot itself.
+    """
+
+    items: Slot = ""
+
+
+def _multi(id_: str, items: list[BaseComponent]) -> BaseComponent:
+    """``items[0]`` unwrapped when there is only one, else a BenchMulti host."""
+    return items[0] if len(items) == 1 else BenchMulti(id=id_, items=items)
+
+
+def _v2_display_primitives() -> list[BaseComponent]:
+    return [
+        PJXIcon(id="p-icon", name="settings"),
+        PJXBadge(id="p-badge", label="new", color="brand"),
+        PJXAvatar(id="p-avatar", initials="AB"),
+        PJXAvatarStack(id="p-avatar-stack"),
+        PJXDivider(id="p-divider"),
+        PJXProgress(id="p-progress", value=42),
+        PJXSkeleton(id="p-skeleton"),
+        PJXSpinner(id="p-spinner"),
+        PJXBreadcrumb(id="p-breadcrumb"),
+    ]
+
+
+def _v2_form_block() -> list[BaseComponent]:
+    return [
+        PJXFormField(
+            id="f-password",
+            content=PJXPasswordInput(id="pw-input", name="password"),
+        ),
+        PJXFormField(id="f-chip", content=PJXChipInput(id="chip-input", name="tags")),
+        PJXSegmentedControl(id="f-segmented", name="mode"),
+        PJXToggleSwitch(id="f-toggle", name="opt-in"),
+        PJXButton(id="f-submit", type="submit", content="Save"),
+    ]
+
+
+def _v2_table(rows: int) -> PJXTable:
+    header_cells = [
+        PJXTableHeaderCell(id="hc-name", content="Name"),
+        PJXTableHeaderCell(id="hc-value", content="Value"),
+        PJXTableHeaderCell(id="hc-score", content="Score"),
+    ]
+    row_items = [
+        PJXTableRow(
+            id=f"r{r}",
+            content=_multi(
+                f"cells-r{r}",
+                [
+                    PJXTableCell(id=f"c{r}a", content=f"name {r}"),
+                    PJXTableCell(
+                        id=f"c{r}b", content=f'<input type="text" value="v{r}"/>'
+                    ),
+                    PJXTableCell(id=f"c{r}c", content=str(r * 3)),
+                ],
+            ),
+        )
+        for r in range(rows)
+    ]
+    return PJXTable(
+        id="bench-table",
+        content=_multi(
+            "bench-table-sections",
+            [
+                PJXTableHead(
+                    id="bench-thead",
+                    content=PJXTableRow(
+                        id="head-row", content=_multi("head-row-cells", header_cells)
+                    ),
+                ),
+                PJXTableBody(
+                    id="bench-tbody", content=_multi("bench-tbody-rows", row_items)
+                ),
+            ],
+        ),
+    )
+
+
+def _v2_data_nav() -> list[BaseComponent]:
+    return [
+        PJXPaginator(
+            id="bench-paginator", page=2, total_pages=10, url="/bench?page={page}"
+        ),
+        PJXRegionLoader(id="bench-region-loader"),
+        PJXPageLoader(id="bench-page-loader"),
+        PJXLazyLoad(id="bench-lazy-load", url="/bench/more"),
+    ]
+
+
+def _v2_shells(inner: list[BaseComponent]) -> PJXModal:
+    """Modal -> Accordion -> TabGroup shell nest, wrapping ``inner``."""
+    return PJXModal(
+        id="bench-modal",
+        content=_multi(
+            "bench-modal-regions",
+            [
+                PJXModalHeader(id="bench-modal-header", content="Details"),
+                PJXModalBody(
+                    id="bench-modal-body",
+                    content=PJXAccordionGroup(
+                        id="bench-acc-group",
+                        content=PJXAccordion(
+                            id="bench-acc",
+                            content=_multi(
+                                "bench-acc-parts",
+                                [
+                                    PJXAccordionTrigger(
+                                        id="bench-acc-trigger", content="Details"
+                                    ),
+                                    PJXAccordionContent(
+                                        id="bench-acc-content",
+                                        content=PJXTabGroup(
+                                            id="bench-tabs",
+                                            content=_multi(
+                                                "bench-tabs-parts",
+                                                [
+                                                    PJXTabList(
+                                                        id="bench-tab-list",
+                                                        content=PJXTab(
+                                                            id="bench-tab-1",
+                                                            panel="bench-tab-panel-1",
+                                                            content="Data",
+                                                        ),
+                                                    ),
+                                                    PJXTabPanel(
+                                                        id="bench-tab-panel-1",
+                                                        content=_multi(
+                                                            "bench-tab-panel-1-content",
+                                                            inner,
+                                                        ),
+                                                    ),
+                                                ],
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                    ),
+                ),
+                PJXModalFooter(id="bench-modal-footer", content="Close"),
+            ],
+        ),
+    )
+
+
+def _v2_cards_dropdown_popover_tooltip() -> list[BaseComponent]:
+    return [
+        PJXCard(
+            id="bench-card",
+            content=_multi(
+                "bench-card-regions",
+                [
+                    PJXCardHeader(id="bench-card-header", content="Overview"),
+                    PJXCardBody(id="bench-card-body", content="Summary text."),
+                    PJXCardFooter(
+                        id="bench-card-footer",
+                        content=_multi(
+                            "bench-card-footer-items",
+                            [
+                                PJXPopover(id="bench-popover"),
+                                PJXDropdown(id="bench-dropdown", trigger="More"),
+                                PJXTooltip(
+                                    id="bench-tooltip",
+                                    content=[
+                                        PJXTooltipTrigger(
+                                            id="bench-tooltip-trigger", content="?"
+                                        ),
+                                        PJXTooltipContent(
+                                            id="bench-tooltip-content",
+                                            content="Help text",
+                                        ),
+                                    ],
+                                ),
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        PJXDrawer(
+            id="bench-drawer",
+            content=_multi(
+                "bench-drawer-regions",
+                [
+                    PJXDrawerHeader(id="bench-drawer-header", content="Filters"),
+                    PJXDrawerBody(id="bench-drawer-body", content="Body"),
+                    PJXDrawerFooter(id="bench-drawer-footer", content="Close"),
+                ],
+            ),
+        ),
+    ]
+
+
+def _v2_js_heavy_tail() -> list[BaseComponent]:
+    return [
+        PJXCarousel(
+            id="bench-carousel",
+            content=[
+                PJXCarouselSlide(id="bench-slide-1", content="One"),
+                PJXCarouselSlide(id="bench-slide-2", content="Two"),
+            ],
+        ),
+        PJXNotification(id="bench-notification", content="Saved"),
+        PJXToastHost(id="bench-toast-host"),
+        PJXAlert(id="bench-alert", body="Heads up"),
+        PJXResizableGroup(
+            id="bench-resizable",
+            content=[
+                PJXResizablePanel(id="bench-resizable-panel-1", content="Left"),
+                PJXResizableHandle(id="bench-resizable-handle"),
+                PJXResizablePanel(id="bench-resizable-panel-2", content="Right"),
+            ],
+        ),
+    ]
+
+
+def build_v2_page(rows: int) -> BenchPage:
+    """The full builtin-heavy page (v2 component tree, root: BenchPage)."""
+    table_and_data: list[BaseComponent] = [_v2_table(rows), *_v2_data_nav()]
+    body = [
+        *_v2_display_primitives(),
+        *_v2_form_block(),
+        _v2_shells(table_and_data),
+        *_v2_cards_dropdown_popover_tooltip(),
+        *_v2_js_heavy_tail(),
+    ]
+    return BenchPage(id="bench-root", content=body)
+
+
+def build_v2_table(rows: int) -> BenchPage:
+    return BenchPage(id="bench-root", content=[_v2_table(rows), *_v2_data_nav()])
+
+
+def build_v2_shells() -> BenchPage:
+    return BenchPage(
+        id="bench-root", content=_v2_shells(_v2_cards_dropdown_popover_tooltip())
+    )

--- a/tests/fixtures/bench_multi.pjx
+++ b/tests/fixtures/bench_multi.pjx
@@ -1,1 +1,1 @@
-<div id="{{ id }}" data-bench-multi>{% if items is string %}{{ items }}{% else %}{% for item in items %}{{ item }}{% endfor %}{% endif %}</div>
+<div id="{{ id }}" data-bench-multi>{% if items is iterable and items is not string %}{% for item in items %}{{ item }}{% endfor %}{% else %}{{ items }}{% endif %}</div>

--- a/tests/fixtures/bench_multi.pjx
+++ b/tests/fixtures/bench_multi.pjx
@@ -1,0 +1,1 @@
+<div id="{{ id }}" data-bench-multi>{% if items is string %}{{ items }}{% else %}{% for item in items %}{{ item }}{% endfor %}{% endif %}</div>

--- a/tests/fixtures/bench_page.pjx
+++ b/tests/fixtures/bench_page.pjx
@@ -1,1 +1,1 @@
-<div id="{{ id }}">{% if content is string %}{{ content }}{% else %}{% for item in content %}{{ item }}{% endfor %}{% endif %}</div>
+<div id="{{ id }}">{% if content is iterable and content is not string %}{% for item in content %}{{ item }}{% endfor %}{% else %}{{ content }}{% endif %}</div>

--- a/tests/fixtures/bench_page.pjx
+++ b/tests/fixtures/bench_page.pjx
@@ -1,0 +1,1 @@
+<div id="{{ id }}">{% if content is string %}{{ content }}{% else %}{% for item in content %}{{ item }}{% endfor %}{% endif %}</div>

--- a/tests/test_bench_fixture_parity.py
+++ b/tests/test_bench_fixture_parity.py
@@ -1,0 +1,23 @@
+"""Cheap CI guard: the v0.36 and v2 bench pages must reference the same components.
+
+Not timing-sensitive — no rendering happens here, only manifest comparison.
+"""
+
+from tests.fixtures.bench_builtin_heavy import V0_MANIFEST, V2_MANIFEST, build_v0_page, build_v2_page
+
+
+def test_manifests_are_the_same_logical_component_set() -> None:
+    assert V0_MANIFEST == V2_MANIFEST
+
+
+def test_manifest_is_not_trivially_small() -> None:
+    # Guards against someone gutting the page to make the bench look good.
+    assert len(V0_MANIFEST) >= 20
+
+
+def test_every_manifest_entry_appears_in_both_page_sources() -> None:
+    v0_src = build_v0_page(rows=3)
+    v2_src = build_v2_page(rows=3)
+    for logical in V0_MANIFEST:
+        assert logical in v0_src, f"{logical} missing from v0 page source"
+        assert logical in v2_src, f"{logical} missing from v2 page source"

--- a/tests/test_bench_fixture_parity.py
+++ b/tests/test_bench_fixture_parity.py
@@ -3,7 +3,13 @@
 Not timing-sensitive — no rendering happens here, only manifest comparison.
 """
 
-from tests.fixtures.bench_builtin_heavy import V0_MANIFEST, V2_MANIFEST, build_v0_page, build_v2_page
+from tests.fixtures.bench_builtin_heavy import (
+    V0_MANIFEST,
+    V2_MANIFEST,
+    build_v0_page,
+    build_v2_page,
+    component_names,
+)
 
 
 def test_manifests_are_the_same_logical_component_set() -> None:
@@ -16,8 +22,16 @@ def test_manifest_is_not_trivially_small() -> None:
 
 
 def test_every_manifest_entry_appears_in_both_page_sources() -> None:
+    """Every manifest tag is a substring of v0's markup, and a class in v2's tree.
+
+    v0's page is a flat markup string (its native shape); v2's page is a real
+    component instance tree (see bench_builtin_heavy's module docstring for
+    why) — so the two sides are checked differently, but assert the same
+    thing: every manifest entry is actually present on both sides.
+    """
     v0_src = build_v0_page(rows=3)
-    v2_src = build_v2_page(rows=3)
+    v2_names = component_names(build_v2_page(rows=3))
     for logical in V0_MANIFEST:
         assert logical in v0_src, f"{logical} missing from v0 page source"
-        assert logical in v2_src, f"{logical} missing from v2 page source"
+    for logical in V2_MANIFEST:
+        assert logical in v2_names, f"{logical} missing from v2 page tree"

--- a/tests/test_bench_fixture_parity.py
+++ b/tests/test_bench_fixture_parity.py
@@ -1,13 +1,25 @@
 """Cheap CI guard: the v0.36 and v2 bench pages must reference the same components.
 
-Not timing-sensitive — no rendering happens here, only manifest comparison.
+Not timing-sensitive — no rendering happens here, only manifest comparison,
+except for `test_v2_table_cell_content_is_pinned_as_escaped_not_a_bug_to_fix_here`
+below, which does render (a single small table) to pin a known, out-of-scope
+str-Slot-escaping gap (see bench_builtin_heavy's module docstring) so a
+future accidental fix to the renderer doesn't slip by unnoticed here.
 """
 
+import pkgutil
+
+import pyjinhx2.builtins
+from pyjinhx2.component import BaseComponent
+from pyjinhx2.discovery import build_registry
+from pyjinhx2.render import render as v2_render
+from pyjinhx2.session import RenderSession
 from tests.fixtures.bench_builtin_heavy import (
     V0_MANIFEST,
     V2_MANIFEST,
     build_v0_page,
     build_v2_page,
+    build_v2_table,
     component_names,
 )
 
@@ -35,3 +47,41 @@ def test_every_manifest_entry_appears_in_both_page_sources() -> None:
         assert logical in v0_src, f"{logical} missing from v0 page source"
     for logical in V2_MANIFEST:
         assert logical in v2_names, f"{logical} missing from v2 page tree"
+
+
+def _v2_registry() -> None:
+    """Import every builtin module and register the discovered classes.
+
+    Mirrors scripts/bench_v0_vs_v2.py's `_import_all_v2_builtins` /
+    `_v2_all_classes` / `build_registry` sequence — needed here because this
+    test actually renders, unlike the manifest-only tests above.
+    """
+    for module_info in pkgutil.walk_packages(
+        pyjinhx2.builtins.__path__, prefix="pyjinhx2.builtins."
+    ):
+        __import__(module_info.name)
+    found: list[type] = []
+    stack = list(BaseComponent.__subclasses__())
+    while stack:
+        cls = stack.pop()
+        found.append(cls)
+        stack.extend(cls.__subclasses__())
+    build_registry("pyjinhx2/builtins", found)
+
+
+def test_v2_table_cell_content_is_pinned_as_escaped_not_a_bug_to_fix_here() -> None:
+    """v2's table cell renders its raw-HTML Slot value escaped, unlike v0.
+
+    v0's equivalent page (`build_v0_table`) renders a live `<input>` element
+    inside this cell; v2 escapes the same markup string to inert text — a
+    pre-existing, out-of-scope-for-#537 str-Slot-escaping gap (see
+    bench_builtin_heavy's module docstring). Pinned as observed, same as
+    `test_a_string_slot_beside_a_component_slot_stays_raw_html` in
+    test_slot_semantics_matrix.py, rather than "fixed" here: wrapping the
+    value in `markupsafe.Markup` does not survive pydantic's plain-`str`
+    coercion on the Slot field, so there is no fixture-only fix available.
+    """
+    _v2_registry()
+    html = v2_render(build_v2_table(rows=1), RenderSession(template_dir="/"))
+    assert "&lt;input" in html
+    assert '<input type="text" value="v0"/>' not in html


### PR DESCRIPTION
## Summary
Add benchmarking infrastructure to compare v0.36 vs v2 performance on a builtin-heavy page, documenting the table-cell raw-HTML Slot escaping gap with fixture pins.

- feat: add v0.36 vs v2 bench script for builtin-heavy page
- fix: build v2 bench page from real component instances
- test: add shared builtin-heavy page fixture for v0 vs v2 bench
- docs: record v0.36 vs v2 bench results in roadmap

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)