### PR TITLE
docs: replace fabricated architecture in 4 code-audit skills with grep-verified ground truth

### DIFF
--- a/.cursor/skills/domain-entity-audit/SKILL.md
+++ b/.cursor/skills/domain-entity-audit/SKILL.md
@@ -22,39 +22,40 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 
 | Concept | Representation | Not |
 |---------|----------------|-----|
-| Reactive UI unit | `ReactiveComponent` | functions in `component.py` only |
-| Load DI | `PjxContext` | `get_load_context()` wrapper |
-| HTTP header source | `ClientBackend` ABC | FastAPI type in `reactive/` |
-| Load memoization | `LoadCache` | procedural `cache.py` |
-| Dirtied keys | `MutationTracker` | scattered ContextVar helpers |
-| Cross-worker fan-out | `InvalidationBackend` + `InvalidationHub` | Redis in `reactive/` |
-| Client manifest | `MountedManifest` | loose dict parsing only |
-| Trigger region | `TriggerManifest` | ad-hoc trigger header parsing |
-| Load round-trip marker | `PjxKey` | magic `{{ key }}` template injection |
-| Loaded asset URLs | `LoadedAssets` | `parse_loaded_assets()` |
-| OOB swap walk | functions in `oob.py` | `OobSwaps` class (algorithm, not entity) |
-| Dev guardrails | module functions + `_DevConfig` | public class |
+| Reactive UI unit | `ReactiveComponent` (`pyjinhx/reactive/component.py:22`) | loose functions over a plain component |
+| Load DI | `PjxContext` (`pyjinhx/context.py:30`), read via `get_load_context()` (`pyjinhx/session.py:213`) | ad-hoc kwargs threaded through `load()` |
+| HTTP header source | request object read at the edge in `pyjinhx/client/inject.py` | a framework adapter class inside `reactive/` |
+| Load memoization | module functions `cache_get` / `cache_has` / `cache_put` / `invalidate` (`pyjinhx/reactive/cache.py`) over request-scoped session stores | a cache *class* — none exists, and none is planned |
+| Dirtied keys | `dirty()` / `mutates()` (`pyjinhx/reactive/mutations.py`) writing through `add_dirtied()` / `get_dirtied()` (`pyjinhx/session.py:166,158`) | a tracker object with its own lifecycle |
+| Cross-worker fan-out | **does not exist** — fan-out is in-process and request-scoped (`pyjinhx/reactive/fanout.py`) | any cross-process hub/backend; do not invent one |
+| Client manifest | `MountedManifest` (`pyjinhx/client/inject.py:138`) | loose dict parsing at each call site |
+| Trigger region | `TriggerManifest` (`pyjinhx/client/inject.py:168`) | ad-hoc trigger header parsing |
+| Load round-trip marker | `PjxKey` (`pyjinhx/reactive/component.py:90`) | magic `{{ key }}` template injection |
+| Loaded asset URLs | `LoadedAssets` (`pyjinhx/client/inject.py:108`) | a bare `frozenset[str]` built inline |
+| OOB swap walk | `walk_manifest()` / `oob_swaps()` over `FanoutCandidate` (`pyjinhx/reactive/fanout.py:307,450,41`) | an `OobSwaps` class (this is an algorithm, not an entity) |
+| Dev guardrails | module functions + private `_DevConfig` (`pyjinhx/dev.py:24,34`) | a public config class |
 
 ## Classification rules
 
