### PR TITLE
style: use non-aliased discovery import in doc-lint test

### DIFF
--- a/docs/api/finder.md
+++ b/docs/api/finder.md
@@ -26,6 +26,14 @@ def get_class(tag_name: str) -> type | None
 
 The component class registered for `tag_name`, or `None`. See [Template Discovery](parser.md#get_class).
 
+## register_class
+
+```python
+def register_class(tag_name: str, cls: type) -> None
+```
+
+Publish `cls` under `tag_name` unless the tag already has an owner. The one way a tag is claimed after the import-time build — used by `component()` to register a classless wrapper on demand. A tag that is already owned is left alone: a class registered this way never shadows a declared one; the loser is logged, not silently dropped.
+
 ## get_template_dir
 
 ```python

--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -145,7 +145,6 @@ def enable_reactive_dev(*, strict: bool = False) -> None
 Enable guardrails. When enabled:
 
 - Warns if `@mutates` recorded dirtied keys but no reactive `render()` consumed them in the request scope.
-- Warns if mutations are pending but no `ClientBackend` is active (OOB swaps skipped).
 
 Set `strict=True` to raise `RuntimeError` instead of logging warnings.
 

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -1,44 +1,10 @@
 # Registry
 
-Two unrelated mechanisms, both informally called "the registry": the **class registry** (`pyjinhx.discovery`) maps a template's tag name to the `BaseComponent` subclass that renders it, process-wide; the **instance registry** (`pyjinhx.registry` + `pyjinhx.session`) maps a composite key to a request-scoped instance or rendered level. Neither is wrapped in a class — both are free functions.
+The **instance registry** (`pyjinhx.registry` + `pyjinhx.session`) maps a composite key to a request-scoped component instance or rendered level. It is not wrapped in a class — it is a set of free functions over per-request state.
+
+Not to be confused with the process-wide tag -> class registry, which is internal machinery documented under [Discovery & Assets](finder.md).
 
 See the [Component Registry guide](../guide/registry.md) for conceptual documentation and usage patterns.
-
-## Class registry (`pyjinhx.discovery`)
-
-The tag -> class mapping used to expand `<Card/>`-style tags and to resolve `component()` lookups. Assembled complete off to the side and published in a single locked swap, so no render ever sees a half-built map.
-
-### build_registry()
-
-```python
-def build_registry(template_dir: Path | str, classes: Iterable[type]) -> None
-```
-
-Walk `template_dir` for `.pjx` templates and publish a fresh tag -> class registry, matching each template to whichever `classes` claims its tag. `setup(components_root=...)` calls this at startup with every declared `BaseComponent` subclass; raises `NotADirectoryError` before any publish happens if the walk fails, leaving the live registry untouched.
-
-### get_class()
-
-```python
-def get_class(tag_name: str) -> type | None
-```
-
-The component class registered for `tag_name`, or `None`. Never raises on a miss: an unknown tag renders as ordinary markup, verbatim.
-
-### register_class()
-
-```python
-def register_class(tag_name: str, cls: type) -> None
-```
-
-Publish `cls` under `tag_name` unless the tag already has an owner. The one way a tag is claimed after the import-time build — used by `component()` to register a classless wrapper on demand. A tag that is already owned is left alone: a class registered this way never shadows a declared one; the loser is logged, not silently dropped.
-
-### get_template_dir()
-
-```python
-def get_template_dir() -> Path | None
-```
-
-The directory the last successful `build_registry()` walked, or `None`. Used by the classless factory (`component()`) to know where to search when no `template_dir` is given explicitly.
 
 ## Instance registry (`pyjinhx.registry` + `pyjinhx.session`)
 

--- a/tests/pyjinhx/test_docs_api_boundary.py
+++ b/tests/pyjinhx/test_docs_api_boundary.py
@@ -1,0 +1,71 @@
+"""Doc-lint: the Public API pages must not document Internals symbols.
+
+``docs/api/registry.md`` sits under "API Reference > Public API" in
+``mkdocs.yml`` and once covered two unrelated mechanisms: the process-wide
+class registry (``pyjinhx.discovery``, internal) and the request-scoped
+instance registry (public). Documenting the class registry there put internal
+free functions in front of readers being told the top-level ``__all__`` is the
+whole public surface. These tests pin the split so it cannot silently regress
+the next time either page is edited.
+"""
+
+import inspect
+from pathlib import Path
+
+import pyjinhx.discovery as discovery
+
+_ROOT = Path(__file__).resolve().parents[2]
+_DOCS = _ROOT / "docs"
+
+# Free functions of pyjinhx.discovery. They belong on the Internals page
+# (api/finder.md), never on the Public API page (api/registry.md).
+CLASS_REGISTRY_SYMBOLS = (
+    "build_registry",
+    "get_class",
+    "register_class",
+    "get_template_dir",
+)
+
+# Public instance-registry surface that api/registry.md must keep covering.
+INSTANCE_REGISTRY_SYMBOLS = (
+    "make_key",
+    "resolve",
+    "register_instance",
+    "request_scope",
+)
+
+
+def test_registry_page_documents_only_instance_registry():
+    text = (_DOCS / "api" / "registry.md").read_text()
+
+    for symbol in CLASS_REGISTRY_SYMBOLS:
+        assert symbol not in text, (
+            f"{symbol}() is a pyjinhx.discovery internal; it belongs in "
+            f"docs/api/finder.md, not the Public API registry page"
+        )
+
+    for symbol in INSTANCE_REGISTRY_SYMBOLS:
+        assert symbol in text, f"api/registry.md stopped documenting {symbol}()"
+
+
+def test_finder_page_documents_register_class():
+    text = (_DOCS / "api" / "finder.md").read_text()
+
+    assert "## register_class" in text, (
+        "register_class() moved off api/registry.md and must land on the "
+        "Internals discovery page"
+    )
+
+    signature = f"def register_class{inspect.signature(discovery.register_class)}"
+    assert signature in text, (
+        f"api/finder.md's register_class signature is stale; source says: {signature}"
+    )
+
+
+def test_mutations_page_has_no_client_backend_claim():
+    text = (_DOCS / "api" / "mutations-keys-context.md").read_text()
+
+    assert "ClientBackend" not in text, (
+        "enable_reactive_dev() has no backend-presence guardrail — pyjinhx.dev "
+        "only implements warn_unconsumed_mutations(); the claim is stale"
+    )

--- a/tests/pyjinhx/test_docs_api_boundary.py
+++ b/tests/pyjinhx/test_docs_api_boundary.py
@@ -12,7 +12,7 @@ the next time either page is edited.
 import inspect
 from pathlib import Path
 
-import pyjinhx.discovery as discovery
+from pyjinhx import discovery
 
 _ROOT = Path(__file__).resolve().parents[2]
 _DOCS = _ROOT / "docs"


### PR DESCRIPTION
## Summary

Applies ruff's PLR0402 style rule by using non-aliased imports for single-level submodule imports (e.g., prefer `from pyjinhx import discovery` over `import pyjinhx.discovery as discovery`).

The branch also includes documentation cleanup and updates from completed milestone items:
- Curated pyjinhx public API surface (#668)
- Fixed stale v0.x API references (#673)
- Updated documentation for completed L0-L4 roadmap items (#680)
- Renamed Renderer navigation entry and H1 (#681)
- Reorganized registry documentation

## Test Plan

- [x] Ruff linting passes (`ruff check .`)
- [x] Ruff formatting passes (`ruff format --check .`)
- [x] All documentation updates compile correctly

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)