### PR TITLE
feat: gate fastapi behind a pyjinhx[fastapi] extra

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,3 +35,36 @@ jobs:
 
     - name: Typecheck pyjinhx (basedpyright, standard mode)
       run: uvx "basedpyright==1.39.9" pyjinhx/
+
+  minimal-install:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.13'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Install pyjinhx without any extra
+      run: |
+        uv venv .venv-min
+        uv pip install --python .venv-min . pytest
+
+    - name: Importing pyjinhx must not need a web framework
+      run: .venv-min/bin/python -c "import pyjinhx; import pyjinhx.config"
+
+    - name: The fastapi extra must be absent on this leg
+      run: |
+        if .venv-min/bin/python -c "import fastapi" 2>/dev/null; then
+          echo "fastapi is installed; this leg is not testing what it claims"
+          exit 1
+        fi
+
+    - name: Run the minimal-install tests
+      run: .venv-min/bin/python -m pytest tests/minimal/ -q

--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 import os
 from collections.abc import Callable
 from dataclasses import dataclass, fields, replace
+from importlib.util import find_spec as _find_spec
 from pathlib import Path
 from typing import Any
 
 from pyjinhx.component import BaseComponent
 from pyjinhx.discovery import build_registry
+from pyjinhx.integrations.base import IntegrationBackend, get_backend
 
 # Sentinel distinguishing "argument omitted" from None or a real value, so
 # setup()'s pass-through keywords never clobber an explicit settings object.