-- **Entity / aggregate** — identity, lifecycle (`ReactiveComponent`, `LoadCache`)
-- **Value object** — parse result, no mutable identity (`MountedManifest.parse` output)
-- **Service / hub** — coordinates subsystem (`InvalidationHub`, `MutationTracker`)
-- **Algorithm** — stateless transform over inputs (`oob_swaps`, `pjx_load_value`, key coercion in `keys.py`)
-- **Port / ABC** — extension point (`ClientBackend`, `InvalidationBackend`)
+- **Entity / aggregate** — identity and lifecycle (`ReactiveComponent`)
+- **Value object** — parse result, no mutable identity (`MountedManifest.parse`, `TriggerManifest.parse`, `LoadedAssets.parse` outputs; `FanoutCandidate`)
+- **Request-scoped module** — state lives in the session, API is free functions (`pyjinhx/reactive/cache.py`, `pyjinhx/reactive/mutations.py`, `pyjinhx/registry.py`)
+- **Algorithm** — stateless transform over inputs (`oob_swaps`, `walk_manifest`, `coerce_reactive_key`)
+- **Port / Protocol** — extension point (`IntegrationBackend`, `pyjinhx/integrations/base.py:35`; sole implementation `FastAPIBackend`, `pyjinhx/integrations/fastapi.py:38`)
 
 ## Flag
 
-- **P2:** Procedural module name for a single dominant class (`cache` vs `LoadCache`)
-- **P2:** Framework name on generic adapter (`FastAPI*` when only `.headers` is used)
-- **P3:** Internal dataclass (`_Candidate`) exposed or imported outside module
-- **P3:** Class that should be a function (no state, no extension point)
+- **P2:** A name that implies state the object does not own (a "tracker"/"hub"/"cache" class wrapping request-scoped session state)
+- **P2:** Framework name on a generic seam (`FastAPI*` outside `pyjinhx/integrations/`)
+- **P3:** Internal dataclass (`_DevConfig`-style private type) imported outside its module
+- **P3:** Class with no state and no extension point (should be a function)
 
 ## Process
 
+0. Grep every symbol you are about to name in a finding against `pyjinhx/` first. If it has zero hits, the finding is wrong — the codebase, not this table, is ground truth.
 1. List public classes and primary functions in scope.
 2. Map each to a domain concept from the table (or document gap).
-3. Check filenames match dominant type (`load_cache.py` ✓, `mutations.py` + `MutationTracker` ✓).
+3. Check the filename matches the dominant concept: a module of request-scoped functions is named for the concern (`cache.py`, `mutations.py`, `fanout.py`); a module whose point is one type is named for it (`component.py` → `ReactiveComponent`).
 
 ## Report
 

--- a/.cursor/skills/duplication-audit/SKILL.md
+++ b/.cursor/skills/duplication-audit/SKILL.md
@@ -21,20 +21,18 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 ## Hunt targets
 
 1. **Parallel orchestration** — same step sequence in 2+ entrypoints.
-   - Fixed: `component.py` + `base.py` render → `reactive/render.py` `reactive_render_bundle`.
+   - Canonical: one render path through `pyjinhx/rendering.py`; the reactive route composes its result into `ReactiveResponse` (`pyjinhx/reactive/response.py:14`).
 2. **Duplicate parsing/validation** — two ways to answer the same question.
-   - Fixed: `client_has_mounted_manifest` vs manifest parse → `MountedManifest.is_present`.
-3. **Decorator ergonomics** — mutation recording must stay one code path.
-   - Canonical: `@mutates` → `MutationTracker.record` only (no parallel context manager).
+   - Canonical: each wire header is parsed exactly once, by its own type's `parse()` in `pyjinhx/client/inject.py` (`LoadedAssets`, `MountedManifest`, `TriggerManifest`).
+3. **Mutation recording** — must stay one code path.
+   - Canonical: `mutates()` and `dirty()` (`pyjinhx/reactive/mutations.py:31,65`) both funnel into `add_dirtied()` (`pyjinhx/session.py:166`). Any third route that writes dirtied keys is a merge candidate.
+4. **Key coercion** — `coerce_reactive_key` / `coerce_reactive_keys` (`pyjinhx/reactive/keys.py:14,33`) are the only normalizers; inline `str()`-ing of keys is duplication.
 
 ## Intentional asymmetry (document, don't merge blindly)
 
-| Path | Difference | Example |
-|------|------------|---------|
-| Class render | Pre-invalidate before primary | `invalidate_before_primary=True` |
-| Instance render | Invalidate inside `oob_swaps` | `invalidate_before_primary=False` |
+No invalidation-ordering asymmetry exists in this codebase: there is a single render path, and `invalidate()` (`pyjinhx/reactive/cache.py:105`) is called once per request against the dirtied set. Do not cite an `invalidate_before_primary` flag — it does not exist.
 
