### PR TITLE
docs: default the AppContext load() param in examples

### DIFF
--- a/docs/api/mutations-keys-context.md
+++ b/docs/api/mutations-keys-context.md
@@ -137,8 +137,8 @@ class TodoList(ReactiveComponent):
     items: list = []
 
     @classmethod
-    def load(cls, ctx: MyAppContext) -> Self:
-        return cls(items=ctx.db.todos_for(ctx.user))
+    def load(cls, ctx: MyAppContext | None = None) -> Self:
+        return cls(items=ctx.db.todos_for(ctx.user) if ctx else [])
 ```
 
 The value comes from the `context_factory` given to `setup()`, called once per

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -592,8 +592,8 @@ setup(app, context_factory=lambda request: MyAppContext(get_db(request), request
 
 class TodoList(ReactiveComponent):
     @classmethod
-    def load(cls, ctx: MyAppContext) -> Self:
-        return cls(items=ctx.db.todos_for(ctx.user))
+    def load(cls, ctx: MyAppContext | None = None) -> Self:
+        return cls(items=ctx.db.todos_for(ctx.user) if ctx else [])
 ```
 
 ### `pyjinhx.render` → `pyjinhx.rendering`

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -425,13 +425,15 @@ class MyAppContext(AppContext):
 
 class Counter(ReactiveComponent, react={Keys.TODOS}):
     @classmethod
-    def load(cls, ctx: MyAppContext) -> Self:
-        return cls(remaining=ctx.db.remaining())
+    def load(cls, ctx: MyAppContext | None = None) -> Self:
+        return cls(remaining=ctx.db.remaining() if ctx else 0)
 ```
 
 `ctx` is injected by annotation, not by parameter name — declare it optional
-(`ctx: MyAppContext | None`) to keep `load()` valid when called outside a request
-scope or one with no context configured, in which case `ctx` is `None`. Set context
+(`ctx: MyAppContext | None = None`) to keep `load()` valid when called outside a request
+scope or one with no context configured, in which case `ctx` is `None`. The default also
+keeps static type checkers from flagging `Component.load()` call sites, since the runtime
+wrapper injects `ctx` and never requires callers to pass it. Set context
 per request via `setup(app, context_factory=...)` or `request_scope(load_context=MyAppContext(db=...))`.
 Cache keys remain `(class, load key)` — context is not part of the cache identity.
 

--- a/pyjinhx/app_context.py
+++ b/pyjinhx/app_context.py
@@ -26,7 +26,8 @@ class AppContext:
             def __init__(self, db, user): ...
 
         class TodoList(ReactiveComponent):
-            def load(self, ctx: MyAppContext): ...
+            @classmethod
+            def load(cls, ctx: MyAppContext | None = None) -> Self: ...
 
     ``ctx`` is whatever that request's ``context_factory`` returned. With no
     factory configured - or when ``load()`` is called outside a request scope -


### PR DESCRIPTION
## Summary

The runtime wrapper installed by `__pydantic_init_subclass__` always injects ctx via `get_load_context()` when a caller omits it from `Component.load()`. Static type checkers only see the original signature, so an undefaulted `ctx: MyAppContext` parameter makes them flag valid `Component.load()` call sites as missing an argument.

This change updates the documented signature to `ctx: MyAppContext | None = None` everywhere it appears in live docs and the AppContext docstring example, matching the shape the runtime already guarantees.

Closes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)