### PR TITLE
feat(examples/todo): add context, store, and keys (#716)

### DIFF
--- a/examples/todo/context.py
+++ b/examples/todo/context.py
@@ -1,0 +1,11 @@
+"""Per-request context for the todo example."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from pyjinhx import AppContext
+
+
+@dataclass(frozen=True)
+class TodoAppContext(AppContext):
+    store: Any

--- a/examples/todo/keys.py
+++ b/examples/todo/keys.py
@@ -1,0 +1,8 @@
+"""Reactive keys for the todo example."""
+
+from pyjinhx import MutationKey
+
+
+class Keys(MutationKey):
+    TODOS = "todos"
+    TODO_LIST = "todo-list"

--- a/examples/todo/store.py
+++ b/examples/todo/store.py
@@ -1,0 +1,75 @@
+"""Tiny in-memory todo store for the reactive demo.
+
+The module-level ``_todos`` dict is the toy demo store — ordinary app-level
+state, not pyjinhx's own mutable state, so it sits outside the framework's
+invariant-4 census. Not a pattern to generalize past this demo.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import count
+
+from pyjinhx import mutates
+
+from .keys import Keys
+
+_ids = count(1)
+_todos: dict[int, Todo] = {}
+
+
+@dataclass
+class Todo:
+    id: int
+    text: str
+    done: bool = False
+
+
+def reset() -> None:
+    global _todos, _ids
+    _todos = {}
+    _ids = count(1)
+    for text in ("Write the docs", "Ship reactivity", "Touch grass"):
+        add(text)
+
+
+@mutates(Keys.TODOS)
+def add(text: str) -> Todo:
+    todo = Todo(id=next(_ids), text=text)
+    _todos[todo.id] = todo
+    return todo
+
+
+@mutates(Keys.TODOS)
+def toggle(todo_id: int) -> Todo:
+    _todos[todo_id].done = not _todos[todo_id].done
+    return _todos[todo_id]
+
+
+@mutates(Keys.TODOS, Keys.TODO_LIST)
+def clear_completed() -> None:
+    for todo_id in [tid for tid, t in _todos.items() if t.done]:
+        del _todos[todo_id]
+
+
+def get(todo_id: int) -> Todo:
+    return _todos[todo_id]
+
+
+def all_todos() -> list[Todo]:
+    return list(_todos.values())
+
+
+def total() -> int:
+    return len(_todos)
+
+
+def remaining() -> int:
+    return sum(1 for t in _todos.values() if not t.done)
+
+
+def completed() -> int:
+    return sum(1 for t in _todos.values() if t.done)
+
+
+reset()

--- a/tests/examples/test_todo_context.py
+++ b/tests/examples/test_todo_context.py
@@ -1,0 +1,33 @@
+"""TodoAppContext is a frozen dataclass the app can hand to context_factory."""
+
+import dataclasses
+
+import pytest
+
+from pyjinhx import AppContext
+
+from examples.todo import store
+from examples.todo.context import TodoAppContext
+
+
+def test_is_a_frozen_dataclass_subclass_of_app_context():
+    assert issubclass(TodoAppContext, AppContext)
+    assert dataclasses.is_dataclass(TodoAppContext)
+    assert TodoAppContext.__dataclass_params__.frozen is True
+
+
+def test_exposes_whatever_store_it_was_given():
+    sentinel = object()
+    assert TodoAppContext(store=sentinel).store is sentinel
+
+
+def test_rejects_mutation_after_construction():
+    ctx = TodoAppContext(store=store)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        ctx.store = None  # type: ignore[misc]
+
+
+def test_works_as_a_context_factory_return_value():
+    factory = lambda request: TodoAppContext(store=store)  # noqa: E731
+    ctx = factory(object())
+    assert ctx.store.total() == store.total()

--- a/tests/examples/test_todo_context.py
+++ b/tests/examples/test_todo_context.py
@@ -4,10 +4,9 @@ import dataclasses
 
 import pytest
 
-from pyjinhx import AppContext
-
 from examples.todo import store
 from examples.todo.context import TodoAppContext
+from pyjinhx import AppContext
 
 
 def test_is_a_frozen_dataclass_subclass_of_app_context():
@@ -28,6 +27,6 @@ def test_rejects_mutation_after_construction():
 
 
 def test_works_as_a_context_factory_return_value():
-    factory = lambda request: TodoAppContext(store=store)  # noqa: E731
+    factory = lambda request: TodoAppContext(store=store)
     ctx = factory(object())
     assert ctx.store.total() == store.total()

--- a/tests/examples/test_todo_keys.py
+++ b/tests/examples/test_todo_keys.py
@@ -1,0 +1,22 @@
+"""Keys for the todo example are real MutationKey members."""
+
+from pyjinhx import MutationKey, mutates
+
+from examples.todo.keys import Keys
+
+
+def test_keys_subclasses_mutation_key():
+    assert issubclass(Keys, MutationKey)
+
+
+def test_keys_have_the_documented_members():
+    assert Keys.TODOS.value == "todos"
+    assert Keys.TODO_LIST.value == "todo-list"
+
+
+def test_keys_are_accepted_by_mutates_without_raising():
+    @mutates(Keys.TODOS, Keys.TODO_LIST)
+    def op() -> str:
+        return "done"
+
+    assert op.__name__ == "op"

--- a/tests/examples/test_todo_keys.py
+++ b/tests/examples/test_todo_keys.py
@@ -1,8 +1,7 @@
 """Keys for the todo example are real MutationKey members."""
 
-from pyjinhx import MutationKey, mutates
-
 from examples.todo.keys import Keys
+from pyjinhx import MutationKey, mutates
 
 
 def test_keys_subclasses_mutation_key():

--- a/tests/examples/test_todo_store.py
+++ b/tests/examples/test_todo_store.py
@@ -2,10 +2,9 @@
 
 import pytest
 
-from pyjinhx.session import get_dirtied, request_scope
-
 from examples.todo import store
 from examples.todo.keys import Keys
+from pyjinhx.session import get_dirtied, request_scope
 
 
 @pytest.fixture(autouse=True)

--- a/tests/examples/test_todo_store.py
+++ b/tests/examples/test_todo_store.py
@@ -1,0 +1,111 @@
+"""The todo example's in-memory store: reads, mutations, and dirtied keys."""
+
+import pytest
+
+from pyjinhx.session import get_dirtied, request_scope
+
+from examples.todo import store
+from examples.todo.keys import Keys
+
+
+@pytest.fixture(autouse=True)
+def fresh_store():
+    store.reset()
+    yield
+    store.reset()
+
+
+def test_reset_seeds_the_demo_todos():
+    assert [t.text for t in store.all_todos()] == [
+        "Write the docs",
+        "Ship reactivity",
+        "Touch grass",
+    ]
+    assert all(not t.done for t in store.all_todos())
+
+
+def test_add_creates_a_todo_with_a_fresh_id():
+    before = store.total()
+    todo = store.add("Feed the cat")
+    assert todo.text == "Feed the cat"
+    assert todo.done is False
+    assert store.total() == before + 1
+    assert store.get(todo.id) is todo
+
+
+def test_add_gives_every_todo_a_unique_id():
+    ids = [store.add(f"task {n}").id for n in range(5)]
+    assert len(set(ids)) == 5
+    assert len({t.id for t in store.all_todos()}) == store.total()
+
+
+def test_all_todos_returns_insertion_order():
+    store.add("last")
+    assert store.all_todos()[-1].text == "last"
+
+
+def test_toggle_flips_done_both_ways():
+    todo = store.add("Feed the cat")
+    assert store.toggle(todo.id).done is True
+    assert store.toggle(todo.id).done is False
+
+
+def test_toggle_raises_on_an_unknown_id():
+    with pytest.raises(KeyError):
+        store.toggle(9999)
+
+
+def test_get_raises_on_an_unknown_id():
+    with pytest.raises(KeyError):
+        store.get(9999)
+
+
+def test_clear_completed_removes_only_done_todos():
+    kept = store.add("keep me")
+    gone = store.add("drop me")
+    store.toggle(gone.id)
+    store.clear_completed()
+    texts = [t.text for t in store.all_todos()]
+    assert "drop me" not in texts
+    assert "keep me" in texts
+    assert store.get(kept.id) is kept
+
+
+def test_counts_track_a_sequence_of_operations():
+    store.reset()
+    assert (store.total(), store.remaining(), store.completed()) == (3, 3, 0)
+    first = store.all_todos()[0]
+    store.toggle(first.id)
+    assert (store.total(), store.remaining(), store.completed()) == (3, 2, 1)
+    store.add("fourth")
+    assert (store.total(), store.remaining(), store.completed()) == (4, 3, 1)
+    store.clear_completed()
+    assert (store.total(), store.remaining(), store.completed()) == (3, 3, 0)
+
+
+def test_add_dirties_todos():
+    with request_scope():
+        store.add("Feed the cat")
+        assert get_dirtied() == {Keys.TODOS.value}
+
+
+def test_toggle_dirties_todos():
+    todo = store.add("Feed the cat")
+    with request_scope():
+        store.toggle(todo.id)
+        assert get_dirtied() == {Keys.TODOS.value}
+
+
+def test_clear_completed_dirties_todos_and_the_list():
+    with request_scope():
+        store.clear_completed()
+        assert get_dirtied() == {Keys.TODOS.value, Keys.TODO_LIST.value}
+
+
+def test_reads_do_not_dirty_anything():
+    with request_scope():
+        store.all_todos()
+        store.total()
+        store.remaining()
+        store.completed()
+        assert get_dirtied() == set()


### PR DESCRIPTION
## Summary
- Add TodoAppContext for managing todo state
- Port in-memory todo store implementation
- Add MutationKey for todo mutations
- Fix import ordering in tests

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session