-Flag as **documented divergence** if asymmetry is required; **merge candidate** if behavior should match.
+Record real asymmetries here only when both branches are grep-confirmed. Flag as **documented divergence** when the difference is required and named in code or docs; **merge candidate** when the behavior should match.
 
 ## Process
 
@@ -43,14 +41,14 @@ Flag as **documented divergence** if asymmetry is required; **merge candidate** 
 3. Grep repeated 5+ line blocks:
 
 ```bash
-rg -n 'warn_reactive_render_without_client|mark_render_consumed|reactive_render_bundle' pyjinhx/
+rg -n 'add_dirtied|coerce_reactive_keys|cache_put|walk_manifest|oob_swaps' pyjinhx/
 ```
 
 4. Classify: merge candidate | documented divergence | unrelated.
 
 ## Checklist
 
-- [ ] No duplicated render/mutation orchestration across `core/` and `reactive/`
+- [ ] No duplicated render/mutation orchestration between the flat kernel modules and `reactive/`
 - [ ] Parsing logic has one canonical implementation per wire format
 - [ ] Shared mutation recording is one code path
 - [ ] Intentional behavioral differences are named in code or docs

--- a/.cursor/skills/module-placement-audit/SKILL.md
+++ b/.cursor/skills/module-placement-audit/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: module-placement-audit
 description: >-
-  Audit Python package layering—which modules belong in core, reactive, integrations,
-  or utils; framework-specific code in generic layers; forbidden upward imports.
+  Audit Python package layering—which modules belong in the flat top-level modules,
+  `reactive/`, `client/`, or `integrations/`; framework-specific code in generic layers; forbidden upward imports.
   Use when asking "should this live in this file", moving adapters, or reviewing
   integration boundaries. Read-only report.
 disable-model-invocation: true
@@ -21,37 +21,43 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 ## Layer rules
 
 ```
-integrations/  →  reactive/  →  core/  →  utils.py
+integrations/  →  reactive/  →  flat top-level pyjinhx/*.py
+                      client/  ↗
 ```
 
 | Layer | Holds | Must not hold |
 |-------|-------|---------------|
-| `pyjinhx/integrations/` | FastAPI middleware, Redis backend, Starlette request adapters | Core render algorithms |
-| `pyjinhx/reactive/` | ABCs, hubs, reactive algorithms, payload parsing | FastAPI/Redis concrete types |
-| `pyjinhx/core/` | Renderer, finder, registry, parser | Framework middleware |
-| `pyjinhx/utils.py` | HTML splice, path helpers, client runtime read | Reactive key coercion |
+| `pyjinhx/integrations/` | `IntegrationBackend` Protocol (`base.py`), `FastAPIBackend` (`fastapi.py`), backend registration | render or fan-out algorithms |
+| `pyjinhx/reactive/` | `ReactiveComponent`, `PjxKey`, cache/mutation/fan-out functions, `ReactiveResponse` | concrete web-framework types |
+| `pyjinhx/client/` | runtime injection and wire-format parsing (`inject.py`, `pjx.js`, htmx bundle) | reactive invalidation policy |
+| flat `pyjinhx/*.py` | kernel: `component.py`, `rendering.py`, `session.py`, `registry.py`, `context.py`, `assets.py`, `config.py`, `dev.py`, … | anything importing `reactive/` or `integrations/` |
 
 ## Precedents (cite in findings)
 
