### PR TITLE
docs(skills): fix fabricated symbols in public-api-audit

### DIFF
--- a/.cursor/skills/dead-code-audit/SKILL.md
+++ b/.cursor/skills/dead-code-audit/SKILL.md
@@ -50,12 +50,13 @@ dirty_keys
 resolve_mounted
 resolve_effective_dirtied
 warn_reactive_render_without_mounted
-get_load_context
 load_scope
-fastapi_client_backend
-parse_loaded_assets
 client_has_mounted_manifest
 data-pjx-key
+StateKey
+PyJinhxSettings
+LoadContext
+PjxLoad
 ```
 
 Also hunt stale **usage patterns** (not necessarily symbol names):
@@ -71,10 +72,10 @@ manifest.*"key"
 | Item | Why it stays |
 |------|----------------|
 | `_render(client=...)` | Tests pass explicit client for asset/runtime paths |
-| `ClientBackend.resolve_client(explicit)` | Supports `_render(client=request)` |
+| `IntegrationBackend` Protocol (`integrations/base.py`) | Structural seam for FastAPI/other hosts |
 | `_pjx_key` | Internal load-cache identity |
 | `depends_on()` default | Load-cache reverse index + dev validation |
-| `MutationTracker.render_was_consumed()` | Dev guardrail |
+| `add_dirtied()` / `get_dirtied()` (`session.py`) | Session-scoped mutation tracking behind `@mutates` |
 | `pyjinhx/__init__.py` re-exports | Public API surface |
 
 Compat shims: flag only when **zero callers** remain (grep the shim body, not just the name).
@@ -90,7 +91,7 @@ Compat shims: flag only when **zero callers** remain (grep the shim body, not ju
 rg -l '\bSYMBOL\b' pyjinhx tests examples docs .cursor/skills
 ```
 
-4. **Export vs usage** — compare `pyjinhx.__all__` to `tests/36_public_api_test.py` and doc tables; flag exports with no docs/tests if newly added.
+4. **Export vs usage** — compare `pyjinhx.__all__` to `tests/test_package_layout.py` (`EXPECTED_EXPORTS`) and doc tables; flag exports with no docs/tests if newly added.
 5. **Branch scan** — read compat helpers (`_manifest_load_arg`, `resolve_client`, etc.): is every branch reachable?
 6. **Test scan** — tests whose names/descriptions reference removed APIs (`mutation_scope`, `data-pjx-key`, instance-tier dirty keys).
 7. **Classify** each hit: delete | migrate caller | document as intentional compat | false positive.
