### PR TITLE
feat: add pastel design system for the todo example

### DIFF
--- a/examples/todo/components/__init__.py
+++ b/examples/todo/components/__init__.py
@@ -1,0 +1,10 @@
+"""The todo example's component tree."""
+
+from examples.todo.components.app import App
+from examples.todo.components.clear_button import ClearButton
+from examples.todo.components.counter import Counter
+from examples.todo.components.item_list import ItemList
+from examples.todo.components.item_row import ItemRow
+from examples.todo.components.total import Total
+
+__all__ = ["App", "ClearButton", "Counter", "ItemList", "ItemRow", "Total"]

--- a/examples/todo/components/app/__init__.py
+++ b/examples/todo/components/app/__init__.py
@@ -1,0 +1,3 @@
+from examples.todo.components.app.app import App
+
+__all__ = ["App"]

--- a/examples/todo/components/app/app.css
+++ b/examples/todo/components/app/app.css
@@ -1,0 +1,288 @@
+/* design tokens — pastel, light, dependency-free */
+:root {
+  --bg: #faf9f7;
+  --panel: #ffffff;
+  --panel-2: #fdfcfb;
+  --edge: #ece8e1;
+  --row: #f7f5f1;
+  --row-hover: #f1eef7;
+  --line: rgba(58, 50, 70, 0.08);
+  --line-2: rgba(58, 50, 70, 0.16);
+  --text: #3a3246;
+  --muted: #7c7488;
+  --faint: #b3aec0;
+  --accent: #b9a6f2;
+  --accent-soft: #ede7fd;
+  --accent-ink: #2e2640;
+  --danger: #e8879b;
+  --radius: 14px;
+  --font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 7vh 1.25rem 4rem;
+  font-family: var(--font);
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--text);
+  background:
+    radial-gradient(120% 80% at 50% -10%, #f3eefc 0%, var(--bg) 60%) fixed;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* panel */
+.panel {
+  position: relative;
+  width: 100%;
+  max-width: 33rem;
+  overflow: hidden;
+  background: linear-gradient(180deg, var(--panel) 0%, var(--panel-2) 100%);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.9),
+    0 24px 50px -30px rgba(58, 50, 70, 0.35);
+  animation: panel-in 0.5s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  padding: 0.9rem 1.15rem;
+  border-bottom: 1px solid var(--line);
+  background: var(--accent-soft);
+}
+.bar__title {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.bar__dot {
+  margin-left: auto;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pulse 2.8s ease-out infinite;
+}
+
+/* composer */
+.composer {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.7rem 1.15rem;
+  border-bottom: 1px solid var(--line);
+  transition: background 0.2s ease;
+}
+.composer:focus-within {
+  background: rgba(185, 166, 242, 0.07);
+}
+.composer__prompt {
+  color: var(--accent);
+  font-weight: 700;
+}
+.composer__input {
+  flex: 1;
+  min-width: 0;
+  padding: 0.4rem 0;
+  font: inherit;
+  color: var(--text);
+  background: transparent;
+  border: 0;
+  outline: none;
+  caret-color: var(--accent);
+}
+.composer__input::placeholder {
+  color: var(--faint);
+}
+.composer__add {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 2.1rem;
+  height: 2.1rem;
+  font: inherit;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--accent-ink);
+  background: var(--accent);
+  border: 0;
+  border-radius: 10px;
+  cursor: pointer;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.1s ease;
+}
+.composer__add:hover {
+  box-shadow: 0 6px 16px -6px var(--accent);
+}
+.composer__add:active {
+  transform: scale(0.94);
+}
+
+/* list + rows */
+.todo-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.55rem 0.7rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-height: 3.5rem;
+}
+.todo-list:empty::after {
+  content: "no todos — add one above";
+  display: block;
+  padding: 1.1rem 0.5rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--faint);
+}
+.todo {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 10px;
+  background: var(--row);
+  border: 1px solid transparent;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+  animation: row-in 0.3s ease both;
+}
+.todo:hover {
+  background: var(--row-hover);
+  border-color: var(--line);
+}
+.todo > button {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 1.55rem;
+  height: 1.55rem;
+  font: inherit;
+  font-size: 0.95rem;
+  line-height: 1;
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+.todo > button:hover {
+  color: var(--accent-ink);
+  border-color: var(--accent);
+}
+.todo.done > button {
+  color: var(--accent-ink);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.todo > span {
+  flex: 1;
+  min-width: 0;
+}
+.todo.done > span {
+  color: var(--muted);
+  text-decoration: line-through;
+  text-decoration-color: var(--faint);
+}
+
+/* status bar */
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75rem 1.15rem;
+  border-top: 1px solid var(--line);
+  background: rgba(185, 166, 242, 0.06);
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+.meta .counter {
+  color: var(--text);
+  font-weight: 600;
+}
+.meta__sep {
+  color: var(--faint);
+}
+.clear {
+  margin-left: auto;
+  padding: 0.35rem 0.75rem;
+  font: inherit;
+  font-size: 0.82rem;
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid var(--line-2);
+  border-radius: 9px;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+.clear:hover:not(:disabled) {
+  color: var(--danger);
+  border-color: var(--danger);
+  background: rgba(232, 135, 155, 0.1);
+}
+.clear:disabled {
+  color: var(--faint);
+  border-color: var(--line);
+  cursor: default;
+}
+
+/* focus + motion */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+@keyframes panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.995);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes row-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(185, 166, 242, 0.55);
+  }
+  70%,
+  100% {
+    box-shadow: 0 0 0 7px rgba(185, 166, 242, 0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/examples/todo/components/app/app.pjx
+++ b/examples/todo/components/app/app.pjx
@@ -1,0 +1,22 @@
+<main class="panel">
+  <header class="bar">
+    <span class="bar__title">todos</span>
+    <span class="bar__dot" aria-hidden="true"></span>
+  </header>
+
+  <form class="composer" hx-post="/todos" hx-target="#list" hx-swap="beforeend"
+        hx-on::after-request="this.reset()">
+    <span class="composer__prompt" aria-hidden="true">+</span>
+    <input class="composer__input" name="text" placeholder="add a todo…" autocomplete="off" required />
+    <button class="composer__add" type="submit" aria-label="add todo">+</button>
+  </form>
+
+  {{ item_list }}
+
+  <footer class="meta">
+    {{ remaining }}
+    <span class="meta__sep" aria-hidden="true">·</span>
+    {{ total_count }}
+    {{ clear_button }}
+  </footer>
+</main>

--- a/examples/todo/components/app/app.py
+++ b/examples/todo/components/app/app.py
@@ -1,0 +1,19 @@
+from examples.todo.components.clear_button import ClearButton
+from examples.todo.components.counter import Counter
+from examples.todo.components.item_list import ItemList
+from examples.todo.components.total import Total
+from pyjinhx import BaseComponent
+
+
+class App(BaseComponent):
+    """The todo panel: a plain shell that composes the reactive pieces.
+
+    Renders a fragment, not a document — the page shell (doctype, head, the
+    htmx script tag) is the app wiring's job, since a component template must
+    render exactly one root element.
+    """
+
+    item_list: ItemList | None = None
+    remaining: Counter | None = None
+    total_count: Total | None = None
+    clear_button: ClearButton | None = None

--- a/examples/todo/components/clear_button/__init__.py
+++ b/examples/todo/components/clear_button/__init__.py
@@ -1,0 +1,3 @@
+from examples.todo.components.clear_button.clear_button import ClearButton
+
+__all__ = ["ClearButton"]

--- a/examples/todo/components/clear_button/clear_button.pjx
+++ b/examples/todo/components/clear_button/clear_button.pjx
@@ -1,0 +1,5 @@
+<button class="clear" hx-post="/todos/clear-completed" hx-target="#list" hx-swap="outerHTML"
+        data-pjx-loading="spinner" data-pjx-loading-extra=".todo.done"
+        {% if not completed %}disabled{% endif %}>
+  Clear completed ({{ completed }})
+</button>

--- a/examples/todo/components/clear_button/clear_button.py
+++ b/examples/todo/components/clear_button/clear_button.py
@@ -1,0 +1,13 @@
+from examples.todo.context import TodoAppContext
+from examples.todo.keys import Keys
+from pyjinhx import ReactiveComponent
+
+
+class ClearButton(ReactiveComponent, react={Keys.TODOS}):
+    """The clear-completed action, disabled while nothing is completed."""
+
+    completed: int = 0
+
+    def load(self, ctx: TodoAppContext):
+        """Read the completed-todo count from the store."""
+        self.completed = ctx.store.completed()

--- a/examples/todo/components/counter/__init__.py
+++ b/examples/todo/components/counter/__init__.py
@@ -1,0 +1,3 @@
+from examples.todo.components.counter.counter import Counter
+
+__all__ = ["Counter"]

--- a/examples/todo/components/counter/counter.pjx
+++ b/examples/todo/components/counter/counter.pjx
@@ -1,0 +1,1 @@
+<span class="counter">{{ remaining }} left</span>

--- a/examples/todo/components/counter/counter.py
+++ b/examples/todo/components/counter/counter.py
@@ -1,0 +1,13 @@
+from examples.todo.context import TodoAppContext
+from examples.todo.keys import Keys
+from pyjinhx import ReactiveComponent
+
+
+class Counter(ReactiveComponent, react={Keys.TODOS}):
+    """How many todos are still open."""
+
+    remaining: int = 0
+
+    def load(self, ctx: TodoAppContext):
+        """Read the open-todo count from the store."""
+        self.remaining = ctx.store.remaining()

--- a/examples/todo/components/item_list/__init__.py
+++ b/examples/todo/components/item_list/__init__.py
@@ -1,0 +1,3 @@
+from examples.todo.components.item_list.item_list import ItemList
+
+__all__ = ["ItemList"]

--- a/examples/todo/components/item_list/item_list.pjx
+++ b/examples/todo/components/item_list/item_list.pjx
@@ -1,0 +1,3 @@
+<ul id="{{ id }}" class="todo-list">
+  {% for item in items %}{{ item }}{% endfor %}
+</ul>

--- a/examples/todo/components/item_list/item_list.py
+++ b/examples/todo/components/item_list/item_list.py
@@ -1,0 +1,26 @@
+from examples.todo.components.item_row import ItemRow
+from examples.todo.context import TodoAppContext
+from examples.todo.keys import Keys
+from pyjinhx import ReactiveComponent
+
+
+class ItemList(ReactiveComponent, react={Keys.TODO_LIST}):
+    """The list of todo rows."""
+
+    items: list[ItemRow] = []  # noqa: RUF012 -- pydantic field, not a shared mutable default
+
+    def load(self, ctx: TodoAppContext):
+        """Build one row per todo and load each one before keeping it.
+
+        The explicit row.load() is load-bearing: pjx_mount() only fires for
+        children the renderer instantiates from a tag, never for instances
+        assigned to a field, so rows built here would otherwise render with
+        their defaults. It takes no argument — the load wrap injects the
+        request's app context.
+        """
+        rows = []
+        for todo in ctx.store.all_todos():
+            row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
+            row.load()
+            rows.append(row)
+        self.items = rows

--- a/examples/todo/components/item_row/__init__.py
+++ b/examples/todo/components/item_row/__init__.py
@@ -1,0 +1,3 @@
+from examples.todo.components.item_row.item_row import ItemRow
+
+__all__ = ["ItemRow"]

--- a/examples/todo/components/item_row/item_row.pjx
+++ b/examples/todo/components/item_row/item_row.pjx
@@ -1,0 +1,5 @@
+<li class="todo{% if done %} done{% endif %}" data-pjx-loading="skeleton">
+  <button hx-post="/rows/{{ todo_id }}/toggle" hx-target="closest [data-pjx-id]" hx-swap="outerHTML"
+          aria-label="toggle">{% if done %}✓{% else %}○{% endif %}</button>
+  <span>{{ title }}</span>
+</li>

--- a/examples/todo/components/item_row/item_row.py
+++ b/examples/todo/components/item_row/item_row.py
@@ -1,0 +1,29 @@
+from typing import Annotated
+
+from examples.todo.context import TodoAppContext
+from examples.todo.keys import Keys
+from pyjinhx import PjxKey, ReactiveComponent
+
+
+class ItemRow(ReactiveComponent, react={Keys.TODOS}):
+    """One todo, keyed by its id so each row caches its own load result."""
+
+    todo_id: Annotated[int, PjxKey()]
+    title: str = ""
+    done: bool = False
+
+    # No return annotation: a `-> None` here trips bug #713.
+    def load(self, ctx: TodoAppContext):
+        """Read this row's todo from the store.
+
+        A todo_id that is not in the store leaves the fields at their defaults
+        rather than raising: a row can outlive the todo it stands for (a
+        clear-completed that landed between render and swap), and a demo page
+        should render an empty row instead of a 500.
+        """
+        try:
+            todo = ctx.store.get(self.todo_id)
+        except KeyError:
+            return
+        self.title = todo.text
+        self.done = todo.done

--- a/examples/todo/components/total/__init__.py
+++ b/examples/todo/components/total/__init__.py
@@ -1,0 +1,3 @@
+from examples.todo.components.total.total import Total
+
+__all__ = ["Total"]

--- a/examples/todo/components/total/total.pjx
+++ b/examples/todo/components/total/total.pjx
@@ -1,0 +1,1 @@
+<span class="total">{{ count }} total</span>

--- a/examples/todo/components/total/total.py
+++ b/examples/todo/components/total/total.py
@@ -1,0 +1,13 @@
+from examples.todo.context import TodoAppContext
+from examples.todo.keys import Keys
+from pyjinhx import ReactiveComponent
+
+
+class Total(ReactiveComponent, react={Keys.TODOS}):
+    """How many todos exist in total."""
+
+    count: int = 0
+
+    def load(self, ctx: TodoAppContext):
+        """Read the total todo count from the store."""
+        self.count = ctx.store.total()

--- a/tests/examples/conftest.py
+++ b/tests/examples/conftest.py
@@ -1,0 +1,43 @@
+"""Shared fixtures for the todo example's component tests.
+
+Every test runs inside its own request_scope: load() results are memoized per
+request, so a shared scope would let one test's cached load leak into the next.
+"""
+
+import pytest
+
+from examples.todo import store as todo_store
+from examples.todo.context import TodoAppContext
+from pyjinhx.assets import AssetMode
+from pyjinhx.session import RenderSession, accumulate_assets, request_scope
+
+
+@pytest.fixture(autouse=True)
+def fresh_store():
+    """Reset the demo store to its three seeded todos around every test."""
+    todo_store.reset()
+    yield
+    todo_store.reset()
+
+
+@pytest.fixture
+def ctx():
+    """The per-request context the todo app's context_factory would return."""
+    return TodoAppContext(store=todo_store)
+
+
+@pytest.fixture
+def session():
+    """A RenderSession that inlines co-located component CSS, as a real page does."""
+    render_session = RenderSession(template_dir="/")
+    render_session.on_rendered.append(accumulate_assets)
+    render_session.css_mode = AssetMode.INLINE
+    render_session.js_mode = AssetMode.INLINE
+    return render_session
+
+
+@pytest.fixture
+def scope(session, ctx):
+    """An active request scope carrying the load context, yielding the session."""
+    with request_scope(session=session, load_context=ctx) as active:
+        yield active

--- a/tests/examples/test_todo_components.py
+++ b/tests/examples/test_todo_components.py
@@ -1,0 +1,164 @@
+"""The todo example's components: what each load() puts on its instance."""
+
+from examples.todo import store as todo_store
+from examples.todo.components import (
+    ClearButton,
+    Counter,
+    ItemList,
+    ItemRow,
+    Total,
+)
+from examples.todo.keys import Keys
+
+
+class TestItemRow:
+    def test_load_populates_title_and_done_from_the_store(self, scope):
+        todo = todo_store.all_todos()[0]
+        row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
+
+        row.load()
+
+        assert row.title == todo.text
+        assert row.done is False
+
+    def test_load_reflects_a_toggled_todo(self, scope):
+        todo = todo_store.all_todos()[0]
+        todo_store.toggle(todo.id)
+        row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
+
+        row.load()
+
+        assert row.done is True
+
+    def test_load_on_a_missing_todo_leaves_the_defaults(self, scope):
+        row = ItemRow(id="row-9999", todo_id=9999)
+
+        row.load()
+
+        assert row.title == ""
+        assert row.done is False
+
+    def test_todo_id_is_the_load_key_field(self):
+        assert ItemRow._pjx_key_field == "todo_id"
+
+    def test_reacts_to_the_todos_key(self):
+        assert ItemRow._pjx_react_keys == (Keys.TODOS.value,)
+
+
+class TestCounter:
+    def test_load_sets_remaining_from_the_store(self, scope):
+        counter = Counter(id="counter")
+
+        counter.load()
+
+        assert counter.remaining == 3
+
+    def test_load_drops_a_toggled_todo_from_remaining(self, scope):
+        todo_store.toggle(todo_store.all_todos()[0].id)
+        counter = Counter(id="counter")
+
+        counter.load()
+
+        assert counter.remaining == 2
+
+    def test_zero_state(self, scope):
+        for todo in list(todo_store.all_todos()):
+            todo_store.toggle(todo.id)
+        todo_store.clear_completed()
+        counter = Counter(id="counter")
+
+        counter.load()
+
+        assert counter.remaining == 0
+
+
+class TestTotal:
+    def test_load_sets_count_from_the_store(self, scope):
+        total = Total(id="total")
+
+        total.load()
+
+        assert total.count == 3
+
+    def test_zero_state(self, scope):
+        for todo in list(todo_store.all_todos()):
+            todo_store.toggle(todo.id)
+        todo_store.clear_completed()
+        total = Total(id="total")
+
+        total.load()
+
+        assert total.count == 0
+
+
+class TestClearButton:
+    def test_load_counts_completed_todos(self, scope):
+        todo_store.toggle(todo_store.all_todos()[0].id)
+        button = ClearButton(id="clear")
+
+        button.load()
+
+        assert button.completed == 1
+
+    def test_zero_state_with_nothing_completed(self, scope):
+        button = ClearButton(id="clear")
+
+        button.load()
+
+        assert button.completed == 0
+
+
+class TestItemList:
+    def test_load_builds_one_row_per_todo(self, scope):
+        item_list = ItemList(id="list")
+
+        item_list.load()
+
+        assert [row.todo_id for row in item_list.items] == [
+            todo.id for todo in todo_store.all_todos()
+        ]
+
+    def test_every_row_comes_back_already_loaded(self, scope):
+        # The regression: assigning ItemRow instances to a field does NOT fire
+        # pjx_mount(), so ItemList.load() has to call each row's load() itself.
+        # Forget that and every row renders with its field defaults.
+        item_list = ItemList(id="list")
+
+        item_list.load()
+
+        assert [row.title for row in item_list.items] == [
+            "Write the docs",
+            "Ship reactivity",
+            "Touch grass",
+        ]
+        assert all(row.title != "" for row in item_list.items)
+
+    def test_row_done_state_survives_into_the_list(self, scope):
+        todo_store.toggle(todo_store.all_todos()[1].id)
+        item_list = ItemList(id="list")
+
+        item_list.load()
+
+        assert [row.done for row in item_list.items] == [False, True, False]
+
+    def test_each_row_carries_a_stable_dom_id(self, scope):
+        item_list = ItemList(id="list")
+
+        item_list.load()
+
+        assert [row.id for row in item_list.items] == [
+            f"row-{todo.id}" for todo in todo_store.all_todos()
+        ]
+
+    def test_empty_list_is_a_zero_state_not_an_error(self, scope):
+        for todo in list(todo_store.all_todos()):
+            todo_store.toggle(todo.id)
+        todo_store.clear_completed()
+        item_list = ItemList(id="list")
+
+        item_list.load()
+
+        assert item_list.items == []
+
+    def test_reacts_to_the_todo_list_key(self):
+        assert ItemList._pjx_react_keys == (Keys.TODO_LIST.value,)

--- a/tests/examples/test_todo_templates.py
+++ b/tests/examples/test_todo_templates.py
@@ -1,0 +1,153 @@
+"""The todo example's templates: each one renders, with its htmx wiring intact."""
+
+from examples.todo import store as todo_store
+from examples.todo.components import (
+    App,
+    ClearButton,
+    Counter,
+    ItemList,
+    ItemRow,
+    Total,
+)
+from pyjinhx.rendering import render
+
+
+def _loaded_app(session):
+    """The whole tree, loaded, the way a route would assemble it."""
+    item_list = ItemList(id="list")
+    item_list.load()
+    remaining = Counter(id="counter")
+    remaining.load()
+    total_count = Total(id="total")
+    total_count.load()
+    clear_button = ClearButton(id="clear")
+    clear_button.load()
+    return App(
+        id="app",
+        item_list=item_list,
+        remaining=remaining,
+        total_count=total_count,
+        clear_button=clear_button,
+    )
+
+
+class TestItemRow:
+    def test_renders_title_and_toggle_wiring(self, scope):
+        todo = todo_store.all_todos()[0]
+        row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
+        row.load()
+
+        html = render(row, scope)
+
+        assert "Write the docs" in html
+        assert f'hx-post="/rows/{todo.id}/toggle"' in html
+        assert 'hx-target="closest [data-pjx-id]"' in html
+
+    def test_keeps_the_skeleton_loading_indicator(self, scope):
+        todo = todo_store.all_todos()[0]
+        row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
+        row.load()
+
+        assert 'data-pjx-loading="skeleton"' in render(row, scope)
+
+    def test_done_row_gets_the_done_class(self, scope):
+        todo = todo_store.all_todos()[0]
+        todo_store.toggle(todo.id)
+        row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
+        row.load()
+
+        assert 'class="todo done"' in render(row, scope)
+
+
+class TestItemList:
+    def test_renders_every_row(self, scope):
+        item_list = ItemList(id="list")
+        item_list.load()
+
+        html = render(item_list, scope)
+
+        assert html.count('data-pjx-loading="skeleton"') == 3
+        assert 'id="list"' in html
+
+    def test_empty_list_renders_an_empty_ul(self, scope):
+        for todo in list(todo_store.all_todos()):
+            todo_store.toggle(todo.id)
+        todo_store.clear_completed()
+        item_list = ItemList(id="list")
+        item_list.load()
+
+        html = render(item_list, scope)
+
+        assert "<li" not in html
+        assert "<ul" in html
+
+
+class TestStatusComponents:
+    def test_counter_renders_its_count(self, scope):
+        counter = Counter(id="counter")
+        counter.load()
+
+        assert "3 left" in render(counter, scope)
+
+    def test_total_renders_its_count(self, scope):
+        total = Total(id="total")
+        total.load()
+
+        assert "3 total" in render(total, scope)
+
+    def test_clear_button_keeps_its_loading_indicator_attrs(self, scope):
+        button = ClearButton(id="clear")
+        button.load()
+
+        html = render(button, scope)
+
+        assert 'data-pjx-loading="spinner"' in html
+        assert 'data-pjx-loading-extra=".todo.done"' in html
+        assert 'hx-post="/todos/clear-completed"' in html
+
+    def test_clear_button_is_disabled_with_nothing_completed(self, scope):
+        button = ClearButton(id="clear")
+        button.load()
+
+        assert "disabled" in render(button, scope)
+
+
+class TestApp:
+    def test_renders_the_whole_tree(self, scope):
+        html = render(_loaded_app(scope), scope)
+
+        assert "Write the docs" in html
+        assert "3 left" in html
+        assert "3 total" in html
+        assert "Clear completed (0)" in html
+
+    def test_renders_the_composer_form(self, scope):
+        html = render(_loaded_app(scope), scope)
+
+        assert 'hx-post="/todos"' in html
+        assert 'name="text"' in html
+
+
+class TestDesignSystem:
+    def test_app_output_inlines_the_stylesheet(self, scope):
+        html = render(_loaded_app(scope), scope)
+
+        assert "<style>" in html
+        assert "--accent" in html
+
+    def test_the_palette_is_the_pastel_one(self, scope):
+        html = render(_loaded_app(scope), scope)
+
+        assert "#faf9f7" in html
+        assert "#b9a6f2" in html
+        # The v0.x neon-terminal accent is gone, not merely overridden.
+        assert "#b8ff4d" not in html
+
+    def test_no_external_font_or_cdn_dependency(self, scope):
+        html = render(_loaded_app(scope), scope)
+
+        assert "fonts.googleapis.com" not in html
+        assert "fonts.gstatic.com" not in html
+        assert "@import" not in html
+        assert "<link" not in html
+        assert "IBM Plex Mono" not in html


### PR DESCRIPTION
## Summary

Complete todo example implementation with component library and pastel design system.

- Shared component test fixtures and smoke tests for App shell
- ItemRow, ItemList, Counter, Total, and ClearButton components
- Full re-skin with pastel tokens and system font stack
- Design system co-located as app.css with inlined assets

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)