-- `FastAPIClientBackend` → `integrations/fastapi.py` (not `reactive/backend.py`)
-- `RedisInvalidationBackend` → `integrations/redis.py` (not `reactive/invalidation.py`)
-- `InvalidationHub` + `InvalidationBackend` ABC stay in `reactive/invalidation.py`
-- `ClientBackend` ABC stays in `reactive/backend.py`
+- `FastAPIBackend` → `pyjinhx/integrations/fastapi.py` (not `reactive/`)
+- `IntegrationBackend` Protocol stays in `pyjinhx/integrations/base.py`; `register_backend()` / `get_backend()` live beside it
+- Fan-out and OOB swap emission stay in `pyjinhx/reactive/fanout.py`
+- Request-scoped stores stay in `pyjinhx/session.py`; `reactive/cache.py` reads them, it does not own them
+- Wire-format parsing (`LoadedAssets`, `MountedManifest`, `TriggerManifest`) stays in `pyjinhx/client/inject.py`
+- The renderer module is `pyjinhx/rendering.py` — the pre-rewrite name is stale and must not appear
 
 ## Checklist
 
-- [ ] No `from pyjinhx.integrations` inside `reactive/` or `core/`
-- [ ] Framework names (`FastAPI`, `Starlette`, `Redis`) only in `integrations/` or config wiring
-- [ ] Config (`config/__init__.py`) wires hubs at startup; does not embed integration logic
-- [ ] Domain reactive code not re-exported through `utils.py`
+- [ ] No `from pyjinhx.integrations` inside `reactive/`, `client/`, or the flat top-level modules
+- [ ] No `from pyjinhx.reactive` inside the flat top-level modules (`reactive/` sits above the kernel)
+- [ ] Framework names (`fastapi`, `starlette`) only under `pyjinhx/integrations/`
+- [ ] `config.py` wires backends at startup; it does not embed integration logic
 
 ## Import scan
 
 ```bash
-rg 'from pyjinhx\.integrations' pyjinhx/reactive pyjinhx/core
+rg 'from pyjinhx\.integrations' pyjinhx/reactive pyjinhx/client
 rg 'from pyjinhx\.reactive' pyjinhx/integrations
-rg 'fastapi|starlette|redis|fakeredis' pyjinhx/reactive pyjinhx/core --glob '*.py' -i
+rg 'from pyjinhx\.(reactive|integrations|client)' pyjinhx/*.py
+rg 'fastapi|starlette' pyjinhx/reactive pyjinhx/client --glob '*.py' -i
 ```
+
+The only currently-expected hit from these scans is `pyjinhx/integrations/fastapi.py:28: from pyjinhx.reactive.response import ReactiveResponse`, which follows the allowed direction.
 
 ## Report
 

--- a/.cursor/skills/state-shape-audit/SKILL.md
+++ b/.cursor/skills/state-shape-audit/SKILL.md
@@ -21,42 +21,45 @@ Read: [CONVENTIONS.md](../code-audit-sweep/CONVENTIONS.md).
 
 | Situation | Shape | pyjinhx example |
 |-----------|-------|-----------------|
-| ContextVar + locks + process/request state | Class with `@classmethod` | `LoadCache`, `MutationTracker`, `InvalidationHub`, `ClientBackend` |
-| Request-scoped opaque DI bag | Static methods on frozen dataclass base | `PjxContext` |
-| Pure input → output | Module functions | `coerce_reactive_key`, `pjx_load_field_names`, `PjxKey` validation |
-| Decorator ergonomics | Module decorator → class method | `@mutates` → `MutationTracker.record` |
-| Plugin extension point | ABC, no hub state | `InvalidationBackend` |
-| Runtime coordinator | Hub class | `InvalidationHub` |
-| Dev toggles | Module fn + private dataclass | `enable_reactive_dev`, `_DevConfig` |
+| Per-request mutable state | Store on the request-scoped session; expose module functions | `pyjinhx/session.py` stores + `cache_get`/`cache_put`/`invalidate` (`reactive/cache.py`) |
+| Dirtied-key accumulation | Module functions over session state | `dirty()` (`reactive/mutations.py:65`) → `add_dirtied()`/`get_dirtied()` (`session.py:166,158`) |
+| Request-scoped opaque DI bag | Frozen dataclass + classmethod accessor | `PjxContext` / `PjxContext.current` (`context.py:30,48`) |
+| Pure input → output | Module functions | `coerce_reactive_key` (`reactive/keys.py:14`), `oob_swaps`/`walk_manifest` (`reactive/fanout.py:450,307`) |
+| Decorator ergonomics | Decorator and its imperative twin share one sink | `mutates()` (`reactive/mutations.py:31`) and `dirty()` both call `add_dirtied()` |
+| Plugin extension point | `Protocol`, no state | `IntegrationBackend` (`integrations/base.py:35`), registered via `register_backend()` |
+| Instance lookup | Module functions over session state | `register_instance` / `resolve` (`pyjinhx/registry.py`) — there is no `Registry` class |
+| Dev toggles | Module fns + private dataclass | `enable_reactive_dev` / `_DevConfig` (`dev.py:34,24`) |
 
 ## Hunt patterns
 
 ```bash
-rg '^_\w+: (ContextVar|threading\.Lock)' pyjinhx/ --glob '*.py'
-rg '^_[a-z_]+ = ' pyjinhx/reactive --glob '*.py'
+rg -n '^_\w+: (ContextVar|threading\.Lock)' pyjinhx/ --glob '*.py'
+rg -n '^_[a-z_]+ = ' pyjinhx/reactive --glob '*.py'
+rg -n 'get_cache_store|get_cache_forward|get_cache_reverse|current_session' pyjinhx/
 ```
 
 For each module-global cluster, ask: should this be methods on one class?
 
 ## Anti-patterns (flag)
 
