### PR TITLE
feat: setup() registers builtins with or without components_root (#738)

### DIFF
--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -9,6 +9,7 @@ importing this module never depends on them.
 from __future__ import annotations
 
 import os
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass, fields, replace
 from importlib.util import find_spec as _find_spec
@@ -151,8 +152,7 @@ def setup(
         static_root=static_root,
         **kwargs,
     )
-    if resolved.components_root is not None:
-        _register_components(resolved.components_root)
+    _register_components(resolved.components_root)
     configure_pyjinhx(resolved)
     if app is None:
         return resolved
@@ -197,12 +197,36 @@ def _load_backend() -> IntegrationBackend:
     return backend
 
 
-def _register_components(components_root: Path | str) -> None:
-    """Walk ``components_root`` and publish the tag -> class registry.
+def _force_load_builtins() -> None:
+    """Eagerly import every shipped builtin, if the package has been imported.
 
-    Every declared component class is offered to the walk; discovery is what
-    decides which of them a template on disk actually claims.
+    ``pyjinhx.builtins`` exposes its classes lazily (#701) to keep import-time
+    cost down: a bare ``import pyjinhx.builtins`` defines no component classes
+    at all, it only makes each one importable on first attribute access.
+    Discovery can only claim a tag for a class that already exists, so without
+    this step a builtin would stay unregistered until something happened to
+    touch that one name. Walking the package's own lazy-import table forces
+    every builtin's module to load, once, without the app having to name each
+    one itself — and does nothing when the app never imported the package.
     """
+    builtins_module = sys.modules.get("pyjinhx.builtins")
+    if builtins_module is None:
+        return
+    lazy_imports = getattr(builtins_module, "_lazy_imports", None)
+    if not lazy_imports:
+        return
+    for name in lazy_imports:
+        getattr(builtins_module, name)
+
+
+def _register_components(components_root: Path | str | None) -> None:
+    """Publish the tag -> class registry for this process.
+
+    ``components_root`` is walked when there is one; classes that already
+    carry their own template on disk — every shipped builtin — claim their
+    tags either way, so an app with no components of its own still gets them.
+    """
+    _force_load_builtins()
     build_registry(components_root, _all_component_classes())
 
 

--- a/pyjinhx/discovery.py
+++ b/pyjinhx/discovery.py
@@ -196,7 +196,9 @@ def build_registry(template_dir: Path | str | None, classes: Iterable[type]) -> 
     fresh: dict[str, type] = {}
     warned: set[str] = set()
     tags: list[str] = (
-        [] if root is None else [candidate.tag_name for candidate in walk_templates(root)]
+        []
+        if root is None
+        else [candidate.tag_name for candidate in walk_templates(root)]
     )
     tags.extend(_tag_for(cls) for cls in offered if _has_own_template(cls))
     for tag_name in dict.fromkeys(tags):

--- a/pyjinhx/discovery.py
+++ b/pyjinhx/discovery.py
@@ -154,8 +154,29 @@ def _resolve_tag_owner(
     return winner
 
 
+def _has_own_template(cls: type) -> bool:
+    """Whether ``cls`` resolved a template of its own on disk.
+
+    The tag a class answers to is decided by the template it already found
+    through its MRO (ADR 0007/0010), so a class whose template ships inside an
+    installed package can claim its tag without that file having to sit under
+    the walked tree. A class with no resolvable template is simply not claimed
+    — the same posture as an orphan `.pjx` with no class behind it.
+    """
+    descriptor = getattr(cls, "__pjx_descriptor__", None)
+    path = getattr(descriptor, "template_path", None)
+    return isinstance(path, Path) and path.is_file()
+
+
 def build_registry(template_dir: Path | str, classes: Iterable[type]) -> None:
     """Walk ``template_dir`` and publish a fresh tag -> class registry.
+
+    Two sources feed the published mapping: every `.pjx` found by walking
+    ``template_dir``, and every offered class that already resolved a template
+    of its own on disk (e.g. a builtin shipped inside the installed package,
+    nowhere near ``template_dir``). Both funnel into the same tag set and the
+    same `_resolve_tag_owner` call, so a tag contested across the two sources
+    still gets exactly one collision decision and one warning.
 
     The new mapping is assembled complete in a local before anything is
     published, so a reader sees either the whole previous registry or the whole
@@ -163,15 +184,18 @@ def build_registry(template_dir: Path | str, classes: Iterable[type]) -> None:
     happens, leaving the live registry untouched.
     """
     root = Path(template_dir)
+    offered: list[type] = list(classes)
     by_tag: dict[str, list[type]] = {}
-    for cls in classes:
+    for cls in offered:
         by_tag.setdefault(_tag_for(cls), []).append(cls)
     fresh: dict[str, type] = {}
     warned: set[str] = set()
-    for candidate in walk_templates(root):
-        owner = _resolve_tag_owner(candidate.tag_name, by_tag, warned)
+    tags: list[str] = [candidate.tag_name for candidate in walk_templates(root)]
+    tags.extend(_tag_for(cls) for cls in offered if _has_own_template(cls))
+    for tag_name in dict.fromkeys(tags):
+        owner = _resolve_tag_owner(tag_name, by_tag, warned)
         if owner is not None:
-            fresh[candidate.tag_name] = owner
+            fresh[tag_name] = owner
     with _registry_lock:
         _registry.mapping = fresh
         _registry.template_dir = root

--- a/pyjinhx/discovery.py
+++ b/pyjinhx/discovery.py
@@ -168,7 +168,7 @@ def _has_own_template(cls: type) -> bool:
     return isinstance(path, Path) and path.is_file()
 
 
-def build_registry(template_dir: Path | str, classes: Iterable[type]) -> None:
+def build_registry(template_dir: Path | str | None, classes: Iterable[type]) -> None:
     """Walk ``template_dir`` and publish a fresh tag -> class registry.
 
     Two sources feed the published mapping: every `.pjx` found by walking
@@ -178,19 +178,26 @@ def build_registry(template_dir: Path | str, classes: Iterable[type]) -> None:
     same `_resolve_tag_owner` call, so a tag contested across the two sources
     still gets exactly one collision decision and one warning.
 
+    ``template_dir`` may be ``None`` — no tree to walk; only classes carrying
+    their own template claim tags. `get_template_dir()` then reports ``None``
+    too, which lets an app with no ``components_root`` of its own still get
+    its builtins registered.
+
     The new mapping is assembled complete in a local before anything is
     published, so a reader sees either the whole previous registry or the whole
     new one. Raises ``NotADirectoryError`` (from the walk) before any publish
     happens, leaving the live registry untouched.
     """
-    root = Path(template_dir)
+    root = Path(template_dir) if template_dir is not None else None
     offered: list[type] = list(classes)
     by_tag: dict[str, list[type]] = {}
     for cls in offered:
         by_tag.setdefault(_tag_for(cls), []).append(cls)
     fresh: dict[str, type] = {}
     warned: set[str] = set()
-    tags: list[str] = [candidate.tag_name for candidate in walk_templates(root)]
+    tags: list[str] = (
+        [] if root is None else [candidate.tag_name for candidate in walk_templates(root)]
+    )
     tags.extend(_tag_for(cls) for cls in offered if _has_own_template(cls))
     for tag_name in dict.fromkeys(tags):
         owner = _resolve_tag_owner(tag_name, by_tag, warned)

--- a/tests/pyjinhx/builtins/test_builtin_autoregistration.py
+++ b/tests/pyjinhx/builtins/test_builtin_autoregistration.py
@@ -1,0 +1,39 @@
+"""End-to-end: a user template mounting builtin tags resolves with no manual
+register_class call (issue #738) — setup(components_root=...) alone is enough.
+"""
+
+import pytest
+
+from pyjinhx import discovery
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """discovery._registry is process-global; don't leak a builtins-populated
+    mapping into whichever test module runs next in the same process."""
+    discovery._registry.mapping = {}
+    discovery._registry.template_dir = None
+    yield
+    discovery._registry.mapping = {}
+    discovery._registry.template_dir = None
+
+
+def test_nested_builtin_tags_expand_after_setup_alone(tmp_path):
+    """A user template using <PJXCard><PJXCardBody> renders with no register_class call."""
+    import pyjinhx.builtins  # noqa: F401
+    from pyjinhx.classless import component
+    from pyjinhx.config import setup
+    from pyjinhx.rendering import render
+    from pyjinhx.session import RenderSession
+
+    (tmp_path / "user_page.pjx").write_text(
+        "<PJXCard><PJXCardBody>hello</PJXCardBody></PJXCard>"
+    )
+    setup(app=None, components_root=tmp_path)
+
+    UserPage = component("UserPage")
+    html = render(UserPage(), RenderSession())  # pyright: ignore[reportCallIssue]
+
+    assert "hello" in html
+    assert 'class="pjx-card' in html  # pjx_card.pjx's actual emitted markup
+    assert "PJXCard" not in html

--- a/tests/pyjinhx/test_config_v2.py
+++ b/tests/pyjinhx/test_config_v2.py
@@ -233,3 +233,37 @@ def test_static_root_is_stored_on_the_settings(tmp_path: Path):
     from pyjinhx.config import setup
 
     assert setup(static_root=tmp_path).static_root == tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _reset_discovery_registry():
+    """Each test starts from an empty published registry and leaves one behind."""
+    from pyjinhx import discovery
+
+    discovery._registry.mapping = {}
+    discovery._registry.template_dir = None
+    yield
+    discovery._registry.mapping = {}
+    discovery._registry.template_dir = None
+
+
+def test_setup_registers_builtins_with_a_components_root(tmp_path):
+    import pyjinhx.builtins  # noqa: F401
+    from pyjinhx import discovery
+    from pyjinhx.config import setup
+
+    (tmp_path / "user_page.pjx").write_text("<div>user</div>")
+    setup(app=None, components_root=tmp_path)
+
+    assert discovery.get_class("pjx_card") is not None
+    assert discovery.get_class("pjx_card").__name__ == "PJXCard"
+
+
+def test_setup_registers_builtins_without_a_components_root():
+    import pyjinhx.builtins  # noqa: F401
+    from pyjinhx import discovery
+    from pyjinhx.config import setup
+
+    setup(app=None, components_root=None)
+
+    assert discovery.get_class("pjx_card") is not None

--- a/tests/pyjinhx/test_config_v2.py
+++ b/tests/pyjinhx/test_config_v2.py
@@ -260,8 +260,9 @@ def test_setup_registers_builtins_with_a_components_root(tmp_path):
     (tmp_path / "user_page.pjx").write_text("<div>user</div>")
     setup(app=None, components_root=tmp_path)
 
-    assert discovery.get_class("pjx_card") is not None
-    assert discovery.get_class("pjx_card").__name__ == "PJXCard"
+    cls = discovery.get_class("pjx_card")
+    assert cls is not None
+    assert cls.__name__ == "PJXCard"
 
 
 def test_setup_registers_builtins_without_a_components_root():

--- a/tests/pyjinhx/test_config_v2.py
+++ b/tests/pyjinhx/test_config_v2.py
@@ -177,17 +177,22 @@ def test_components_root_builds_the_registry(
     assert calls[0][0] == tmp_path
 
 
-def test_no_components_root_does_not_build_the_registry(
+def test_no_components_root_still_builds_the_registry_with_no_walked_dir(
     monkeypatch: pytest.MonkeyPatch,
 ):
+    """Issue #738: builtins claim tags off their own template even with no
+    components_root, so the registry build must still run — with
+    template_dir=None rather than being skipped outright."""
     from pyjinhx import config
 
     calls: list[object] = []
     monkeypatch.setattr(
-        config, "build_registry", lambda template_dir, classes: calls.append(1)
+        config,
+        "build_registry",
+        lambda template_dir, classes: calls.append(template_dir),
     )
     config.setup()
-    assert calls == []
+    assert calls == [None]
 
 
 def test_setup_rejects_a_non_asgi_app():

--- a/tests/pyjinhx/test_discovery.py
+++ b/tests/pyjinhx/test_discovery.py
@@ -1,6 +1,7 @@
 """Tests for the .pjx template-tree walk (issue #357)."""
 
 import importlib.util
+import logging
 import sys
 from pathlib import Path
 
@@ -142,3 +143,73 @@ def test_class_with_template_outside_template_dir_is_claimed(tmp_path: Path):
     discovery.build_registry(walked, [OutsideWidget])
 
     assert discovery.get_class("outside_widget") is OutsideWidget
+
+
+def test_user_class_with_replace_shadows_an_outside_class(tmp_path, caplog):
+    """A user class declaring replace takes the tag from an outside-template class, silently."""
+    outside = tmp_path / "installed"
+    outside.mkdir()
+    (outside / "user_thing.pjx").write_text("<div>outside</div>")
+    (outside / "user_thing.py").write_text(
+        "from pyjinhx.component import BaseComponent\n\n\n"
+        "class UserThing(BaseComponent):\n"
+        "    pass\n"
+    )
+    OutsideThing = _load_class_from_module(
+        outside / "user_thing.py", "test_outside_thing_mod", "UserThing"
+    )
+
+    walked = tmp_path / "components"
+    walked.mkdir()
+    (walked / "user_thing.pjx").write_text("<div>user</div>")
+    (walked / "user_thing.py").write_text(
+        "from pyjinhx.component import BaseComponent\n\n\n"
+        "class UserThing(BaseComponent, pjx_replace=True):\n"
+        "    pass\n"
+    )
+    UserThing = _load_class_from_module(
+        walked / "user_thing.py", "test_user_thing_mod", "UserThing"
+    )
+    # `pjx_replace=True` is a class-kwarg consumed by
+    # BaseComponent.__init_subclass__ (pyjinhx/component.py), not a decorator
+    # or a plain class attribute.
+
+    discovery.build_registry(walked, [OutsideThing, UserThing])
+
+    assert discovery.get_class("user_thing") is UserThing
+    assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+
+def test_unintended_collision_across_sources_warns_once(tmp_path, caplog):
+    """Neither side declaring replace: alphabetical qualified-name tie-break, one warning naming both."""
+    outside = tmp_path / "installed"
+    outside.mkdir()
+    (outside / "user_thing.pjx").write_text("<div>outside</div>")
+    (outside / "user_thing.py").write_text(
+        "from pyjinhx.component import BaseComponent\n\n\n"
+        "class UserThing(BaseComponent):\n"
+        "    pass\n"
+    )
+    OutsideThing = _load_class_from_module(
+        outside / "user_thing.py", "test_outside_thing_mod2", "UserThing"
+    )
+
+    walked = tmp_path / "components"
+    walked.mkdir()
+    (walked / "user_thing.pjx").write_text("<div>user</div>")
+    (walked / "user_thing.py").write_text(
+        "from pyjinhx.component import BaseComponent\n\n\n"
+        "class UserThing(BaseComponent):\n"
+        "    pass\n"
+    )
+    UserThing = _load_class_from_module(
+        walked / "user_thing.py", "test_user_thing_mod2", "UserThing"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        discovery.build_registry(walked, [OutsideThing, UserThing])
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert "test_outside_thing_mod2.UserThing" in warnings[0].getMessage()
+    assert "test_user_thing_mod2.UserThing" in warnings[0].getMessage()

--- a/tests/pyjinhx/test_discovery.py
+++ b/tests/pyjinhx/test_discovery.py
@@ -213,3 +213,22 @@ def test_unintended_collision_across_sources_warns_once(tmp_path, caplog):
     assert len(warnings) == 1
     assert "test_outside_thing_mod2.UserThing" in warnings[0].getMessage()
     assert "test_user_thing_mod2.UserThing" in warnings[0].getMessage()
+
+
+def test_build_registry_with_no_template_dir_still_claims_own_template_classes(tmp_path):
+    outside = tmp_path / "installed"
+    outside.mkdir()
+    (outside / "lonely_widget.pjx").write_text("<div>lonely</div>")
+    (outside / "lonely_widget.py").write_text(
+        "from pyjinhx.component import BaseComponent\n\n\n"
+        "class LonelyWidget(BaseComponent):\n"
+        "    pass\n"
+    )
+    LonelyWidget = _load_class_from_module(
+        outside / "lonely_widget.py", "test_lonely_widget_mod", "LonelyWidget"
+    )
+
+    discovery.build_registry(None, [LonelyWidget])
+
+    assert discovery.get_class("lonely_widget") is LonelyWidget
+    assert discovery.get_template_dir() is None

--- a/tests/pyjinhx/test_discovery.py
+++ b/tests/pyjinhx/test_discovery.py
@@ -23,7 +23,9 @@ def reset_registry():
     discovery._registry.template_dir = None
 
 
-def _load_class_from_module(module_path: Path, module_name: str, class_name: str) -> type:
+def _load_class_from_module(
+    module_path: Path, module_name: str, class_name: str
+) -> type:
     """Import ``module_path`` under a throwaway module name and return one of its classes.
 
     Mirrors how a real builtin resolves its template: the class's __module__
@@ -215,7 +217,9 @@ def test_unintended_collision_across_sources_warns_once(tmp_path, caplog):
     assert "test_user_thing_mod2.UserThing" in warnings[0].getMessage()
 
 
-def test_build_registry_with_no_template_dir_still_claims_own_template_classes(tmp_path):
+def test_build_registry_with_no_template_dir_still_claims_own_template_classes(
+    tmp_path,
+):
     outside = tmp_path / "installed"
     outside.mkdir()
     (outside / "lonely_widget.pjx").write_text("<div>lonely</div>")

--- a/tests/pyjinhx/test_discovery.py
+++ b/tests/pyjinhx/test_discovery.py
@@ -1,12 +1,40 @@
 """Tests for the .pjx template-tree walk (issue #357)."""
 
+import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
 
+from pyjinhx import discovery
 from pyjinhx.discovery import TemplateCandidate, walk_templates
 
 DISCOVERY_DIR = Path(__file__).parent.parent / "templates" / "discovery"
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Each test starts from an empty published mapping, and leaves one behind."""
+    discovery._registry.mapping = {}
+    discovery._registry.template_dir = None
+    yield
+    discovery._registry.mapping = {}
+    discovery._registry.template_dir = None
+
+
+def _load_class_from_module(module_path: Path, module_name: str, class_name: str) -> type:
+    """Import ``module_path`` under a throwaway module name and return one of its classes.
+
+    Mirrors how a real builtin resolves its template: the class's __module__
+    must have a __file__ that actually lives beside the .pjx file, which a
+    class body attribute cannot fake (see pyjinhx/component.py::_defining_module_dir).
+    """
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return getattr(module, class_name)
 
 
 def tags(candidates):
@@ -85,7 +113,6 @@ def test_walk_does_not_deduplicate_same_tag_name_in_different_dirs():
 
 def test_walk_is_pure_no_registry_side_effect():
     assert list(walk_templates(DISCOVERY_DIR)) == list(walk_templates(DISCOVERY_DIR))
-    from pyjinhx import discovery
 
     mutable = [
         name
@@ -93,3 +120,25 @@ def test_walk_is_pure_no_registry_side_effect():
         if isinstance(value, (dict, list, set)) and not name.startswith("__")
     ]
     assert mutable == []
+
+
+def test_class_with_template_outside_template_dir_is_claimed(tmp_path: Path):
+    """A class whose own template lives outside the walked tree still claims its tag."""
+    outside = tmp_path / "installed"
+    outside.mkdir()
+    (outside / "outside_widget.pjx").write_text("<div>outside</div>")
+    (outside / "outside_widget.py").write_text(
+        "from pyjinhx.component import BaseComponent\n\n\n"
+        "class OutsideWidget(BaseComponent):\n"
+        "    pass\n"
+    )
+    walked = tmp_path / "components"
+    walked.mkdir()
+
+    OutsideWidget = _load_class_from_module(
+        outside / "outside_widget.py", "test_outside_widget_mod", "OutsideWidget"
+    )
+
+    discovery.build_registry(walked, [OutsideWidget])
+
+    assert discovery.get_class("outside_widget") is OutsideWidget


### PR DESCRIPTION
## Summary

- Claim tags from each class's own resolved template path, enabling components to work without requiring a `components_root` directory walk
- Allow `build_registry(None, classes)` to work without a walked tree
- Enable `setup()` to register builtins with or without `components_root`
- Add end-to-end tests for nested builtin tags rendering with just `setup()` alone

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)