@@ -100,13 +101,13 @@ rg -l '\bSYMBOL\b' pyjinhx tests examples docs .cursor/skills
 
 ```bash
 # Removed API ghosts (expand list as APIs drop)
-rg -n 'mutation_scope|coerce_dirty_args|interpolate_reactive_keys|dirty_keys|resolve_mounted|resolve_effective_dirtied|warn_reactive_render_without_mounted|get_load_context|fastapi_client_backend|data-pjx-key' \
+rg -n 'mutation_scope|coerce_dirty_args|interpolate_reactive_keys|dirty_keys|resolve_mounted|resolve_effective_dirtied|warn_reactive_render_without_mounted|StateKey|PyJinhxSettings|LoadContext|PjxLoad|data-pjx-key' \
   pyjinhx tests examples docs .cursor/skills
 
 # Stale render kwargs in docs/examples (not in pyjinhx — may be intentional in migration docs)
 rg -n 'render\([^)]*dirtied=|render\([^)]*mounted=' docs examples .cursor/skills
 
-# Top-level invalidate wrapper (canonical: LoadCache.invalidate)
+# Top-level invalidate re-export (canonical: pyjinhx.reactive.cache.invalidate)
 rg -n 'from pyjinhx import .*invalidate|pyjinhx\.invalidate\b' docs examples README.md
 
 # Unused imports (run ruff; triage F401 in scope only)
@@ -124,11 +125,11 @@ uv run ruff check .
 
 - [ ] No removed symbols in `pyjinhx/` (except CHANGELOG/historical notes if any)
 - [ ] No removed symbols in `tests/` imports or assertions
-- [ ] `docs/` and `examples/` use current API (`PjxKey`, `Cls.render(*args)`, `@mutates` state keys only)
+- [ ] `docs/` and `examples/` use current API (`PjxKey`, `@mutates` state keys only)
 - [ ] No orphan compat branches (manifest `key` alias, stem invalidation index, etc.) without tests or callers
 - [ ] No tests asserting deleted behavior unless explicitly marked legacy
 - [ ] Audit skills grep current symbols (`warn_reactive_render_without_client`, not `..._mounted`)
-- [ ] `__all__` / `36_public_api_test.py` / `docs/reference/public-api.md` agree
+- [ ] `__all__` / `tests/test_package_layout.py` / `docs/reference/public-api.md` agree
 
 ## Relationship to sibling audits
 

--- a/.cursor/skills/indirection-audit/SKILL.md
+++ b/.cursor/skills/indirection-audit/SKILL.md
@@ -22,16 +22,16 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 
 | Pattern | pyjinhx precedent | Fix shape |
 |---------|-------------------|-----------|
-| Module fn → classmethod only | removed `invalidate()` → `LoadCache.invalidate` | Delete wrapper; call classmethod |
-| One-line factory | removed `FastAPIClientBackend.from_request` | Use constructor |
-| Parse wrapper | removed `parse_loaded_assets` | Export `LoadedAssets.parse` |
-| Nested closure for capture | old `_cached_load` in `install_cached_load` | Store on class (`_pjx_raw_load`); one shared classmethod |
+| Module fn → classmethod only | wrapper around `LoadedAssets.parse` (`client/inject.py`) | Delete wrapper; call the staticmethod |
+| One-line factory | `FastAPIBackend(...)` wrapped in a `make_*` helper (`integrations/fastapi.py`) | Use the constructor |
+| Parse wrapper | free `parse_*` helper duplicating `MountedManifest.parse` / `TriggerManifest.parse` | Export the staticmethod |
+| Re-export of a module fn | `pyjinhx.invalidate` forwarding to `reactive.cache.invalidate` | Import from the owning module |
 | Migration shim module | deleted `client.py` re-export | Migrate imports; delete shim |
 | Classmethod → module fn only | N/A if module fn **is** the implementation | OK |
 
 ## What is OK (do not flag)
 
-- `pyjinhx/__init__.py` re-exporting `FastAPIClientBackend` from `integrations.fastapi`
+- `pyjinhx/__init__.py` re-exporting `FastAPIBackend` from `integrations.fastapi`
 - Module-level `enable_reactive_dev()` with module-private `_DevConfig` (implementation lives there)
 - Lazy imports inside functions to break cycles
 

--- a/.cursor/skills/public-api-audit/SKILL.md
+++ b/.cursor/skills/public-api-audit/SKILL.md
@@ -2,7 +2,7 @@
 name: public-api-audit
 description: >-
   Audit pyjinhx public API surface—pyjinhx.__all__, top-level exports vs canonical
-  implementations, docs/reference/public-api.md alignment, tests/36_public_api_test.py.
+  implementations, docs/reference/public-api.md alignment, tests/test_package_layout.py.
   Use before releases, after refactors, or when removing deprecated symbols. Read-only.
 disable-model-invocation: true
 ---
@@ -25,25 +25,25 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
    - `docs/api/*.md`
    - `README.md` examples (or updated to canonical names)
 3. Integration concretes may be re-exported from top-level if impl lives in `integrations/`:
-   - `from pyjinhx.integrations.fastapi import FastAPIClientBackend` in `__init__.py` ✓
+   - `from pyjinhx.integrations.fastapi import FastAPIBackend` in `__init__.py` ✓
 4. Prefer classmethods on exported types over free function wrappers:
-   - `LoadCache.invalidate`, `MountedManifest.parse`, `MutationTracker.record`
+   - `MountedManifest.parse`, `TriggerManifest.parse` (and keep `reactive.cache.invalidate` a module fn — it has no owning class)
 5. README documents API shape decisions when exports change.
 
 ## Checklist
 
 - [ ] `import pyjinhx; set(pyjinhx.__all__) == set(dir intended)`
-- [ ] No removed symbols in docs (`mutation_scope`, `dirty_keys`, `get_load_context`, `fastapi_client_backend`, top-level `invalidate`, etc.)
+- [ ] No removed symbols in docs (`mutation_scope`, `dirty_keys`, `StateKey`, `PyJinhxSettings`, `LoadContext`, `PjxLoad`, etc.)
 - [ ] New exports documented (`PjxKey`, `TriggerManifest`, `PJX_TRIGGER_HEADER`)
-- [ ] `tests/36_public_api_test.py` imports match `__all__`
-- [ ] Examples use canonical names (`PjxContext.current`, not `get_load_context`)
+- [ ] `tests/test_package_layout.py` `EXPECTED_EXPORTS` matches `pyjinhx.__all__`
+- [ ] Examples use canonical names (`PjxContext`, not `LoadContext`; `PjxKey`, not `PjxLoad`)
 - [ ] Breaking renames noted in README if user-facing
 
 ## Mechanical checks
 
 ```bash
 python -c "import pyjinhx; print(sorted(pyjinhx.__all__))"
-rg 'mutation_scope|dirty_keys|get_load_context|load_scope|fastapi_client_backend|data-pjx-key|dirtied=|mounted=|parse_loaded_assets|client_has_mounted_manifest|set_invalidation_backend|get_load_cache_scope' docs/ README.md
+rg 'mutation_scope|dirty_keys|load_scope|data-pjx-key|dirtied=|mounted=|client_has_mounted_manifest|StateKey|PyJinhxSettings|LoadContext|PjxLoad' docs/ README.md
 ```
 
 Compare `docs/reference/public-api.md` table to `pyjinhx.__all__`.


### PR DESCRIPTION
## Summary
- Corrects FastAPIClientBackend -> FastAPIBackend in public-api-audit
- Drops fictional LoadCache/MutationTracker classes
- Points test references at tests/test_package_layout.py
- Swaps get_load_context (real/current) out of removed-symbols grep list in favor of verified historical renames (StateKey, PyJinhxSettings, LoadContext, PjxLoad)
- Fixes related fabricated precedents in indirection-audit and dead-code-audit

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)