-- **P2:** Multiple free functions mutating the same module-global ContextVar (pre-`LoadCache` style)
-- **P2:** Instance singleton injection for request scope (reverted pattern—use classmethod + ContextVar)
-- **P3:** Class with a single `@staticmethod` and no state (prefer function unless grouping API)
+- **P2:** Process-global mutable state that should be request-scoped (must live on the session, not a module dict)
+- **P2:** A wrapper class introduced purely to hold functions that already read session state
+- **P3:** Class with a single `@staticmethod` and no state (prefer a function unless it groups a parse API, as `MountedManifest.parse` does)
 
 ## OK patterns (do not flag)
 
-- `_dev_config` module global with functions as canonical dev API
-- Module-level ContextVar with static methods on owning type (`PjxContext.current` / `Registry.request_scope` pattern)
-- Lazy import inside method to avoid cycles
-- `CacheScope` enum at module level next to `LoadCache` class
+- `_dev_config` module global with `enable_reactive_dev` / `disable_reactive_dev` as the canonical dev API (`pyjinhx/dev.py`)
+- Request state entered via the free `request_scope()` contextmanager (`pyjinhx/session.py:224`) and read via `get_load_context()` (`session.py:213`)
+- `PjxContext.current` classmethod over a module-level ContextVar
+- Lazy import inside a function to avoid an import cycle
+- Grouping related parse helpers as `@staticmethod`s on a wire-format type (`LoadedAssets`, `MountedManifest`, `TriggerManifest`)
 
 ## Checklist
 
-- [ ] Each ContextVar has one owning class
-- [ ] Hubs separate from ABCs (`InvalidationHub` vs `InvalidationBackend`)
-- [ ] Pure key/string transforms remain functions in `keys.py`
-- [ ] Tests reset via `.clear()`, `.reset()`, `.reset_request()` on owning class
+- [ ] Request-scoped state lives on the session, not in module globals
+- [ ] Extension points are `Protocol`s with no state (`IntegrationBackend`)
+- [ ] Pure key transforms remain functions in `pyjinhx/reactive/keys.py`
+- [ ] Tests reset state by re-entering `request_scope()`, not by poking module globals
 
 ## Report
 


### PR DESCRIPTION
## Summary

Replaces fabricated architecture descriptions in domain-entity-audit, module-placement-audit, duplication-audit, and state-shape-audit SKILL.md files with grep-verified ground truth. The rewritten tables now accurately describe pyjinhx's real structure (flat top-level modules + reactive/, client/, integrations/) instead of invented types like LoadCache, MutationTracker, InvalidationHub, ClientBackend, and Registry class that don't exist in the codebase. All symbols kept in the rewritten tables were grep-confirmed against pyjinhx/ at this commit.

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)