@@ -154,7 +156,8 @@ def setup(
     configure_pyjinhx(resolved)
     if app is None:
         return resolved
-    if not _is_asgi_app(app):
+    backend = _load_backend()
+    if not backend.accepts(app):  # pyright: ignore[reportAttributeAccessIssue]
         raise TypeError(
             "setup(app=...) needs a Starlette/FastAPI-like app with "
             "add_middleware and router attributes."
@@ -167,13 +170,23 @@ def setup(
     return resolved
 
 
-def _is_asgi_app(app: object) -> bool:
-    """Whether ``app`` looks like a Starlette/FastAPI application.
+def _load_backend() -> IntegrationBackend:
+    """The framework adapter ``setup(app=...)`` wires through.
 
-    Duck-typed rather than isinstance-checked so pyjinhx never imports
-    Starlette to answer a question about an object the caller already built.
+    The distribution is probed with find_spec rather than caught as an
+    ImportError from the adapter: a genuine bug inside the adapter would
+    otherwise be reported to the caller as a missing extra.
     """
-    return hasattr(app, "add_middleware") and hasattr(app, "router")
+    if _find_spec("fastapi") is None:
+        raise ImportError(
+            "setup(app=...) needs a web framework adapter, and none is "
+            "installed. Install the extra: pip install 'pyjinhx[fastapi]'."
+        )
+    import pyjinhx.integrations.fastapi  # noqa: F401  # registers the backend
+
+    backend = get_backend()
+    assert backend is not None, "importing the adapter must register a backend"
+    return backend
 
 
 def _register_components(components_root: Path | str) -> None:

--- a/pyjinhx/integrations/base.py
+++ b/pyjinhx/integrations/base.py
@@ -83,3 +83,22 @@ class IntegrationBackend(Protocol):
         every handler return without inspecting it first.
         """
         ...
+
+
+_backend: IntegrationBackend | None = None
+
+
+def register_backend(backend: IntegrationBackend) -> None:
+    """Publish ``backend`` as the adapter ``setup(app=...)`` dispatches through.
+
+    One slot, not a dict keyed by framework: a process wires pyjinhx into one
+    app, and the adapter module that registers is only imported when the caller
+    already asked for that framework.
+    """
+    global _backend
+    _backend = backend
+
+
+def get_backend() -> IntegrationBackend | None:
+    """The registered adapter, or None when no adapter module was imported."""
+    return _backend

--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -20,6 +20,11 @@ from pyjinhx.client.inject import (
 )
 from pyjinhx.component import BaseComponent
 from pyjinhx.config import PjxSettings, configure_pyjinhx, shutdown_pyjinhx
+from pyjinhx.integrations.base import (
+    SETUP_FLAG,
+    ContextFactory,
+    register_backend,
+)
 from pyjinhx.reactive.response import ReactiveResponse
 from pyjinhx.render import render
 from pyjinhx.session import current_session, request_scope
@@ -30,47 +35,118 @@ if TYPE_CHECKING:
 logger = logging.getLogger("pyjinhx")
 
 
+class FastAPIBackend:
+    """The FastAPI adapter's Protocol surface: install flag, lifecycle, static, responses.
+
+    It holds the settings because ``on_startup`` takes only the app: chaining a
+    lifespan is where configure runs, and the settings resolved by ``setup()``
+    have to reach that call somehow.
+    """
+
+    def __init__(
+        self,
+        settings: PjxSettings | None = None,
+        *,
+        context_factory: ContextFactory | None = None,
+    ) -> None:
+        self.settings = settings if settings is not None else PjxSettings()
+        self.context_factory = context_factory
+
+    def accepts(self, app: object) -> bool:
+        """Whether ``app`` is an application this adapter can wire into.
+
+        Duck-typed rather than isinstance-checked so a caller passing a plain
+        Starlette app, a sub-application or a test double is not rejected for
+        the sake of a type name.
+        """
+        return hasattr(app, "add_middleware") and hasattr(app, "router")
+
+    def is_installed(self, app: object) -> bool:
+        return bool(getattr(getattr(app, "state", None), SETUP_FLAG, False))
+
+    def mark_installed(self, app: object) -> None:
+        setattr(app.state, SETUP_FLAG, True)  # pyright: ignore[reportAttributeAccessIssue]
+
+    def mount_static(self, app: object, directory: str) -> None:
+        from starlette.staticfiles import StaticFiles
+
+        app.mount(  # pyright: ignore[reportAttributeAccessIssue]
+            "/static", StaticFiles(directory=directory), name="static"
+        )
+
+    def on_startup(self, app: object) -> None:
+        configure_pyjinhx(self.settings)
+
+    def on_shutdown(self, app: object) -> None:
+        shutdown_pyjinhx()
+
+    def to_response(self, result: object, request: object | None) -> object:
+        """Adapt a pjx handler return into an HTML response, or pass it through.
+
+        A ReactiveResponse already carries its composed body and htmx headers
+        (T2); a bare component is this request's primary render, so the runtime
+        is offered to it and inlined only when the request is not already
+        mounted (T1).
+        """
+        if isinstance(result, ReactiveResponse):
+            return HTMLResponse(str(result.body), headers=result.headers)
+        if isinstance(result, BaseComponent):
+            session = current_session()
+            # Always set: to_response only runs from inside PjxScopeMiddleware's
+            # request_scope(), which is the sole entry point for a pjx endpoint.
+            assert session is not None, "component return outside a request_scope()"
+            inject_runtime(session, request or getattr(session, "pjx_request", None))
+            return HTMLResponse(render(result, session=session))
+        return result
+
+    def chain_lifespan(self, app: Starlette) -> None:
+        """Run the startup/shutdown hooks around whatever lifespan app has.
+
+        Chaining is spelled per framework, which is why the Protocol fixes only
+        the two call points and leaves this out of the interface.
+        """
+        original = app.router.lifespan_context
+
+        @asynccontextmanager
+        async def pyjinhx_lifespan(app_instance: object):
+            self.on_startup(app_instance)
+            try:
+                if original is not None:
+                    async with original(app_instance) as state:
+                        yield state
+                else:
+                    yield
+            finally:
+                self.on_shutdown(app_instance)
+
+        app.router.lifespan_context = pyjinhx_lifespan  # pyright: ignore[reportAttributeAccessIssue]
+
+
 def apply_setup(
     app: Starlette,
     settings: PjxSettings,
     *,
     context_factory: Callable[[Any], object | None] | None = None,
 ) -> None:
-    """Wire pyjinhx into ``app``: lifespan, request scope, static files.
+    """Wire pyjinhx into ``app``: lifespan, request scope, static files, routes.
 
     Applying setup a second time to the same app is a no-op, so a re-entrant
     ``setup()`` cannot stack two scopes or two lifespans on one request.
     """
-    if getattr(app.state, "pyjinhx_setup", False):
+    backend = FastAPIBackend(settings, context_factory=context_factory)
+    if backend.is_installed(app):
         logger.warning("pyjinhx setup already applied to this app; skipping")
         return
-    _chain_lifespan(app, settings)
+    backend.chain_lifespan(app)
     app.add_middleware(PjxScopeMiddleware, context_factory=context_factory)
     if settings.static_root is not None:
-        from starlette.staticfiles import StaticFiles
-
-        app.mount("/static", StaticFiles(directory=settings.static_root), name="static")
-    _install_route_adaptation(app)
-    app.state.pyjinhx_setup = True
+        backend.mount_static(app, str(settings.static_root))
+    _install_route_adaptation(backend, app)
+    backend.mark_installed(app)
 
 
-def _chain_lifespan(app: Starlette, settings: PjxSettings) -> None:
-    """Run configure/shutdown around whatever lifespan the app already has."""
-    original = app.router.lifespan_context
-
-    @asynccontextmanager
-    async def pyjinhx_lifespan(app_instance: object):
-        configure_pyjinhx(settings)
-        try:
-            if original is not None:
-                async with original(app_instance) as state:
-                    yield state
-            else:
-                yield
-        finally:
-            shutdown_pyjinhx()
-
-    app.router.lifespan_context = pyjinhx_lifespan  # pyright: ignore[reportAttributeAccessIssue]
+_BACKEND = FastAPIBackend()
+register_backend(_BACKEND)
 
 
 class PjxScopeMiddleware(BaseHTTPMiddleware):
@@ -106,25 +182,6 @@ class PjxScopeMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
 
-def _to_response(result: object, request: Any) -> object:
-    """Adapt a pjx handler return into an HTML response, or pass it through.
-
-    A ReactiveResponse already carries its composed body and htmx headers (T2);
-    a bare component is this request's primary render, so the runtime is offered
-    to it and inlined only when the request is not already mounted (T1).
-    """
-    if isinstance(result, ReactiveResponse):
-        return HTMLResponse(str(result.body), headers=result.headers)
-    if isinstance(result, BaseComponent):
-        session = current_session()
-        # Always set: _to_response only runs from inside PjxScopeMiddleware's
-        # request_scope(), which is the sole entry point for a pjx endpoint.
-        assert session is not None, "component return outside a request_scope()"
-        inject_runtime(session, request or getattr(session, "pjx_request", None))
-        return HTMLResponse(render(result, session=session))
-    return result
-
-
 def _request_from(kwargs: dict[str, Any]) -> Any:
     """The ``Request`` argument FastAPI injected, if the handler declared one."""
     from starlette.requests import Request
@@ -135,7 +192,9 @@ def _request_from(kwargs: dict[str, Any]) -> Any:
     return None
 
 
-def _adapt_endpoint(endpoint: Callable[..., Any]) -> Callable[..., Any]:
+def _adapt_endpoint(
+    backend: FastAPIBackend, endpoint: Callable[..., Any]
+) -> Callable[..., Any]:
     """Return a version of ``endpoint`` whose pjx returns become responses."""
 
     @functools.wraps(endpoint)
@@ -143,7 +202,7 @@ def _adapt_endpoint(endpoint: Callable[..., Any]) -> Callable[..., Any]:
         result = endpoint(*args, **kwargs)
         if inspect.isawaitable(result):
             result = await result
-        return _to_response(result, _request_from(kwargs))
+        return backend.to_response(result, _request_from(kwargs))
 
     return adapted
 
@@ -160,7 +219,7 @@ def _returns_pjx(endpoint: Callable[..., Any]) -> bool:
     )
 
 
-def _install_route_adaptation(app: Starlette) -> None:
+def _install_route_adaptation(backend: FastAPIBackend, app: Starlette) -> None:
     """Adapt pjx returns for routes registered before and after setup().
 
     A handler annotated ``-> ReactiveResponse`` on a route declared before
@@ -176,10 +235,10 @@ def _install_route_adaptation(app: Starlette) -> None:
         def __init__(self, path: str, endpoint: Callable[..., Any], **kwargs: Any):
             if _returns_pjx(endpoint):
                 kwargs["response_model"] = None
-            super().__init__(path, _adapt_endpoint(endpoint), **kwargs)
+            super().__init__(path, _adapt_endpoint(backend, endpoint), **kwargs)
 
     app.router.route_class = PjxRoute  # pyright: ignore[reportAttributeAccessIssue]
     for route in app.router.routes:
         if isinstance(route, APIRoute) and route.dependant.call is not None:
-            route.dependant.call = _adapt_endpoint(route.dependant.call)
+            route.dependant.call = _adapt_endpoint(backend, route.dependant.call)
             route.app = request_response(route.get_route_handler())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ extraPaths = ["docs"]
 
 [project.optional-dependencies]
 redis = ["redis>=5.0.0", "fakeredis>=2.26.0"]
+fastapi = ["fastapi>=0.115.0", "starlette>=0.40.0"]
 
 [dependency-groups]
 dev = [

--- a/tests/minimal/test_bare_install.py
+++ b/tests/minimal/test_bare_install.py
@@ -1,0 +1,33 @@
+"""What must hold when only the base distribution is installed.
+
+Runnable against an environment with no fastapi/starlette, which is how CI's
+minimal leg runs it; it must also pass in the full dev environment, so it
+never asserts that the extra is absent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+def test_importing_pyjinhx_needs_no_web_framework() -> None:
+    import pyjinhx  # noqa: F401
+    from pyjinhx.config import PjxSettings, setup  # noqa: F401
+
+
+def test_setup_without_an_app_works() -> None:
+    from pyjinhx.config import PjxSettings, setup
+
+    resolved = setup(settings=PjxSettings(inject_htmx=False))
+    assert resolved.inject_htmx is False
+
+
+def test_setup_with_an_app_names_the_extra_when_it_is_missing() -> None:
+    from pyjinhx.config import setup
+
+    if importlib.util.find_spec("fastapi") is not None:
+        pytest.skip("the fastapi extra is installed in this environment")
+    with pytest.raises(ImportError, match=r"pyjinhx\[fastapi\]"):
+        setup(app=object())

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -1,10 +1,11 @@
 """The FastAPI adapter: request scope, header parsing, T1/T2 response adaptation."""
 
 from pathlib import Path
+from typing import cast
 
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
-from starlette.responses import PlainTextResponse
+from starlette.responses import HTMLResponse, PlainTextResponse
 
 from pyjinhx.component import BaseComponent
 from pyjinhx.config import PjxSettings
@@ -303,7 +304,10 @@ def test_backend_to_response_adapts_reactive_and_passes_others_through():
     from pyjinhx.integrations.fastapi import FastAPIBackend
 
     backend = FastAPIBackend(_settings())
-    adapted = backend.to_response(ReactiveResponse(primary="<div>hi</div>"), None)
+    adapted = cast(
+        HTMLResponse,
+        backend.to_response(ReactiveResponse(primary="<div>hi</div>"), None),
+    )
     assert adapted.status_code == 200
     assert adapted.body == b"<div>hi</div>"
     assert backend.to_response({"json": True}, None) == {"json": True}

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -256,3 +256,61 @@ def test_non_pjx_returns_pass_through_untouched():
         plain = client.get("/plain")
         assert plain.text == "raw"
         assert plain.headers["content-type"].startswith("text/plain")
+
+
+def test_backend_satisfies_the_integration_protocol():
+    from pyjinhx.integrations.base import IntegrationBackend
+    from pyjinhx.integrations.fastapi import FastAPIBackend
+
+    assert isinstance(FastAPIBackend(_settings()), IntegrationBackend)
+
+
+def test_backend_install_flag_uses_the_shared_setup_flag_name():
+    from pyjinhx.integrations.base import SETUP_FLAG
+    from pyjinhx.integrations.fastapi import FastAPIBackend
+
+    app = FastAPI()
+    backend = FastAPIBackend(_settings())
+    assert backend.is_installed(app) is False
+    backend.mark_installed(app)
+    assert getattr(app.state, SETUP_FLAG) is True
+    assert backend.is_installed(app) is True
+
+
+def test_backend_mount_static_serves_the_directory(tmp_path: Path):
+    from pyjinhx.integrations.fastapi import FastAPIBackend
+
+    (tmp_path / "app.css").write_text("body{}", encoding="utf-8")
+    app = FastAPI()
+    FastAPIBackend(_settings()).mount_static(app, str(tmp_path))
+    with TestClient(app) as client:
+        assert client.get("/static/app.css").status_code == 200
+
+
+def test_backend_startup_and_shutdown_move_the_process_settings(tmp_path: Path):
+    from pyjinhx.config import current_settings
+    from pyjinhx.integrations.fastapi import FastAPIBackend
+
+    app = FastAPI()
+    backend = FastAPIBackend(_settings(static_root=str(tmp_path)))
+    backend.on_startup(app)
+    assert current_settings().static_root == str(tmp_path)
+    backend.on_shutdown(app)
+    assert current_settings().static_root is None
+
+
+def test_backend_to_response_adapts_reactive_and_passes_others_through():
+    from pyjinhx.integrations.fastapi import FastAPIBackend
+
+    backend = FastAPIBackend(_settings())
+    adapted = backend.to_response(ReactiveResponse(primary="<div>hi</div>"), None)
+    assert adapted.status_code == 200
+    assert adapted.body == b"<div>hi</div>"
+    assert backend.to_response({"json": True}, None) == {"json": True}
+
+
+def test_registering_the_module_publishes_a_backend():
+    import pyjinhx.integrations.fastapi  # noqa: F401
+    from pyjinhx.integrations.base import IntegrationBackend, get_backend
+
+    assert isinstance(get_backend(), IntegrationBackend)

--- a/tests/pyjinhx/integrations/test_registry.py
+++ b/tests/pyjinhx/integrations/test_registry.py
@@ -1,0 +1,67 @@
+"""The one-slot backend registry: no web framework required to exercise it."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyjinhx.integrations.base import (
+    IntegrationBackend,
+    get_backend,
+    register_backend,
+)
+
+
+class StubBackend:
+    """Minimal Protocol conformer, so the registry can be driven standalone."""
+
+    def is_installed(self, app: object) -> bool:
+        return False
+
+    def mark_installed(self, app: object) -> None:
+        return None
+
+    def mount_static(self, app: object, directory: str) -> None:
+        return None
+
+    def on_startup(self, app: object) -> None:
+        return None
+
+    def on_shutdown(self, app: object) -> None:
+        return None
+
+    def to_response(self, result: object, request: object | None) -> object:
+        return result
+
+
+@pytest.fixture
+def clean_registry():
+    """Restore whatever backend the process already had registered."""
+    from pyjinhx.integrations import base
+
+    previous = base._backend
+    yield
+    base._backend = previous
+
+
+def test_registering_a_backend_makes_it_retrievable(clean_registry) -> None:
+    backend = StubBackend()
+    register_backend(backend)
+    assert get_backend() is backend
+
+
+def test_registering_again_replaces_the_slot(clean_registry) -> None:
+    first, second = StubBackend(), StubBackend()
+    register_backend(first)
+    register_backend(second)
+    assert get_backend() is second
+
+
+def test_no_backend_registered_returns_none(clean_registry) -> None:
+    from pyjinhx.integrations import base
+
+    base._backend = None
+    assert get_backend() is None
+
+
+def test_stub_backend_satisfies_the_protocol() -> None:
+    assert isinstance(StubBackend(), IntegrationBackend)

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -336,6 +336,7 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
             "pyjinhx.component",
             "pyjinhx.discovery",
             "pyjinhx.dev",
+            "pyjinhx.integrations.base",
             "pyjinhx.integrations.fastapi",
         }
     ),

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -358,7 +358,8 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # The framework adapter sits at the very top with config: it orchestrates
     # the request cycle by calling published entry points (request_scope,
     # render, inject_runtime, ReactiveResponse) and nothing imports it back
-    # except config's deferred setup() edge.
+    # except config's deferred setup() edge. It reads integrations.base for the
+    # Protocol's shared names and to register itself at import time.
     "integrations.__init__": frozenset(),
     # base defines the backend-agnostic Protocol other adapters implement; it
     # only touches session.py's request_scope() by documented contract, never
@@ -369,6 +370,7 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
             "pyjinhx.client.inject",
             "pyjinhx.component",
             "pyjinhx.config",
+            "pyjinhx.integrations.base",
             "pyjinhx.reactive.response",
             "pyjinhx.render",
             "pyjinhx.session",

--- a/tests/pyjinhx/test_setup_backend_dispatch.py
+++ b/tests/pyjinhx/test_setup_backend_dispatch.py
@@ -1,0 +1,41 @@
+"""setup(app=...) dispatches through the registered backend, or says why it can't."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyjinhx import config
+from pyjinhx.config import PjxSettings, setup
+
+
+def test_setup_without_an_app_needs_no_backend(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(config, "_find_spec", lambda name: None)
+    resolved = setup(settings=PjxSettings(inject_htmx=False))
+    assert resolved.inject_htmx is False
+
+
+def test_setup_with_an_app_and_no_extra_names_the_extra(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(config, "_find_spec", lambda name: None)
+    with pytest.raises(ImportError, match=r"pyjinhx\[fastapi\]"):
+        setup(app=object())
+
+
+def test_setup_rejects_an_app_the_backend_does_not_accept():
+    with pytest.raises(TypeError, match="add_middleware"):
+        setup(app=object())
+
+
+def test_setup_wires_a_fastapi_app_through_the_backend():
+    from fastapi import FastAPI
+
+    from pyjinhx.integrations.base import SETUP_FLAG
+
+    app = FastAPI()
+    setup(app=app)
+    assert getattr(app.state, SETUP_FLAG) is True
+    assert any(
+        middleware.cls.__name__ == "PjxScopeMiddleware"  # pyright: ignore[reportAttributeAccessIssue]
+        for middleware in app.user_middleware
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -671,6 +671,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+    { name = "starlette" },
+]
 redis = [
     { name = "fakeredis" },
     { name = "redis" },
@@ -693,12 +697,14 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fakeredis", marker = "extra == 'redis'", specifier = ">=2.26.0" },
+    { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.115.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "markupsafe", specifier = ">=3.0.3" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
+    { name = "starlette", marker = "extra == 'fastapi'", specifier = ">=0.40.0" },
 ]
-provides-extras = ["redis"]
+provides-extras = ["redis", "fastapi"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Implement a one-slot backend registry to decouple FastAPI integration from core
- Gate FastAPI behind `pyjinhx[fastapi]` optional dependency extra
- Add minimal-install CI leg to test core without FastAPI
- Dispatch `setup(app=...)` through registered backend interface
- Add type cast for HTMLResponse to satisfy basedpyright

## Test count

6 commits included; all existing tests pass with the new architecture.

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)