### PR TITLE
fix: suppress type checking errors in load() override tests

### DIFF
--- a/examples/todo/app.py
+++ b/examples/todo/app.py
@@ -34,14 +34,14 @@ def index():
     populates them for us: a child assigned to a field is never mounted by the
     renderer, and an unloaded one would render as its defaults.
     """
-    item_list = ItemList(id="list")
-    item_list.load()
-    remaining = Counter(id="counter")
-    remaining.load()
-    total_count = Total(id="total")
-    total_count.load()
-    clear_button = ClearButton(id="clear")
-    clear_button.load()
+    item_list = ItemList.load()
+    item_list.id = "list"
+    remaining = Counter.load()
+    remaining.id = "counter"
+    total_count = Total.load()
+    total_count.id = "total"
+    clear_button = ClearButton.load()
+    clear_button.id = "clear"
     return App(
         id="app",
         item_list=item_list,
@@ -60,8 +60,8 @@ def add_todo(request: Request, text: str = Form(...)):
     refreshes the mounted counters that store.add's @mutates just dirtied.
     """
     todo = store.add(text)
-    row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
-    row.load()
+    row = ItemRow.load(todo.id)
+    row.id = f"row-{todo.id}"
     return ReactiveResponse(primary=render(row, current_session()), mounted=request)
 
 
@@ -77,8 +77,8 @@ def toggle_todo(request: Request, todo_id: int):
         store.toggle(todo_id)
     except KeyError:
         raise HTTPException(status_code=404, detail=f"no todo {todo_id}") from None
-    row = ItemRow(id=f"row-{todo_id}", todo_id=todo_id)
-    row.load()
+    row = ItemRow.load(todo_id)
+    row.id = f"row-{todo_id}"
     return ReactiveResponse(primary=render(row, current_session()), mounted=request)
 
 

--- a/examples/todo/components/clear_button/clear_button.py
+++ b/examples/todo/components/clear_button/clear_button.py
@@ -8,6 +8,7 @@ class ClearButton(ReactiveComponent, react={Keys.TODOS}):
 
     completed: int = 0
 
-    def load(self, ctx: TodoAppContext):
+    @classmethod
+    def load(cls, ctx: TodoAppContext) -> "ClearButton":
         """Read the completed-todo count from the store."""
-        self.completed = ctx.store.completed()
+        return cls(completed=ctx.store.completed())

--- a/examples/todo/components/counter/counter.py
+++ b/examples/todo/components/counter/counter.py
@@ -8,6 +8,7 @@ class Counter(ReactiveComponent, react={Keys.TODOS}):
 
     remaining: int = 0
 
-    def load(self, ctx: TodoAppContext):
+    @classmethod
+    def load(cls, ctx: TodoAppContext) -> "Counter":
         """Read the open-todo count from the store."""
-        self.remaining = ctx.store.remaining()
+        return cls(remaining=ctx.store.remaining())

--- a/examples/todo/components/item_list/item_list.py
+++ b/examples/todo/components/item_list/item_list.py
@@ -9,18 +9,21 @@ class ItemList(ReactiveComponent, react={Keys.TODO_LIST}):
 
     items: list[ItemRow] = []  # noqa: RUF012 -- pydantic field, not a shared mutable default
 
-    def load(self, ctx: TodoAppContext):
-        """Build one row per todo and load each one before keeping it.
+    @classmethod
+    def load(cls, ctx: TodoAppContext) -> "ItemList":
+        """Build one cache-routed row per todo.
 
-        The explicit row.load() is load-bearing: pjx_mount() only fires for
+        ``ItemRow.load(todo.id)`` is load-bearing: pjx_mount() only fires for
         children the renderer instantiates from a tag, never for instances
-        assigned to a field, so rows built here would otherwise render with
-        their defaults. It takes no argument — the load wrap injects the
-        request's app context.
+        assigned to a field, so rows built here go through the factory
+        directly instead. The dom id is stamped after: it identifies the
+        mounted region, not the loaded data, so it is never a load()
+        parameter, and the cached instance is shared across renders of the
+        same todo_id regardless of which row happens to touch it first.
         """
         rows = []
         for todo in ctx.store.all_todos():
-            row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
-            row.load()
+            row = ItemRow.load(todo.id)
+            row.id = f"row-{todo.id}"
             rows.append(row)
-        self.items = rows
+        return cls(items=rows)

--- a/examples/todo/components/item_row/item_row.py
+++ b/examples/todo/components/item_row/item_row.py
@@ -12,18 +12,18 @@ class ItemRow(ReactiveComponent, react={Keys.TODOS}):
     title: str = ""
     done: bool = False
 
-    # No return annotation: a `-> None` here trips bug #713.
-    def load(self, ctx: TodoAppContext):
-        """Read this row's todo from the store.
+    @classmethod
+    def load(cls, todo_id: int, ctx: TodoAppContext) -> "ItemRow":
+        """Build this row from the store.
 
-        A todo_id that is not in the store leaves the fields at their defaults
-        rather than raising: a row can outlive the todo it stands for (a
+        A todo_id that is not in the store returns a field-default row rather
+        than raising: a row can outlive the todo it stands for (a
         clear-completed that landed between render and swap), and a demo page
-        should render an empty row instead of a 500.
+        should render an empty row instead of a 500. The self-referencing
+        return annotation (`-> "ItemRow"`) exercises #713's fix.
         """
         try:
-            todo = ctx.store.get(self.todo_id)
+            todo = ctx.store.get(todo_id)
         except KeyError:
-            return
-        self.title = todo.text
-        self.done = todo.done
+            return cls(todo_id=todo_id)
+        return cls(todo_id=todo_id, title=todo.text, done=todo.done)

--- a/examples/todo/components/total/total.py
+++ b/examples/todo/components/total/total.py
@@ -8,6 +8,7 @@ class Total(ReactiveComponent, react={Keys.TODOS}):
 
     count: int = 0
 
-    def load(self, ctx: TodoAppContext):
+    @classmethod
+    def load(cls, ctx: TodoAppContext) -> "Total":
         """Read the total todo count from the store."""
-        self.count = ctx.store.total()
+        return cls(count=ctx.store.total())

--- a/pyjinhx/app_context.py
+++ b/pyjinhx/app_context.py
@@ -11,9 +11,9 @@ request state and is not meant to be subclassed by apps.
 from __future__ import annotations
 
 import inspect
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from types import UnionType
-from typing import Any, Union, get_args, get_origin, get_type_hints
+from typing import Any, Union, get_args, get_origin
 
 
 class AppContext:
@@ -49,6 +49,31 @@ def _is_app_context(annotation: Any) -> bool:
     return False
 
 
+def _param_hints(
+    func: Callable[..., Any], parameters: Mapping[str, inspect.Parameter]
+) -> dict[str, Any]:
+    """Resolve only the parameter annotations, one at a time.
+
+    ``get_type_hints(func)`` evaluates the return annotation too, and a factory
+    ``load`` naturally returns its own class — a forward ref that does not
+    resolve while that class is still being built (#713). Each parameter is
+    resolved on its own so one unevaluable annotation drops only itself.
+    """
+    globalns = getattr(func, "__globals__", {})
+    hints: dict[str, Any] = {}
+    for name, param in parameters.items():
+        annotation = param.annotation
+        if annotation is inspect.Parameter.empty:
+            continue
+        if isinstance(annotation, str):
+            try:
+                annotation = eval(annotation, globalns, None)  # noqa: S307
+            except Exception:  # noqa: BLE001 -- an unevaluable annotation is simply not a context
+                continue
+        hints[name] = annotation
+    return hints
+
+
 def resolve_load_context_param(func: Callable[..., Any]) -> str | None:
     """Return the name of ``func``'s app-context parameter, or None when it has none.
 
@@ -63,16 +88,10 @@ def resolve_load_context_param(func: Callable[..., Any]) -> str | None:
         TypeError: More than one parameter is annotated as an app context.
     """
     try:
-        hints = get_type_hints(func)
-    except (NameError, TypeError, AttributeError):
-        # An annotation that cannot be evaluated - a forward ref to something
-        # never imported, say - is not a match. Raising here would let an
-        # unrelated bad annotation break class definition outright.
-        return None
-    try:
         parameters = inspect.signature(func).parameters
     except (TypeError, ValueError):
         return None
+    hints = _param_hints(func, parameters)
     names = [
         name for name in parameters if name in hints and _is_app_context(hints[name])
     ]

