### PR TITLE
Define the backend-agnostic integration interface

### DIFF
--- a/pyjinhx/integrations/base.py
+++ b/pyjinhx/integrations/base.py
@@ -1,0 +1,85 @@
+"""The backend interface: what any framework adapter must provide to pyjinhx.
+
+Route adaptation is deliberately absent. Turning a handler's pjx return into a
+framework response is expressed here as to_response(), but *wiring* that onto
+routes is not: FastAPI does it by swapping APIRoute subclasses and blanking
+response_model, a Flask adapter would do it with an after_request hook, and a
+bare-WSGI one with a decorator. Nothing useful survives generalising those, so
+each backend owns its own wiring and the interface stays thin over the core
+primitives in session.py that are already framework-agnostic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol, runtime_checkable
+
+SETUP_FLAG = "pyjinhx_setup"
+"""Attribute name a backend marks an app with once setup has been applied."""
+
+ContextFactory = Callable[[Any], object | None]
+"""Turns a backend's native request object into this request's load context."""
+
+
+def load_context_for(request: object, factory: ContextFactory | None) -> object | None:
+    """Return the load context for ``request``, or None when no factory is set.
+
+    A backend passes the result to ``request_scope(load_context=...)``, which is
+    what makes it readable from ``get_load_context()`` for the life of the
+    request. An app with no factory configured is the normal case, not an error.
+    """
+    return factory(request) if factory is not None else None
+
+
+@runtime_checkable
+class IntegrationBackend(Protocol):
+    """What a framework adapter implements so ``setup()`` can wire pyjinhx in.
+
+    A backend binds one ``request_scope(load_context=...)`` per request around
+    its handler - that primitive is already framework-agnostic, so it is a
+    contract this interface states rather than a method it redeclares. The
+    methods below are the parts that genuinely differ per framework.
+
+    Calling these outside their lifecycle (``mount_static`` before setup,
+    ``on_shutdown`` without a prior ``on_startup``) is undefined: this is an
+    interface definition, not a hardened runtime, and backends are not required
+    to guard it.
+    """
+
+    def is_installed(self, app: object) -> bool:
+        """Whether setup has already been applied to ``app``.
+
+        A backend's setup returns early when this is true, so a re-entrant
+        setup cannot stack two scopes or two lifespans on one request.
+        """
+        ...
+
+    def mark_installed(self, app: object) -> None:
+        """Record that setup has been applied to ``app``."""
+        ...
+
+    def mount_static(self, app: object, directory: str) -> None:
+        """Serve the files in ``directory`` at ``/static`` on ``app``."""
+        ...
+
+    def on_startup(self, app: object) -> None:
+        """Run pyjinhx's configure step as ``app`` starts.
+
+        Two plain hooks rather than one contextmanager: chaining around an app's
+        own lifespan is an idiom each framework spells differently, so the
+        interface fixes only the call points and leaves the chaining to the
+        backend.
+        """
+        ...
+
+    def on_shutdown(self, app: object) -> None:
+        """Run pyjinhx's shutdown step as ``app`` stops."""
+        ...
+
+    def to_response(self, result: object, request: object | None) -> object:
+        """Adapt a pjx handler return into this framework's response type.
+
+        Non-pjx results pass through untouched, so a backend can call this on
+        every handler return without inspecting it first.
+        """
+        ...

