### PR TITLE
feat: add pjx_badge.css styling (#694)

### DIFF
--- a/pyjinhx/builtins/ui/pjx_badge/pjx_badge.css
+++ b/pyjinhx/builtins/ui/pjx_badge/pjx_badge.css
@@ -1,0 +1,85 @@
+:where(:root) {
+  --pjx-badge-padding:       0.2rem 0.5rem;
+  --pjx-badge-font-size:     var(--font-size-xs);
+  --pjx-badge-font-weight:   600;
+  --pjx-badge-line-height:   1.4;
+  --pjx-badge-min-height:    1.25rem;
+  --pjx-badge-radius:        var(--radius-sm);
+  --pjx-badge-bg:            var(--surface-alt);
+  --pjx-badge-text:          var(--text);
+  --pjx-badge-border:        var(--border);
+  --pjx-badge-brand-bg:      var(--brand-subtle);
+  --pjx-badge-brand-text:    var(--brand);
+  --pjx-badge-brand-border:  var(--brand-muted);
+  --pjx-badge-error-bg:      var(--error-bg);
+  --pjx-badge-error-text:    var(--error);
+  --pjx-badge-error-border:  var(--error-border);
+  --pjx-badge-muted-bg:      color-mix(in srgb, var(--text-muted) 12%, transparent);
+  --pjx-badge-muted-text:    var(--text-muted);
+  --pjx-badge-muted-border:  color-mix(in srgb, var(--text-muted) 30%, transparent);
+}
+
+.pjx-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  min-height: var(--pjx-badge-min-height, 1.25rem);
+  padding: var(--pjx-badge-padding, 0.2rem 0.5rem);
+  font-size: var(--pjx-badge-font-size, var(--font-size-xs));
+  font-weight: var(--pjx-badge-font-weight, 600);
+  line-height: var(--pjx-badge-line-height, 1.4);
+  white-space: nowrap;
+  vertical-align: middle;
+  background: var(--pjx-badge-bg, var(--surface-alt));
+  color: var(--pjx-badge-text, var(--text));
+  border: 1px solid var(--pjx-badge-border, var(--border));
+  border-radius: var(--pjx-badge-radius, var(--radius-sm));
+}
+
+.pjx-badge--brand {
+  background: var(--pjx-badge-brand-bg, var(--brand-subtle));
+  color: var(--pjx-badge-brand-text, var(--brand));
+  border-color: var(--pjx-badge-brand-border, var(--brand-muted));
+}
+
+.pjx-badge--error {
+  background: var(--pjx-badge-error-bg, var(--error-bg));
+  color: var(--pjx-badge-error-text, var(--error));
+  border-color: var(--pjx-badge-error-border, var(--error-border));
+}
+
+.pjx-badge--neutral {
+  background: var(--pjx-badge-bg, var(--surface-alt));
+  color: var(--pjx-badge-text, var(--text));
+  border-color: var(--pjx-badge-border, var(--border));
+}
+
+.pjx-badge--muted {
+  background: var(--pjx-badge-muted-bg, transparent);
+  color: var(--pjx-badge-muted-text, var(--text-muted));
+  border-color: var(--pjx-badge-muted-border, var(--border));
+}
+
+.pjx-badge--square {
+  border-radius: 0;
+}
+
+.pjx-badge--sm {
+  min-height: 1.05rem;
+  padding: 0.1rem 0.4rem;
+  font-size: var(--font-size-xs);
+  border-radius: var(--radius-sm);
+}
+
+.pjx-badge--md {
+  min-height: 1.45rem;
+  padding: 0.25rem 0.6rem;
+  font-size: var(--font-size-sm);
+  border-radius: var(--radius-md);
+}
+
+.pjx-badge--full {
+  padding: 0.25rem 0.75rem;
+  border-radius: var(--radius-full);
+}

--- a/tests/pyjinhx/builtins/pjx_badge/test_pjx_badge.py
+++ b/tests/pyjinhx/builtins/pjx_badge/test_pjx_badge.py
@@ -73,3 +73,37 @@ def test_undeclared_attr_is_rejected():
     """
     with pytest.raises(ValidationError):
         PJXBadge(id="b", **{"data-x": "y"})  # pyright: ignore[reportCallIssue, reportArgumentType]
+
+
+def test_descriptor_finds_snake_case_css():
+    """The descriptor probes "<snake_case class name>.css" next to the module.
+
+    Mirrors tests/pyjinhx/builtins/pjx_avatar/test_pjx_avatar.py: css_paths is a
+    tuple with 0 or 1 entries (one probe per class, per ADR 0007).
+    """
+    css_paths = PJXBadge.__pjx_descriptor__.css_paths
+    assert len(css_paths) == 1
+    assert css_paths[0].name == "pjx_badge.css"
+
+
+@pytest.mark.parametrize("color", ["brand", "error", "neutral", "muted"])
+def test_css_styles_every_color_variant(color):
+    """Every value of the color Literal has a matching rule; none renders unstyled."""
+    css = PJXBadge.__pjx_descriptor__.css_paths[0].read_text(encoding="utf-8")
+    assert f".pjx-badge--{color}" in css
+
+
+@pytest.mark.parametrize("shape", ["square", "sm", "md", "full"])
+def test_css_styles_every_shape_variant(shape):
+    css = PJXBadge.__pjx_descriptor__.css_paths[0].read_text(encoding="utf-8")
+    assert f".pjx-badge--{shape}" in css
+
+
+def test_css_uses_shared_tokens_not_hardcoded_hex():
+    """Colors come from docs/demos/base.css tokens so light/dark repaint for free."""
+    css = PJXBadge.__pjx_descriptor__.css_paths[0].read_text(encoding="utf-8")
+    assert ":where(:root)" in css
+    assert "--pjx-badge-" in css
+    assert "var(--brand" in css
+    assert "var(--error" in css
+    assert "#" not in css


### PR DESCRIPTION
## Summary

Adds `pjx_badge.css` with styling for all PJXBadge color and shape variants. The component had no CSS backing, so badges previously rendered as unstyled inline text.

- Custom-property block sourced from `docs/demos/base.css` tokens (--surface-alt, --text, --border, --brand*, --error*, --radius-*)
- Follows pjx_dropdown.css convention: var() with fallback tokens, no hardcoded hex values
- Styles all 4 color variants (brand/error/neutral/muted) and 4 shape variants (square/sm/md/full)
- Light/dark repaint automatic via tokens
- Investigated pjx_accordion_content: no CSS file needed (correctly deferred)
- Added descriptor/content assertion tests (3 tests) mirroring pjx_avatar precedent

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)