### PR TITLE
fix: restore raw HTML slot values in render context

### DIFF
--- a/pyjinhx/component.py
+++ b/pyjinhx/component.py
@@ -19,6 +19,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Union, get_args, get_origin
 
+from markupsafe import Markup
 from pydantic import (
     AfterValidator,
     BaseModel,
@@ -497,6 +498,11 @@ class BaseComponent(BaseModel):
             value = getattr(self, name)
             if isinstance(value, BaseComponent):
                 props[name] = value
+            elif isinstance(value, str) and _is_slot_field(type(self), name):
+                # `.props.x` is the sanctioned read of a child's own values, so
+                # it must hand back the same raw-markup string the render
+                # context would; a non-slot str stays escapable.
+                props[name] = Markup(value)
             elif isinstance(value, list):
                 props[name] = list(value)
             elif isinstance(value, dict):

--- a/pyjinhx/render_context.py
+++ b/pyjinhx/render_context.py
@@ -8,7 +8,40 @@ from typing import Any
 from markupsafe import Markup
 
 from pyjinhx.component import BaseComponent
-from pyjinhx.markers import ComponentNode
+from pyjinhx.markers import ComponentNode, finalize_slot_node
+
+
+def _slot_item_html(item: object) -> str:
+    """The markup one collection entry contributes when the container itself
+    is interpolated bare (``{{ content }}``, no ``{% for %}``).
+
+    A ComponentNode is swapped for its placeholder token exactly the way a
+    lone component-valued slot already is, so the same post-render
+    substitution pass fills in its real markup. Anything else is escaped
+    like ordinary template data — a collection entry is not itself
+    author-declared markup the way the slot's own string form is.
+    """
+    if isinstance(item, ComponentNode):
+        return str(finalize_slot_node(item))
+    return str(Markup.escape(item))
+
+
+class _SlotList(list):
+    """A list of slot entries that also renders composed markup when
+    interpolated directly, so ``{{ content }}`` and ``{% for %}`` both work.
+    """
+
+    def __html__(self) -> str:
+        return "".join(_slot_item_html(item) for item in self)
+
+
+class _SlotDict(dict):
+    """A dict of slot entries that also renders composed markup when
+    interpolated directly, so ``{{ content }}`` and ``{% for %}`` both work.
+    """
+
+    def __html__(self) -> str:
+        return "".join(_slot_item_html(item) for item in self.values())
 
 
 def _wrap_slot_value(
@@ -19,12 +52,14 @@ def _wrap_slot_value(
 ) -> object:
     """Wrap the components inside a slot value, one opaque node each.
 
-    A list or dict slot comes back as a plain list or dict so a template can
-    walk it with ``{% for %}``: opacity is a per-child guarantee (ADR 0003),
-    and a ComponentNode refuses to be iterated, so wrapping the container
-    itself would make the collection unusable. A plain string comes back as
-    ``Markup`` — a slot's string value is authored markup. Anything else — an
-    empty container, a non-component item — passes through untouched.
+    A list or dict slot comes back as a list/dict subclass so a template can
+    still walk it with ``{% for %}`` (opacity is a per-child guarantee, ADR
+    0003, and a ComponentNode refuses to be iterated, so wrapping the
+    container itself would make the collection unusable) while also
+    composing correctly when interpolated bare (``{{ content }}``, no loop).
+    A plain string comes back as ``Markup`` — a slot's string value is
+    authored markup. Anything else — an empty container, a non-component
+    item — passes through untouched.
     """
 
     def node(component: BaseComponent) -> ComponentNode:
@@ -43,14 +78,14 @@ def _wrap_slot_value(
     if isinstance(value, BaseComponent):
         return node(value)
     if isinstance(value, list):
-        return [
+        return _SlotList(
             node(item) if isinstance(item, BaseComponent) else item for item in value
-        ]
+        )
     if isinstance(value, dict):
-        return {
-            key: node(item) if isinstance(item, BaseComponent) else item
+        return _SlotDict(
+            (key, node(item) if isinstance(item, BaseComponent) else item)
             for key, item in value.items()
-        }
+        )
     return value
 
 

--- a/pyjinhx/render_context.py
+++ b/pyjinhx/render_context.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from markupsafe import Markup
+
 from pyjinhx.component import BaseComponent
 from pyjinhx.markers import ComponentNode
 
@@ -20,8 +22,9 @@ def _wrap_slot_value(
     A list or dict slot comes back as a plain list or dict so a template can
     walk it with ``{% for %}``: opacity is a per-child guarantee (ADR 0003),
     and a ComponentNode refuses to be iterated, so wrapping the container
-    itself would make the collection unusable. Anything that is not a
-    component — literal markup, an empty container — passes through untouched.
+    itself would make the collection unusable. A plain string comes back as
+    ``Markup`` — a slot's string value is authored markup. Anything else — an
+    empty container, a non-component item — passes through untouched.
     """
 
     def node(component: BaseComponent) -> ComponentNode:
@@ -32,6 +35,11 @@ def _wrap_slot_value(
             field_name=field_name,
         )
 
+    if isinstance(value, str):
+        # A string on a slot field is authored markup, not user data: ADR 0003
+        # exempts it from autoescape. Only slot fields reach this function, so
+        # ordinary str fields keep escaping.
+        return Markup(value)
     if isinstance(value, BaseComponent):
         return node(value)
     if isinstance(value, list):

--- a/pyjinhx/rendering.py
+++ b/pyjinhx/rendering.py
@@ -194,7 +194,8 @@ def render_level(
         warn_stale_def_header(component.__class__)
 
     # Phase 2: Context build — component-valued slots arrive as ComponentNode,
-    # string-valued slots stay plain strings.
+    # string-valued slots arrive as Markup so authored markup survives
+    # autoescape.
     context = build_context(component, descriptor)
 
     # Phase 3: Jinja render with autoescape ON

--- a/tests/fixtures/bench_builtin_heavy.py
+++ b/tests/fixtures/bench_builtin_heavy.py
@@ -25,24 +25,17 @@ later level's parse to deal with" (see `segments.py`); that later level's
 parse only sees the nested tags if the string carrying them survives into the
 child's own template unescaped. As verified with a throwaway two-line
 repro (`<PJXCard><PJXCardBody>...` one level deep, run outside this fixture
-during Task 3's exploration) plain `str`-typed Slot content does *not* survive
-Jinja's `autoescape=True` unescaped, so a markup string nested more than one
-custom tag deep silently renders as escaped text on the v2 side — a
-pre-existing renderer gap, not something #537 is scoped to fix (its
-non-goals explicitly rule out changing either renderer to fix a finding).
-The same gap also bites a *single* Slot passed a raw-HTML string directly
-with no custom-tag nesting at all — `PJXTableCell.content` in `_v2_table`
-below is given a literal `<input .../>` string, which v0's markup-string
-page renders as a real `<input>` element but v2 renders as escaped text
-(`&lt;input .../&gt;`). Wrapping the value in `markupsafe.Markup` does
-*not* fix it: `PJXTableCell.content` is a plain-`str`-typed Slot field, and
-pydantic's `str` coercion strips `Markup`'s `__html__` protocol back down to
-a plain `str` on assignment (confirmed by direct construction), so the
-value re-enters the same unescaped-str code path either way. Same
-pre-existing, out-of-scope-for-#537 renderer gap as above; the two table
-cells at `c{r}b` are therefore not byte-identical across sides even though
-this doesn't affect timing (no markers or row counts depend on this cell's
-content, so `_sanity()` doesn't need to and does not check it).
+during Task 3's exploration) plain `str`-typed Slot content did *not* survive
+Jinja's `autoescape=True` unescaped at the time of writing, so a markup
+string nested more than one custom tag deep silently rendered as escaped
+text on the v2 side — out of scope for #537, later fixed by #686
+(`_wrap_slot_value` now wraps a slot's `str` value in `markupsafe.Markup`
+after retrieval, so pydantic's plain-`str` coercion on assignment no longer
+matters). The same gap also used to bite a *single* Slot passed a raw-HTML
+string directly with no custom-tag nesting at all — `PJXTableCell.content`
+in `_v2_table` below is given a literal `<input .../>` string, which now
+renders as a real `<input>` element on both sides post-#686; the two table
+cells at `c{r}b` are byte-identical across sides.
 So: `build_v0_page`/`build_v0_table`/`build_v0_shells` return **markup
 strings** (v0's native shape); `build_v2_page`/`build_v2_table`/
 `build_v2_shells` return a **component instance tree** built by nesting real

--- a/tests/pyjinhx/builtins/pjx_accordion/test_pjx_accordion.py
+++ b/tests/pyjinhx/builtins/pjx_accordion/test_pjx_accordion.py
@@ -49,12 +49,11 @@ def test_empty_class_name_adds_nothing(accordion_session):
     assert 'class="pjx-accordion"' in _html(accordion_session, class_name="")
 
 
-def test_string_content_renders_escaped_inside_root(accordion_session):
-    """v2 narrowing of v0.x: a plain str in a Slot is escaped; only components emit markup."""
+def test_string_content_renders_raw_inside_root(accordion_session):
+    """ADR 0003: a plain str in a Slot is authored markup, not escaped."""
     html = _html(accordion_session, content="<p>raw</p>")
     assert html.count("<details") == 1
-    assert "&lt;p&gt;raw&lt;/p&gt;" in html
-    assert "<p>raw</p>" not in html
+    assert "<p>raw</p>" in html
 
 
 class AccordionChild(BaseComponent):

--- a/tests/pyjinhx/builtins/pjx_accordion_content/test_pjx_accordion_content.py
+++ b/tests/pyjinhx/builtins/pjx_accordion_content/test_pjx_accordion_content.py
@@ -34,10 +34,10 @@ def test_empty_class_name_adds_nothing(content_session):
     assert 'class="pjx-accordion__content"' in _html(content_session, class_name="")
 
 
-def test_string_content_renders_escaped_inside_root(content_session):
+def test_string_content_renders_raw_inside_root(content_session):
+    # ADR 0003: a plain str in a Slot is authored markup, not escaped.
     html = _html(content_session, content="<p>raw</p>")
-    assert "&lt;p&gt;raw&lt;/p&gt;" in html
-    assert "<p>raw</p>" not in html
+    assert "<p>raw</p>" in html
 
 
 class ContentChild(BaseComponent):

--- a/tests/pyjinhx/builtins/pjx_alert/test_pjx_alert.py
+++ b/tests/pyjinhx/builtins/pjx_alert/test_pjx_alert.py
@@ -79,10 +79,10 @@ class TestRender:
             session, body="Saved"
         )
 
-    def test_body_string_is_emitted_escaped(self, session):
+    def test_body_string_is_emitted_raw(self, session):
+        # ADR 0003: a plain str in a Slot is authored markup, not escaped.
         html = _html(session, body="<b>x</b>")
-        assert "<b>x</b>" not in html
-        assert "&lt;b&gt;x&lt;/b&gt;" in html
+        assert "<b>x</b>" in html
 
     def test_component_body_renders_nested(self, session):
         html = _html(session, body=PJXDivider(id="d"))

--- a/tests/pyjinhx/builtins/pjx_button/test_pjx_button.py
+++ b/tests/pyjinhx/builtins/pjx_button/test_pjx_button.py
@@ -117,10 +117,10 @@ class TestRender:
         html = _html(session, content="X", extra_attrs={"hx-post": "/save"})
         assert 'hx-post="/save"' in html[: html.index(">")]
 
-    def test_content_is_escaped(self, session):
+    def test_content_stays_raw(self, session):
+        # ADR 0003: a plain str in a Slot is authored markup, not escaped.
         html = _html(session, content="<script>x</script>")
-        assert "&lt;script&gt;x&lt;/script&gt;" in html
-        assert "<script>" not in html
+        assert "<script>x</script>" in html
 
 
 class TestAssets:

--- a/tests/pyjinhx/builtins/pjx_card/test_pjx_card.py
+++ b/tests/pyjinhx/builtins/pjx_card/test_pjx_card.py
@@ -44,12 +44,11 @@ def test_component_content_renders_nested(card_session):
     assert "Revenue grew 12%." in html
 
 
-def test_string_content_renders_escaped_inside_root(card_session):
-    """v2 narrowing of v0.x: a plain str in a Slot is escaped; only components emit markup."""
+def test_string_content_renders_raw_inside_root(card_session):
+    """ADR 0003: a plain str in a Slot is authored markup, not escaped."""
     html = _html(card_session, content="<p>raw</p>")
     assert html.count("<article") == 1
-    assert "&lt;p&gt;raw&lt;/p&gt;" in html
-    assert "<p>raw</p>" not in html
+    assert "<p>raw</p>" in html
 
 
 def test_clean_break_removed_fields():

--- a/tests/pyjinhx/builtins/pjx_card_body/test_pjx_card_body.py
+++ b/tests/pyjinhx/builtins/pjx_card_body/test_pjx_card_body.py
@@ -27,11 +27,11 @@ def test_default_render_is_single_empty_div(card_body_session):
     assert _html(card_body_session) == '<div id="b" class="pjx-card__body"></div>'
 
 
-def test_string_content_renders_escaped_inside_root(card_body_session):
+def test_string_content_renders_raw_inside_root(card_body_session):
+    # ADR 0003: a plain str in a Slot is authored markup, not escaped.
     html = _html(card_body_session, content="<p>hi</p>")
     assert html.count("<div") == 1
-    assert "&lt;p&gt;hi&lt;/p&gt;" in html
-    assert "<p>hi</p>" not in html
+    assert "<p>hi</p>" in html
 
 
 def test_component_content_renders_nested(card_body_session):

--- a/tests/pyjinhx/builtins/pjx_card_footer/test_pjx_card_footer.py
+++ b/tests/pyjinhx/builtins/pjx_card_footer/test_pjx_card_footer.py
@@ -30,10 +30,10 @@ def test_text_content_renders_inside_root(card_footer_session):
     assert "Updated" in html
 
 
-def test_string_content_renders_escaped(card_footer_session):
+def test_string_content_renders_raw(card_footer_session):
+    # ADR 0003: a plain str in a Slot is authored markup, not escaped.
     html = _html(card_footer_session, content="<b>x</b>")
-    assert "&lt;b&gt;x&lt;/b&gt;" in html
-    assert "<b>x</b>" not in html
+    assert "<b>x</b>" in html
 
 
 def test_class_name_appended_to_root(card_footer_session):

--- a/tests/pyjinhx/builtins/pjx_carousel/test_pjx_carousel.py
+++ b/tests/pyjinhx/builtins/pjx_carousel/test_pjx_carousel.py
@@ -164,10 +164,10 @@ class TestRender:
         html = _html(session, extra_attrs={"data-foo": "bar"})
         assert 'data-foo="bar"' in _root_tag(html)
 
-    def test_content_string_is_emitted_escaped(self, session):
+    def test_content_string_is_emitted_raw(self, session):
+        # ADR 0003: a plain str in a Slot is authored markup, not escaped.
         html = _html(session, content="<div data-pjx-carousel-slide>X</div>")
-        assert "<div data-pjx-carousel-slide>X</div>" not in html
-        assert "&lt;div" in html
+        assert "<div data-pjx-carousel-slide>X</div>" in html
 
 
 class TestIcons:

--- a/tests/pyjinhx/builtins/pjx_carousel_slide/test_pjx_carousel_slide.py
+++ b/tests/pyjinhx/builtins/pjx_carousel_slide/test_pjx_carousel_slide.py
@@ -75,10 +75,10 @@ class TestRender:
     def test_content_lands_inside_the_slide(self, session):
         assert ">Bridge</div>" in _html(session, content="Bridge")
 
-    def test_content_string_is_emitted_escaped(self, session):
+    def test_content_string_is_emitted_raw(self, session):
+        # ADR 0003: a plain str in a Slot is authored markup, not escaped.
         html = _html(session, content="<img src='/a.png'>")
-        assert "<img src='/a.png'>" not in html
-        assert "&lt;img" in html
+        assert "<img src='/a.png'>" in html
 
     def test_component_content_renders_nested(self, session):
         assert 'id="d"' in _html(session, content=PJXDivider(id="d"))

--- a/tests/pyjinhx/builtins/pjx_drawer/test_pjx_drawer.py
+++ b/tests/pyjinhx/builtins/pjx_drawer/test_pjx_drawer.py
@@ -105,12 +105,11 @@ def test_component_content_renders_inside_the_box(drawer_session):
     assert "Links here" in html
 
 
-def test_string_content_renders_escaped_inside_root(drawer_session):
-    """v2 narrowing of v0.x: a plain str in a Slot is escaped; only components emit markup."""
+def test_string_content_renders_raw_inside_root(drawer_session):
+    """ADR 0003: a plain str in a Slot is authored markup, not escaped."""
     html = _html(drawer_session, content="<p>raw</p>")
     assert html.count("<dialog") == 1
-    assert "&lt;p&gt;raw&lt;/p&gt;" in html
-    assert "<p>raw</p>" not in html
+    assert "<p>raw</p>" in html
 
 
 def test_clean_break_removed_fields():

--- a/tests/pyjinhx/builtins/pjx_drawer_body/test_pjx_drawer_body.py
+++ b/tests/pyjinhx/builtins/pjx_drawer_body/test_pjx_drawer_body.py
@@ -48,9 +48,8 @@ def test_component_content_renders_nested(drawer_body_session):
     assert '<hr id="d"' in html
 
 
-def test_string_content_renders_escaped_inside_root(drawer_body_session):
-    """Golden drawer_body.html's raw <p> markup now arrives escaped (autoescape on)."""
+def test_string_content_renders_raw_inside_root(drawer_body_session):
+    """ADR 0003: golden drawer_body.html's raw <p> markup stays raw (Slot exemption)."""
     html = _html(drawer_body_session, content="<p>Body content</p>")
     assert html.count("<div") == 1
-    assert "&lt;p&gt;Body content&lt;/p&gt;" in html
-    assert "<p>Body content</p>" not in html
+    assert "<p>Body content</p>" in html

--- a/tests/pyjinhx/builtins/pjx_drawer_footer/test_pjx_drawer_footer.py
+++ b/tests/pyjinhx/builtins/pjx_drawer_footer/test_pjx_drawer_footer.py
@@ -51,9 +51,8 @@ def test_component_content_renders_nested(drawer_footer_session):
     assert '<hr id="d"' in html
 
 
-def test_string_content_renders_escaped_inside_root(drawer_footer_session):
-    """Golden drawer_footer.html's raw <button> markup now arrives escaped."""
+def test_string_content_renders_raw_inside_root(drawer_footer_session):
+    """ADR 0003: golden drawer_footer.html's raw <button> markup stays raw (Slot exemption)."""
     html = _html(drawer_footer_session, content="<button>Save</button>")
     assert html.count("<footer") == 1
-    assert "&lt;button&gt;Save&lt;/button&gt;" in html
-    assert "<button>Save</button>" not in html
+    assert "<button>Save</button>" in html

--- a/tests/pyjinhx/builtins/pjx_drawer_header/test_pjx_drawer_header.py
+++ b/tests/pyjinhx/builtins/pjx_drawer_header/test_pjx_drawer_header.py
@@ -66,11 +66,10 @@ def test_title_wins_over_content(drawer_header_session):
     assert '<hr id="d"' not in html
 
 
-def test_string_content_renders_escaped(drawer_header_session):
-    """v2 narrowing of v0.x: golden drawer_header_content.html's raw <strong> is now escaped."""
+def test_string_content_renders_raw(drawer_header_session):
+    """ADR 0003: golden drawer_header_content.html's raw <strong> stays raw (Slot exemption)."""
     html = _html(drawer_header_session, content="<strong>Nav</strong>")
-    assert "&lt;strong&gt;Nav&lt;/strong&gt;" in html
-    assert "<strong>Nav</strong>" not in html
+    assert "<strong>Nav</strong>" in html
 
 
 def test_close_label_defaults_to_close(drawer_header_session):

--- a/tests/pyjinhx/builtins/pjx_empty_state/test_pjx_empty_state.py
+++ b/tests/pyjinhx/builtins/pjx_empty_state/test_pjx_empty_state.py
@@ -35,10 +35,10 @@ def test_no_suggestions_block_when_suggestions_is_empty(empty_state_session):
     assert "pjx-empty-state__chip" not in html
 
 
-def test_string_content_renders_escaped_inside_root(empty_state_session):
+def test_string_content_renders_raw_inside_root(empty_state_session):
+    # ADR 0003: a plain str in a Slot is authored markup, not escaped.
     html = _html(empty_state_session, content="<script>x</script>")
-    assert "&lt;script&gt;x&lt;/script&gt;" in html
-    assert "<script>" not in html
+    assert "<script>x</script>" in html
 
 
 def test_component_content_renders_nested(empty_state_session):

--- a/tests/pyjinhx/builtins/pjx_form_field/test_pjx_form_field.py
+++ b/tests/pyjinhx/builtins/pjx_form_field/test_pjx_form_field.py
@@ -129,11 +129,11 @@ class TestRender:
     def test_no_required_marker_without_a_label(self, session):
         assert "pjx-form-field__required" not in _html(session, required=True)
 
-    def test_string_content_lands_in_the_control_wrapper_escaped(self, session):
+    def test_string_content_lands_in_the_control_wrapper_raw(self, session):
+        # ADR 0003: a plain str in a Slot is authored markup, not escaped.
         html = _html(session, content="<script>x</script>")
         control = html[html.index("pjx-form-field__control") :]
-        assert "&lt;script&gt;x&lt;/script&gt;" in control
-        assert "<script>" not in html
+        assert "<script>x</script>" in control
 
     def test_component_content_renders_inside_the_control_wrapper(self, session):
         html = _html(session, content=PJXSpinner(id="ff-spin"))

--- a/tests/pyjinhx/builtins/pjx_modal/test_pjx_modal.py
+++ b/tests/pyjinhx/builtins/pjx_modal/test_pjx_modal.py
@@ -67,12 +67,11 @@ def test_component_content_renders_inside_the_box(modal_session):
     assert "Confirm?" in html
 
 
-def test_string_content_renders_escaped_inside_root(modal_session):
-    """v2 narrowing of v0.x: a plain str in a Slot is escaped; only components emit markup."""
+def test_string_content_renders_raw_inside_root(modal_session):
+    """ADR 0003: a plain str in a Slot is authored markup, not escaped."""
     html = _html(modal_session, content="<p>raw</p>")
     assert html.count("<dialog") == 1
-    assert "&lt;p&gt;raw&lt;/p&gt;" in html
-    assert "<p>raw</p>" not in html
+    assert "<p>raw</p>" in html
 
 
 def test_clean_break_removed_fields():

--- a/tests/pyjinhx/builtins/pjx_modal_body/test_pjx_modal_body.py
+++ b/tests/pyjinhx/builtins/pjx_modal_body/test_pjx_modal_body.py
@@ -38,8 +38,8 @@ def test_component_content_renders_nested(modal_body_session):
     assert '<hr id="d"' in html
 
 
-def test_string_content_renders_escaped_inside_root(modal_body_session):
+def test_string_content_renders_raw_inside_root(modal_body_session):
+    # ADR 0003: a plain str in a Slot is authored markup, not escaped.
     html = _html(modal_body_session, content="<p>hi</p>")
     assert html.count("<div") == 1
-    assert "&lt;p&gt;hi&lt;/p&gt;" in html
-    assert "<p>hi</p>" not in html
+    assert "<p>hi</p>" in html

--- a/tests/pyjinhx/builtins/pjx_modal_footer/test_pjx_modal_footer.py
+++ b/tests/pyjinhx/builtins/pjx_modal_footer/test_pjx_modal_footer.py
@@ -41,8 +41,8 @@ def test_component_content_renders_nested(modal_footer_session):
     assert '<hr id="d"' in html
 
 
-def test_string_content_renders_escaped_inside_root(modal_footer_session):
+def test_string_content_renders_raw_inside_root(modal_footer_session):
+    # ADR 0003: a plain str in a Slot is authored markup, not escaped.
     html = _html(modal_footer_session, content="<p>hi</p>")
     assert html.count("<footer") == 1
-    assert "&lt;p&gt;hi&lt;/p&gt;" in html
-    assert "<p>hi</p>" not in html
+    assert "<p>hi</p>" in html

--- a/tests/pyjinhx/builtins/pjx_notification/test_pjx_notification.py
+++ b/tests/pyjinhx/builtins/pjx_notification/test_pjx_notification.py
@@ -87,10 +87,10 @@ class TestRender:
         html = _html(session, content="Saved")
         assert '<div class="pjx-notification__content">Saved</div>' in html
 
-    def test_content_string_is_emitted_escaped(self, session):
+    def test_content_string_is_emitted_raw(self, session):
+        # ADR 0003: a plain str in a Slot is authored markup, not escaped.
         html = _html(session, content="<b>x</b>")
-        assert "<b>x</b>" not in html
-        assert "&lt;b&gt;x&lt;/b&gt;" in html
+        assert "<b>x</b>" in html
 
     def test_component_content_renders_nested(self, session):
         html = _html(session, content=PJXDivider(id="d"))

--- a/tests/pyjinhx/builtins/pjx_resizable_panel/test_pjx_resizable_panel.py
+++ b/tests/pyjinhx/builtins/pjx_resizable_panel/test_pjx_resizable_panel.py
@@ -143,10 +143,10 @@ class TestRender:
         assert "--pjx-resizable-min" not in style
         assert "--pjx-resizable-max" not in style
 
-    def test_content_string_is_emitted_escaped(self, session):
+    def test_content_string_is_emitted_raw(self, session):
+        # ADR 0003: a plain str in a Slot is authored markup, not escaped.
         html = _html(session, content="<b>x</b>")
-        assert "<b>x</b>" not in html
-        assert "&lt;b&gt;" in html
+        assert "<b>x</b>" in html
 
 
 class TestAssets:

--- a/tests/pyjinhx/builtins/pjx_tab/test_pjx_tab.py
+++ b/tests/pyjinhx/builtins/pjx_tab/test_pjx_tab.py
@@ -93,12 +93,11 @@ def test_class_name_appended_to_root(tab_session, icon_registered):
     assert 'class="pjx-tab mine"' in _html(tab_session, class_name="mine")
 
 
-def test_string_content_renders_escaped_inside_the_label(tab_session, icon_registered):
-    """v2 narrowing of v0.x: a plain str in a Slot is escaped; only components emit markup."""
+def test_string_content_renders_raw_inside_the_label(tab_session, icon_registered):
+    """ADR 0003: a plain str in a Slot is authored markup, not escaped."""
     html = _html(tab_session, content="<p>raw</p>")
     assert html.count('<div id="t"') == 1
-    assert "&lt;p&gt;raw&lt;/p&gt;" in html
-    assert "<p>raw</p>" not in html
+    assert "<p>raw</p>" in html
 
 
 def test_css_is_discovered_from_the_component_directory():

--- a/tests/pyjinhx/builtins/pjx_tab_group/test_pjx_tab_group.py
+++ b/tests/pyjinhx/builtins/pjx_tab_group/test_pjx_tab_group.py
@@ -33,12 +33,11 @@ def test_empty_class_name_adds_nothing(tab_group_session):
     assert 'class="pjx-tab-group"' in _html(tab_group_session, class_name="")
 
 
-def test_string_content_renders_escaped_inside_root(tab_group_session):
-    """v2 narrowing of v0.x: a plain str in a Slot is escaped; only components emit markup."""
+def test_string_content_renders_raw_inside_root(tab_group_session):
+    """ADR 0003: a plain str in a Slot is authored markup, not escaped."""
     html = _html(tab_group_session, content="<p>raw</p>")
     assert html.count("<div") == 1
-    assert "&lt;p&gt;raw&lt;/p&gt;" in html
-    assert "<p>raw</p>" not in html
+    assert "<p>raw</p>" in html
 
 
 def test_undeclared_field_is_rejected(tab_group_session):

--- a/tests/pyjinhx/builtins/pjx_tab_list/test_pjx_tab_list.py
+++ b/tests/pyjinhx/builtins/pjx_tab_list/test_pjx_tab_list.py
@@ -43,12 +43,11 @@ def test_class_name_appended_to_root(tab_list_session):
     )
 
 
-def test_string_content_renders_escaped_inside_root(tab_list_session):
-    """v2 narrowing of v0.x: a plain str in a Slot is escaped; only components emit markup."""
+def test_string_content_renders_raw_inside_root(tab_list_session):
+    """ADR 0003: a plain str in a Slot is authored markup, not escaped."""
     html = _html(tab_list_session, content="<p>raw</p>")
     assert html.count("<div") == 1
-    assert "&lt;p&gt;raw&lt;/p&gt;" in html
-    assert "<p>raw</p>" not in html
+    assert "<p>raw</p>" in html
 
 
 def test_css_is_discovered_from_the_component_directory():

--- a/tests/pyjinhx/builtins/pjx_tab_panel/test_pjx_tab_panel.py
+++ b/tests/pyjinhx/builtins/pjx_tab_panel/test_pjx_tab_panel.py
@@ -39,12 +39,11 @@ def test_class_name_appended_to_root(tab_panel_session):
     )
 
 
-def test_string_content_renders_escaped_inside_root(tab_panel_session):
-    """v2 narrowing of v0.x: a plain str in a Slot is escaped; only components emit markup."""
+def test_string_content_renders_raw_inside_root(tab_panel_session):
+    """ADR 0003: a plain str in a Slot is authored markup, not escaped."""
     html = _html(tab_panel_session, content="<p>raw</p>")
     assert html.count("<div") == 1
-    assert "&lt;p&gt;raw&lt;/p&gt;" in html
-    assert "<p>raw</p>" not in html
+    assert "<p>raw</p>" in html
 
 
 def test_css_is_discovered_from_the_component_directory():

--- a/tests/pyjinhx/builtins/test_family_display_primitives_sweep.py
+++ b/tests/pyjinhx/builtins/test_family_display_primitives_sweep.py
@@ -253,14 +253,13 @@ def test_classless_host_nesting_a_classless_host(family_dir, session):
 XSS = "<script>alert(1)</script>"
 
 
-def test_string_slot_value_escaped_across_nested_components(family_dir, session):
-    """A hostile string reaching a slot two levels down is escaped, not executed."""
+def test_string_slot_value_stays_raw_across_nested_components(family_dir, session):
+    """A plain string reaching a slot two levels down is authored markup (ADR 0003), not escaped."""
     html = render(
         Wrapper(id="wrap", content=PJXEmptyState(id="empty", content=XSS)), session
     )
 
-    assert XSS not in html
-    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert XSS in html
 
 
 def test_string_fields_escaped_when_the_component_is_a_nested_child(

--- a/tests/pyjinhx/builtins/test_family_js_heavy_sweep.py
+++ b/tests/pyjinhx/builtins/test_family_js_heavy_sweep.py
@@ -277,26 +277,22 @@ def test_every_js_heavy_builtin_emits_one_root_when_nested(family_dir, session, 
 XSS = '<script>alert("1") & more</script>'
 
 
-def test_string_slot_value_escaped_across_nested_components(family_dir, session):
-    """A hostile string reaching a slot two levels down is escaped, not executed.
-
-    This asserts the behavior that ships today. ADR 0003 describes slots as
-    opaque raw HTML, but string-valued Slot fields are not Markup-exempted
-    anywhere in the L0/L1 pipeline yet (see the note in
-    tests/pyjinhx/test_render_context.py) — a known, deferred gap, not
-    something this sweep fixes.
-    """
+def test_string_slot_value_stays_raw_across_nested_components(family_dir, session):
+    """A plain string reaching a slot two levels down is authored markup (ADR 0003), not escaped."""
     html = render(Wrapper(id="wrap", content=PJXAlert(id="alert", body=XSS)), session)
 
-    assert "<script>" not in html
-    assert "&lt;script&gt;" in html
-    assert "&amp;" in html
+    assert XSS in html
 
 
 def test_string_fields_escaped_when_the_component_is_a_nested_child(
     family_dir, session
 ):
-    """Nesting does not bypass a child's own field escaping."""
+    """Nesting does not bypass a child's own field escaping for non-slot fields.
+
+    `PJXResizablePanel.content` is a Slot field, so its string value stays raw
+    (ADR 0003); the other three occurrences (title, label x2 aria+data) are
+    plain str fields and still escape.
+    """
     html = render(
         Panel(
             id="panel",
@@ -307,10 +303,8 @@ def test_string_fields_escaped_when_the_component_is_a_nested_child(
         session,
     )
 
-    assert "<script>" not in html
-    assert (
-        html.count("&lt;script&gt;") == 4
-    )  # title, panel body, label x2 (aria + data)
+    assert XSS in html  # PJXResizablePanel.content, a Slot field, stays raw
+    assert html.count("&lt;script&gt;") == 3  # title, label x2 (aria + data)
 
 
 def test_component_slot_value_not_double_escaped_across_nested_components(

--- a/tests/pyjinhx/builtins/test_pjx_lazy_load.py
+++ b/tests/pyjinhx/builtins/test_pjx_lazy_load.py
@@ -80,13 +80,10 @@ class TestRender:
         assert 'hx-swap="innerHTML"' in _html(session, swap="innerHTML")
 
     def test_string_content_renders_inside_the_root(self, session):
-        # pyjinhx's Slot exemption (unlike v0.x's) only makes BaseComponent
-        # values render raw via ComponentNode; a plain str in a Slot field
-        # still goes through Jinja's autoescape — verified against
-        # tests/pyjinhx/builtins/test_pjx_table_cell.py::test_string_content_is_escaped
-        # and by direct reproduction against build_context/render_level.
+        # ADR 0003: a plain str in a Slot field is authored markup, so it
+        # stays raw through render.
         assert _html(session, content="Loading&hellip;").endswith(
-            "Loading&amp;hellip;</div>"
+            "Loading&hellip;</div>"
         )
 
     def test_component_content_renders_inside_the_root(self, session):
@@ -119,13 +116,10 @@ class TestErrorAffordance:
         html = _html(session, error_text="Could not load comments")
         assert 'data-pjx-error-text="Could not load comments"' in html
 
-    def test_error_string_is_escaped_inside_the_template(self, session):
-        # A plain string in a Slot field still autoescapes in pyjinhx (only
-        # BaseComponent values render raw) — see the TestRender note above.
+    def test_error_string_renders_raw_inside_the_template(self, session):
+        # ADR 0003: a plain string in a Slot field is authored markup.
         html = _html(session, error="<p>Boom</p>")
-        assert (
-            "<template data-pjx-lazy-error>&lt;p&gt;Boom&lt;/p&gt;</template>" in html
-        )
+        assert "<template data-pjx-lazy-error><p>Boom</p></template>" in html
 
     def test_error_component_renders_raw_inside_the_template(self, session):
         from pyjinhx.builtins.ui.pjx_badge import PJXBadge

--- a/tests/pyjinhx/builtins/test_pjx_table_body.py
+++ b/tests/pyjinhx/builtins/test_pjx_table_body.py
@@ -39,10 +39,11 @@ class TestRender:
             == '<tbody id="b1" class="pjx-table__body sticky"></tbody>'
         )
 
-    def test_string_content_is_escaped(self, session):
+    def test_string_content_stays_raw(self, session):
+        # ADR 0003: a plain str in a Slot field is authored markup.
         assert (
             render(PJXTableBody(id="b1", content="a & b"), session)
-            == '<tbody id="b1" class="pjx-table__body">a &amp; b</tbody>'
+            == '<tbody id="b1" class="pjx-table__body">a & b</tbody>'
         )
 
     def test_component_content_renders_as_an_opaque_child(self, session):

--- a/tests/pyjinhx/builtins/test_pjx_table_cell.py
+++ b/tests/pyjinhx/builtins/test_pjx_table_cell.py
@@ -43,10 +43,11 @@ class TestRender:
             == '<td id="c1" class="pjx-table__cell num"></td>'
         )
 
-    def test_string_content_is_escaped(self, session):
+    def test_string_content_stays_raw(self, session):
+        # ADR 0003: a plain str in a Slot field is authored markup.
         assert (
             render(PJXTableCell(id="c1", content="a & b"), session)
-            == '<td id="c1" class="pjx-table__cell">a &amp; b</td>'
+            == '<td id="c1" class="pjx-table__cell">a & b</td>'
         )
 
     def test_component_content_renders_as_an_opaque_child(self, session):

--- a/tests/pyjinhx/builtins/test_pjx_table_head.py
+++ b/tests/pyjinhx/builtins/test_pjx_table_head.py
@@ -39,10 +39,11 @@ class TestRender:
             == '<thead id="h1" class="pjx-table__head sticky"></thead>'
         )
 
-    def test_string_content_is_escaped(self, session):
+    def test_string_content_stays_raw(self, session):
+        # ADR 0003: a plain str in a Slot field is authored markup.
         assert (
             render(PJXTableHead(id="h1", content="a & b"), session)
-            == '<thead id="h1" class="pjx-table__head">a &amp; b</thead>'
+            == '<thead id="h1" class="pjx-table__head">a & b</thead>'
         )
 
     def test_component_content_renders_as_an_opaque_child(self, session):

--- a/tests/pyjinhx/test_slot_collections.py
+++ b/tests/pyjinhx/test_slot_collections.py
@@ -146,7 +146,9 @@ class TestBuildContext:
         context = build_context(Card(content=[a, b]), Card.__pjx_descriptor__)
         value = context["content"]
 
-        assert type(value) is list
+        # A list subclass (so bare `{{ content }}` also composes markup), but
+        # an ordinary list for every purpose a template or test cares about.
+        assert isinstance(value, list)
         assert not isinstance(value, ComponentNode)
         assert [type(v) for v in value] == [ComponentNode, ComponentNode]
         assert [v.component for v in value] == [a, b]
@@ -161,7 +163,9 @@ class TestBuildContext:
         context = build_context(Card(content={"one": a}), Card.__pjx_descriptor__)
         value = context["content"]
 
-        assert type(value) is dict
+        # A dict subclass (so bare `{{ content }}` also composes markup), but
+        # an ordinary dict for every purpose a template or test cares about.
+        assert isinstance(value, dict)
         assert list(value.keys()) == ["one"]
         assert type(value["one"]) is ComponentNode
         assert value["one"].component is a
@@ -499,3 +503,31 @@ class TestCollectionTruthiness:
         Card.__pjx_descriptor__ = descriptor("slot_if.html", frozenset({"content"}))
 
         assert render(Card(content={}), session()) == "<div>NONE</div>"
+
+
+class TestBuiltinCardWithListContent:
+    """A list of components on a builtin's plain `Slot` field composes.
+
+    The container stays an ordinary list so `{{ content }}` and `{% for %}`
+    both work; each entry is its own opaque node, so nothing leaks a repr.
+    """
+
+    def test_a_card_with_a_list_of_regions_renders_composed_markup(self):
+        from pyjinhx.builtins.ui.pjx_card import PJXCard
+        from pyjinhx.builtins.ui.pjx_card_body import PJXCardBody
+        from pyjinhx.builtins.ui.pjx_card_header import PJXCardHeader
+
+        output = render(
+            PJXCard(
+                content=[
+                    PJXCardHeader(content="Title"),
+                    PJXCardBody(content="Body"),
+                ]
+            ),
+            RenderSession(template_dir="/"),
+        )
+
+        assert "Title" in output
+        assert "Body" in output
+        assert "ComponentNode(" not in output
+        assert output.index("Title") < output.index("Body")

--- a/tests/pyjinhx/test_slot_props_view.py
+++ b/tests/pyjinhx/test_slot_props_view.py
@@ -488,5 +488,6 @@ class TestStringSlotThroughProps:
         card = Card(content=Inner(body="<b>hi</b>"))
         context = build_context(card, Card.__pjx_descriptor__)
 
-        assert context["content"].props.body == "<b>hi</b>"
-        assert context["content"].props.body.__html__() == "<b>hi</b>"
+        body = context["content"].props.body
+        assert body == "<b>hi</b>"
+        assert body.__html__() == "<b>hi</b>"  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/pyjinhx/test_slot_props_view.py
+++ b/tests/pyjinhx/test_slot_props_view.py
@@ -435,3 +435,58 @@ class TestPropsRegressions:
         assert nested.component is leaf
         with pytest.raises(TypeError, match=r"slot 'content\.props\.inner'"):
             str(nested)
+
+
+class TestStringSlotThroughProps:
+    """The `.props` escape hatch must not re-escape a slot's authored markup."""
+
+    def test_a_string_slot_field_comes_back_as_markup(self):
+        from markupsafe import Markup
+
+        class Card(BaseComponent):
+            body: Slot = ""
+
+        props = Card(body="<b>hi</b>").pjx_props()
+
+        assert isinstance(props["body"], Markup)
+        assert props["body"] == "<b>hi</b>"
+
+    def test_a_string_children_field_comes_back_as_markup(self):
+        from markupsafe import Markup
+
+        class Card(BaseComponent):
+            body: Children = ""
+
+        assert isinstance(Card(body="<b>hi</b>").pjx_props()["body"], Markup)
+
+    def test_a_non_slot_string_field_stays_a_plain_str(self):
+        from markupsafe import Markup
+
+        class Card(BaseComponent):
+            label: str = ""
+
+        value = Card(label="<b>hi</b>").pjx_props()["label"]
+
+        assert not isinstance(value, Markup)
+        assert value == "<b>hi</b>"
+
+    def test_props_reads_the_string_slot_unescaped_through_a_node(self):
+        from pyjinhx.render_context import build_context
+
+        class Inner(BaseComponent):
+            body: Slot = ""
+
+        Inner.__pjx_descriptor__ = descriptor("slot_leaf.html", frozenset({"body"}))
+
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        Card.__pjx_descriptor__ = descriptor(
+            "nest_content.html", frozenset({"content"})
+        )
+
+        card = Card(content=Inner(body="<b>hi</b>"))
+        context = build_context(card, Card.__pjx_descriptor__)
+
+        assert context["content"].props.body == "<b>hi</b>"
+        assert context["content"].props.body.__html__() == "<b>hi</b>"

--- a/tests/pyjinhx/test_slot_semantics_matrix.py
+++ b/tests/pyjinhx/test_slot_semantics_matrix.py
@@ -113,18 +113,14 @@ class TestTruthinessWithInterpolation:
         assert "pjx-slot-" not in output
 
     def test_a_string_slot_beside_a_component_slot_stays_raw_html(self):
-        # Production gap, not a fixture bug: ADR 0003 constraint 2 says
-        # plain-string Slot fields stay raw-HTML-capable, but with
-        # autoescape ON (shipped after #367-#372) a bare string slot value
-        # is escaped like any other Jinja variable — nothing in the render
-        # pipeline currently marks Slot-typed strings as Markup. Pinned as
-        # observed; flagged for follow-up rather than patched here.
+        # ADR 0003 constraint 2: plain-string Slot fields stay raw-HTML-capable.
+        # Fixed by wrapping str slot values in Markup (see _wrap_slot_value).
         Card = self.card("slot_mixed_kinds.html", frozenset({"content", "note"}))
 
         output = render(Card(content=Leaf(text="c"), note="<em>raw</em>"), session())
 
         assert output == (
-            '<div class="card"><span class="leaf">c</span>&lt;em&gt;raw&lt;/em&gt;</div>'
+            '<div class="card"><span class="leaf">c</span><em>raw</em></div>'
         )
 
     def test_a_string_slot_is_not_wrapped_in_a_component_node(self):
@@ -630,3 +626,39 @@ class TestCrossRenderIsolation:
 
         assert first == second == '<div class="card"><span class="leaf">a</span></div>'
         assert "pjx-slot-" not in first + second
+
+
+class TestStringSlotStaysRawHtml:
+    """ADR 0003: a Slot field holding a plain string is raw-HTML-capable."""
+
+    def card(self):
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        Card.__pjx_descriptor__ = descriptor(
+            "nest_content.html", frozenset({"content"})
+        )
+        return Card
+
+    def test_a_string_slot_renders_unescaped_through_render(self):
+        card = self.card()(content="<b>hi</b>")
+
+        assert render(card, session()) == '<div class="card"><b>hi</b></div>'
+
+    def test_a_string_slot_is_markup_in_the_built_context(self):
+        from markupsafe import Markup
+
+        card = self.card()(content="<b>hi</b>")
+
+        context = build_context(card, type(card).__pjx_descriptor__)
+
+        assert isinstance(context["content"], Markup)
+        assert context["content"] == "<b>hi</b>"
+
+    def test_an_empty_string_slot_still_renders_empty(self):
+        assert render(self.card()(content=""), session()) == '<div class="card"></div>'
+
+    def test_a_string_slot_interpolated_bare_is_not_escaped(self):
+        card = self.card()(content="<i>x</i>")
+
+        assert render_expr("{{ content }}", card) == "<i>x</i>"

--- a/tests/pyjinhx/test_slot_semantics_matrix.py
+++ b/tests/pyjinhx/test_slot_semantics_matrix.py
@@ -406,7 +406,9 @@ class TestCollectionsMatrix:
 
         value = build_context(Card(content=[a, b]), Card.__pjx_descriptor__)["content"]
 
-        assert type(value) is list
+        # A list subclass (so bare `{{ content }}` also composes markup), but
+        # an ordinary list for every purpose a template or test cares about.
+        assert isinstance(value, list)
         assert [type(v) for v in value] == [ComponentNode, ComponentNode]
         assert {v.field_name for v in value} == {"content"}
         assert [v.component for v in value] == [a, b]

--- a/tests/pyjinhx/test_slot_type_v2.py
+++ b/tests/pyjinhx/test_slot_type_v2.py
@@ -15,7 +15,6 @@ from pyjinhx.component import (
 )
 from pyjinhx.descriptor import ClassDescriptor
 from pyjinhx.render_context import build_context
-from pyjinhx.rendering import render
 from pyjinhx.session import RenderSession
 
 

--- a/tests/pyjinhx/test_slot_type_v2.py
+++ b/tests/pyjinhx/test_slot_type_v2.py
@@ -1,6 +1,8 @@
+from pathlib import Path
 from typing import Annotated, ClassVar, Optional
 
 import pytest
+from markupsafe import Markup
 from pydantic import BaseModel, ValidationError
 
 from pyjinhx.component import (
@@ -11,6 +13,10 @@ from pyjinhx.component import (
     _is_component_typed_annotation,
     _is_slot_field,
 )
+from pyjinhx.descriptor import ClassDescriptor
+from pyjinhx.render_context import build_context
+from pyjinhx.rendering import render
+from pyjinhx.session import RenderSession
 
 
 class TestPjxSlotMarker:
@@ -502,3 +508,54 @@ class TestIsSlotFieldStructuralCondition:
 
     def test_unknown_field_name_is_still_not_a_slot(self):
         assert _is_slot_field(_AutoSlots, "not_a_field") is False
+
+
+class TestMarkupExemptionIsScopedToSlots:
+    """The Slot exemption must not become global un-escaping."""
+
+    def descriptor(self, template: str, slots: frozenset[str]):
+        return ClassDescriptor(
+            template_path=Path(template),
+            slot_fields=slots,
+            children_field=None,
+            css_paths=(),
+            js_paths=(),
+            strict=True,
+            provenance={},
+        )
+
+    def test_a_non_slot_str_field_is_not_markup_in_the_context(self):
+        class Card(BaseComponent):
+            content: Slot = ""
+            label: str = ""
+
+        Card.__pjx_descriptor__ = self.descriptor(
+            "nest_content.html", frozenset({"content"})
+        )
+
+        context = build_context(
+            Card(content="<b>a</b>", label="<b>b</b>"), Card.__pjx_descriptor__
+        )
+
+        assert isinstance(context["content"], Markup)
+        assert not isinstance(context["label"], Markup)
+
+    def test_a_non_slot_str_field_still_autoescapes_when_rendered(self):
+        class Card(BaseComponent):
+            content: Slot = ""
+
+        Card.__pjx_descriptor__ = self.descriptor(
+            "nest_content.html", frozenset({"content"})
+        )
+        session = RenderSession(template_dir="tests/templates")
+        template = session.jinja_env.from_string("{{ label }}")
+        context = build_context(Card(content=""), Card.__pjx_descriptor__)
+        context["label"] = "<b>b</b>"
+
+        assert template.render(context) == "&lt;b&gt;b&lt;/b&gt;"
+
+    def test_is_slot_field_still_rejects_a_plain_str_field(self):
+        class Card(BaseComponent):
+            label: str = ""
+
+        assert _is_slot_field(Card, "label") is False

--- a/tests/pyjinhx/test_slot_type_v2.py
+++ b/tests/pyjinhx/test_slot_type_v2.py
@@ -256,7 +256,7 @@ class TestSlotInterpolation:
         assert "ComponentNode" not in html
         assert "pjx-slot-" not in html
 
-    def test_string_slot_still_interpolates_escaped(self):
+    def test_string_slot_still_interpolates_raw(self):
         from pyjinhx.rendering import render
         from pyjinhx.session import RenderSession
 
@@ -267,7 +267,7 @@ class TestSlotInterpolation:
         session = RenderSession(template_dir="tests/templates")
         html = render(StringBox(content="<b>x</b>"), session)
 
-        assert html == '<div class="box">before &lt;b&gt;x&lt;/b&gt; after</div>'
+        assert html == '<div class="box">before <b>x</b> after</div>'
 
     def test_component_slot_is_rendered_exactly_once(self):
         from pyjinhx.session import RenderSession

--- a/tests/test_bench_fixture_parity.py
+++ b/tests/test_bench_fixture_parity.py
@@ -1,10 +1,10 @@
 """Cheap CI guard: the v0.36 and v2 bench pages must reference the same components.
 
 Not timing-sensitive — no rendering happens here, only manifest comparison,
-except for `test_v2_table_cell_content_is_pinned_as_escaped_not_a_bug_to_fix_here`
-below, which does render (a single small table) to pin a known, out-of-scope
-str-Slot-escaping gap (see bench_builtin_heavy's module docstring) so a
-future accidental fix to the renderer doesn't slip by unnoticed here.
+except for `test_v2_table_cell_content_stays_raw_html` below, which does
+render (a single small table) to pin the fixed str-Slot behavior (see
+bench_builtin_heavy's module docstring) — #686 restored ADR 0003's
+raw-HTML-capable Slot invariant, so this now matches v0's rendering.
 """
 
 import pkgutil
@@ -69,19 +69,15 @@ def _v2_registry() -> None:
     build_registry("pyjinhx/builtins", found)
 
 
-def test_v2_table_cell_content_is_pinned_as_escaped_not_a_bug_to_fix_here() -> None:
-    """v2's table cell renders its raw-HTML Slot value escaped, unlike v0.
+def test_v2_table_cell_content_stays_raw_html() -> None:
+    """v2's table cell renders its raw-HTML Slot value raw, matching v0.
 
-    v0's equivalent page (`build_v0_table`) renders a live `<input>` element
-    inside this cell; v2 escapes the same markup string to inert text — a
-    pre-existing, out-of-scope-for-#537 str-Slot-escaping gap (see
-    bench_builtin_heavy's module docstring). Pinned as observed, same as
-    `test_a_string_slot_beside_a_component_slot_stays_raw_html` in
-    test_slot_semantics_matrix.py, rather than "fixed" here: wrapping the
-    value in `markupsafe.Markup` does not survive pydantic's plain-`str`
-    coercion on the Slot field, so there is no fixture-only fix available.
+    #686 restored ADR 0003's invariant that a plain-`str` Slot value is
+    raw-HTML-capable: `_wrap_slot_value` now wraps it in `markupsafe.Markup`
+    after retrieval, so pydantic's plain-`str` coercion on assignment (which
+    strips `Markup`'s `__html__` protocol) is no longer in the way.
     """
     _v2_registry()
     html = v2_render(build_v2_table(rows=1), RenderSession(template_dir="/"))
-    assert "&lt;input" in html
-    assert '<input type="text" value="v0"/>' not in html
+    assert '<input type="text" value="v0"/>' in html
+    assert "&lt;input" not in html


### PR DESCRIPTION
## Summary

Restore the raw-HTML-capable Slot invariant from ADR 0003 by:
- Wrapping slot string values in markupsafe.Markup after retrieval
- Fixing composition of list/dict components on plain Slot fields
- Adding test guard to keep Markup exemption scoped to slot fields
- Updating 30+ pre-existing tests that pinned the escaped-string bug

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)