### PR TITLE
fix: expose all builtin components via pyjinhx.builtins

### DIFF
--- a/pyjinhx/builtins/__init__.py
+++ b/pyjinhx/builtins/__init__.py
@@ -2,5 +2,264 @@
 
 One directory per component: the module, its ``.pjx`` template and any
 co-located asset live together so the descriptor's module-dir walk finds them
-without configuration.
+without configuration. This module re-exports every builtin's public class,
+lazily, so callers can do ``from pyjinhx.builtins import PJXButton`` instead
+of reaching into the individual component's submodule.
 """
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+__all__ = [  # noqa: RUF022
+    "PJXAccordion",
+    "PJXAccordionContent",
+    "PJXAccordionGroup",
+    "PJXAccordionTrigger",
+    "PJXAlert",
+    "PJXAvatar",
+    "PJXAvatarStack",
+    "PJXBadge",
+    "PJXBreadcrumb",
+    "PJXButton",
+    "PJXCard",
+    "PJXCardBody",
+    "PJXCardFooter",
+    "PJXCardHeader",
+    "PJXCarousel",
+    "PJXCarouselSlide",
+    "PJXChipInput",
+    "PJXDivider",
+    "PJXDrawer",
+    "PJXDrawerBody",
+    "PJXDrawerFooter",
+    "PJXDrawerHeader",
+    "PJXDropdown",
+    "PJXEmptyState",
+    "PJXFormField",
+    "PJXIcon",
+    "PJXLazyLoad",
+    "PJXModal",
+    "PJXModalBody",
+    "PJXModalFooter",
+    "PJXModalHeader",
+    "PJXNotification",
+    "PJXPageLoader",
+    "PJXPaginator",
+    "PJXPasswordInput",
+    "PJXPopover",
+    "PJXPopoverPanel",
+    "PJXPopoverTrigger",
+    "PJXProgress",
+    "PJXRegionLoader",
+    "PJXResizableGroup",
+    "PJXResizableHandle",
+    "PJXResizablePanel",
+    "PJXSegmentedControl",
+    "PJXSkeleton",
+    "PJXSpinner",
+    "PJXTab",
+    "PJXTabGroup",
+    "PJXTable",
+    "PJXTableBody",
+    "PJXTableCell",
+    "PJXTableHead",
+    "PJXTableHeaderCell",
+    "PJXTableRow",
+    "PJXTabList",
+    "PJXTabPanel",
+    "PJXToastHost",
+    "PJXToggleSwitch",
+    "PJXTooltip",
+    "PJXTooltipContent",
+    "PJXTooltipTrigger",
+]
+
+_lazy_imports = {
+    "PJXAccordion": ("pyjinhx.builtins.ui.pjx_accordion.pjx_accordion", "PJXAccordion"),
+    "PJXAccordionContent": (
+        "pyjinhx.builtins.ui.pjx_accordion_content.pjx_accordion_content",
+        "PJXAccordionContent",
+    ),
+    "PJXAccordionGroup": (
+        "pyjinhx.builtins.ui.pjx_accordion_group.pjx_accordion_group",
+        "PJXAccordionGroup",
+    ),
+    "PJXAccordionTrigger": (
+        "pyjinhx.builtins.ui.pjx_accordion_trigger.pjx_accordion_trigger",
+        "PJXAccordionTrigger",
+    ),
+    "PJXAlert": ("pyjinhx.builtins.ui.pjx_alert.pjx_alert", "PJXAlert"),
+    "PJXAvatar": ("pyjinhx.builtins.ui.pjx_avatar.pjx_avatar", "PJXAvatar"),
+    "PJXAvatarStack": (
+        "pyjinhx.builtins.ui.pjx_avatar_stack.pjx_avatar_stack",
+        "PJXAvatarStack",
+    ),
+    "PJXBadge": ("pyjinhx.builtins.ui.pjx_badge.pjx_badge", "PJXBadge"),
+    "PJXBreadcrumb": (
+        "pyjinhx.builtins.ui.pjx_breadcrumb.pjx_breadcrumb",
+        "PJXBreadcrumb",
+    ),
+    "PJXButton": ("pyjinhx.builtins.ui.pjx_button.pjx_button", "PJXButton"),
+    "PJXCard": ("pyjinhx.builtins.ui.pjx_card.pjx_card", "PJXCard"),
+    "PJXCardBody": ("pyjinhx.builtins.ui.pjx_card_body.pjx_card_body", "PJXCardBody"),
+    "PJXCardFooter": (
+        "pyjinhx.builtins.ui.pjx_card_footer.pjx_card_footer",
+        "PJXCardFooter",
+    ),
+    "PJXCardHeader": (
+        "pyjinhx.builtins.ui.pjx_card_header.pjx_card_header",
+        "PJXCardHeader",
+    ),
+    "PJXCarousel": ("pyjinhx.builtins.ui.pjx_carousel.pjx_carousel", "PJXCarousel"),
+    "PJXCarouselSlide": (
+        "pyjinhx.builtins.ui.pjx_carousel_slide.pjx_carousel_slide",
+        "PJXCarouselSlide",
+    ),
+    "PJXChipInput": (
+        "pyjinhx.builtins.ui.pjx_chip_input.pjx_chip_input",
+        "PJXChipInput",
+    ),
+    "PJXDivider": ("pyjinhx.builtins.ui.pjx_divider.pjx_divider", "PJXDivider"),
+    "PJXDrawer": ("pyjinhx.builtins.ui.pjx_drawer.pjx_drawer", "PJXDrawer"),
+    "PJXDrawerBody": (
+        "pyjinhx.builtins.ui.pjx_drawer_body.pjx_drawer_body",
+        "PJXDrawerBody",
+    ),
+    "PJXDrawerFooter": (
+        "pyjinhx.builtins.ui.pjx_drawer_footer.pjx_drawer_footer",
+        "PJXDrawerFooter",
+    ),
+    "PJXDrawerHeader": (
+        "pyjinhx.builtins.ui.pjx_drawer_header.pjx_drawer_header",
+        "PJXDrawerHeader",
+    ),
+    "PJXDropdown": ("pyjinhx.builtins.ui.pjx_dropdown.pjx_dropdown", "PJXDropdown"),
+    "PJXEmptyState": (
+        "pyjinhx.builtins.ui.pjx_empty_state.pjx_empty_state",
+        "PJXEmptyState",
+    ),
+    "PJXFormField": (
+        "pyjinhx.builtins.ui.pjx_form_field.pjx_form_field",
+        "PJXFormField",
+    ),
+    "PJXIcon": ("pyjinhx.builtins.ui.pjx_icon.pjx_icon", "PJXIcon"),
+    "PJXLazyLoad": ("pyjinhx.builtins.pjx_lazy_load.pjx_lazy_load", "PJXLazyLoad"),
+    "PJXModal": ("pyjinhx.builtins.ui.pjx_modal.pjx_modal", "PJXModal"),
+    "PJXModalBody": (
+        "pyjinhx.builtins.ui.pjx_modal_body.pjx_modal_body",
+        "PJXModalBody",
+    ),
+    "PJXModalFooter": (
+        "pyjinhx.builtins.ui.pjx_modal_footer.pjx_modal_footer",
+        "PJXModalFooter",
+    ),
+    "PJXModalHeader": (
+        "pyjinhx.builtins.ui.pjx_modal_header.pjx_modal_header",
+        "PJXModalHeader",
+    ),
+    "PJXNotification": (
+        "pyjinhx.builtins.ui.pjx_notification.pjx_notification",
+        "PJXNotification",
+    ),
+    "PJXPageLoader": (
+        "pyjinhx.builtins.pjx_page_loader.pjx_page_loader",
+        "PJXPageLoader",
+    ),
+    "PJXPaginator": ("pyjinhx.builtins.pjx_paginator.pjx_paginator", "PJXPaginator"),
+    "PJXPasswordInput": (
+        "pyjinhx.builtins.ui.pjx_password_input.pjx_password_input",
+        "PJXPasswordInput",
+    ),
+    "PJXPopover": ("pyjinhx.builtins.ui.pjx_popover.pjx_popover", "PJXPopover"),
+    "PJXPopoverPanel": (
+        "pyjinhx.builtins.ui.pjx_popover_panel.pjx_popover_panel",
+        "PJXPopoverPanel",
+    ),
+    "PJXPopoverTrigger": (
+        "pyjinhx.builtins.ui.pjx_popover_trigger.pjx_popover_trigger",
+        "PJXPopoverTrigger",
+    ),
+    "PJXProgress": ("pyjinhx.builtins.ui.pjx_progress.pjx_progress", "PJXProgress"),
+    "PJXRegionLoader": (
+        "pyjinhx.builtins.pjx_region_loader.pjx_region_loader",
+        "PJXRegionLoader",
+    ),
+    "PJXResizableGroup": (
+        "pyjinhx.builtins.ui.pjx_resizable_group.pjx_resizable_group",
+        "PJXResizableGroup",
+    ),
+    "PJXResizableHandle": (
+        "pyjinhx.builtins.ui.pjx_resizable_handle.pjx_resizable_handle",
+        "PJXResizableHandle",
+    ),
+    "PJXResizablePanel": (
+        "pyjinhx.builtins.ui.pjx_resizable_panel.pjx_resizable_panel",
+        "PJXResizablePanel",
+    ),
+    "PJXSegmentedControl": (
+        "pyjinhx.builtins.ui.pjx_segmented_control.pjx_segmented_control",
+        "PJXSegmentedControl",
+    ),
+    "PJXSkeleton": ("pyjinhx.builtins.ui.pjx_skeleton.pjx_skeleton", "PJXSkeleton"),
+    "PJXSpinner": ("pyjinhx.builtins.ui.pjx_spinner.pjx_spinner", "PJXSpinner"),
+    "PJXTab": ("pyjinhx.builtins.ui.pjx_tab.pjx_tab", "PJXTab"),
+    "PJXTabGroup": ("pyjinhx.builtins.ui.pjx_tab_group.pjx_tab_group", "PJXTabGroup"),
+    "PJXTable": ("pyjinhx.builtins.pjx_table.pjx_table", "PJXTable"),
+    "PJXTableBody": ("pyjinhx.builtins.pjx_table_body.pjx_table_body", "PJXTableBody"),
+    "PJXTableCell": ("pyjinhx.builtins.pjx_table_cell.pjx_table_cell", "PJXTableCell"),
+    "PJXTableHead": ("pyjinhx.builtins.pjx_table_head.pjx_table_head", "PJXTableHead"),
+    "PJXTableHeaderCell": (
+        "pyjinhx.builtins.pjx_table_header_cell.pjx_table_header_cell",
+        "PJXTableHeaderCell",
+    ),
+    "PJXTableRow": ("pyjinhx.builtins.pjx_table_row.pjx_table_row", "PJXTableRow"),
+    "PJXTabList": ("pyjinhx.builtins.ui.pjx_tab_list.pjx_tab_list", "PJXTabList"),
+    "PJXTabPanel": ("pyjinhx.builtins.ui.pjx_tab_panel.pjx_tab_panel", "PJXTabPanel"),
+    "PJXToastHost": (
+        "pyjinhx.builtins.ui.pjx_toast_host.pjx_toast_host",
+        "PJXToastHost",
+    ),
+    "PJXToggleSwitch": (
+        "pyjinhx.builtins.ui.pjx_toggle_switch.pjx_toggle_switch",
+        "PJXToggleSwitch",
+    ),
+    "PJXTooltip": ("pyjinhx.builtins.ui.pjx_tooltip.pjx_tooltip", "PJXTooltip"),
+    "PJXTooltipContent": (
+        "pyjinhx.builtins.ui.pjx_tooltip_content.pjx_tooltip_content",
+        "PJXTooltipContent",
+    ),
+    "PJXTooltipTrigger": (
+        "pyjinhx.builtins.ui.pjx_tooltip_trigger.pjx_tooltip_trigger",
+        "PJXTooltipTrigger",
+    ),
+}
+
+_cached_imports: dict[str, Any] = {}
+
+
+class _PyjinhxBuiltinsModule(types.ModuleType):
+    """Custom module that provides lazy-loaded builtin exports."""
+
+    def __getattr__(self, name: str) -> Any:
+        """Lazy-load builtin exports on demand."""
+        if name in _lazy_imports:
+            if name in _cached_imports:
+                return _cached_imports[name]
+
+            module_name, attr_name = _lazy_imports[name]
+            module = __import__(module_name, fromlist=[attr_name])
+            result = getattr(module, attr_name)
+
+            _cached_imports[name] = result
+            return result
+
+        raise AttributeError(f"module {self.__name__!r} has no attribute {name!r}")
+
+
+_current_module = sys.modules[__name__]
+_new_module = _PyjinhxBuiltinsModule(__name__)
+_new_module.__dict__.update(_current_module.__dict__)
+sys.modules[__name__] = _new_module

--- a/pyjinhx/builtins/__init__.pyi
+++ b/pyjinhx/builtins/__init__.pyi
@@ -1,0 +1,191 @@
+"""Type stubs for pyjinhx.builtins public API."""
+
+from pyjinhx.builtins.pjx_lazy_load.pjx_lazy_load import PJXLazyLoad as PJXLazyLoad
+from pyjinhx.builtins.pjx_page_loader.pjx_page_loader import (
+    PJXPageLoader as PJXPageLoader,
+)
+from pyjinhx.builtins.pjx_paginator.pjx_paginator import PJXPaginator as PJXPaginator
+from pyjinhx.builtins.pjx_region_loader.pjx_region_loader import (
+    PJXRegionLoader as PJXRegionLoader,
+)
+from pyjinhx.builtins.pjx_table.pjx_table import PJXTable as PJXTable
+from pyjinhx.builtins.pjx_table_body.pjx_table_body import PJXTableBody as PJXTableBody
+from pyjinhx.builtins.pjx_table_cell.pjx_table_cell import PJXTableCell as PJXTableCell
+from pyjinhx.builtins.pjx_table_head.pjx_table_head import PJXTableHead as PJXTableHead
+from pyjinhx.builtins.pjx_table_header_cell.pjx_table_header_cell import (
+    PJXTableHeaderCell as PJXTableHeaderCell,
+)
+from pyjinhx.builtins.pjx_table_row.pjx_table_row import PJXTableRow as PJXTableRow
+from pyjinhx.builtins.ui.pjx_accordion.pjx_accordion import PJXAccordion as PJXAccordion
+from pyjinhx.builtins.ui.pjx_accordion_content.pjx_accordion_content import (
+    PJXAccordionContent as PJXAccordionContent,
+)
+from pyjinhx.builtins.ui.pjx_accordion_group.pjx_accordion_group import (
+    PJXAccordionGroup as PJXAccordionGroup,
+)
+from pyjinhx.builtins.ui.pjx_accordion_trigger.pjx_accordion_trigger import (
+    PJXAccordionTrigger as PJXAccordionTrigger,
+)
+from pyjinhx.builtins.ui.pjx_alert.pjx_alert import PJXAlert as PJXAlert
+from pyjinhx.builtins.ui.pjx_avatar.pjx_avatar import PJXAvatar as PJXAvatar
+from pyjinhx.builtins.ui.pjx_avatar_stack.pjx_avatar_stack import (
+    PJXAvatarStack as PJXAvatarStack,
+)
+from pyjinhx.builtins.ui.pjx_badge.pjx_badge import PJXBadge as PJXBadge
+from pyjinhx.builtins.ui.pjx_breadcrumb.pjx_breadcrumb import (
+    PJXBreadcrumb as PJXBreadcrumb,
+)
+from pyjinhx.builtins.ui.pjx_button.pjx_button import PJXButton as PJXButton
+from pyjinhx.builtins.ui.pjx_card.pjx_card import PJXCard as PJXCard
+from pyjinhx.builtins.ui.pjx_card_body.pjx_card_body import PJXCardBody as PJXCardBody
+from pyjinhx.builtins.ui.pjx_card_footer.pjx_card_footer import (
+    PJXCardFooter as PJXCardFooter,
+)
+from pyjinhx.builtins.ui.pjx_card_header.pjx_card_header import (
+    PJXCardHeader as PJXCardHeader,
+)
+from pyjinhx.builtins.ui.pjx_carousel.pjx_carousel import PJXCarousel as PJXCarousel
+from pyjinhx.builtins.ui.pjx_carousel_slide.pjx_carousel_slide import (
+    PJXCarouselSlide as PJXCarouselSlide,
+)
+from pyjinhx.builtins.ui.pjx_chip_input.pjx_chip_input import (
+    PJXChipInput as PJXChipInput,
+)
+from pyjinhx.builtins.ui.pjx_divider.pjx_divider import PJXDivider as PJXDivider
+from pyjinhx.builtins.ui.pjx_drawer.pjx_drawer import PJXDrawer as PJXDrawer
+from pyjinhx.builtins.ui.pjx_drawer_body.pjx_drawer_body import (
+    PJXDrawerBody as PJXDrawerBody,
+)
+from pyjinhx.builtins.ui.pjx_drawer_footer.pjx_drawer_footer import (
+    PJXDrawerFooter as PJXDrawerFooter,
+)
+from pyjinhx.builtins.ui.pjx_drawer_header.pjx_drawer_header import (
+    PJXDrawerHeader as PJXDrawerHeader,
+)
+from pyjinhx.builtins.ui.pjx_dropdown.pjx_dropdown import PJXDropdown as PJXDropdown
+from pyjinhx.builtins.ui.pjx_empty_state.pjx_empty_state import (
+    PJXEmptyState as PJXEmptyState,
+)
+from pyjinhx.builtins.ui.pjx_form_field.pjx_form_field import (
+    PJXFormField as PJXFormField,
+)
+from pyjinhx.builtins.ui.pjx_icon.pjx_icon import PJXIcon as PJXIcon
+from pyjinhx.builtins.ui.pjx_modal.pjx_modal import PJXModal as PJXModal
+from pyjinhx.builtins.ui.pjx_modal_body.pjx_modal_body import (
+    PJXModalBody as PJXModalBody,
+)
+from pyjinhx.builtins.ui.pjx_modal_footer.pjx_modal_footer import (
+    PJXModalFooter as PJXModalFooter,
+)
+from pyjinhx.builtins.ui.pjx_modal_header.pjx_modal_header import (
+    PJXModalHeader as PJXModalHeader,
+)
+from pyjinhx.builtins.ui.pjx_notification.pjx_notification import (
+    PJXNotification as PJXNotification,
+)
+from pyjinhx.builtins.ui.pjx_password_input.pjx_password_input import (
+    PJXPasswordInput as PJXPasswordInput,
+)
+from pyjinhx.builtins.ui.pjx_popover.pjx_popover import PJXPopover as PJXPopover
+from pyjinhx.builtins.ui.pjx_popover_panel.pjx_popover_panel import (
+    PJXPopoverPanel as PJXPopoverPanel,
+)
+from pyjinhx.builtins.ui.pjx_popover_trigger.pjx_popover_trigger import (
+    PJXPopoverTrigger as PJXPopoverTrigger,
+)
+from pyjinhx.builtins.ui.pjx_progress.pjx_progress import PJXProgress as PJXProgress
+from pyjinhx.builtins.ui.pjx_resizable_group.pjx_resizable_group import (
+    PJXResizableGroup as PJXResizableGroup,
+)
+from pyjinhx.builtins.ui.pjx_resizable_handle.pjx_resizable_handle import (
+    PJXResizableHandle as PJXResizableHandle,
+)
+from pyjinhx.builtins.ui.pjx_resizable_panel.pjx_resizable_panel import (
+    PJXResizablePanel as PJXResizablePanel,
+)
+from pyjinhx.builtins.ui.pjx_segmented_control.pjx_segmented_control import (
+    PJXSegmentedControl as PJXSegmentedControl,
+)
+from pyjinhx.builtins.ui.pjx_skeleton.pjx_skeleton import PJXSkeleton as PJXSkeleton
+from pyjinhx.builtins.ui.pjx_spinner.pjx_spinner import PJXSpinner as PJXSpinner
+from pyjinhx.builtins.ui.pjx_tab.pjx_tab import PJXTab as PJXTab
+from pyjinhx.builtins.ui.pjx_tab_group.pjx_tab_group import PJXTabGroup as PJXTabGroup
+from pyjinhx.builtins.ui.pjx_tab_list.pjx_tab_list import PJXTabList as PJXTabList
+from pyjinhx.builtins.ui.pjx_tab_panel.pjx_tab_panel import PJXTabPanel as PJXTabPanel
+from pyjinhx.builtins.ui.pjx_toast_host.pjx_toast_host import (
+    PJXToastHost as PJXToastHost,
+)
+from pyjinhx.builtins.ui.pjx_toggle_switch.pjx_toggle_switch import (
+    PJXToggleSwitch as PJXToggleSwitch,
+)
+from pyjinhx.builtins.ui.pjx_tooltip.pjx_tooltip import PJXTooltip as PJXTooltip
+from pyjinhx.builtins.ui.pjx_tooltip_content.pjx_tooltip_content import (
+    PJXTooltipContent as PJXTooltipContent,
+)
+from pyjinhx.builtins.ui.pjx_tooltip_trigger.pjx_tooltip_trigger import (
+    PJXTooltipTrigger as PJXTooltipTrigger,
+)
+
+__all__ = [
+    "PJXAccordion",
+    "PJXAccordionContent",
+    "PJXAccordionGroup",
+    "PJXAccordionTrigger",
+    "PJXAlert",
+    "PJXAvatar",
+    "PJXAvatarStack",
+    "PJXBadge",
+    "PJXBreadcrumb",
+    "PJXButton",
+    "PJXCard",
+    "PJXCardBody",
+    "PJXCardFooter",
+    "PJXCardHeader",
+    "PJXCarousel",
+    "PJXCarouselSlide",
+    "PJXChipInput",
+    "PJXDivider",
+    "PJXDrawer",
+    "PJXDrawerBody",
+    "PJXDrawerFooter",
+    "PJXDrawerHeader",
+    "PJXDropdown",
+    "PJXEmptyState",
+    "PJXFormField",
+    "PJXIcon",
+    "PJXLazyLoad",
+    "PJXModal",
+    "PJXModalBody",
+    "PJXModalFooter",
+    "PJXModalHeader",
+    "PJXNotification",
+    "PJXPageLoader",
+    "PJXPaginator",
+    "PJXPasswordInput",
+    "PJXPopover",
+    "PJXPopoverPanel",
+    "PJXPopoverTrigger",
+    "PJXProgress",
+    "PJXRegionLoader",
+    "PJXResizableGroup",
+    "PJXResizableHandle",
+    "PJXResizablePanel",
+    "PJXSegmentedControl",
+    "PJXSkeleton",
+    "PJXSpinner",
+    "PJXTab",
+    "PJXTabGroup",
+    "PJXTabList",
+    "PJXTabPanel",
+    "PJXTable",
+    "PJXTableBody",
+    "PJXTableCell",
+    "PJXTableHead",
+    "PJXTableHeaderCell",
+    "PJXTableRow",
+    "PJXToastHost",
+    "PJXToggleSwitch",
+    "PJXTooltip",
+    "PJXTooltipContent",
+    "PJXTooltipTrigger",
+]


### PR DESCRIPTION
## Summary
- `pyjinhx.builtins` re-exported nothing at the top level, forcing callers to import each builtin from its full submodule path (`pyjinhx.builtins.ui.pjx_button.PJXButton`).
- Now lazily re-exports all 61 builtin classes, mirroring the pattern already used by top-level `pyjinhx/__init__.py`.
- Added a matching `pyjinhx/builtins/__init__.pyi` stub for type checking (same precedent as `pyjinhx/__init__.pyi` from #696).

## Test plan
- All 61 classes verified to resolve correctly via `getattr`.
- `basedpyright`: 0 errors, 0 warnings against the new stub.
- Full suite: 2799 passed, 1 skipped.
- `ruff check`/`format`: clean.

Closes #700