### PR TITLE
fix(config): respect an already-registered backend before probing fastapi

### DIFF
--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -173,10 +173,18 @@ def setup(
 def _load_backend() -> IntegrationBackend:
     """The framework adapter ``setup(app=...)`` wires through.
 
+    An already-registered backend wins outright: importing an adapter is how a
+    backend normally gets registered, so a caller that registered its own would
+    otherwise be overruled by whatever the fastapi probe finds.
+
     The distribution is probed with find_spec rather than caught as an
     ImportError from the adapter: a genuine bug inside the adapter would
     otherwise be reported to the caller as a missing extra.
     """
+    registered = get_backend()
+    if registered is not None:
+        return registered
+
     if _find_spec("fastapi") is None:
         raise ImportError(
             "setup(app=...) needs a web framework adapter, and none is "

--- a/tests/pyjinhx/test_setup_backend_dispatch.py
+++ b/tests/pyjinhx/test_setup_backend_dispatch.py
@@ -8,6 +8,18 @@ from pyjinhx import config
 from pyjinhx.config import PjxSettings, setup
 
 
+@pytest.fixture(autouse=True)
+def _empty_backend_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test in this file with no backend registered.
+
+    Without this, whichever test in the full suite happens to import the
+    fastapi adapter first leaves the module-global registry populated for the
+    rest of the process, so tests here that expect the no-backend fall-through
+    path become order-dependent on what ran before them.
+    """
+    _reset_registry(monkeypatch)
+
+
 def test_setup_without_an_app_needs_no_backend(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(config, "_find_spec", lambda name: None)
     resolved = setup(settings=PjxSettings(inject_htmx=False))

--- a/tests/pyjinhx/test_setup_backend_dispatch.py
+++ b/tests/pyjinhx/test_setup_backend_dispatch.py
@@ -39,3 +39,107 @@ def test_setup_wires_a_fastapi_app_through_the_backend():
         middleware.cls.__name__ == "PjxScopeMiddleware"  # pyright: ignore[reportAttributeAccessIssue]
         for middleware in app.user_middleware
     )
+
+
+def _reset_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty the one-slot backend registry for the duration of a test.
+
+    Also evicts ``pyjinhx.integrations.fastapi`` from ``sys.modules``: once any
+    earlier test in this file has imported it (e.g.
+    ``test_setup_wires_a_fastapi_app_through_the_backend``), a bare
+    ``import pyjinhx.integrations.fastapi`` is a cache hit that does not
+    re-execute the module body, so ``register_backend(_BACKEND)`` never runs
+    again and ``_load_backend()``'s ``assert backend is not None`` trips even
+    though the fall-through path is otherwise exercised correctly. Deleting
+    the module from ``sys.modules`` forces the next import to re-run it.
+    """
+    import sys
+
+    from pyjinhx.integrations import base
+
+    monkeypatch.setattr(base, "_backend", None)
+    monkeypatch.delitem(sys.modules, "pyjinhx.integrations.fastapi", raising=False)
+
+
+class _SentinelBackend:
+    """A backend object that is not the FastAPI one, to prove identity."""
+
+    def is_installed(self, app: object) -> bool:
+        return False
+
+    def mark_installed(self, app: object) -> None: ...
+
+    def mount_static(self, app: object, directory: str) -> None: ...
+
+    def on_startup(self, app: object) -> None: ...
+
+    def on_shutdown(self, app: object) -> None: ...
+
+    def to_response(self, result: object, request: object | None) -> object:
+        return result
+
+
+def test_load_backend_returns_an_already_registered_backend(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from pyjinhx.integrations.base import IntegrationBackend, register_backend
+
+    _reset_registry(monkeypatch)
+
+    def _no_probe(name: str):
+        raise AssertionError(f"_find_spec must not be called, got {name!r}")
+
+    monkeypatch.setattr(config, "_find_spec", _no_probe)
+
+    sentinel = _SentinelBackend()
+    assert isinstance(sentinel, IntegrationBackend)
+    register_backend(sentinel)
+
+    assert config._load_backend() is sentinel
+
+
+def test_load_backend_does_not_import_the_adapter_when_one_is_registered(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import builtins
+
+    from pyjinhx.integrations.base import register_backend
+
+    _reset_registry(monkeypatch)
+    monkeypatch.setattr(config, "_find_spec", lambda name: object())
+
+    real_import = builtins.__import__
+    imported: list[str] = []
+
+    def _tracking_import(name: str, *args: object, **kwargs: object):
+        imported.append(name)
+        return real_import(name, *args, **kwargs)  # pyright: ignore[reportArgumentType]
+
+    monkeypatch.setattr(builtins, "__import__", _tracking_import)
+
+    sentinel = _SentinelBackend()
+    register_backend(sentinel)
+
+    assert config._load_backend() is sentinel
+    assert not any(name.startswith("pyjinhx.integrations.fastapi") for name in imported)
+
+
+def test_load_backend_imports_the_adapter_when_nothing_is_registered(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_registry(monkeypatch)
+    monkeypatch.setattr(config, "_find_spec", lambda name: object())
+
+    from pyjinhx.integrations.fastapi import _BACKEND
+
+    assert config._load_backend() is _BACKEND
+
+
+def test_load_backend_names_the_extra_when_nothing_is_registered(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_registry(monkeypatch)
+    monkeypatch.setattr(config, "_find_spec", lambda name: None)
+
+    with pytest.raises(ImportError, match=r"pyjinhx\[fastapi\]"):
+        config._load_backend()


### PR DESCRIPTION
## Summary
- Fix configuration registry behavior to respect an already-registered backend before probing fastapi
- Add test to pin the registry-first behavior

Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)