--- a/pyjinhx/app_context.py
+++ b/pyjinhx/app_context.py
@@ -67,8 +67,8 @@ def _param_hints(
             continue
         if isinstance(annotation, str):
             try:
-                annotation = eval(annotation, globalns, None)  # noqa: S307
-            except Exception:  # noqa: BLE001 -- an unevaluable annotation is simply not a context
+                annotation = eval(annotation, globalns, None)
+            except Exception:  # noqa: BLE001, S112 -- an unevaluable annotation is simply not a context
                 continue
         hints[name] = annotation
     return hints

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -62,14 +62,19 @@ class ReactiveComponent(BaseComponent):
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
     def pjx_mount(self) -> None:
-        """Run the cache-routed ``load()`` before this instance's recursive render.
+        """Populate this instance from the cache-routed ``load()`` factory.
 
-        Overrides BaseComponent's no-op: rendering.py calls this hook on every
-        child it instantiates from a ChildRef without knowing anything about
-        ReactiveComponent, so mounting a reactive child never needs a manual
-        ``load()`` call from the template author.
+        A shim: rendering.py still constructs a child and then mounts it, so
+        the factory's result is copied onto the instance that already exists.
+        #727 rewires ``_fill_children`` to call ``Cls.load(**key_args)``
+        directly and deletes this hook.
         """
-        self.load()
+        cls = type(self)
+        field = cls._pjx_key_field
+        loaded = cls.load(**({field: getattr(self, field)} if field else {}))
+        for name in cls.model_fields:
+            if name != "id":
+                setattr(self, name, getattr(loaded, name))
 
     def __init_subclass__(cls, *, react: Iterable[object] = (), **kwargs: Any) -> None:
         """Consume the ``react`` class kwarg and record it as normalized keys.

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -40,7 +40,7 @@ class ReactiveComponent(BaseComponent):
     one outright rather than adding to it."""
 
     @classmethod
-    def load(cls) -> "ReactiveComponent":
+    def load(cls, *args: Any, **kwargs: Any) -> "ReactiveComponent":  # type: ignore[misc]
         """Build this component for the current request. Override in subclasses.
 
         The default builds a field-default instance, so a reactive component

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -288,26 +288,73 @@ def _wrap_load(
             caller so this stays a pure per-call cache dance.
     """
 
-    def wrapped_load(self: Any) -> Any:
-        # An unmarked class has no per-instance key, so all its instances keep
-        # sharing the one entry under the null key.
-        field = cls._pjx_key_field
-        key = coerce_load_key_str(getattr(self, field, None)) if field else None
+    full_signature = inspect.signature(real_load)
+    protocol_mode = cls.model_config.get("extra") == "allow"
+    # The public signature callers bind against excludes the context param:
+    # it is injected from the request scope, never passed in by a caller, so
+    # binding against the full signature would demand it as a required arg.
+    if context_param is not None:
+        signature = full_signature.replace(
+            parameters=[
+                param
+                for name, param in full_signature.parameters.items()
+                if name != context_param
+            ]
+        )
+    else:
+        signature = full_signature
+
+    def wrapped_load(bound_cls: type[Any], *args: Any, **kwargs: Any) -> Any:
+        bound = signature.bind(bound_cls, *args, **kwargs)
+        bound.apply_defaults()
+        supplied = dict(bound.arguments)
+        supplied.pop("cls", None)
+        if context_param is not None:
+            supplied.pop(context_param, None)
+        key = _cache_key(cls, supplied, protocol_mode=protocol_mode)
         if cache_has(cls, key):
             return cache_get(cls, key)
-        if context_param is None:
-            result = real_load(self)
-        else:
-            result = real_load(self, **{context_param: get_load_context()})
+        call_kwargs = dict(supplied)
+        if context_param is not None:
+            call_kwargs[context_param] = get_load_context()
+        result = real_load(bound_cls, **call_kwargs)
+        if not isinstance(result, cls):
+            raise TypeError(
+                f"{cls.__name__}.load must return an instance of {cls.__name__}; "
+                f"got {type(result).__name__}."
+            )
         # Index under both the static react keys (a bare "todos" dirties every
-        # instance) and, when this instance has a load key, the per-instance
-        # "todos:1" composite form reactive_key() produces — @mutates(key=...)
-        # and dirty(reactive_key(...)) dirty only the composite, never the bare
-        # key alongside it, so invalidate() needs both forms to find this entry.
+        # instance) and, when this call has a load key, the per-instance
+        # "todos:1" composite reactive_key() produces — @mutates(key=...) and
+        # dirty(reactive_key(...)) dirty only the composite, so invalidate()
+        # needs both forms to find this entry.
         react_keys = cls._pjx_react_keys
-        if key is not None:
-            react_keys = (*react_keys, *(f"{rk}:{key}" for rk in cls._pjx_react_keys))
+        field = cls._pjx_key_field
+        load_key = coerce_load_key_str(supplied.get(field)) if field else None
+        if load_key is not None:
+            react_keys = (
+                *react_keys,
+                *(f"{rk}:{load_key}" for rk in cls._pjx_react_keys),
+            )
         cache_put(cls, key, result, react_keys=react_keys)
         return result
 
     return wrapped_load
+
+
+def _cache_key(
+    cls: type["ReactiveComponent"], supplied: dict[str, Any], *, protocol_mode: bool
+) -> object:
+    """This call's cache key: the key-field value, or every bound argument.
+
+    Under ``extra="allow"`` the extra parameters are part of what was asked
+    for, so two calls that differ only there must not collide; strict mode has
+    nothing but the key field to distinguish calls by, and keeping its key the
+    plain coerced string leaves fanout's ``_load_key()`` derivation intact.
+    """
+    if protocol_mode:
+        return tuple(sorted((name, repr(value)) for name, value in supplied.items()))
+    field = cls._pjx_key_field
+    if field is None:
+        return None
+    return coerce_load_key_str(supplied.get(field))

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -210,7 +210,9 @@ def _unwrap_load(cls: type[Any]) -> tuple[Callable[..., Any], bool]:
     raise TypeError(f"{cls.__name__} has no load()")
 
 
-def _validate_load_is_classmethod(cls: type[Any], func: Callable[..., Any], is_cm: bool) -> None:
+def _validate_load_is_classmethod(
+    cls: type[Any], func: Callable[..., Any], is_cm: bool
+) -> None:
     """Reject an instance-method ``load``, pointing at the migration.
 
     Raises:
@@ -225,7 +227,9 @@ def _validate_load_is_classmethod(cls: type[Any], func: Callable[..., Any], is_c
         )
 
 
-def _load_value_params(func: Callable[..., Any], context_param: str | None) -> list[str]:
+def _load_value_params(
+    func: Callable[..., Any], context_param: str | None
+) -> list[str]:
     """``load``'s parameters minus ``cls`` and the app-context one.
 
     Uses ``inspect.signature`` and never ``get_type_hints``: this runs while the
@@ -277,7 +281,9 @@ def _validate_load_params(
 
 
 def _wrap_load(
-    cls: type["ReactiveComponent"], real_load: Callable[..., Any], context_param: str | None
+    cls: type["ReactiveComponent"],
+    real_load: Callable[..., Any],
+    context_param: str | None,
 ) -> Callable[[Any], Any]:
     """Build the memoizing wrapper around one class's ``load``.
 

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -72,7 +72,8 @@ class ReactiveComponent(BaseComponent):
         cls = type(self)
         field = cls._pjx_key_field
         loaded = cls.load(**({field: getattr(self, field)} if field else {}))
-        for name in cls.model_fields:
+        names = list(cls.model_fields) + list(loaded.__pydantic_extra__ or ())
+        for name in names:
             if name != "id":
                 setattr(self, name, getattr(loaded, name))
 

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -97,7 +97,9 @@ class ReactiveComponent(BaseComponent):
             return
         real_load, is_classmethod = _unwrap_load(cls)
         _validate_load_is_classmethod(cls, real_load, is_classmethod)
-        cls.load = classmethod(_wrap_load(cls, real_load))  # pyright: ignore[reportAttributeAccessIssue]
+        context_param = resolve_load_context_param(real_load)
+        _validate_load_params(cls, real_load, context_param)
+        cls.load = classmethod(_wrap_load(cls, real_load, context_param))  # pyright: ignore[reportAttributeAccessIssue]
 
 
 class PjxKey:
@@ -218,8 +220,59 @@ def _validate_load_is_classmethod(cls: type[Any], func: Callable[..., Any], is_c
         )
 
 
+def _load_value_params(func: Callable[..., Any], context_param: str | None) -> list[str]:
+    """``load``'s parameters minus ``cls`` and the app-context one.
+
+    Uses ``inspect.signature`` and never ``get_type_hints``: this runs while the
+    class is still being built, where a self-referencing return annotation is an
+    unresolvable forward ref (#713).
+    """
+    names = [name for name in inspect.signature(func).parameters if name != "cls"]
+    if context_param is not None and context_param in names:
+        names.remove(context_param)
+    return names
+
+
+def _validate_load_params(
+    cls: type[Any], func: Callable[..., Any], context_param: str | None
+) -> None:
+    """Check ``load``'s parameters against the class's PjxKey field names.
+
+    Strict by default: the parameter list must be exactly the key fields. Under
+    ``extra="allow"`` the key fields are a required minimum only — anything
+    beyond them is the class's own protocol, so it is not checked.
+
+    Raises:
+        TypeError: The parameters do not satisfy the class's key fields.
+    """
+    expected = pjx_key_field_names(cls)
+    given = _load_value_params(func, context_param)
+    if cls.model_config.get("extra") == "allow":
+        missing = [name for name in expected if name not in given]
+        if missing:
+            raise TypeError(
+                f"{cls.__name__}.load must accept its PjxKey field(s) {missing!r}; "
+                f"it declares {given!r}."
+            )
+        return
+    if not expected:
+        if given:
+            raise TypeError(
+                f"{cls.__name__} declares no PjxKey field, so load() must take no "
+                f"parameters beyond cls; it declares {given!r}."
+            )
+        return
+    if given != expected:
+        extra = [name for name in given if name not in expected]
+        missing = [name for name in expected if name not in given]
+        raise TypeError(
+            f"{cls.__name__}.load parameters must be exactly its PjxKey fields "
+            f"{expected!r}; got {given!r} (missing {missing!r}, extra {extra!r})."
+        )
+
+
 def _wrap_load(
-    cls: type["ReactiveComponent"], real_load: Callable[..., Any]
+    cls: type["ReactiveComponent"], real_load: Callable[..., Any], context_param: str | None
 ) -> Callable[[Any], Any]:
     """Build the memoizing wrapper around one class's ``load``.
 
@@ -228,14 +281,12 @@ def _wrap_load(
     request scope the cache reads miss and the writes vanish, so the real body
     simply runs every time - no special case is needed here for that.
 
-    The app-context parameter, if the signature declares one, is resolved here
-    too and closed over: signature introspection is a per-class fact, and doing
-    it on every load() would put it on the hot render path.
-
-    Raises:
-        TypeError: ``load`` declares more than one app-context parameter.
+    Args:
+        cls: The subclass being defined.
+        real_load: The undecorated function behind ``load``.
+        context_param: The app-context parameter's name, pre-resolved by the
+            caller so this stays a pure per-call cache dance.
     """
-    context_param = resolve_load_context_param(real_load)
 
     def wrapped_load(self: Any) -> Any:
         # An unmarked class has no per-instance key, so all its instances keep

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -6,6 +6,7 @@ at registration, never per render.
 """
 
 import hashlib
+import inspect
 import json
 from collections.abc import Callable, Iterable
 from typing import Annotated, Any, ClassVar, get_args, get_origin, get_type_hints
@@ -38,13 +39,14 @@ class ReactiveComponent(BaseComponent):
     """Field names left out of the state hash. A subclass's value replaces this
     one outright rather than adding to it."""
 
-    def load(self) -> Any:
-        """Fetch this component's data. Override in subclasses.
+    @classmethod
+    def load(cls) -> "ReactiveComponent":
+        """Build this component for the current request. Override in subclasses.
 
-        The default does nothing, so a reactive component that has no data to
-        fetch stays valid and the wrap always has a body to call.
+        The default builds a field-default instance, so a reactive component
+        with nothing to fetch stays valid and the wrap always has a body.
         """
-        return None
+        return cls()
 
     def state_hash(self) -> str:
         """Return a SHA-256 hex digest of this instance's output-relevant field values.
@@ -84,7 +86,18 @@ class ReactiveComponent(BaseComponent):
         """Run BaseComponent's registration, resolve the key field, install the wrap."""
         super().__pydantic_init_subclass__(**kwargs)
         cls._pjx_key_field = resolve_pjx_key_field(cls)
-        cls.load = _wrap_load(cls, cls.load)  # pyright: ignore[reportAttributeAccessIssue]
+        if "load" not in cls.__dict__:
+            # cls inherits load unchanged: the ancestor that defines it already
+            # validated and wrapped it, closing over *that* ancestor's cls for
+            # cache-key derivation. Re-running _unwrap_load here would grab the
+            # already-wrapped function (not a raw user def) and either reject
+            # it outright or, worse, rewrap with the wrong cls closed in,
+            # silently mis-keying this subclass's cache entries under the
+            # ancestor's identity.
+            return
+        real_load, is_classmethod = _unwrap_load(cls)
+        _validate_load_is_classmethod(cls, real_load, is_classmethod)
+        cls.load = classmethod(_wrap_load(cls, real_load))  # pyright: ignore[reportAttributeAccessIssue]
 
 
 class PjxKey:
@@ -164,6 +177,45 @@ def resolve_pjx_key_field(model_cls: type[Any]) -> str | None:
             f"at most one is allowed."
         )
     return names[0]
+
+
+_MIGRATION_HINT = (
+    "load() is now a classmethod factory that returns an instance:\n"
+    "    @classmethod\n"
+    "    def load(cls, row_id: int) -> 'Row': return cls(row_id=row_id, ...)\n"
+    "instead of the old instance method `def load(self) -> None`."
+)
+
+
+def _unwrap_load(cls: type[Any]) -> tuple[Callable[..., Any], bool]:
+    """The raw function behind ``cls.load`` and whether it was a classmethod.
+
+    Read off ``__dict__`` rather than ``getattr``: a classmethod accessed
+    through the class is already bound, and the binding is exactly the fact
+    being tested.
+    """
+    for klass in cls.__mro__:
+        raw = klass.__dict__.get("load")
+        if raw is not None:
+            return (raw.__func__ if isinstance(raw, classmethod) else raw), isinstance(
+                raw, classmethod
+            )
+    raise TypeError(f"{cls.__name__} has no load()")
+
+
+def _validate_load_is_classmethod(cls: type[Any], func: Callable[..., Any], is_cm: bool) -> None:
+    """Reject an instance-method ``load``, pointing at the migration.
+
+    Raises:
+        TypeError: ``load`` is not a classmethod, or its first parameter is not
+            ``cls``.
+    """
+    params = list(inspect.signature(func).parameters)
+    if not is_cm or not params or params[0] != "cls":
+        raise TypeError(
+            f"{cls.__name__}.load must be a @classmethod whose first parameter "
+            f"is `cls`. {_MIGRATION_HINT}"
+        )
 
 
 def _wrap_load(

--- a/pyjinhx/reactive/fanout.py
+++ b/pyjinhx/reactive/fanout.py
@@ -149,17 +149,18 @@ def _build_dirty(
 ) -> tuple[ReactiveComponent, object]:
     """Re-run this candidate's load and render, and hand back both.
 
-    ``instance.load()`` goes through the L3.2 memo wrap, which is what writes
-    the fresh entry to the cache — fanout never calls ``cache_put`` itself, so
-    the key derivation stays in exactly one place. ``render_level()`` rather
-    than ``render()``: ``oob_swaps()`` splices at a root_span, and only the
-    level carries one.
+    ``cls.load()`` goes through the L3.2 memo wrap, which is what writes the
+    fresh entry to the cache — fanout never calls ``cache_put`` itself, so the
+    key derivation stays in exactly one place. ``render_level()`` rather than
+    ``render()``: ``oob_swaps()`` splices at a root_span, and only the level
+    carries one. The id is stamped after: it identifies the mounted region, not
+    the loaded data, so it is never a load() parameter.
     """
-    fields: dict[str, Any] = {"id": instance_id}
+    key_args: dict[str, Any] = {}
     if cls._pjx_key_field is not None:
-        fields[cls._pjx_key_field] = load
-    instance = cls(**fields)
-    instance.load()
+        key_args[cls._pjx_key_field] = load
+    instance = cls.load(**key_args)
+    instance.id = instance_id
     return instance, render_level(instance, session)
 
 

--- a/tests/examples/test_todo_components.py
+++ b/tests/examples/test_todo_components.py
@@ -14,9 +14,8 @@ from examples.todo.keys import Keys
 class TestItemRow:
     def test_load_populates_title_and_done_from_the_store(self, scope):
         todo = todo_store.all_todos()[0]
-        row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
 
-        row.load()
+        row = ItemRow.load(todo.id)
 
         assert row.title == todo.text
         assert row.done is False
@@ -24,16 +23,13 @@ class TestItemRow:
     def test_load_reflects_a_toggled_todo(self, scope):
         todo = todo_store.all_todos()[0]
         todo_store.toggle(todo.id)
-        row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
 
-        row.load()
+        row = ItemRow.load(todo.id)
 
         assert row.done is True
 
     def test_load_on_a_missing_todo_leaves_the_defaults(self, scope):
-        row = ItemRow(id="row-9999", todo_id=9999)
-
-        row.load()
+        row = ItemRow.load(9999)
 
         assert row.title == ""
         assert row.done is False
@@ -47,84 +43,56 @@ class TestItemRow:
 
 class TestCounter:
     def test_load_sets_remaining_from_the_store(self, scope):
-        counter = Counter(id="counter")
-
-        counter.load()
-
-        assert counter.remaining == 3
+        assert Counter.load().remaining == 3
 
     def test_load_drops_a_toggled_todo_from_remaining(self, scope):
         todo_store.toggle(todo_store.all_todos()[0].id)
-        counter = Counter(id="counter")
 
-        counter.load()
-
-        assert counter.remaining == 2
+        assert Counter.load().remaining == 2
 
     def test_zero_state(self, scope):
         for todo in list(todo_store.all_todos()):
             todo_store.toggle(todo.id)
         todo_store.clear_completed()
-        counter = Counter(id="counter")
 
-        counter.load()
-
-        assert counter.remaining == 0
+        assert Counter.load().remaining == 0
 
 
 class TestTotal:
     def test_load_sets_count_from_the_store(self, scope):
-        total = Total(id="total")
-
-        total.load()
-
-        assert total.count == 3
+        assert Total.load().count == 3
 
     def test_zero_state(self, scope):
         for todo in list(todo_store.all_todos()):
             todo_store.toggle(todo.id)
         todo_store.clear_completed()
-        total = Total(id="total")
 
-        total.load()
-
-        assert total.count == 0
+        assert Total.load().count == 0
 
 
 class TestClearButton:
     def test_load_counts_completed_todos(self, scope):
         todo_store.toggle(todo_store.all_todos()[0].id)
-        button = ClearButton(id="clear")
 
-        button.load()
-
-        assert button.completed == 1
+        assert ClearButton.load().completed == 1
 
     def test_zero_state_with_nothing_completed(self, scope):
-        button = ClearButton(id="clear")
-
-        button.load()
-
-        assert button.completed == 0
+        assert ClearButton.load().completed == 0
 
 
 class TestItemList:
     def test_load_builds_one_row_per_todo(self, scope):
-        item_list = ItemList(id="list")
-
-        item_list.load()
+        item_list = ItemList.load()
 
         assert [row.todo_id for row in item_list.items] == [
             todo.id for todo in todo_store.all_todos()
         ]
 
     def test_every_row_comes_back_already_loaded(self, scope):
-        # The regression: assigning ItemRow instances to a field does NOT fire
-        # pjx_mount(), so ItemList.load() has to call each row's load() itself.
-        # Forget that and every row renders with its field defaults.
-        item_list = ItemList(id="list")
-
-        item_list.load()
+        # The regression: ItemList.load() has to route each row through
+        # ItemRow.load() itself, not just construct plain instances - forget
+        # that and every row renders with its field defaults.
+        item_list = ItemList.load()
 
         assert [row.title for row in item_list.items] == [
             "Write the docs",
@@ -135,16 +103,13 @@ class TestItemList:
 
     def test_row_done_state_survives_into_the_list(self, scope):
         todo_store.toggle(todo_store.all_todos()[1].id)
-        item_list = ItemList(id="list")
 
-        item_list.load()
+        item_list = ItemList.load()
 
         assert [row.done for row in item_list.items] == [False, True, False]
 
     def test_each_row_carries_a_stable_dom_id(self, scope):
-        item_list = ItemList(id="list")
-
-        item_list.load()
+        item_list = ItemList.load()
 
         assert [row.id for row in item_list.items] == [
             f"row-{todo.id}" for todo in todo_store.all_todos()
@@ -154,11 +119,8 @@ class TestItemList:
         for todo in list(todo_store.all_todos()):
             todo_store.toggle(todo.id)
         todo_store.clear_completed()
-        item_list = ItemList(id="list")
 
-        item_list.load()
-
-        assert item_list.items == []
+        assert ItemList.load().items == []
 
     def test_reacts_to_the_todo_list_key(self):
         assert ItemList._pjx_react_keys == (Keys.TODO_LIST.value,)

--- a/tests/examples/test_todo_templates.py
+++ b/tests/examples/test_todo_templates.py
@@ -14,14 +14,14 @@ from pyjinhx.rendering import render
 
 def _loaded_app(session):
     """The whole tree, loaded, the way a route would assemble it."""
-    item_list = ItemList(id="list")
-    item_list.load()
-    remaining = Counter(id="counter")
-    remaining.load()
-    total_count = Total(id="total")
-    total_count.load()
-    clear_button = ClearButton(id="clear")
-    clear_button.load()
+    item_list = ItemList.load()
+    item_list.id = "list"
+    remaining = Counter.load()
+    remaining.id = "counter"
+    total_count = Total.load()
+    total_count.id = "total"
+    clear_button = ClearButton.load()
+    clear_button.id = "clear"
     return App(
         id="app",
         item_list=item_list,
@@ -34,8 +34,8 @@ def _loaded_app(session):
 class TestItemRow:
     def test_renders_title_and_toggle_wiring(self, scope):
         todo = todo_store.all_todos()[0]
-        row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
-        row.load()
+        row = ItemRow.load(todo.id)
+        row.id = f"row-{todo.id}"
 
         html = render(row, scope)
 
@@ -45,24 +45,24 @@ class TestItemRow:
 
     def test_keeps_the_skeleton_loading_indicator(self, scope):
         todo = todo_store.all_todos()[0]
-        row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
-        row.load()
+        row = ItemRow.load(todo.id)
+        row.id = f"row-{todo.id}"
 
         assert 'data-pjx-loading="skeleton"' in render(row, scope)
 
     def test_done_row_gets_the_done_class(self, scope):
         todo = todo_store.all_todos()[0]
         todo_store.toggle(todo.id)
-        row = ItemRow(id=f"row-{todo.id}", todo_id=todo.id)
-        row.load()
+        row = ItemRow.load(todo.id)
+        row.id = f"row-{todo.id}"
 
         assert 'class="todo done"' in render(row, scope)
 
 
 class TestItemList:
     def test_renders_every_row(self, scope):
-        item_list = ItemList(id="list")
-        item_list.load()
+        item_list = ItemList.load()
+        item_list.id = "list"
 
         html = render(item_list, scope)
 
@@ -73,8 +73,8 @@ class TestItemList:
         for todo in list(todo_store.all_todos()):
             todo_store.toggle(todo.id)
         todo_store.clear_completed()
-        item_list = ItemList(id="list")
-        item_list.load()
+        item_list = ItemList.load()
+        item_list.id = "list"
 
         html = render(item_list, scope)
 
@@ -84,20 +84,20 @@ class TestItemList:
 
 class TestStatusComponents:
     def test_counter_renders_its_count(self, scope):
-        counter = Counter(id="counter")
-        counter.load()
+        counter = Counter.load()
+        counter.id = "counter"
 
         assert "3 left" in render(counter, scope)
 
     def test_total_renders_its_count(self, scope):
-        total = Total(id="total")
-        total.load()
+        total = Total.load()
+        total.id = "total"
 
         assert "3 total" in render(total, scope)
 
     def test_clear_button_keeps_its_loading_indicator_attrs(self, scope):
-        button = ClearButton(id="clear")
-        button.load()
+        button = ClearButton.load()
+        button.id = "clear"
 
         html = render(button, scope)
 
@@ -106,8 +106,8 @@ class TestStatusComponents:
         assert 'hx-post="/todos/clear-completed"' in html
 
     def test_clear_button_is_disabled_with_nothing_completed(self, scope):
-        button = ClearButton(id="clear")
-        button.load()
+        button = ClearButton.load()
+        button.id = "clear"
 
         assert "disabled" in render(button, scope)
 

--- a/tests/pyjinhx/builtins/test_family_data_htmx_sweep.py
+++ b/tests/pyjinhx/builtins/test_family_data_htmx_sweep.py
@@ -88,21 +88,30 @@ class TableRegion(ReactiveComponent, react=(ROWS,)):
     rows: list[str] = Field(default_factory=list)
     table: Slot = ""
 
-    def load(self) -> None:
-        LOAD_CALLS.append(f"table:{self.pjx_key}")
-        self.rows = list(STORE["rows"])
-        self.table = PJXTable(
-            id=f"tbl-{self.id}",
+    @classmethod
+    def load(cls, pjx_key: str) -> "TableRegion":
+        LOAD_CALLS.append(f"table:{pjx_key}")
+        rows = list(STORE["rows"])
+        instance = cls(pjx_key=pjx_key, rows=rows)
+        # Nested ids are keyed off pjx_key, not instance.id: this instance is a
+        # throwaway the pjx_mount() shim copies fields out of (see #726), so
+        # its own auto-generated id is not the mounted region's final id and,
+        # worse, keeps incrementing across request scopes - deriving from it
+        # would make these nested ids leak that global counter instead of
+        # staying a pure function of which key was loaded.
+        instance.table = PJXTable(
+            id=f"tbl-{pjx_key}",
             content=PJXTableBody(
-                id=f"tbody-{self.id}",
+                id=f"tbody-{pjx_key}",
                 content=PJXTableRow(
-                    id=f"row-{self.id}",
+                    id=f"row-{pjx_key}",
                     content=PJXTableCell(
-                        id=f"cell-{self.id}", content=", ".join(self.rows)
+                        id=f"cell-{pjx_key}", content=", ".join(rows)
                     ),
                 ),
             ),
         )
+        return instance
 
 
 class PaginatorRegion(ReactiveComponent, react=(PAGE,)):
@@ -111,9 +120,10 @@ class PaginatorRegion(ReactiveComponent, react=(PAGE,)):
     pjx_key: Annotated[str, PjxKey()] = "main"
     page: int = 1
 
-    def load(self) -> None:
-        LOAD_CALLS.append(f"paginator:{self.pjx_key}")
-        self.page = int(STORE["page"])
+    @classmethod
+    def load(cls, pjx_key: str) -> "PaginatorRegion":
+        LOAD_CALLS.append(f"paginator:{pjx_key}")
+        return cls(pjx_key=pjx_key, page=int(STORE["page"]))
 
 
 class PageShell(ReactiveComponent, react=(PAGE,)):
@@ -121,14 +131,17 @@ class PageShell(ReactiveComponent, react=(PAGE,)):
 
     pjx_key: Annotated[str, PjxKey()] = "shell"
 
-    def load(self) -> None:
+    @classmethod
+    def load(cls, pjx_key: str) -> "PageShell":
         LOAD_CALLS.append("shell")
+        return cls(pjx_key=pjx_key)
 
 
 class BoomRegion(ReactiveComponent, react=(ROWS,)):
     """A region whose load() raises, to prove failures stay local."""
 
-    def load(self) -> None:
+    @classmethod
+    def load(cls) -> "BoomRegion":
         raise RuntimeError("boom")
 
 

--- a/tests/pyjinhx/builtins/test_family_data_htmx_sweep.py
+++ b/tests/pyjinhx/builtins/test_family_data_htmx_sweep.py
@@ -105,9 +105,7 @@ class TableRegion(ReactiveComponent, react=(ROWS,)):
                 id=f"tbody-{pjx_key}",
                 content=PJXTableRow(
                     id=f"row-{pjx_key}",
-                    content=PJXTableCell(
-                        id=f"cell-{pjx_key}", content=", ".join(rows)
-                    ),
+                    content=PJXTableCell(id=f"cell-{pjx_key}", content=", ".join(rows)),
                 ),
             ),
         )

--- a/tests/pyjinhx/integrations/test_reactive_request_cycle.py
+++ b/tests/pyjinhx/integrations/test_reactive_request_cycle.py
@@ -60,9 +60,10 @@ class CycleCard(ReactiveComponent, react=(Keys.CYCLE,)):
 
     pjx_key: Annotated[str, PjxKey()] = ""
 
-    def load(self) -> int:
-        LOAD_CALLS.append(self.pjx_key)
-        return STORE.get(self.pjx_key, 0)
+    @classmethod
+    def load(cls, pjx_key: str) -> "CycleCard":
+        LOAD_CALLS.append(pjx_key)
+        return cls(pjx_key=pjx_key)
 
 
 class CycleBadge(ReactiveComponent, react=(Keys.CYCLE,)):
@@ -70,9 +71,10 @@ class CycleBadge(ReactiveComponent, react=(Keys.CYCLE,)):
 
     pjx_key: Annotated[str, PjxKey()] = ""
 
-    def load(self) -> int:
-        LOAD_CALLS.append(f"badge:{self.pjx_key}")
-        return STORE.get(self.pjx_key, 0)
+    @classmethod
+    def load(cls, pjx_key: str) -> "CycleBadge":
+        LOAD_CALLS.append(f"badge:{pjx_key}")
+        return cls(pjx_key=pjx_key)
 
 
 ASSET_DIR = Path(__file__).parent.parent.parent / "templates"
@@ -530,8 +532,11 @@ class RequestAppContext(AppContext):
 class ContextCard(ReactiveComponent):
     """A card whose load() declares the app context and echoes it back."""
 
-    def load(self, ctx: RequestAppContext | None) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
-        return "no-context" if ctx is None else ctx.path
+    echoed: str = ""
+
+    @classmethod
+    def load(cls, ctx: RequestAppContext | None) -> "ContextCard":
+        return cls(echoed="no-context" if ctx is None else ctx.path)
 
 
 def test_load_receives_the_context_factory_result_over_a_real_request():
@@ -544,7 +549,7 @@ def test_load_receives_the_context_factory_result_over_a_real_request():
 
     @app.get("/ctx-echo")
     def ctx_echo() -> dict[str, str]:
-        return {"loaded": ContextCard().load()}  # pyright: ignore[reportCallIssue]
+        return {"loaded": ContextCard.load().echoed}
 
     with TestClient(app) as client:
         response = client.get("/ctx-echo")
@@ -559,7 +564,7 @@ def test_without_a_context_factory_the_injected_context_is_none():
 
     @app.get("/ctx-none")
     def ctx_none() -> dict[str, str]:
-        return {"loaded": ContextCard().load()}  # pyright: ignore[reportCallIssue]
+        return {"loaded": ContextCard.load().echoed}
 
     with TestClient(app) as client:
         response = client.get("/ctx-none")

--- a/tests/pyjinhx/integrations/test_reactive_request_cycle.py
+++ b/tests/pyjinhx/integrations/test_reactive_request_cycle.py
@@ -549,7 +549,7 @@ def test_load_receives_the_context_factory_result_over_a_real_request():
 
     @app.get("/ctx-echo")
     def ctx_echo() -> dict[str, str]:
-        return {"loaded": ContextCard.load().echoed}
+        return {"loaded": ContextCard.load().echoed}  # type: ignore[reportCallIssue]
 
     with TestClient(app) as client:
         response = client.get("/ctx-echo")
@@ -564,7 +564,7 @@ def test_without_a_context_factory_the_injected_context_is_none():
 
     @app.get("/ctx-none")
     def ctx_none() -> dict[str, str]:
-        return {"loaded": ContextCard.load().echoed}
+        return {"loaded": ContextCard.load().echoed}  # type: ignore[reportCallIssue]
 
     with TestClient(app) as client:
         response = client.get("/ctx-none")

--- a/tests/pyjinhx/reactive/test_fanout_assets.py
+++ b/tests/pyjinhx/reactive/test_fanout_assets.py
@@ -20,8 +20,9 @@ class Keys(MutationKey):
 class AssetWidget(ReactiveComponent, react=(Keys.WIDGET,)):
     """A reactive component whose descriptor is repointed at real asset files."""
 
-    def load(self) -> int:
-        return 0
+    @classmethod
+    def load(cls) -> "AssetWidget":
+        return cls()
 
 
 @pytest.fixture
@@ -96,8 +97,9 @@ def test_garbage_tokens_are_treated_as_having_nothing(asset_files):
 
 def test_a_class_with_no_assets_is_a_no_op_not_an_error():
     class Bare(ReactiveComponent, react=(Keys.WIDGET,)):
-        def load(self) -> int:
-            return 0
+        @classmethod
+        def load(cls) -> "Bare":
+            return cls()
 
     bare = dataclasses.replace(candidate(), component_class=Bare)
     assert missing_asset_oob([bare], frozenset(), RenderSession()) == ""

--- a/tests/pyjinhx/reactive/test_reactive_component.py
+++ b/tests/pyjinhx/reactive/test_reactive_component.py
@@ -412,3 +412,44 @@ def test_two_app_context_params_are_rejected_at_class_definition():
         class Widget(ReactiveComponent):
             def load(self, first: DemoAppContext, second: OtherAppContext) -> None:  # pyright: ignore[reportIncompatibleMethodOverride]
                 return None
+
+
+def test_classmethod_load_is_accepted():
+    class Widget(ReactiveComponent):
+        @classmethod
+        def load(cls) -> "Widget":
+            return cls()
+
+    assert isinstance(Widget.load(), Widget)
+
+
+def test_instance_method_load_is_rejected_at_class_definition():
+    with pytest.raises(TypeError, match="@classmethod"):
+
+        class Widget(ReactiveComponent):
+            def load(self) -> None:  # pyright: ignore[reportIncompatibleMethodOverride]
+                return None
+
+
+def test_instance_method_rejection_names_the_migration():
+    with pytest.raises(TypeError, match=r"def load\(cls"):
+
+        class Widget(ReactiveComponent):
+            def load(self) -> None:  # pyright: ignore[reportIncompatibleMethodOverride]
+                return None
+
+
+def test_grandchild_that_does_not_override_load_is_not_rewrapped():
+    """A subclass of a subclass, with no load of its own, must not trip the
+    classmethod validator against its parent's already-wrapped function, and
+    must not silently mis-key its cache entries under the parent's identity."""
+
+    class Base(ReactiveComponent):
+        @classmethod
+        def load(cls) -> "Base":
+            return cls()
+
+    class Child(Base):
+        pass
+
+    assert isinstance(Child.load(), Child)

--- a/tests/pyjinhx/reactive/test_reactive_component.py
+++ b/tests/pyjinhx/reactive/test_reactive_component.py
@@ -543,3 +543,22 @@ def test_protocol_mode_still_requires_the_key_params():
             @classmethod
             def load(cls, flavor: str = "plain") -> "Row":
                 return cls()
+
+
+def test_self_referencing_return_annotation_keeps_context_injection():
+    """#713: `-> "Row"` is an unresolvable forward ref while the class is being
+    built; that must not silently drop the AppContext parameter."""
+    from typing import Annotated
+
+    from pyjinhx.reactive.component import PjxKey
+
+    class Row(ReactiveComponent):
+        row_id: Annotated[int, PjxKey()] = 0
+        user: str = ""
+
+        @classmethod
+        def load(cls, row_id: int, ctx: DemoAppContext) -> "Row":
+            return cls(row_id=row_id, user=ctx.user)
+
+    with request_scope(load_context=DemoAppContext(user="ada")):
+        assert Row.load(1).user == "ada"

--- a/tests/pyjinhx/reactive/test_reactive_component.py
+++ b/tests/pyjinhx/reactive/test_reactive_component.py
@@ -15,8 +15,9 @@ def test_reactive_component_is_a_base_component():
 
 
 def test_defining_a_subclass_replaces_load_with_the_wrapper():
-    def original(self: Any) -> str:
-        return "value"
+    @classmethod
+    def original(cls: type[Any]) -> Any:
+        return cls()
 
     Widget = type("Widget", (ReactiveComponent,), {"load": original})
 
@@ -27,31 +28,34 @@ def test_load_body_runs_once_per_request_scope():
     calls: list[int] = []
 
     class Widget(ReactiveComponent):
-        def load(self) -> str:
-            calls.append(1)
-            return "loaded"
+        value: str = ""
 
-    widget = Widget()
+        @classmethod
+        def load(cls) -> "Widget":
+            calls.append(1)
+            return cls(value="loaded")
+
     with request_scope():
-        assert widget.load() == "loaded"
-        assert widget.load() == "loaded"
+        assert Widget.load().value == "loaded"
+        assert Widget.load().value == "loaded"
 
     assert len(calls) == 1
 
 
-def test_a_cached_none_is_not_reloaded():
+def test_a_cached_default_result_is_not_reloaded():
     calls: list[int] = []
 
     class Widget(ReactiveComponent):
-        def load(self) -> None:
+        @classmethod
+        def load(cls) -> "Widget":
             calls.append(1)
-            return None  # noqa: RET501, PLR1711 -- explicit for readability of the assertion below
+            return cls()
 
-    widget = Widget()
     with request_scope():
-        assert widget.load() is None
-        assert widget.load() is None
+        first = Widget.load()
+        second = Widget.load()
 
+    assert first is second
     assert len(calls) == 1
 
 
@@ -59,13 +63,15 @@ def test_load_runs_every_call_outside_a_request_scope():
     calls: list[int] = []
 
     class Widget(ReactiveComponent):
-        def load(self) -> str:
-            calls.append(1)
-            return "loaded"
+        value: str = ""
 
-    widget = Widget()
-    assert widget.load() == "loaded"
-    assert widget.load() == "loaded"
+        @classmethod
+        def load(cls) -> "Widget":
+            calls.append(1)
+            return cls(value="loaded")
+
+    assert Widget.load().value == "loaded"
+    assert Widget.load().value == "loaded"
     assert len(calls) == 2
 
 
@@ -73,15 +79,15 @@ def test_each_request_scope_starts_cold():
     calls: list[int] = []
 
     class Widget(ReactiveComponent):
-        def load(self) -> str:
+        @classmethod
+        def load(cls) -> "Widget":
             calls.append(1)
-            return "loaded"
+            return cls()
 
-    widget = Widget()
     with request_scope():
-        widget.load()
+        Widget.load()
     with request_scope():
-        widget.load()
+        Widget.load()
 
     assert len(calls) == 2
 
@@ -90,15 +96,15 @@ def test_react_keys_are_forwarded_to_cache_put():
     from unittest.mock import patch
 
     class Widget(ReactiveComponent, react=("todos",)):
-        def load(self) -> str:
-            return "loaded"
+        @classmethod
+        def load(cls) -> "Widget":
+            return cls()
 
-    widget = Widget()
     with (
         request_scope(),
         patch("pyjinhx.reactive.component.cache_put") as spy,
     ):
-        widget.load()
+        Widget.load()
 
     assert spy.call_args.kwargs["react_keys"] == ("todos",)
 
@@ -109,23 +115,24 @@ def test_declared_react_keys_make_the_entry_evictable():
     calls: list[int] = []
 
     class Widget(ReactiveComponent, react=("todos",)):
-        def load(self) -> str:
+        @classmethod
+        def load(cls) -> "Widget":
             calls.append(1)
-            return "loaded"
+            return cls()
 
-    widget = Widget()
     with request_scope():
-        widget.load()
+        Widget.load()
         invalidate(["todos"])
-        widget.load()
+        Widget.load()
 
     assert len(calls) == 2
 
 
 def test_react_keys_default_to_empty():
     class Widget(ReactiveComponent):
-        def load(self) -> str:
-            return "loaded"
+        @classmethod
+        def load(cls) -> "Widget":
+            return cls()
 
     assert Widget._pjx_react_keys == ()
 
@@ -137,8 +144,9 @@ def test_enum_react_keys_are_normalized_to_their_values():
         TODOS = "todos"
 
     class Widget(ReactiveComponent, react=(Keys.TODOS,)):
-        def load(self) -> str:
-            return "loaded"
+        @classmethod
+        def load(cls) -> "Widget":
+            return cls()
 
     assert Widget._pjx_react_keys == ("todos",)
 
@@ -147,7 +155,7 @@ def test_subclass_without_load_returns_none():
     class Widget(ReactiveComponent):
         pass
 
-    assert Widget().load() is None
+    assert isinstance(Widget.load(), Widget)
 
 
 def test_base_component_registration_still_fires():
@@ -161,8 +169,9 @@ def test_base_component_registration_still_fires():
 
 def test_the_descriptor_is_attached_to_reactive_subclasses():
     class Widget(ReactiveComponent):
-        def load(self) -> str:
-            return "loaded"
+        @classmethod
+        def load(cls) -> "Widget":
+            return cls()
 
     assert Widget.__pjx_descriptor__ is not None
 
@@ -216,13 +225,14 @@ def test_unmarked_instances_share_one_cache_entry():
     calls: list[int] = []
 
     class Widget(ReactiveComponent):
-        def load(self) -> str:
+        @classmethod
+        def load(cls) -> "Widget":
             calls.append(1)
-            return "loaded"
+            return cls()
 
     with request_scope():
-        Widget().load()
-        Widget().load()
+        Widget.load()
+        Widget.load()
 
     assert len(calls) == 1
 
@@ -236,14 +246,16 @@ def test_distinct_pjx_key_values_load_independently():
 
     class Row(ReactiveComponent):
         row_id: Annotated[int, PjxKey()] = 0
+        value: int = 0
 
-        def load(self) -> int:
-            calls.append(self.row_id)
-            return self.row_id * 10
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            calls.append(row_id)
+            return cls(row_id=row_id, value=row_id * 10)
 
     with request_scope():
-        assert Row(row_id=1).load() == 10
-        assert Row(row_id=2).load() == 20
+        assert Row.load(1).value == 10
+        assert Row.load(2).value == 20
 
     assert calls == [1, 2]
 
@@ -258,13 +270,14 @@ def test_equal_pjx_key_values_share_one_cache_entry():
     class Row(ReactiveComponent):
         row_id: Annotated[int, PjxKey()] = 0
 
-        def load(self) -> str:
-            calls.append(self.row_id)
-            return "loaded"
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            calls.append(row_id)
+            return cls(row_id=row_id)
 
     with request_scope():
-        Row(row_id=1).load()
-        Row(row_id=1).load()
+        Row.load(1)
+        Row.load(1)
 
     assert len(calls) == 1
 
@@ -279,12 +292,13 @@ def test_pjx_key_equal_values_share_object_identity():
     class Row(ReactiveComponent):
         row_id: Annotated[int, PjxKey()] = 0
 
-        def load(self) -> dict[str, int]:
-            return {"row_id": self.row_id}
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            return cls(row_id=row_id)
 
     with request_scope():
-        result_a = Row(row_id=1).load()
-        result_b = Row(row_id=1).load()
+        result_a = Row.load(1)
+        result_b = Row.load(1)
 
     assert result_a is result_b
 
@@ -298,15 +312,17 @@ def test_pjx_key_distinct_values_differ_in_identity():
 
     class Row(ReactiveComponent):
         row_id: Annotated[int, PjxKey()] = 0
+        shape: str = "same"
 
-        def load(self) -> dict[str, str]:
-            return {"shape": "same"}
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            return cls(row_id=row_id, shape="same")
 
     with request_scope():
-        result_a = Row(row_id=1).load()
-        result_b = Row(row_id=2).load()
+        result_a = Row.load(1)
+        result_b = Row.load(2)
 
-    assert result_a == result_b
+    assert result_a.shape == result_b.shape
     assert result_a is not result_b
 
 
@@ -319,70 +335,82 @@ class DemoAppContext(AppContext):
 
 def test_load_receives_the_requests_app_context():
     class Widget(ReactiveComponent):
-        def load(self, ctx: DemoAppContext) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
-            return ctx.user
+        user: str = ""
 
-    widget = Widget()
+        @classmethod
+        def load(cls, ctx: DemoAppContext) -> "Widget":
+            return cls(user=ctx.user)
+
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert widget.load() == "ada"  # pyright: ignore[reportCallIssue]
+        assert Widget.load().user == "ada"
 
 
 def test_each_request_gets_its_own_app_context():
     class Widget(ReactiveComponent):
-        def load(self, ctx: DemoAppContext) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
-            return ctx.user
+        user: str = ""
 
-    widget = Widget()
+        @classmethod
+        def load(cls, ctx: DemoAppContext) -> "Widget":
+            return cls(user=ctx.user)
+
     with request_scope(load_context=DemoAppContext(user="ada")):
-        first = widget.load()  # pyright: ignore[reportCallIssue]
+        first = Widget.load()
     with request_scope(load_context=DemoAppContext(user="grace")):
-        second = widget.load()  # pyright: ignore[reportCallIssue]
+        second = Widget.load()
 
-    assert (first, second) == ("ada", "grace")
+    assert (first.user, second.user) == ("ada", "grace")
 
 
 def test_injection_is_by_annotation_not_by_parameter_name():
     class Widget(ReactiveComponent):
-        def load(self, whatever: DemoAppContext) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
-            return whatever.user
+        user: str = ""
 
-    widget = Widget()
+        @classmethod
+        def load(cls, whatever: DemoAppContext) -> "Widget":
+            return cls(user=whatever.user)
+
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert widget.load() == "ada"  # pyright: ignore[reportCallIssue]
+        assert Widget.load().user == "ada"
 
 
 def test_optional_app_context_annotation_is_injected():
     class Widget(ReactiveComponent):
-        def load(self, ctx: DemoAppContext | None) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
-            return "none" if ctx is None else ctx.user
+        user: str = ""
 
-    widget = Widget()
+        @classmethod
+        def load(cls, ctx: DemoAppContext | None) -> "Widget":
+            return cls(user="none" if ctx is None else ctx.user)
+
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert widget.load() == "ada"  # pyright: ignore[reportCallIssue]
+        assert Widget.load().user == "ada"
 
 
 def test_no_context_bound_injects_none():
     class Widget(ReactiveComponent):
-        def load(self, ctx: DemoAppContext | None) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
-            return "none" if ctx is None else ctx.user
+        user: str = ""
 
-    widget = Widget()
+        @classmethod
+        def load(cls, ctx: DemoAppContext | None) -> "Widget":
+            return cls(user="none" if ctx is None else ctx.user)
+
     with request_scope():
-        assert widget.load() == "none"  # pyright: ignore[reportCallIssue]
+        assert Widget.load().user == "none"
 
 
 def test_zero_arg_load_is_untouched_when_a_context_is_bound():
     calls: list[int] = []
 
     class Widget(ReactiveComponent):
-        def load(self) -> str:
-            calls.append(1)
-            return "loaded"
+        value: str = ""
 
-    widget = Widget()
+        @classmethod
+        def load(cls) -> "Widget":
+            calls.append(1)
+            return cls(value="loaded")
+
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert widget.load() == "loaded"
-        assert widget.load() == "loaded"
+        assert Widget.load().value == "loaded"
+        assert Widget.load().value == "loaded"
 
     assert len(calls) == 1
 
@@ -391,14 +419,16 @@ def test_an_injected_load_is_still_cached_per_request():
     calls: list[int] = []
 
     class Widget(ReactiveComponent):
-        def load(self, ctx: DemoAppContext) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
-            calls.append(1)
-            return ctx.user
+        user: str = ""
 
-    widget = Widget()
+        @classmethod
+        def load(cls, ctx: DemoAppContext) -> "Widget":
+            calls.append(1)
+            return cls(user=ctx.user)
+
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert widget.load() == "ada"  # pyright: ignore[reportCallIssue]
-        assert widget.load() == "ada"  # pyright: ignore[reportCallIssue]
+        assert Widget.load().user == "ada"
+        assert Widget.load().user == "ada"
 
     assert len(calls) == 1
 
@@ -410,8 +440,9 @@ def test_two_app_context_params_are_rejected_at_class_definition():
     with pytest.raises(TypeError, match="at most one"):
 
         class Widget(ReactiveComponent):
-            def load(self, first: DemoAppContext, second: OtherAppContext) -> None:  # pyright: ignore[reportIncompatibleMethodOverride]
-                return None
+            @classmethod
+            def load(cls, first: DemoAppContext, second: OtherAppContext) -> "Widget":
+                return cls()
 
 
 def test_classmethod_load_is_accepted():

--- a/tests/pyjinhx/reactive/test_reactive_component.py
+++ b/tests/pyjinhx/reactive/test_reactive_component.py
@@ -342,7 +342,7 @@ def test_load_receives_the_requests_app_context():
             return cls(user=ctx.user)
 
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert Widget.load().user == "ada"
+        assert Widget.load().user == "ada"  # type: ignore[reportCallIssue]
 
 
 def test_each_request_gets_its_own_app_context():
@@ -354,9 +354,9 @@ def test_each_request_gets_its_own_app_context():
             return cls(user=ctx.user)
 
     with request_scope(load_context=DemoAppContext(user="ada")):
-        first = Widget.load()
+        first = Widget.load()  # type: ignore[reportCallIssue]
     with request_scope(load_context=DemoAppContext(user="grace")):
-        second = Widget.load()
+        second = Widget.load()  # type: ignore[reportCallIssue]
 
     assert (first.user, second.user) == ("ada", "grace")
 
@@ -370,7 +370,7 @@ def test_injection_is_by_annotation_not_by_parameter_name():
             return cls(user=whatever.user)
 
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert Widget.load().user == "ada"
+        assert Widget.load().user == "ada"  # type: ignore[reportCallIssue]
 
 
 def test_optional_app_context_annotation_is_injected():
@@ -382,7 +382,7 @@ def test_optional_app_context_annotation_is_injected():
             return cls(user="none" if ctx is None else ctx.user)
 
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert Widget.load().user == "ada"
+        assert Widget.load().user == "ada"  # type: ignore[reportCallIssue]
 
 
 def test_no_context_bound_injects_none():
@@ -394,7 +394,7 @@ def test_no_context_bound_injects_none():
             return cls(user="none" if ctx is None else ctx.user)
 
     with request_scope():
-        assert Widget.load().user == "none"
+        assert Widget.load().user == "none"  # type: ignore[reportCallIssue]
 
 
 def test_zero_arg_load_is_untouched_when_a_context_is_bound():
@@ -427,8 +427,8 @@ def test_an_injected_load_is_still_cached_per_request():
             return cls(user=ctx.user)
 
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert Widget.load().user == "ada"
-        assert Widget.load().user == "ada"
+        assert Widget.load().user == "ada"  # type: ignore[reportCallIssue]
+        assert Widget.load().user == "ada"  # type: ignore[reportCallIssue]
 
     assert len(calls) == 1
 
@@ -592,7 +592,7 @@ def test_self_referencing_return_annotation_keeps_context_injection():
             return cls(row_id=row_id, user=ctx.user)
 
     with request_scope(load_context=DemoAppContext(user="ada")):
-        assert Row.load(1).user == "ada"
+        assert Row.load(1).user == "ada"  # type: ignore[reportCallIssue]
 
 
 def test_cache_hit_returns_the_same_populated_instance():
@@ -651,11 +651,11 @@ def test_protocol_mode_cache_key_uses_the_full_bound_args():
 
         @classmethod
         def load(cls, row_id: int, flavor: str = "plain") -> "Row":
-            return cls(row_id=row_id, flavor=flavor)
+            return cls(row_id=row_id, flavor=flavor)  # type: ignore[reportCallIssue]
 
     with request_scope():
         plain = Row.load(1)
-        spicy = Row.load(1, flavor="spicy")
+        spicy = Row.load(1, flavor="spicy")  # type: ignore[reportCallIssue]
         again = Row.load(1, flavor="spicy")
 
     assert plain is not spicy
@@ -684,8 +684,8 @@ def test_app_context_is_excluded_from_the_cache_key():
             return cls(user=ctx.user)
 
     with request_scope(load_context=DemoAppContext(user="ada")):
-        first = Widget.load()
-        second = Widget.load()
+        first = Widget.load()  # type: ignore[reportCallIssue]
+        second = Widget.load()  # type: ignore[reportCallIssue]
 
     assert first is second
     assert first.user == "ada"

--- a/tests/pyjinhx/reactive/test_reactive_component.py
+++ b/tests/pyjinhx/reactive/test_reactive_component.py
@@ -562,3 +562,100 @@ def test_self_referencing_return_annotation_keeps_context_injection():
 
     with request_scope(load_context=DemoAppContext(user="ada")):
         assert Row.load(1).user == "ada"
+
+
+def test_cache_hit_returns_the_same_populated_instance():
+    """#726: the second load() in one request hands back the cached instance,
+    not a second one whose fields were never filled."""
+    from typing import Annotated
+
+    from pyjinhx.reactive.component import PjxKey
+
+    calls: list[int] = []
+
+    class Row(ReactiveComponent):
+        row_id: Annotated[int, PjxKey()] = 0
+        title: str = ""
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            calls.append(row_id)
+            return cls(row_id=row_id, title=f"row {row_id}")
+
+    with request_scope():
+        first = Row.load(1)
+        second = Row.load(1)
+
+    assert first is second
+    assert second.title == "row 1"
+    assert calls == [1]
+
+
+def test_distinct_keys_do_not_share_a_cache_entry():
+    from typing import Annotated
+
+    from pyjinhx.reactive.component import PjxKey
+
+    class Row(ReactiveComponent):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            return cls(row_id=row_id)
+
+    with request_scope():
+        assert Row.load(1) is not Row.load(2)
+
+
+def test_protocol_mode_cache_key_uses_the_full_bound_args():
+    from typing import Annotated
+
+    from pydantic import ConfigDict
+
+    from pyjinhx.reactive.component import PjxKey
+
+    class Row(ReactiveComponent):
+        model_config = ConfigDict(extra="allow")
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int, flavor: str = "plain") -> "Row":
+            return cls(row_id=row_id, flavor=flavor)
+
+    with request_scope():
+        plain = Row.load(1)
+        spicy = Row.load(1, flavor="spicy")
+        again = Row.load(1, flavor="spicy")
+
+    assert plain is not spicy
+    assert spicy is again
+
+
+def test_load_returning_the_wrong_type_raises():
+    class Widget(ReactiveComponent):
+        @classmethod
+        def load(cls) -> "Widget":
+            return "not a widget"  # pyright: ignore[reportReturnType]
+
+    with request_scope(), pytest.raises(TypeError, match="Widget"):
+        Widget.load()
+
+
+def test_app_context_is_excluded_from_the_cache_key():
+    calls: list[int] = []
+
+    class Widget(ReactiveComponent):
+        user: str = ""
+
+        @classmethod
+        def load(cls, ctx: DemoAppContext) -> "Widget":
+            calls.append(1)
+            return cls(user=ctx.user)
+
+    with request_scope(load_context=DemoAppContext(user="ada")):
+        first = Widget.load()
+        second = Widget.load()
+
+    assert first is second
+    assert first.user == "ada"
+    assert len(calls) == 1

--- a/tests/pyjinhx/reactive/test_reactive_component.py
+++ b/tests/pyjinhx/reactive/test_reactive_component.py
@@ -453,3 +453,93 @@ def test_grandchild_that_does_not_override_load_is_not_rewrapped():
         pass
 
     assert isinstance(Child.load(), Child)
+
+
+def test_load_params_must_match_the_pjx_key_field():
+    from typing import Annotated
+
+    from pyjinhx.reactive.component import PjxKey
+
+    class Row(ReactiveComponent):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            return cls(row_id=row_id)
+
+    assert Row.load(1).row_id == 1
+
+
+def test_load_missing_the_key_param_is_rejected():
+    from typing import Annotated
+
+    from pyjinhx.reactive.component import PjxKey
+
+    with pytest.raises(TypeError, match="row_id"):
+
+        class Row(ReactiveComponent):
+            row_id: Annotated[int, PjxKey()] = 0
+
+            @classmethod
+            def load(cls) -> "Row":
+                return cls()
+
+
+def test_load_with_an_extra_param_is_rejected():
+    from typing import Annotated
+
+    from pyjinhx.reactive.component import PjxKey
+
+    with pytest.raises(TypeError, match="extra"):
+
+        class Row(ReactiveComponent):
+            row_id: Annotated[int, PjxKey()] = 0
+
+            @classmethod
+            def load(cls, row_id: int, extra: int) -> "Row":
+                return cls(row_id=row_id)
+
+
+def test_zero_key_class_load_must_take_no_params():
+    with pytest.raises(TypeError, match="no parameters"):
+
+        class Widget(ReactiveComponent):
+            @classmethod
+            def load(cls, stray: int) -> "Widget":
+                return cls()
+
+
+def test_protocol_mode_allows_extra_params():
+    from typing import Annotated
+
+    from pydantic import ConfigDict
+
+    from pyjinhx.reactive.component import PjxKey
+
+    class Row(ReactiveComponent):
+        model_config = ConfigDict(extra="allow")
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int, flavor: str = "plain") -> "Row":
+            return cls(row_id=row_id)
+
+    assert Row.load(1, flavor="spicy").row_id == 1
+
+
+def test_protocol_mode_still_requires_the_key_params():
+    from typing import Annotated
+
+    from pydantic import ConfigDict
+
+    from pyjinhx.reactive.component import PjxKey
+
+    with pytest.raises(TypeError, match="row_id"):
+
+        class Row(ReactiveComponent):
+            model_config = ConfigDict(extra="allow")
+            row_id: Annotated[int, PjxKey()] = 0
+
+            @classmethod
+            def load(cls, flavor: str = "plain") -> "Row":
+                return cls()

--- a/tests/pyjinhx/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx/reactive/test_reactive_fanout.py
@@ -30,10 +30,12 @@ class FanoutWidget(ReactiveComponent, react=("todos",)):
     """A reactive component keyed by ``pjx_key``, whose load() is counted."""
 
     pjx_key: Annotated[str, PjxKey()] = ""
+    data: str = ""
 
-    def load(self) -> str:
-        LOAD_CALLS.append(self.pjx_key)
-        return f"data:{self.pjx_key}"
+    @classmethod
+    def load(cls, pjx_key: str) -> "FanoutWidget":
+        LOAD_CALLS.append(pjx_key)
+        return cls(pjx_key=pjx_key, data=f"data:{pjx_key}")
 
 
 class QuietWidget(ReactiveComponent, react=("other",)):
@@ -253,7 +255,7 @@ def fresh_hash_for(load: object) -> str:
     test can seed a manifest entry with the *matching* hash without hardcoding
     a digest that changes whenever the model's fields do.
     """
-    return FanoutWidget(id="probe", pjx_key=str(load)).state_hash()
+    return FanoutWidget(id="probe", pjx_key=str(load), data=f"data:{load}").state_hash()
 
 
 def test_dirty_candidate_whose_fresh_hash_matches_the_manifest_hash_is_dropped():

--- a/tests/pyjinhx/reactive/test_reactive_mount.py
+++ b/tests/pyjinhx/reactive/test_reactive_mount.py
@@ -9,6 +9,7 @@ BaseComponent child must be unaffected — it declares no load() at all.
 from pathlib import Path
 
 import pytest
+from pydantic import ConfigDict
 
 from pyjinhx import discovery
 from pyjinhx.component import BaseComponent, _pascal_to_snake
@@ -98,6 +99,27 @@ def test_plain_child_mounted_via_childref_is_unaffected():
 
     assert "plain" in "".join(str(s) for s in result.segments)
     assert _load_calls == []
+
+
+class PJXProtocolWidget(ReactiveComponent):
+    model_config = ConfigDict(extra="allow")
+
+    row_id: int = 0
+
+    @classmethod
+    def load(cls, row_id: int = 0) -> "PJXProtocolWidget":
+        return cls(row_id=row_id, flavor="plain")
+
+
+def test_pjx_mount_copies_extra_fields_from_protocol_mode_load():
+    """Under extra='allow', load() may set undeclared attributes (e.g. via a
+    protocol-style constructor call); pjx_mount() must copy those onto self
+    too, not just the declared model_fields."""
+    component = PJXProtocolWidget(row_id=1)
+
+    component.pjx_mount()
+
+    assert getattr(component, "flavor", "MISSING") == "plain"
 
 
 def test_base_component_pjx_mount_is_noop():

--- a/tests/pyjinhx/reactive/test_reactive_mount.py
+++ b/tests/pyjinhx/reactive/test_reactive_mount.py
@@ -17,12 +17,14 @@ from pyjinhx.reactive.component import ReactiveComponent
 from pyjinhx.rendering import render_level
 from pyjinhx.session import RenderSession
 
-_load_calls: list[str] = []
+_load_calls: list[int] = []
 
 
 class PJXReactiveWidget(ReactiveComponent):
-    def load(self) -> None:
-        _load_calls.append(self.id)
+    @classmethod
+    def load(cls) -> "PJXReactiveWidget":
+        _load_calls.append(1)
+        return cls()
 
 
 class PJXPlainWidget(BaseComponent):

--- a/tests/pyjinhx/reactive/test_reactive_mount.py
+++ b/tests/pyjinhx/reactive/test_reactive_mount.py
@@ -108,7 +108,7 @@ class PJXProtocolWidget(ReactiveComponent):
 
     @classmethod
     def load(cls, row_id: int = 0) -> "PJXProtocolWidget":
-        return cls(row_id=row_id, flavor="plain")
+        return cls(row_id=row_id, flavor="plain")  # type: ignore[reportCallIssue]
 
 
 def test_pjx_mount_copies_extra_fields_from_protocol_mode_load():

--- a/tests/pyjinhx/reactive/test_reactive_response.py
+++ b/tests/pyjinhx/reactive/test_reactive_response.py
@@ -21,10 +21,12 @@ class ResponseWidget(ReactiveComponent, react=("todos",)):
     """A reactive component keyed by ``pjx_key``, dirtied by the ``todos`` key."""
 
     pjx_key: Annotated[str, PjxKey()] = ""
+    data: str = ""
 
-    def load(self) -> str:
-        LOAD_CALLS.append(self.pjx_key)
-        return f"data:{self.pjx_key}"
+    @classmethod
+    def load(cls, pjx_key: str) -> "ResponseWidget":
+        LOAD_CALLS.append(pjx_key)
+        return cls(pjx_key=pjx_key, data=f"data:{pjx_key}")
 
 
 _TEMPLATE_DIR = "templates"
@@ -303,7 +305,7 @@ def test_a_dynamic_dirty_key_evicts_the_instance_it_names():
     """
     with scope():
         registry.register_instance(ResponseWidget.__name__, "a", "entry")
-        ResponseWidget(pjx_key="1").load()
+        ResponseWidget.load("1")
         add_dirtied(["todos:1"])
         [candidate] = ReactiveResponse(
             primary="", mounted=[mounted_entry("a", load="1")]


### PR DESCRIPTION
## Summary

Suppresses type checking errors in load() override tests, completing the classmethod load() contract refactoring work for issue #726.

This branch includes a comprehensive refactor of the load() pattern to enforce classmethod shape, validate parameters against PjxKey fields, copy factory results onto instances via pjx_mount(), and integrate fanout builds through cls.load().

## Test count

14 commits with comprehensive test coverage for:
- Classmethod load() contract validation
- Load() parameter signature validation
- Cache-hit and cache-key behavior
- Reactive test suite migration
- pjx_mount() extra/protocol-mode field handling

Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)