--- a/tests/pyjinhx/integrations/test_base.py
+++ b/tests/pyjinhx/integrations/test_base.py
@@ -1,0 +1,172 @@
+"""The backend interface works with a fake backend and no web framework."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import pytest
+
+from pyjinhx.component import BaseComponent
+from pyjinhx.integrations.base import (
+    SETUP_FLAG,
+    ContextFactory,
+    IntegrationBackend,
+    load_context_for,
+)
+from pyjinhx.reactive.response import ReactiveResponse
+from pyjinhx.session import current_session, get_load_context, request_scope
+
+
+def test_module_has_no_web_framework_imports() -> None:
+    source = sys.modules["pyjinhx.integrations.base"].__file__
+    assert source is not None
+    with open(source, encoding="utf-8") as handle:
+        text = handle.read()
+    assert "fastapi" not in text
+    assert "starlette" not in text
+
+
+def test_setup_flag_name_is_stable() -> None:
+    assert SETUP_FLAG == "pyjinhx_setup"
+    assert IntegrationBackend is not None
+
+
+@dataclass
+class FakeApp:
+    """Stands in for a framework application object."""
+
+    installed: bool = False
+    static_mounts: list[str] = field(default_factory=list)
+    events: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FakeResponse:
+    """Stands in for a framework HTML response."""
+
+    body: str
+    headers: dict[str, str] = field(default_factory=dict)
+
+
+class FakeBackend:
+    """A backend with no web framework behind it, used to drive the interface."""
+
+    def __init__(self, context_factory: ContextFactory | None = None) -> None:
+        self.context_factory = context_factory
+
+    def is_installed(self, app: object) -> bool:
+        assert isinstance(app, FakeApp)
+        return app.installed
+
+    def mark_installed(self, app: object) -> None:
+        assert isinstance(app, FakeApp)
+        app.installed = True
+
+    def mount_static(self, app: object, directory: str) -> None:
+        assert isinstance(app, FakeApp)
+        app.static_mounts.append(directory)
+
+    def on_startup(self, app: object) -> None:
+        assert isinstance(app, FakeApp)
+        app.events.append("startup")
+
+    def on_shutdown(self, app: object) -> None:
+        assert isinstance(app, FakeApp)
+        app.events.append("shutdown")
+
+    def to_response(self, result: object, request: object | None) -> object:
+        if isinstance(result, ReactiveResponse):
+            return FakeResponse(str(result.body), dict(result.headers))
+        if isinstance(result, BaseComponent):
+            return FakeResponse(type(result).__name__)
+        return result
+
+    def handle(self, request: object, handler: Callable[[], object]) -> object:
+        """Bind one request scope around ``handler`` and adapt its return."""
+        load_context = load_context_for(request, self.context_factory)
+        with request_scope(load_context=load_context):
+            return self.to_response(handler(), request)
+
+
+def test_fake_backend_satisfies_the_protocol() -> None:
+    assert isinstance(FakeBackend(), IntegrationBackend)
+
+
+def test_load_context_is_visible_inside_the_scope_and_cleared_outside() -> None:
+    backend = FakeBackend(context_factory=lambda request: {"user": request})
+    seen: dict[str, object] = {}
+
+    def handler() -> object:
+        seen["session"] = current_session()
+        seen["context"] = get_load_context()
+        return "plain"
+
+    assert backend.handle("alice", handler) == "plain"
+    assert seen["session"] is not None
+    assert seen["context"] == {"user": "alice"}
+    assert current_session() is None
+    assert get_load_context() is None
+
+
+def test_no_context_factory_leaves_the_load_context_unset() -> None:
+    backend = FakeBackend()
+    seen: list[object] = []
+    backend.handle("bob", lambda: seen.append(get_load_context()))
+    assert seen == [None]
+
+
+def test_scope_is_reset_when_the_handler_raises() -> None:
+    backend = FakeBackend(context_factory=lambda request: request)
+
+    def boom() -> object:
+        raise ValueError("handler exploded")
+
+    with pytest.raises(ValueError, match="handler exploded"):
+        backend.handle("carol", boom)
+    assert current_session() is None
+    assert get_load_context() is None
+
+
+def test_setup_guard_reports_installed_only_after_marking() -> None:
+    backend = FakeBackend()
+    app = FakeApp()
+    assert backend.is_installed(app) is False
+    backend.mark_installed(app)
+    assert backend.is_installed(app) is True
+    backend.mark_installed(app)
+    assert backend.is_installed(app) is True
+
+
+def test_mount_static_records_the_directory() -> None:
+    backend = FakeBackend()
+    app = FakeApp()
+    backend.mount_static(app, "assets")
+    assert app.static_mounts == ["assets"]
+
+
+def test_lifecycle_hooks_fire_in_order() -> None:
+    backend = FakeBackend()
+    app = FakeApp()
+    backend.on_startup(app)
+    backend.on_shutdown(app)
+    assert app.events == ["startup", "shutdown"]
+
+
+def test_to_response_adapts_reactive_and_passes_others_through() -> None:
+    backend = FakeBackend()
+    reactive = ReactiveResponse(primary="<div>hi</div>")
+    adapted = backend.to_response(reactive, None)
+    assert isinstance(adapted, FakeResponse)
+    assert adapted.body == "<div>hi</div>"
+    assert adapted.headers == {}
+    assert backend.to_response({"json": True}, None) == {"json": True}
+
+
+def test_test_file_does_not_import_a_web_framework() -> None:
+    with open(__file__, encoding="utf-8") as handle:
+        text = handle.read()
+    banned = "fast" + "api", "star" + "lette"
+    occurrences = [name for name in banned if text.count(name) > 1]
+    assert occurrences == []

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -360,6 +360,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # render, inject_runtime, ReactiveResponse) and nothing imports it back
     # except config's deferred setup() edge.
     "integrations.__init__": frozenset(),
+    # base defines the backend-agnostic Protocol other adapters implement; it
+    # only touches session.py's request_scope() by documented contract, never
+    # by import, so it has no internal edges of its own.
+    "integrations.base": frozenset(),
     "integrations.fastapi": frozenset(
         {
             "pyjinhx.client.inject",


### PR DESCRIPTION
## Summary

- Adds IntegrationBackend, a runtime-checkable Protocol that captures framework-agnostic concerns like setup-once guards, static mounting, startup/shutdown hooks, and response adaptation
- Defines load_context_for() helper for request context factories and the SETUP_FLAG constant for marking completed setup
- Includes a throwaway fake backend in tests to demonstrate the interface works with zero fastapi/starlette imports
- Registers integrations.base in the import graph edge table (as empty, since it has no internal pyjinhx imports)

## Test plan

- 172 new lines of test coverage for the integration interface via a fake backend
- Existing integration graph tests verify the new module is properly declared
- All existing tests pass

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)