### PR TITLE
feat(client): dispatch region-loading and page-loading events instead of classList mutation

### DIFF
--- a/docs/api/client-backend.md
+++ b/docs/api/client-backend.md
@@ -55,6 +55,7 @@ Inside the scope, `get_load_context()` returns that value for the life of the re
 ```python
 from pyjinhx.session import get_load_context
 
+
 def load(self):
     request = get_load_context()
 ```

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -201,7 +201,9 @@ def index():
     session = RenderSession(template_dir="./components")
     session.css_mode = AssetMode.NONE
     session.js_mode = AssetMode.NONE
-    return str(MyApp(id="app").render(session))  # bundle already linked in layout <head>
+    return str(
+        MyApp(id="app").render(session)
+    )  # bundle already linked in layout <head>
 ```
 
 ## Asset helpers reference

--- a/pyjinhx/assets.py
+++ b/pyjinhx/assets.py
@@ -91,6 +91,8 @@ def emit_assets(
         ValueError: If a kind is in LINK mode and no resolver was given.
     """
     tags: list[str] = []
+    if session.runtime_style is not None:
+        tags.append(session.runtime_style)
     if session.css_mode is AssetMode.INLINE:
         tags += _inline_tags(session.css_assets, "<style>", "</style>")
     elif session.css_mode is AssetMode.LINK:

--- a/pyjinhx/client/__init__.py
+++ b/pyjinhx/client/__init__.py
@@ -48,7 +48,6 @@ def read_page_loader_js() -> str:
 
 def read_pjx_style_css() -> str:
     """Return the always-on runtime CSS: loading-indicator then page-loader."""
-    return (
-        LOADING_INDICATOR_CSS_PATH.read_text(encoding="utf-8")
-        + PAGE_LOADER_CSS_PATH.read_text(encoding="utf-8")
-    )
+    return LOADING_INDICATOR_CSS_PATH.read_text(
+        encoding="utf-8"
+    ) + PAGE_LOADER_CSS_PATH.read_text(encoding="utf-8")

--- a/pyjinhx/client/__init__.py
+++ b/pyjinhx/client/__init__.py
@@ -24,3 +24,31 @@ def read_vendored_htmx() -> str:
     """
     source = HTMX_RUNTIME_PATH.read_text(encoding="utf-8")
     return f"if (!window.htmx) {{\n{source}\n}}\n"
+
+
+# loading_indicator and page_loader live here rather than under builtins/ui/:
+# they have no host element, no .pjx template and no per-request descriptor
+# to gate delivery on, so the L4 lazy-asset door doesn't apply — they ship
+# unconditionally with every cold render of the runtime.
+LOADING_INDICATOR_JS_PATH = Path(__file__).parent / "loading_indicator.js"
+LOADING_INDICATOR_CSS_PATH = Path(__file__).parent / "loading_indicator.css"
+PAGE_LOADER_JS_PATH = Path(__file__).parent / "page_loader.js"
+PAGE_LOADER_CSS_PATH = Path(__file__).parent / "page_loader.css"
+
+
+def read_loading_indicator_js() -> str:
+    """Return the loading-indicator artifact's source text."""
+    return LOADING_INDICATOR_JS_PATH.read_text(encoding="utf-8")
+
+
+def read_page_loader_js() -> str:
+    """Return the page-loader artifact's source text."""
+    return PAGE_LOADER_JS_PATH.read_text(encoding="utf-8")
+
+
+def read_pjx_style_css() -> str:
+    """Return the always-on runtime CSS: loading-indicator then page-loader."""
+    return (
+        LOADING_INDICATOR_CSS_PATH.read_text(encoding="utf-8")
+        + PAGE_LOADER_CSS_PATH.read_text(encoding="utf-8")
+    )

--- a/pyjinhx/client/inject.py
+++ b/pyjinhx/client/inject.py
@@ -7,7 +7,13 @@ import logging
 from typing import Any
 
 from pyjinhx.assets import AssetMode
-from pyjinhx.client import read_pjx_runtime, read_vendored_htmx
+from pyjinhx.client import (
+    read_loading_indicator_js,
+    read_page_loader_js,
+    read_pjx_runtime,
+    read_pjx_style_css,
+    read_vendored_htmx,
+)
 from pyjinhx.session import RenderSession
 
 logger = logging.getLogger(__name__)
@@ -79,7 +85,8 @@ def inject_runtime(session: RenderSession, request: Any = None) -> None:
             None outside a request.
 
     Raises:
-        OSError: If pjx.js or the vendored htmx source cannot be read.
+        OSError: If pjx.js, the vendored htmx source, or a loading artifact
+            cannot be read.
     """
     if _is_mounted_request(request):
         return
@@ -88,10 +95,13 @@ def inject_runtime(session: RenderSession, request: Any = None) -> None:
     if session.js_mode is not AssetMode.INLINE:
         return
     # htmx first, so window.htmx exists by the time pjx.js registers its
-    # listeners; its own guard makes re-defining a page's htmx a no-op.
+    # listeners; its own guard makes re-defining a page's htmx a no-op. The two
+    # loading artifacts come last: they call pjx.region/pjx.loadingTargets.
     session.runtime_script = (
-        f"<script>{read_vendored_htmx()}{read_pjx_runtime()}</script>"
+        f"<script>{read_vendored_htmx()}{read_pjx_runtime()}"
+        f"{read_loading_indicator_js()}{read_page_loader_js()}</script>"
     )
+    session.runtime_style = f'<style id="pjx-style">{read_pjx_style_css()}</style>'
     session.runtime_injected = True
 
 

--- a/pyjinhx/client/loading_indicator.css
+++ b/pyjinhx/client/loading_indicator.css
@@ -1,0 +1,33 @@
+.pjx-loading--skeleton,
+.pjx-loading--spinner { pointer-events: none }
+.pjx-loading--skeleton {
+  color: transparent !important;
+  border-radius: var(--pjx-skeleton-radius, 6px);
+  background-image: linear-gradient(90deg,
+    var(--pjx-skeleton-color, rgba(127,127,127,.12)),
+    var(--pjx-skeleton-highlight, rgba(127,127,127,.30)) 50%,
+    var(--pjx-skeleton-color, rgba(127,127,127,.12)));
+  background-size: 200% 100%;
+  animation: pjx-shimmer var(--pjx-skeleton-speed, 1.2s) ease-in-out infinite;
+}
+.pjx-loading--skeleton * { visibility: hidden }
+.pjx-loading--spinner { position: relative }
+.pjx-loading--spinner::before {
+  content: ''; position: absolute; inset: 0;
+  background: var(--pjx-spinner-overlay, rgba(0,0,0,.45));
+  backdrop-filter: blur(var(--pjx-spinner-blur, 2px));
+  -webkit-backdrop-filter: blur(var(--pjx-spinner-blur, 2px));
+  border-radius: inherit;
+}
+.pjx-loading--spinner::after {
+  content: ''; position: absolute; top: 50%; left: 50%;
+  width: var(--pjx-spinner-size, 1.1em); height: var(--pjx-spinner-size, 1.1em);
+  margin: calc(var(--pjx-spinner-size, 1.1em) / -2) 0 0 calc(var(--pjx-spinner-size, 1.1em) / -2);
+  box-sizing: border-box;
+  border: var(--pjx-spinner-thickness, 2px) solid var(--pjx-spinner-track, rgba(255,255,255,.4));
+  border-top-color: var(--pjx-spinner-color, rgba(255,255,255,.95));
+  border-radius: 50%;
+  animation: pjx-spin var(--pjx-spinner-speed, .6s) linear infinite;
+}
+@keyframes pjx-shimmer { from { background-position: 100% 0 } to { background-position: -100% 0 } }
+@keyframes pjx-spin { to { transform: rotate(360deg) } }

--- a/pyjinhx/client/loading_indicator.js
+++ b/pyjinhx/client/loading_indicator.js
@@ -1,0 +1,21 @@
+// Applies the region loading class. Lives next to pjx.js rather than under
+// builtins/ui/ because it has no host element, no template and no descriptor:
+// it ships unconditionally with the runtime, not through the lazy-asset door.
+(function () {
+  function targets(id) {
+    var region = window.pjx && pjx.region(id);
+    return region ? pjx.loadingTargets(region) : [];
+  }
+
+  document.addEventListener("pjx:region-loading-start", function (evt) {
+    targets(evt.detail.id).forEach(function (t) {
+      t.classList.add(pjx.loadingClass(t));
+    });
+  });
+
+  document.addEventListener("pjx:region-loading-end", function (evt) {
+    targets(evt.detail.id).forEach(function (t) {
+      t.classList.remove(pjx.loadingClass(t));
+    });
+  });
+})();

--- a/pyjinhx/client/page_loader.css
+++ b/pyjinhx/client/page_loader.css
@@ -1,0 +1,1 @@
+.pjx-loading--page { cursor: progress }

--- a/pyjinhx/client/page_loader.js
+++ b/pyjinhx/client/page_loader.js
@@ -1,0 +1,10 @@
+// Applies the page-level loading class off core's page-loading events.
+(function () {
+  document.addEventListener("pjx:page-loading-start", function () {
+    document.documentElement.classList.add("pjx-loading--page");
+  });
+
+  document.addEventListener("pjx:page-loading-end", function () {
+    document.documentElement.classList.remove("pjx-loading--page");
+  });
+})();

--- a/pyjinhx/client/pjx.js
+++ b/pyjinhx/client/pjx.js
@@ -298,17 +298,18 @@
 
   var pjxPageLoading = 0;
 
-  // Toggle the page-level CSS hook. Only a class is set: the overlay markup is
-  // an L4 page-loader builtin's business, this is the state it hangs off.
+  // Toggle the page-level loading state. Only the state and the event are
+  // core's; the overlay class and its CSS belong to the page-loader artifact.
   function pjxLoaderPage(on) {
     if (on) {
       pjxPageLoading += 1;
-      document.documentElement.classList.add("pjx-loading--page");
+      pjxFire("pjx:page-loading-start", {});
       return;
     }
+    var was = pjxPageLoading;
     pjxPageLoading = Math.max(0, pjxPageLoading - 1);
-    if (pjxPageLoading === 0) {
-      document.documentElement.classList.remove("pjx-loading--page");
+    if (was > 0 && pjxPageLoading === 0) {
+      pjxFire("pjx:page-loading-end", {});
     }
   }
 

--- a/pyjinhx/client/pjx.js
+++ b/pyjinhx/client/pjx.js
@@ -2,6 +2,9 @@
 // X-PJX-Mounted/X-PJX-Assets/X-PJX-Trigger request headers on every htmx
 // request, and applies the one swap mechanic htmx core can't do natively --
 // relocating [data-pjx-asset] head assets that arrive via OOB or cold render.
+// Loading state is dispatch-only: core tracks region/page loading state and
+// fires pjx:region-loading-*/pjx:page-loading-* events, never touching
+// classList itself -- that's the loading-indicator/page-loader artifacts' job.
 (function () {
   var pjx = {};
 
@@ -113,40 +116,6 @@
         document.head.appendChild(node); // appendChild relocates body -> head
       }
     );
-  }
-
-  // Injected once so loading indicators work with zero app CSS; every visual
-  // knob is a --pjx-* custom property the app can override in its own sheet.
-  function pjxInjectStyle() {
-    if (document.getElementById("pjx-style")) {
-      return;
-    }
-    var style = document.createElement("style");
-    style.id = "pjx-style";
-    style.textContent =
-      ".pjx-loading--skeleton,.pjx-loading--spinner{pointer-events:none}" +
-      ".pjx-loading--skeleton{color:transparent !important;" +
-      "border-radius:var(--pjx-skeleton-radius,6px);background-image:linear-gradient(90deg," +
-      "var(--pjx-skeleton-color,rgba(127,127,127,.12))," +
-      "var(--pjx-skeleton-highlight,rgba(127,127,127,.30)) 50%," +
-      "var(--pjx-skeleton-color,rgba(127,127,127,.12)));background-size:200% 100%;" +
-      "animation:pjx-shimmer var(--pjx-skeleton-speed,1.2s) ease-in-out infinite}" +
-      ".pjx-loading--skeleton *{visibility:hidden}" +
-      ".pjx-loading--spinner{position:relative}" +
-      ".pjx-loading--spinner::before{content:'';position:absolute;inset:0;" +
-      "background:var(--pjx-spinner-overlay,rgba(0,0,0,.45));" +
-      "backdrop-filter:blur(var(--pjx-spinner-blur,2px));" +
-      "-webkit-backdrop-filter:blur(var(--pjx-spinner-blur,2px));border-radius:inherit}" +
-      ".pjx-loading--spinner::after{content:'';position:absolute;top:50%;left:50%;" +
-      "width:var(--pjx-spinner-size,1.1em);height:var(--pjx-spinner-size,1.1em);" +
-      "margin:calc(var(--pjx-spinner-size,1.1em)/-2) 0 0 calc(var(--pjx-spinner-size,1.1em)/-2);" +
-      "box-sizing:border-box;border:var(--pjx-spinner-thickness,2px) solid " +
-      "var(--pjx-spinner-track,rgba(255,255,255,.4));" +
-      "border-top-color:var(--pjx-spinner-color,rgba(255,255,255,.95));" +
-      "border-radius:50%;animation:pjx-spin var(--pjx-spinner-speed,.6s) linear infinite}" +
-      "@keyframes pjx-shimmer{from{background-position:100% 0}to{background-position:-100% 0}}" +
-      "@keyframes pjx-spin{to{transform:rotate(360deg)}}";
-    document.head.appendChild(style);
   }
 
   var pjxLoadingByXhr = new Map(); // xhr -> [region id, ...]
@@ -334,7 +303,6 @@
   pjx.trigger = pjxTrigger;
   pjx.applyHeadAssets = pjxApplyHeadAssets;
   pjx.promoteInlineAssets = pjxPromoteInlineAssets;
-  pjx.injectStyle = pjxInjectStyle;
   pjx.toast = pjxToast;
   pjx.loader = { page: pjxLoaderPage, region: pjxLoaderRegion };
   pjx.loadingCount = function (id) {
@@ -352,7 +320,6 @@
     );
   }
 
-  pjxInjectStyle();
   pjxPromoteInlineAssets();
   document.body.addEventListener("htmx:configRequest", pjxConfigRequest);
   document.body.addEventListener("htmx:afterRequest", pjxApplyHeadAssetsFromRequest);

--- a/pyjinhx/client/pjx.js
+++ b/pyjinhx/client/pjx.js
@@ -184,6 +184,14 @@
     return targets;
   }
 
+  // Dispatch-only, like pjxToast: applying the class is the loading-indicator
+  // artifact's job, so core stays a pure state machine over region ids.
+  function pjxFire(name, detail) {
+    document.dispatchEvent(
+      new CustomEvent(name, { detail: detail || {}, bubbles: false })
+    );
+  }
+
   function pjxLight(region, ids) {
     var id = region.getAttribute("data-pjx-id");
     if (!id || ids.indexOf(id) !== -1) {
@@ -193,11 +201,9 @@
     if (!targets.length) {
       return;
     }
-    targets.forEach(function (t) {
-      t.classList.add(pjxLoadingClass(t));
-    });
     pjxLoading[id] = (pjxLoading[id] || 0) + 1;
     ids.push(id);
+    pjxFire("pjx:region-loading-start", { id: id });
   }
 
   function pjxBeginLoading(evt) {
@@ -272,23 +278,13 @@
       return;
     }
     delete pjxLoading[id];
-    var region = pjxRegion(id);
-    if (region) {
-      pjxLoadingTargets(region).forEach(function (t) {
-        t.classList.remove(pjxLoadingClass(t));
-      });
-    }
+    pjxFire("pjx:region-loading-end", { id: id });
   }
 
   // a swap can replace a region another in-flight request still needs lit
   function pjxReapplyLoading() {
     Object.keys(pjxLoading).forEach(function (id) {
-      var region = pjxRegion(id);
-      if (region) {
-        pjxLoadingTargets(region).forEach(function (t) {
-          t.classList.add(pjxLoadingClass(t));
-        });
-      }
+      pjxFire("pjx:region-loading-start", { id: id });
     });
   }
 
@@ -343,6 +339,9 @@
   pjx.loadingCount = function (id) {
     return pjxLoading[id] || 0;
   };
+  pjx.region = pjxRegion;
+  pjx.loadingTargets = pjxLoadingTargets;
+  pjx.loadingClass = pjxLoadingClass;
   window.pjx = pjx;
 
   if (!window.htmx) {

--- a/pyjinhx/session.py
+++ b/pyjinhx/session.py
@@ -82,6 +82,9 @@ class RenderSession:
         # no path of its own. The flag is what makes a nested render — or a
         # second inject_runtime call on the same session — a no-op.
         self.runtime_script: str | None = None
+        # The always-on runtime CSS block, emitted with the other <style> tags
+        # so runtime_script stays a single pure <script>.
+        self.runtime_style: str | None = None
         self.runtime_injected: bool = False
         # A plain list, not an event bus: render fires it once per component and
         # subscribers (asset accumulation, the reactive instance registry) just

--- a/tests/pyjinhx/client/conftest.py
+++ b/tests/pyjinhx/client/conftest.py
@@ -15,7 +15,12 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from pyjinhx.client import read_pjx_runtime
+from pyjinhx.client import (
+    read_loading_indicator_js,
+    read_page_loader_js,
+    read_pjx_runtime,
+    read_pjx_style_css,
+)
 
 if TYPE_CHECKING:
     from playwright.sync_api import Page
@@ -30,7 +35,7 @@ def _require_chromium(request: pytest.FixtureRequest) -> None:
     # hit a raw Playwright launch failure instead of a clean skip. Only the
     # browser tests need chromium, so still avoid resolving `browser_type`
     # (or importing playwright) for a test that never asked for a page.
-    if "pjx_page" not in request.fixturenames:
+    if not {"pjx_page", "pjx_full_page", "page"} & set(request.fixturenames):
         return
     pytest.importorskip("playwright")
     browser_type: Any = request.getfixturevalue("browser_type")
@@ -54,6 +59,27 @@ def pjx_page(page: Page) -> Iterator[Callable[..., Page]]:
         if with_htmx:
             page.evaluate("window.htmx = {}")
         page.add_script_tag(content=read_pjx_runtime())
+        return page
+
+    yield load
+
+
+@pytest.fixture
+def pjx_full_page(page: Page) -> Iterator[Callable[..., Page]]:
+    """`pjx_page` plus everything `inject_runtime` ships: artifacts and CSS.
+
+    Separate from `pjx_page` so the core tests keep proving pjx.js alone never
+    touches classList.
+    """
+
+    def load(body: str, head: str = "", with_htmx: bool = True) -> Page:
+        page.set_content(f"<head>{head}</head><body>{body}</body>")
+        if with_htmx:
+            page.evaluate("window.htmx = {}")
+        page.add_script_tag(content=read_pjx_runtime())
+        page.add_script_tag(content=read_loading_indicator_js())
+        page.add_script_tag(content=read_page_loader_js())
+        page.add_style_tag(content=read_pjx_style_css())
         return page
 
     yield load

--- a/tests/pyjinhx/client/test_inject.py
+++ b/tests/pyjinhx/client/test_inject.py
@@ -8,7 +8,13 @@ import logging
 import pytest
 
 from pyjinhx.assets import AssetMode
-from pyjinhx.client import read_pjx_runtime, read_vendored_htmx
+from pyjinhx.client import (
+    read_loading_indicator_js,
+    read_page_loader_js,
+    read_pjx_runtime,
+    read_pjx_style_css,
+    read_vendored_htmx,
+)
 from pyjinhx.client.inject import PJX_MOUNTED_HEADER, inject_runtime
 from pyjinhx.session import RenderSession
 
@@ -29,6 +35,42 @@ def test_cold_render_injects_htmx_then_pjx():
     assert script.index("if (!window.htmx)") < script.index(read_pjx_runtime())
     assert read_vendored_htmx() in script
     assert session.runtime_injected is True
+
+
+def test_cold_render_bundles_the_loading_artifacts_into_the_same_script():
+    session = RenderSession()
+
+    inject_runtime(session)
+
+    script = session.runtime_script
+    assert script is not None
+    assert script.startswith("<script>") and script.endswith("</script>")
+    assert read_loading_indicator_js() in script
+    assert read_page_loader_js() in script
+    assert script.index(read_pjx_runtime()) < script.index(read_loading_indicator_js())
+
+
+def test_cold_render_emits_the_pjx_style_block():
+    session = RenderSession()
+
+    inject_runtime(session)
+
+    style = session.runtime_style
+    assert style is not None
+    assert style.startswith('<style id="pjx-style">') and style.endswith("</style>")
+    assert read_pjx_style_css() in style
+
+
+def test_runtime_style_survives_a_non_inline_css_mode():
+    from pyjinhx.assets import emit_assets
+
+    session = RenderSession()
+    session.css_mode = AssetMode.LINK
+
+    inject_runtime(session)
+
+    assert session.runtime_style is not None
+    assert session.runtime_style in emit_assets(session, resolver=lambda p: str(p))
 
 
 def test_request_none_is_treated_as_cold():

--- a/tests/pyjinhx/client/test_loading_artifacts.py
+++ b/tests/pyjinhx/client/test_loading_artifacts.py
@@ -16,22 +16,27 @@ def fire(page, name, detail="{}"):
 def test_region_start_applies_the_variant_class(pjx_full_page):
     page = pjx_full_page(REGION)
     fire(page, "pjx:region-loading-start", "{id: 't'}")
-    assert page.evaluate(
-        "document.querySelector('[data-pjx-id=\"t\"]').className"
-    ) == "pjx-loading--skeleton"
+    assert (
+        page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className")
+        == "pjx-loading--skeleton"
+    )
 
 
 def test_region_end_removes_the_class(pjx_full_page):
     page = pjx_full_page(REGION)
     fire(page, "pjx:region-loading-start", "{id: 't'}")
     fire(page, "pjx:region-loading-end", "{id: 't'}")
-    assert page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className") == ""
+    assert (
+        page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className") == ""
+    )
 
 
 def test_region_events_for_an_unknown_id_are_a_no_op(pjx_full_page):
     page = pjx_full_page(REGION)
     fire(page, "pjx:region-loading-start", "{id: 'nope'}")
-    assert page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className") == ""
+    assert (
+        page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className") == ""
+    )
 
 
 def test_spinner_variant_is_honoured(pjx_full_page):
@@ -39,9 +44,10 @@ def test_spinner_variant_is_honoured(pjx_full_page):
         '<div data-pjx-id="s" data-pjx-reacts="c" data-pjx-loading="spinner"></div>'
     )
     fire(page, "pjx:region-loading-start", "{id: 's'}")
-    assert page.evaluate(
-        "document.querySelector('[data-pjx-id=\"s\"]').className"
-    ) == "pjx-loading--spinner"
+    assert (
+        page.evaluate("document.querySelector('[data-pjx-id=\"s\"]').className")
+        == "pjx-loading--spinner"
+    )
 
 
 def test_page_events_toggle_the_documented_hook(pjx_full_page):

--- a/tests/pyjinhx/client/test_loading_artifacts.py
+++ b/tests/pyjinhx/client/test_loading_artifacts.py
@@ -1,0 +1,52 @@
+"""The loading-indicator / page-loader artifacts, driven by core's events."""
+
+from __future__ import annotations
+
+REGION = (
+    '<div data-pjx-id="t" data-pjx-reacts="count" data-pjx-loading="skeleton"></div>'
+)
+
+
+def fire(page, name, detail="{}"):
+    page.evaluate(
+        f"document.dispatchEvent(new CustomEvent('{name}', {{detail: {detail}}}))"
+    )
+
+
+def test_region_start_applies_the_variant_class(pjx_full_page):
+    page = pjx_full_page(REGION)
+    fire(page, "pjx:region-loading-start", "{id: 't'}")
+    assert page.evaluate(
+        "document.querySelector('[data-pjx-id=\"t\"]').className"
+    ) == "pjx-loading--skeleton"
+
+
+def test_region_end_removes_the_class(pjx_full_page):
+    page = pjx_full_page(REGION)
+    fire(page, "pjx:region-loading-start", "{id: 't'}")
+    fire(page, "pjx:region-loading-end", "{id: 't'}")
+    assert page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className") == ""
+
+
+def test_region_events_for_an_unknown_id_are_a_no_op(pjx_full_page):
+    page = pjx_full_page(REGION)
+    fire(page, "pjx:region-loading-start", "{id: 'nope'}")
+    assert page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className") == ""
+
+
+def test_spinner_variant_is_honoured(pjx_full_page):
+    page = pjx_full_page(
+        '<div data-pjx-id="s" data-pjx-reacts="c" data-pjx-loading="spinner"></div>'
+    )
+    fire(page, "pjx:region-loading-start", "{id: 's'}")
+    assert page.evaluate(
+        "document.querySelector('[data-pjx-id=\"s\"]').className"
+    ) == "pjx-loading--spinner"
+
+
+def test_page_events_toggle_the_documented_hook(pjx_full_page):
+    page = pjx_full_page("<div></div>")
+    fire(page, "pjx:page-loading-start")
+    assert page.evaluate("document.documentElement.className") == "pjx-loading--page"
+    fire(page, "pjx:page-loading-end")
+    assert page.evaluate("document.documentElement.className") == ""

--- a/tests/pyjinhx/client/test_pjx_htmx_guard.py
+++ b/tests/pyjinhx/client/test_pjx_htmx_guard.py
@@ -45,11 +45,6 @@ def test_loading_and_toast_apis_exist_without_htmx(pjx_page):
     assert page.evaluate("typeof pjx.loader.region") == "function"
 
 
-def test_style_is_injected_even_without_htmx(pjx_page):
-    page = pjx_page("<div></div>", with_htmx=False)
-    assert page.evaluate("document.querySelectorAll('#pjx-style').length") == 1
-
-
 def test_loader_and_toast_do_not_throw_without_htmx(pjx_page):
     page = pjx_page("<div></div>", with_htmx=False)
     assert (

--- a/tests/pyjinhx/client/test_pjx_loader_api.py
+++ b/tests/pyjinhx/client/test_pjx_loader_api.py
@@ -15,14 +15,14 @@ def region_classes(page):
     return page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className")
 
 
-def test_loader_page_on_sets_the_documented_css_hook(pjx_page):
-    page = pjx_page("<div></div>")
+def test_loader_page_on_sets_the_documented_css_hook(pjx_full_page):
+    page = pjx_full_page("<div></div>")
     page.evaluate("pjx.loader.page(true)")
     assert html_classes(page) == "pjx-loading--page"
 
 
-def test_loader_page_ref_counts_before_clearing(pjx_page):
-    page = pjx_page("<div></div>")
+def test_loader_page_ref_counts_before_clearing(pjx_full_page):
+    page = pjx_full_page("<div></div>")
     page.evaluate(
         "pjx.loader.page(true); pjx.loader.page(true); pjx.loader.page(false)"
     )
@@ -31,37 +31,37 @@ def test_loader_page_ref_counts_before_clearing(pjx_page):
     assert html_classes(page) == ""
 
 
-def test_loader_page_clamps_at_zero(pjx_page):
-    page = pjx_page("<div></div>")
+def test_loader_page_clamps_at_zero(pjx_full_page):
+    page = pjx_full_page("<div></div>")
     page.evaluate("pjx.loader.page(false); pjx.loader.page(false)")
     page.evaluate("pjx.loader.page(true); pjx.loader.page(false)")
     assert html_classes(page) == ""
 
 
-def test_loader_region_lights_and_clears_the_regions_targets(pjx_page):
-    page = pjx_page(REGION)
+def test_loader_region_lights_and_clears_the_regions_targets(pjx_full_page):
+    page = pjx_full_page(REGION)
     page.evaluate("pjx.loader.region('t', true)")
     assert region_classes(page) == "pjx-loading--skeleton"
     page.evaluate("pjx.loader.region('t', false)")
     assert region_classes(page) == ""
 
 
-def test_loader_region_shares_the_ref_count_with_htmx_driven_loading(pjx_page):
-    page = pjx_page(REGION)
+def test_loader_region_shares_the_ref_count_with_htmx_driven_loading(pjx_full_page):
+    page = pjx_full_page(REGION)
     page.evaluate("pjx.loader.region('t', true); pjx.loader.region('t', true)")
     assert page.evaluate("pjx.loadingCount('t')") == 2
     page.evaluate("pjx.loader.region('t', false)")
     assert region_classes(page) == "pjx-loading--skeleton"
 
 
-def test_loader_region_clamps_at_zero(pjx_page):
-    page = pjx_page(REGION)
+def test_loader_region_clamps_at_zero(pjx_full_page):
+    page = pjx_full_page(REGION)
     page.evaluate("pjx.loader.region('t', false)")
     assert page.evaluate("pjx.loadingCount('t')") == 0
     assert region_classes(page) == ""
 
 
-def test_loader_region_for_an_unknown_id_is_a_no_op(pjx_page):
-    page = pjx_page(REGION)
+def test_loader_region_for_an_unknown_id_is_a_no_op(pjx_full_page):
+    page = pjx_full_page(REGION)
     assert page.evaluate("pjx.loader.region('nope', true), 'ok'") == "ok"
     assert page.evaluate("pjx.loadingCount('nope')") == 0

--- a/tests/pyjinhx/client/test_pjx_loading.py
+++ b/tests/pyjinhx/client/test_pjx_loading.py
@@ -129,7 +129,9 @@ def test_xhr_loadend_releases_the_region(pjx_full_page):
     assert classes(page, '[data-pjx-id="t"]') == [""]
 
 
-def test_overlapping_requests_keep_the_region_lit_until_the_last_resolves(pjx_full_page):
+def test_overlapping_requests_keep_the_region_lit_until_the_last_resolves(
+    pjx_full_page,
+):
     page = pjx_full_page(BODY)
     fire(page, "#btn", name="a")
     fire(page, "#btn", name="b")
@@ -139,7 +141,9 @@ def test_overlapping_requests_keep_the_region_lit_until_the_last_resolves(pjx_fu
     assert classes(page, '[data-pjx-id="t"]') == [""]
 
 
-def test_cancelled_request_neither_lights_nor_registers_a_loadend_listener(pjx_full_page):
+def test_cancelled_request_neither_lights_nor_registers_a_loadend_listener(
+    pjx_full_page,
+):
     page = pjx_full_page(BODY)
     fire(page, "#btn", cancel=True)
     assert classes(page, '[data-pjx-id="t"]') == [""]

--- a/tests/pyjinhx/client/test_pjx_loading.py
+++ b/tests/pyjinhx/client/test_pjx_loading.py
@@ -1,4 +1,8 @@
-"""Loading indicators: which regions light on htmx:beforeRequest, and why."""
+"""Loading indicators: which regions light on htmx:beforeRequest, and why.
+
+Exercises core (event dispatch) and the loading-indicator artifact
+(class application) together, via pjx_full_page.
+"""
 
 from __future__ import annotations
 
@@ -29,8 +33,8 @@ def classes(page, selector):
     return page.evaluate(CLASSES, selector)
 
 
-def test_beforerequest_lights_a_region_reacting_to_the_dirtied_keys(pjx_page):
-    page = pjx_page(
+def test_beforerequest_lights_a_region_reacting_to_the_dirtied_keys(pjx_full_page):
+    page = pjx_full_page(
         '<div data-pjx-id="t" data-pjx-reacts="count" data-pjx-loading="skeleton">'
         '<button id="btn"></button></div>'
     )
@@ -38,8 +42,8 @@ def test_beforerequest_lights_a_region_reacting_to_the_dirtied_keys(pjx_page):
     assert classes(page, '[data-pjx-id="t"]') == ["pjx-loading--skeleton"]
 
 
-def test_beforerequest_leaves_regions_reacting_to_other_keys_dark(pjx_page):
-    page = pjx_page(
+def test_beforerequest_leaves_regions_reacting_to_other_keys_dark(pjx_full_page):
+    page = pjx_full_page(
         '<div data-pjx-id="t" data-pjx-reacts="count"><button id="btn"></button></div>'
         '<div data-pjx-id="o" data-pjx-reacts="name" data-pjx-loading="skeleton"></div>'
     )
@@ -47,8 +51,8 @@ def test_beforerequest_leaves_regions_reacting_to_other_keys_dark(pjx_page):
     assert classes(page, '[data-pjx-id="o"]') == [""]
 
 
-def test_keyed_regions_light_only_the_instance_matching_the_trigger_load(pjx_page):
-    page = pjx_page(
+def test_keyed_regions_light_only_the_instance_matching_the_trigger_load(pjx_full_page):
+    page = pjx_full_page(
         '<div data-pjx-id="t" data-pjx-reacts="rows" data-pjx-load="7">'
         '<button id="btn"></button></div>'
         '<div data-pjx-id="r7" data-pjx-reacts="rows" data-pjx-load="7" data-pjx-loading="skeleton"></div>'
@@ -59,8 +63,8 @@ def test_keyed_regions_light_only_the_instance_matching_the_trigger_load(pjx_pag
     assert classes(page, '[data-pjx-id="r8"]') == [""]
 
 
-def test_nested_reactive_region_targets_are_not_owned_by_the_parent(pjx_page):
-    page = pjx_page(
+def test_nested_reactive_region_targets_are_not_owned_by_the_parent(pjx_full_page):
+    page = pjx_full_page(
         '<div data-pjx-id="p" data-pjx-reacts="count"><button id="btn"></button>'
         '<span id="own" data-pjx-loading="skeleton"></span>'
         '<div data-pjx-id="c" data-pjx-reacts="other">'
@@ -71,8 +75,8 @@ def test_nested_reactive_region_targets_are_not_owned_by_the_parent(pjx_page):
     assert classes(page, "#inner") == [""]
 
 
-def test_loading_extra_selector_lights_regions_that_do_not_react(pjx_page):
-    page = pjx_page(
+def test_loading_extra_selector_lights_regions_that_do_not_react(pjx_full_page):
+    page = pjx_full_page(
         '<div data-pjx-id="t" data-pjx-reacts="count" data-pjx-loading-extra=".row">'
         '<button id="btn"></button></div>'
         '<div class="row" data-pjx-id="r1" data-pjx-reacts="name" data-pjx-loading="spinner"></div>'
@@ -111,22 +115,22 @@ import pytest
 
 
 @pytest.mark.parametrize("event", END_EVENTS)
-def test_each_completion_event_strips_the_loading_class(pjx_page, event):
-    page = pjx_page(BODY)
+def test_each_completion_event_strips_the_loading_class(pjx_full_page, event):
+    page = pjx_full_page(BODY)
     fire(page, "#btn")
     end(page, event)
     assert classes(page, '[data-pjx-id="t"]') == [""]
 
 
-def test_xhr_loadend_releases_the_region(pjx_page):
-    page = pjx_page(BODY)
+def test_xhr_loadend_releases_the_region(pjx_full_page):
+    page = pjx_full_page(BODY)
     fire(page, "#btn")
     page.evaluate("window.__xhrs.a.loadend()")
     assert classes(page, '[data-pjx-id="t"]') == [""]
 
 
-def test_overlapping_requests_keep_the_region_lit_until_the_last_resolves(pjx_page):
-    page = pjx_page(BODY)
+def test_overlapping_requests_keep_the_region_lit_until_the_last_resolves(pjx_full_page):
+    page = pjx_full_page(BODY)
     fire(page, "#btn", name="a")
     fire(page, "#btn", name="b")
     end(page, "htmx:afterOnLoad", name="a")
@@ -135,15 +139,15 @@ def test_overlapping_requests_keep_the_region_lit_until_the_last_resolves(pjx_pa
     assert classes(page, '[data-pjx-id="t"]') == [""]
 
 
-def test_cancelled_request_neither_lights_nor_registers_a_loadend_listener(pjx_page):
-    page = pjx_page(BODY)
+def test_cancelled_request_neither_lights_nor_registers_a_loadend_listener(pjx_full_page):
+    page = pjx_full_page(BODY)
     fire(page, "#btn", cancel=True)
     assert classes(page, '[data-pjx-id="t"]') == [""]
     assert page.evaluate("window.__xhrs.a.handlers.length") == 0
 
 
-def test_duplicate_completion_events_are_a_no_op(pjx_page):
-    page = pjx_page(BODY)
+def test_duplicate_completion_events_are_a_no_op(pjx_full_page):
+    page = pjx_full_page(BODY)
     fire(page, "#btn")
     end(page, "htmx:afterOnLoad")
     end(page, "htmx:afterOnLoad")
@@ -164,14 +168,14 @@ SWAP = """
 """
 
 
-def test_aftersettle_relights_a_region_swapped_while_in_flight(pjx_page):
-    page = pjx_page(BODY)
+def test_aftersettle_relights_a_region_swapped_while_in_flight(pjx_full_page):
+    page = pjx_full_page(BODY)
     fire(page, "#btn")
     page.evaluate(SWAP)
     assert classes(page, '[data-pjx-id="t"]') == ["pjx-loading--skeleton"]
 
 
-def test_aftersettle_leaves_idle_regions_dark(pjx_page):
-    page = pjx_page(BODY)
+def test_aftersettle_leaves_idle_regions_dark(pjx_full_page):
+    page = pjx_full_page(BODY)
     page.evaluate(SWAP)
     assert classes(page, '[data-pjx-id="t"]') == [""]

--- a/tests/pyjinhx/client/test_pjx_loading_events.py
+++ b/tests/pyjinhx/client/test_pjx_loading_events.py
@@ -1,0 +1,54 @@
+"""Core pjx.js emits loading events; it never writes classList itself."""
+
+from __future__ import annotations
+
+FIRE = """
+(arg) => {
+  const elt = document.querySelector(arg.trigger);
+  const xhr = { handlers: [], addEventListener(t, fn) { this.handlers.push([t, fn]); },
+                loadend() { this.handlers.forEach(([t, fn]) => t === 'loadend' && fn()); } };
+  window.__xhrs = window.__xhrs || {};
+  window.__xhrs[arg.name] = xhr;
+  const evt = new CustomEvent('htmx:beforeRequest',
+    { bubbles: true, cancelable: true, detail: { elt: elt, xhr: xhr } });
+  elt.dispatchEvent(evt);
+}
+"""
+
+RECORD = """
+() => {
+  window.__evts = [];
+  ['pjx:region-loading-start', 'pjx:region-loading-end',
+   'pjx:page-loading-start', 'pjx:page-loading-end'].forEach((name) => {
+    document.addEventListener(name, (e) => {
+      window.__evts.push([name, e.detail && e.detail.id]);
+    });
+  });
+}
+"""
+
+BODY = (
+    '<div data-pjx-id="t" data-pjx-reacts="count" data-pjx-loading="skeleton">'
+    '<button id="btn"></button></div>'
+)
+
+
+def test_beforerequest_dispatches_region_loading_start(pjx_page):
+    page = pjx_page(BODY)
+    page.evaluate(RECORD)
+    page.evaluate(FIRE, {"trigger": "#btn", "name": "a"})
+    assert page.evaluate("window.__evts") == [["pjx:region-loading-start", "t"]]
+
+
+def test_core_alone_never_applies_the_loading_class(pjx_page):
+    page = pjx_page(BODY)
+    page.evaluate(FIRE, {"trigger": "#btn", "name": "a"})
+    assert page.evaluate('document.querySelector(\'[data-pjx-id="t"]\').className') == ""
+
+
+def test_completion_dispatches_region_loading_end(pjx_page):
+    page = pjx_page(BODY)
+    page.evaluate(FIRE, {"trigger": "#btn", "name": "a"})
+    page.evaluate(RECORD)
+    page.evaluate("window.__xhrs.a.loadend()")
+    assert page.evaluate("window.__evts") == [["pjx:region-loading-end", "t"]]

--- a/tests/pyjinhx/client/test_pjx_loading_events.py
+++ b/tests/pyjinhx/client/test_pjx_loading_events.py
@@ -43,7 +43,9 @@ def test_beforerequest_dispatches_region_loading_start(pjx_page):
 def test_core_alone_never_applies_the_loading_class(pjx_page):
     page = pjx_page(BODY)
     page.evaluate(FIRE, {"trigger": "#btn", "name": "a"})
-    assert page.evaluate('document.querySelector(\'[data-pjx-id="t"]\').className') == ""
+    assert (
+        page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className") == ""
+    )
 
 
 def test_completion_dispatches_region_loading_end(pjx_page):

--- a/tests/pyjinhx/client/test_pjx_loading_events.py
+++ b/tests/pyjinhx/client/test_pjx_loading_events.py
@@ -52,3 +52,30 @@ def test_completion_dispatches_region_loading_end(pjx_page):
     page.evaluate(RECORD)
     page.evaluate("window.__xhrs.a.loadend()")
     assert page.evaluate("window.__evts") == [["pjx:region-loading-end", "t"]]
+
+
+def test_loader_page_dispatches_start_and_end_with_ref_counting(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(RECORD)
+    page.evaluate(
+        "pjx.loader.page(true); pjx.loader.page(true); pjx.loader.page(false)"
+    )
+    assert page.evaluate("window.__evts") == [
+        ["pjx:page-loading-start", None],
+        ["pjx:page-loading-start", None],
+    ]
+    page.evaluate("pjx.loader.page(false)")
+    assert page.evaluate("window.__evts")[-1] == ["pjx:page-loading-end", None]
+
+
+def test_core_alone_never_sets_the_page_loading_class(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate("pjx.loader.page(true)")
+    assert page.evaluate("document.documentElement.className") == ""
+
+
+def test_page_false_from_zero_never_dispatches_an_end_event(pjx_page):
+    page = pjx_page("<div></div>")
+    page.evaluate(RECORD)
+    page.evaluate("pjx.loader.page(false)")
+    assert page.evaluate("window.__evts") == []

--- a/tests/pyjinhx/client/test_pjx_style.py
+++ b/tests/pyjinhx/client/test_pjx_style.py
@@ -1,28 +1,36 @@
-"""pjxInjectStyle(): one <style id="pjx-style"> per page, no matter how often it runs."""
+"""The always-on runtime CSS: one server-emitted <style id="pjx-style"> per render."""
 
 from __future__ import annotations
 
+from pyjinhx.assets import emit_assets
+from pyjinhx.client.inject import inject_runtime
+from pyjinhx.session import RenderSession
 
-def test_style_tag_is_injected_on_load(pjx_page):
-    page = pjx_page("<div></div>")
-    assert page.evaluate("!!document.getElementById('pjx-style')")
+
+def emitted() -> str:
+    session = RenderSession()
+    inject_runtime(session)
+    return emit_assets(session)
 
 
-def test_style_defines_the_skeleton_and_spinner_classes(pjx_page):
-    page = pjx_page("<div></div>")
-    css = page.evaluate("document.getElementById('pjx-style').textContent")
+def test_the_style_block_is_emitted_once():
+    assert emitted().count('<style id="pjx-style">') == 1
+
+
+def test_the_style_block_defines_the_skeleton_and_spinner_classes():
+    css = emitted()
     assert ".pjx-loading--skeleton" in css
     assert ".pjx-loading--spinner" in css
 
 
-def test_style_rules_read_overridable_custom_properties(pjx_page):
-    page = pjx_page("<div></div>")
-    css = page.evaluate("document.getElementById('pjx-style').textContent")
+def test_the_style_rules_read_overridable_custom_properties():
+    css = emitted()
     assert "--pjx-skeleton-color" in css
     assert "--pjx-spinner-size" in css
 
 
-def test_reinjecting_keeps_a_single_style_tag(pjx_page):
-    page = pjx_page("<div></div>")
-    page.evaluate("pjx.injectStyle(); pjx.injectStyle()")
-    assert page.evaluate("document.querySelectorAll('#pjx-style').length") == 1
+def test_a_second_inject_on_the_same_session_does_not_duplicate_it():
+    session = RenderSession()
+    inject_runtime(session)
+    inject_runtime(session)
+    assert emit_assets(session).count('<style id="pjx-style">') == 1

--- a/tests/pyjinhx/client/test_runtime_bundle_e2e.py
+++ b/tests/pyjinhx/client/test_runtime_bundle_e2e.py
@@ -33,15 +33,21 @@ def test_inject_runtime_payload_alone_drives_the_loading_indicator(page):
     page.set_content(f"<body>{BODY}{emit_assets(session)}</body>")
 
     page.evaluate(FIRE)
-    assert page.evaluate(
-        "document.querySelector('[data-pjx-id=\"t\"]').className"
-    ) == "pjx-loading--skeleton"
-    assert page.evaluate(
-        "getComputedStyle(document.querySelector('[data-pjx-id=\"t\"]')).pointerEvents"
-    ) == "none"
+    assert (
+        page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className")
+        == "pjx-loading--skeleton"
+    )
+    assert (
+        page.evaluate(
+            "getComputedStyle(document.querySelector('[data-pjx-id=\"t\"]')).pointerEvents"
+        )
+        == "none"
+    )
 
     page.evaluate("window.__xhr.loadend()")
-    assert page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className") == ""
+    assert (
+        page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className") == ""
+    )
 
 
 def test_inject_runtime_payload_alone_drives_the_page_loader(page):

--- a/tests/pyjinhx/client/test_runtime_bundle_e2e.py
+++ b/tests/pyjinhx/client/test_runtime_bundle_e2e.py
@@ -1,0 +1,55 @@
+"""One cold-render payload, no component includes: indicators still work."""
+
+from __future__ import annotations
+
+from pyjinhx.assets import emit_assets
+from pyjinhx.client.inject import inject_runtime
+from pyjinhx.session import RenderSession
+
+BODY = (
+    '<div data-pjx-id="t" data-pjx-reacts="count" data-pjx-loading="skeleton">'
+    '<button id="btn"></button></div>'
+)
+
+FIRE = """
+() => {
+  const elt = document.querySelector('#btn');
+  const xhr = { handlers: [], addEventListener(t, fn) { this.handlers.push([t, fn]); },
+                loadend() { this.handlers.forEach(([t, fn]) => t === 'loadend' && fn()); } };
+  window.__xhr = xhr;
+  elt.dispatchEvent(new CustomEvent('htmx:beforeRequest',
+    { bubbles: true, cancelable: true, detail: { elt: elt, xhr: xhr } }));
+}
+"""
+
+
+def test_inject_runtime_payload_alone_drives_the_loading_indicator(page):
+    session = RenderSession()
+    inject_runtime(session)
+    # Runtime payload at the end of <body>, mirroring real usage: a <script>
+    # placed in <head> would execute before document.body exists, which trips
+    # pjxPromoteInlineAssets's null check -- an unrelated, out-of-scope bug in
+    # head-asset relocation, not something #675 touches.
+    page.set_content(f"<body>{BODY}{emit_assets(session)}</body>")
+
+    page.evaluate(FIRE)
+    assert page.evaluate(
+        "document.querySelector('[data-pjx-id=\"t\"]').className"
+    ) == "pjx-loading--skeleton"
+    assert page.evaluate(
+        "getComputedStyle(document.querySelector('[data-pjx-id=\"t\"]')).pointerEvents"
+    ) == "none"
+
+    page.evaluate("window.__xhr.loadend()")
+    assert page.evaluate("document.querySelector('[data-pjx-id=\"t\"]').className") == ""
+
+
+def test_inject_runtime_payload_alone_drives_the_page_loader(page):
+    session = RenderSession()
+    inject_runtime(session)
+    page.set_content(f"<body>{BODY}{emit_assets(session)}</body>")
+
+    page.evaluate("pjx.loader.page(true)")
+    assert page.evaluate("document.documentElement.className") == "pjx-loading--page"
+    page.evaluate("pjx.loader.page(false)")
+    assert page.evaluate("document.documentElement.className") == ""


### PR DESCRIPTION
## Summary

Refactored pjx.js and client-side loading behavior to dispatch events instead of directly mutating classList:
- Dispatches `pjx:region-loading-start` and `pjx:region-loading-end` events with `{id}` detail
- Dispatches `pjx:page-loading-start` and `pjx:page-loading-end` events for page-level loading state
- Adds `loading-indicator` and `page-loader` artifacts to the runtime bundle
- Removes `pjxInjectStyle` export as it's no longer needed with dispatch-based architecture
- Updates all tests to work with new event-driven loading architecture
- Adds `pjx_full_page` fixture for page-level loading tests and e2e regressions

This enables third-party artifact control over loading UI presentation while keeping core pjx.js dispatch-only and concerns separated.

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)