### PR TITLE
docs: fix stale render.py and fabricated pyjinhx/core refs in audit skills

### DIFF
--- a/.cursor/skills/code-audit-sweep/SKILL.md
+++ b/.cursor/skills/code-audit-sweep/SKILL.md
@@ -44,10 +44,3 @@ Read shared rules: [CONVENTIONS.md](CONVENTIONS.md).
 ## Single-lens runs
 
 If the user names one lens only (e.g. "indirection audit on this PR"), run that child skill alone; skip merge step.
-
-## Expected baselines (post reactive refactor)
-
-- `pyjinhx/reactive/` — expect zero P1 if refactor landed; P3 doc nits OK.
-- `pyjinhx/core/` — likely P2/P3 backlog (renderer size, module-level autodiscover helpers).
-
-Use dry-run results to calibrate; do not suppress real findings to match baselines.

--- a/.cursor/skills/file-responsibility-audit/SKILL.md
+++ b/.cursor/skills/file-responsibility-audit/SKILL.md
@@ -41,9 +41,11 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 | Wire format / header parsing | `payload.py` |
 | HTMX OOB algorithm | `oob.py` |
 | Runtime `<script>` injection | `runtime.py` |
-| Shared render orchestration | `render.py` |
+| Shared render orchestration | `rendering.py` |
 
 Do not create nested packages until >12 modules in the directory.
+
+Avoid a target name that collides with a re-exported symbol: `pyjinhx/__init__.py` once did `from pyjinhx.render import render`, which shadowed the `pyjinhx.render` submodule and broke `import pyjinhx.render`; the module is now `rendering.py`.
 
 ## When NOT to split
 
@@ -61,7 +63,11 @@ For each file over threshold in scope, list public symbols and group by concern.
 
 ## pyjinhx reference layout
 
-See module map in `pyjinhx/reactive/__init__.py` docstring.
+There is no maintained module map document. Derive the layout from the tree itself:
+
+```bash
+ls pyjinhx/ pyjinhx/reactive/ pyjinhx/integrations/ pyjinhx/client/ pyjinhx/builtins/
+```
 
 ## Report
 


### PR DESCRIPTION
## Summary

Fixed stale references to `render.py` and fabricated `pyjinhx/core` module paths in audit skills documentation. These references were outdated and could mislead contributors.

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)