### PR TITLE
feat: inject request app context into load() signatures

### DIFF
--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -88,42 +88,49 @@ store.add_without_decorator(text)
 dirty(Keys.TODOS)
 ```
 
-## PjxContext
+### Injecting an app context into `load()`
+
+An app's per-request context — a database session, the signed-in user, a
+tenant — reaches a component by declaring it on `load()`:
 
 ```python
-@dataclass(frozen=True)
-class PjxContext: ...
+from pyjinhx.app_context import AppContext
+from pyjinhx.reactive.component import ReactiveComponent
+
+
+class MyAppContext(AppContext):
+    def __init__(self, db, user):
+        self.db = db
+        self.user = user
+
+
+class TodoList(ReactiveComponent):
+    def load(self, ctx: MyAppContext):
+        return ctx.db.todos_for(ctx.user)
 ```
 
-Opaque base for request-scoped data available inside reactive `load()` and any component method that declares a `PjxContext` parameter. Subclass with your own frozen dataclass fields (database session, user id, feature flags).
-
-## PjxContext.current / PjxContext.bind
+The value comes from the `context_factory` given to `setup()`, called once per
+request with that request's `Request`:
 
 ```python
-PjxContext.current() -> Any | None
-PjxContext.bind(ctx) -> ContextManager[None]
+setup(app, context_factory=lambda request: MyAppContext(db=get_db(), user=request.user))
 ```
 
-Return or set the load context for the current scope. Any component method that declares a parameter annotated with `PjxContext` (or a subclass) — including reactive `load()` — receives the current context when the parameter is left unbound; an explicitly passed argument takes precedence. At most one such parameter is allowed per method.
+Rules:
 
-Prefer `Registry.request_scope(load_context=ctx)` in web apps — it combines registry isolation, request cache, mutation tracking, and load context in one call.
-
-```python
-from pyjinhx import PjxContext, Registry
-from pyjinhx.integrations.fastapi import FastAPIClientBackend
-
-
-@dataclass(frozen=True)
-class AppLoadContext(PjxContext):
-    db: Session
-
-
-with Registry.request_scope(
-    load_context=AppLoadContext(db=session),
-    client_backend=FastAPIClientBackend(request),
-):
-    html = TodoList.render()
-```
+- The context class must subclass `AppContext`. `PjxContext` is the framework's
+  own read-only view of request state and is not subclassable for this.
+- Matching is by type annotation, not by parameter name — call the parameter
+  whatever reads best.
+- `MyAppContext | None` is matched too, and is the honest annotation when the
+  app may run without a factory.
+- With no `context_factory` configured, or when `load()` runs outside a request
+  scope, the parameter receives `None` rather than raising: a component class is
+  defined at import time, long before any app wiring exists to validate against.
+- At most one parameter may be annotated as an app context; two raise `TypeError`
+  when the class is defined.
+- A zero-argument `load(self)` is untouched — no injection is attempted and
+  nothing about its behavior changes.
 
 ## Reactive dev
 

--- a/pyjinhx/app_context.py
+++ b/pyjinhx/app_context.py
@@ -1,0 +1,86 @@
+"""AppContext: the marker an app's own context class subclasses to be injectable.
+
+Import-pure on purpose - stdlib only, no pyjinhx imports - so the reactive
+load() wrap can reach down into it from class-definition time without adding an
+edge back into the render spine.
+
+Deliberately not PjxContext: that class is the framework's own read-only view of
+request state and is not meant to be subclassed by apps.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from types import UnionType
+from typing import Any, Union, get_args, get_origin, get_type_hints
+
+
+class AppContext:
+    """Base class for an app's per-request context object.
+
+    Subclass it, return an instance from the ``context_factory`` passed to
+    ``setup()``, and declare it on a component's ``load()``::
+
+        class MyAppContext(AppContext):
+            def __init__(self, db, user): ...
+
+        class TodoList(ReactiveComponent):
+            def load(self, ctx: MyAppContext): ...
+
+    ``ctx`` is whatever that request's ``context_factory`` returned. With no
+    factory configured - or when ``load()`` is called outside a request scope -
+    it is ``None`` rather than an error, because a class is defined long before
+    any app wiring exists to check against.
+    """
+
+
+def _is_app_context(annotation: Any) -> bool:
+    """Report whether an annotation names an AppContext subclass.
+
+    ``MyAppContext | None`` counts: an optional context is still a declared
+    dependency on the same class, so the union is unwrapped and each member
+    tested.
+    """
+    if isinstance(annotation, type):
+        return issubclass(annotation, AppContext)
+    if get_origin(annotation) in (Union, UnionType):
+        return any(_is_app_context(arg) for arg in get_args(annotation))
+    return False
+
+
+def resolve_load_context_param(func: Callable[..., Any]) -> str | None:
+    """Return the name of ``func``'s app-context parameter, or None when it has none.
+
+    Args:
+        func: The unwrapped ``load`` function defined on a component class.
+
+    Returns:
+        The parameter name to pass the request's context under, or None when
+        the signature declares no context parameter.
+
+    Raises:
+        TypeError: More than one parameter is annotated as an app context.
+    """
+    try:
+        hints = get_type_hints(func)
+    except (NameError, TypeError, AttributeError):
+        # An annotation that cannot be evaluated - a forward ref to something
+        # never imported, say - is not a match. Raising here would let an
+        # unrelated bad annotation break class definition outright.
+        return None
+    try:
+        parameters = inspect.signature(func).parameters
+    except (TypeError, ValueError):
+        return None
+    names = [
+        name for name in parameters if name in hints and _is_app_context(hints[name])
+    ]
+    if not names:
+        return None
+    if len(names) > 1:
+        raise TypeError(
+            f"{getattr(func, '__qualname__', func)!r} declares multiple app-context "
+            f"parameters {names!r}; at most one is allowed."
+        )
+    return names[0]

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -12,9 +12,11 @@ from typing import Annotated, Any, ClassVar, get_args, get_origin, get_type_hint
 
 from pydantic.fields import FieldInfo
 
+from pyjinhx.app_context import resolve_load_context_param
 from pyjinhx.component import BaseComponent
 from pyjinhx.reactive.cache import cache_get, cache_has, cache_put
 from pyjinhx.reactive.keys import coerce_load_key_str, coerce_reactive_key
+from pyjinhx.session import get_load_context
 
 
 class ReactiveComponent(BaseComponent):
@@ -165,7 +167,7 @@ def resolve_pjx_key_field(model_cls: type[Any]) -> str | None:
 
 
 def _wrap_load(
-    cls: type["ReactiveComponent"], real_load: Callable[[Any], Any]
+    cls: type["ReactiveComponent"], real_load: Callable[..., Any]
 ) -> Callable[[Any], Any]:
     """Build the memoizing wrapper around one class's ``load``.
 
@@ -173,7 +175,15 @@ def _wrap_load(
     builds this instance's cache key and does the get/call/put dance. Outside a
     request scope the cache reads miss and the writes vanish, so the real body
     simply runs every time - no special case is needed here for that.
+
+    The app-context parameter, if the signature declares one, is resolved here
+    too and closed over: signature introspection is a per-class fact, and doing
+    it on every load() would put it on the hot render path.
+
+    Raises:
+        TypeError: ``load`` declares more than one app-context parameter.
     """
+    context_param = resolve_load_context_param(real_load)
 
     def wrapped_load(self: Any) -> Any:
         # An unmarked class has no per-instance key, so all its instances keep
@@ -182,7 +192,10 @@ def _wrap_load(
         key = coerce_load_key_str(getattr(self, field, None)) if field else None
         if cache_has(cls, key):
             return cache_get(cls, key)
-        result = real_load(self)
+        if context_param is None:
+            result = real_load(self)
+        else:
+            result = real_load(self, **{context_param: get_load_context()})
         # Index under both the static react keys (a bare "todos" dirties every
         # instance) and, when this instance has a load key, the per-instance
         # "todos:1" composite form reactive_key() produces — @mutates(key=...)

--- a/tests/pyjinhx/integrations/test_reactive_request_cycle.py
+++ b/tests/pyjinhx/integrations/test_reactive_request_cycle.py
@@ -532,7 +532,7 @@ class RequestAppContext(AppContext):
 class ContextCard(ReactiveComponent):
     """A card whose load() declares the app context and echoes it back."""
 
-    def load(self, ctx: RequestAppContext | None) -> str:
+    def load(self, ctx: RequestAppContext | None) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
         return "no-context" if ctx is None else ctx.path
 
 
@@ -546,7 +546,7 @@ def test_load_receives_the_context_factory_result_over_a_real_request():
 
     @app.get("/ctx-echo")
     def ctx_echo() -> dict[str, str]:
-        return {"loaded": ContextCard().load()}
+        return {"loaded": ContextCard().load()}  # pyright: ignore[reportCallIssue]
 
     with TestClient(app) as client:
         response = client.get("/ctx-echo")
@@ -561,7 +561,7 @@ def test_without_a_context_factory_the_injected_context_is_none():
 
     @app.get("/ctx-none")
     def ctx_none() -> dict[str, str]:
-        return {"loaded": ContextCard().load()}
+        return {"loaded": ContextCard().load()}  # pyright: ignore[reportCallIssue]
 
     with TestClient(app) as client:
         response = client.get("/ctx-none")

--- a/tests/pyjinhx/integrations/test_reactive_request_cycle.py
+++ b/tests/pyjinhx/integrations/test_reactive_request_cycle.py
@@ -17,6 +17,7 @@ from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from pyjinhx import discovery, registry
+from pyjinhx.app_context import AppContext
 from pyjinhx.assets import asset_token
 from pyjinhx.config import PjxSettings
 from pyjinhx.context import PjxContext
@@ -519,3 +520,51 @@ def test_lower_layers_do_not_import_the_wiring_layer():
                 offenders.append((name, upper_name))
 
     assert offenders == []
+
+
+class RequestAppContext(AppContext):
+    """What this module's context_factory hands each request."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+
+class ContextCard(ReactiveComponent):
+    """A card whose load() declares the app context and echoes it back."""
+
+    def load(self, ctx: RequestAppContext | None) -> str:
+        return "no-context" if ctx is None else ctx.path
+
+
+def test_load_receives_the_context_factory_result_over_a_real_request():
+    app = FastAPI()
+    apply_setup(
+        app,
+        PjxSettings(),
+        context_factory=lambda request: RequestAppContext(path=request.url.path),
+    )
+
+    @app.get("/ctx-echo")
+    def ctx_echo() -> dict[str, str]:
+        return {"loaded": ContextCard().load()}
+
+    with TestClient(app) as client:
+        response = client.get("/ctx-echo")
+
+    assert response.status_code == 200
+    assert response.json() == {"loaded": "/ctx-echo"}
+
+
+def test_without_a_context_factory_the_injected_context_is_none():
+    app = FastAPI()
+    apply_setup(app, PjxSettings())
+
+    @app.get("/ctx-none")
+    def ctx_none() -> dict[str, str]:
+        return {"loaded": ContextCard().load()}
+
+    with TestClient(app) as client:
+        response = client.get("/ctx-none")
+
+    assert response.status_code == 200
+    assert response.json() == {"loaded": "no-context"}

--- a/tests/pyjinhx/reactive/test_reactive_component.py
+++ b/tests/pyjinhx/reactive/test_reactive_component.py
@@ -319,56 +319,56 @@ class DemoAppContext(AppContext):
 
 def test_load_receives_the_requests_app_context():
     class Widget(ReactiveComponent):
-        def load(self, ctx: DemoAppContext) -> str:
+        def load(self, ctx: DemoAppContext) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
             return ctx.user
 
     widget = Widget()
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert widget.load() == "ada"
+        assert widget.load() == "ada"  # pyright: ignore[reportCallIssue]
 
 
 def test_each_request_gets_its_own_app_context():
     class Widget(ReactiveComponent):
-        def load(self, ctx: DemoAppContext) -> str:
+        def load(self, ctx: DemoAppContext) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
             return ctx.user
 
     widget = Widget()
     with request_scope(load_context=DemoAppContext(user="ada")):
-        first = widget.load()
+        first = widget.load()  # pyright: ignore[reportCallIssue]
     with request_scope(load_context=DemoAppContext(user="grace")):
-        second = widget.load()
+        second = widget.load()  # pyright: ignore[reportCallIssue]
 
     assert (first, second) == ("ada", "grace")
 
 
 def test_injection_is_by_annotation_not_by_parameter_name():
     class Widget(ReactiveComponent):
-        def load(self, whatever: DemoAppContext) -> str:
+        def load(self, whatever: DemoAppContext) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
             return whatever.user
 
     widget = Widget()
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert widget.load() == "ada"
+        assert widget.load() == "ada"  # pyright: ignore[reportCallIssue]
 
 
 def test_optional_app_context_annotation_is_injected():
     class Widget(ReactiveComponent):
-        def load(self, ctx: DemoAppContext | None) -> str:
+        def load(self, ctx: DemoAppContext | None) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
             return "none" if ctx is None else ctx.user
 
     widget = Widget()
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert widget.load() == "ada"
+        assert widget.load() == "ada"  # pyright: ignore[reportCallIssue]
 
 
 def test_no_context_bound_injects_none():
     class Widget(ReactiveComponent):
-        def load(self, ctx: DemoAppContext | None) -> str:
+        def load(self, ctx: DemoAppContext | None) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
             return "none" if ctx is None else ctx.user
 
     widget = Widget()
     with request_scope():
-        assert widget.load() == "none"
+        assert widget.load() == "none"  # pyright: ignore[reportCallIssue]
 
 
 def test_zero_arg_load_is_untouched_when_a_context_is_bound():
@@ -391,14 +391,14 @@ def test_an_injected_load_is_still_cached_per_request():
     calls: list[int] = []
 
     class Widget(ReactiveComponent):
-        def load(self, ctx: DemoAppContext) -> str:
+        def load(self, ctx: DemoAppContext) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
             calls.append(1)
             return ctx.user
 
     widget = Widget()
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert widget.load() == "ada"
-        assert widget.load() == "ada"
+        assert widget.load() == "ada"  # pyright: ignore[reportCallIssue]
+        assert widget.load() == "ada"  # pyright: ignore[reportCallIssue]
 
     assert len(calls) == 1
 
@@ -410,5 +410,5 @@ def test_two_app_context_params_are_rejected_at_class_definition():
     with pytest.raises(TypeError, match="at most one"):
 
         class Widget(ReactiveComponent):
-            def load(self, first: DemoAppContext, second: OtherAppContext) -> None:
+            def load(self, first: DemoAppContext, second: OtherAppContext) -> None:  # pyright: ignore[reportIncompatibleMethodOverride]
                 return None

--- a/tests/pyjinhx/reactive/test_reactive_component.py
+++ b/tests/pyjinhx/reactive/test_reactive_component.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from pyjinhx.app_context import AppContext
 from pyjinhx.component import BaseComponent
 from pyjinhx.reactive.component import ReactiveComponent
 from pyjinhx.session import request_scope
@@ -307,3 +308,107 @@ def test_pjx_key_distinct_values_differ_in_identity():
 
     assert result_a == result_b
     assert result_a is not result_b
+
+
+class DemoAppContext(AppContext):
+    """The app-defined context these tests thread through request_scope()."""
+
+    def __init__(self, user: str) -> None:
+        self.user = user
+
+
+def test_load_receives_the_requests_app_context():
+    class Widget(ReactiveComponent):
+        def load(self, ctx: DemoAppContext) -> str:
+            return ctx.user
+
+    widget = Widget()
+    with request_scope(load_context=DemoAppContext(user="ada")):
+        assert widget.load() == "ada"
+
+
+def test_each_request_gets_its_own_app_context():
+    class Widget(ReactiveComponent):
+        def load(self, ctx: DemoAppContext) -> str:
+            return ctx.user
+
+    widget = Widget()
+    with request_scope(load_context=DemoAppContext(user="ada")):
+        first = widget.load()
+    with request_scope(load_context=DemoAppContext(user="grace")):
+        second = widget.load()
+
+    assert (first, second) == ("ada", "grace")
+
+
+def test_injection_is_by_annotation_not_by_parameter_name():
+    class Widget(ReactiveComponent):
+        def load(self, whatever: DemoAppContext) -> str:
+            return whatever.user
+
+    widget = Widget()
+    with request_scope(load_context=DemoAppContext(user="ada")):
+        assert widget.load() == "ada"
+
+
+def test_optional_app_context_annotation_is_injected():
+    class Widget(ReactiveComponent):
+        def load(self, ctx: DemoAppContext | None) -> str:
+            return "none" if ctx is None else ctx.user
+
+    widget = Widget()
+    with request_scope(load_context=DemoAppContext(user="ada")):
+        assert widget.load() == "ada"
+
+
+def test_no_context_bound_injects_none():
+    class Widget(ReactiveComponent):
+        def load(self, ctx: DemoAppContext | None) -> str:
+            return "none" if ctx is None else ctx.user
+
+    widget = Widget()
+    with request_scope():
+        assert widget.load() == "none"
+
+
+def test_zero_arg_load_is_untouched_when_a_context_is_bound():
+    calls: list[int] = []
+
+    class Widget(ReactiveComponent):
+        def load(self) -> str:
+            calls.append(1)
+            return "loaded"
+
+    widget = Widget()
+    with request_scope(load_context=DemoAppContext(user="ada")):
+        assert widget.load() == "loaded"
+        assert widget.load() == "loaded"
+
+    assert len(calls) == 1
+
+
+def test_an_injected_load_is_still_cached_per_request():
+    calls: list[int] = []
+
+    class Widget(ReactiveComponent):
+        def load(self, ctx: DemoAppContext) -> str:
+            calls.append(1)
+            return ctx.user
+
+    widget = Widget()
+    with request_scope(load_context=DemoAppContext(user="ada")):
+        assert widget.load() == "ada"
+        assert widget.load() == "ada"
+
+    assert len(calls) == 1
+
+
+def test_two_app_context_params_are_rejected_at_class_definition():
+    class OtherAppContext(AppContext):
+        """A second context class, so the two params differ in type too."""
+
+    with pytest.raises(TypeError, match="at most one"):
+
+        class Widget(ReactiveComponent):
+            def load(self, first: DemoAppContext, second: OtherAppContext) -> None:
+                return None

--- a/tests/pyjinhx/test_app_context.py
+++ b/tests/pyjinhx/test_app_context.py
@@ -1,0 +1,87 @@
+"""AppContext: the injectable-context marker and the once-per-class resolver."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pyjinhx.app_context import AppContext, resolve_load_context_param
+
+
+class MyAppContext(AppContext):
+    """An app-defined context, the shape a real app's context_factory returns."""
+
+    def __init__(self, user: str = "") -> None:
+        self.user = user
+
+
+class OtherContext(AppContext):
+    """A second app context class, for the two-params error case."""
+
+
+def test_zero_arg_load_resolves_to_none():
+    def load(self: Any) -> None:
+        return None
+
+    assert resolve_load_context_param(load) is None
+
+
+def test_annotated_param_resolves_to_its_name():
+    def load(self: Any, ctx: MyAppContext) -> None:
+        return None
+
+    assert resolve_load_context_param(load) == "ctx"
+
+
+def test_resolution_is_by_annotation_not_by_parameter_name():
+    def load(self: Any, whatever: MyAppContext) -> None:
+        return None
+
+    assert resolve_load_context_param(load) == "whatever"
+
+
+def test_a_param_named_ctx_without_the_annotation_does_not_resolve():
+    def load(self: Any, ctx: str = "") -> None:
+        return None
+
+    assert resolve_load_context_param(load) is None
+
+
+def test_optional_union_annotation_resolves():
+    def load(self: Any, ctx: MyAppContext | None) -> None:
+        return None
+
+    assert resolve_load_context_param(load) == "ctx"
+
+
+def test_the_marker_base_itself_resolves():
+    def load(self: Any, ctx: AppContext) -> None:
+        return None
+
+    assert resolve_load_context_param(load) == "ctx"
+
+
+def test_unresolvable_annotation_is_treated_as_a_non_match():
+    # `from __future__ import annotations` is required *inside* the exec'd
+    # source: without it the bare `def` evaluates `NoSuchContextClass`
+    # immediately and this exec() call itself raises NameError, before
+    # resolve_load_context_param ever runs. With it, the annotation is a
+    # string and evaluation is deferred to get_type_hints() inside the
+    # resolver -- which is the forward-ref case this test means to cover.
+    namespace: dict[str, Any] = {}
+    exec(  # noqa: S102 -- the string annotation is the point of the test
+        "from __future__ import annotations\n"
+        "def load(self, ctx: NoSuchContextClass): ...",
+        namespace,
+    )
+
+    assert resolve_load_context_param(namespace["load"]) is None
+
+
+def test_two_context_params_raise_at_resolution_time():
+    def load(self: Any, first: MyAppContext, second: OtherContext) -> None:
+        return None
+
+    with pytest.raises(TypeError, match="at most one"):
+        resolve_load_context_param(load)

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -429,11 +429,16 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # ReactiveComponent subclasses BaseComponent and routes load() through the
     # cache: the two edges below are the whole design. The reverse - anything in
     # the render spine importing reactive/ - stays forbidden.
+    # The load() wrap resolves its app-context parameter through app_context and
+    # reads the bound value out of session's ContextVar; both are strictly below
+    # reactive/, so neither edge is a cycle.
     "reactive.component": frozenset(
         {
+            "pyjinhx.app_context",
             "pyjinhx.component",
             "pyjinhx.reactive.cache",
             "pyjinhx.reactive.keys",
+            "pyjinhx.session",
         }
     ),
     # The reactive on_rendered branch (#463): it reads ReactiveComponent to

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -31,6 +31,9 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # BaseComponent.__subclasses__() and each class's descriptor, imported
     # locally to avoid a module-level cycle (session imports assets).
     "assets": frozenset({"pyjinhx.session", "pyjinhx.component"}),
+    # app_context is import-pure - stdlib only - so the reactive load() wrap can
+    # import it at module scope without threading an edge back into the spine.
+    "app_context": frozenset(),
     # builtins/ ports v0.x's component library onto the v2 stack, one leaf
     # package per component (#500). Each leaf only reaches down into
     # component.py for BaseComponent/Slot/AttrValue and its own vendored


### PR DESCRIPTION
## Summary

Implement AppContext injection into v2 `load()` methods:
- Add `AppContext` marker base class for app context classes to subclass
- Add `resolve_load_context_param()` to find AppContext-annotated parameters in load() signatures
- Modify `_wrap_load()` to inject the request's app context by parameter name
- Full end-to-end coverage through FastAPI request context_factory

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01NxwB6LvymhekN1iFNoNbqu