### PR TITLE
docs: fix stale comment on pjx_request referencing request.state manifests

### DIFF
--- a/pyjinhx/context.py
+++ b/pyjinhx/context.py
@@ -2,7 +2,7 @@
 
 This is deliberately narrower than v0.x's PjxContext: no user-data injection,
 no load()-parameter introspection, no mutation methods. It is a view over
-state that already lives in session.py's ContextVars and on request.state —
+state that already lives in session.py's ContextVars and on the session —
 constructed on demand, never itself ContextVar-bound.
 """
 
@@ -32,7 +32,7 @@ class PjxContext:
 
     Exposes the session bound by ``request_scope()``, the dirtied reactive
     keys, the instance registry, the two load-cache stores, the pjx header
-    manifests parsed onto ``request.state``, and the ``context_factory``
+    manifests parsed onto the session, and the ``context_factory``
     result bound by ``request_scope()``. Read-only: dirtying and mutation
     stay with ``reactive.mutations``.
     """
@@ -84,32 +84,28 @@ class PjxContext:
         return get_cache_reverse()
 
     @property
-    def mounted(self) -> Any:
-        """The MountedManifest the middleware parsed onto this request."""
-        return self._state("pjx_mounted")
+    def mounted(self) -> list[dict[str, Any]]:
+        """The MountedManifest the middleware parsed onto this session."""
+        session = current_session()
+        return [] if session is None else session.pjx_mounted
 
     @property
-    def assets(self) -> Any:
-        """The LoadedAssets manifest the middleware parsed onto this request."""
-        return self._state("pjx_assets")
+    def assets(self) -> frozenset[str]:
+        """The LoadedAssets manifest the middleware parsed onto this session."""
+        session = current_session()
+        return frozenset() if session is None else session.pjx_assets
 
     @property
-    def trigger(self) -> Any:
-        """The TriggerManifest the middleware parsed onto this request."""
-        return self._state("pjx_trigger")
+    def trigger(self) -> dict[str, Any] | None:
+        """The TriggerManifest the middleware parsed onto this session."""
+        session = current_session()
+        return None if session is None else session.pjx_trigger
 
     @property
     def app_context(self) -> Any:
         """Whatever the app's configured ``context_factory`` returned, or None.
 
-        Unlike the manifest accessors this one does not go through
-        ``request.state``: the value is bound on the scope itself, so it is
-        readable in a scope entered without a Starlette request at all.
+        The value is bound on the scope itself, so it is readable in a scope
+        entered without a Starlette request at all.
         """
         return get_load_context()
-
-    def _state(self, name: str) -> Any:
-        """The named ``request.state`` attribute, or None when unset."""
-        if self.request is None:
-            return None
-        return getattr(self.request.state, name, None)

--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -173,9 +173,6 @@ class PjxScopeMiddleware(BaseHTTPMiddleware):
         self.context_factory = context_factory
 
     async def dispatch(self, request: Any, call_next: Any) -> Any:
-        request.state.pjx_mounted = MountedManifest.parse(request)
-        request.state.pjx_assets = LoadedAssets.parse(request)
-        request.state.pjx_trigger = TriggerManifest.parse(request)
         load_context = (
             self.context_factory(request) if self.context_factory is not None else None
         )
@@ -193,6 +190,9 @@ class PjxScopeMiddleware(BaseHTTPMiddleware):
         session.on_rendered.append(register_rendered_instance)
         with request_scope(session=session, load_context=load_context) as session:
             session.pjx_request = request  # pyright: ignore[reportAttributeAccessIssue]
+            session.pjx_mounted = MountedManifest.parse(request)
+            session.pjx_assets = LoadedAssets.parse(request)
+            session.pjx_trigger = TriggerManifest.parse(request)
             return await call_next(request)
 
 

--- a/pyjinhx/session.py
+++ b/pyjinhx/session.py
@@ -125,6 +125,12 @@ class RenderSession:
         # The Starlette request object for this render, set by middleware and
         # read by PjxContext to expose request.state manifests and app context.
         self.pjx_request: Any = None
+        # The parsed pjx request headers. They live on the session, not on
+        # request.state, because the response composer is framework-free: it
+        # has no Request to read manifests from, only the active session.
+        self.pjx_mounted: list[dict[str, Any]] = []
+        self.pjx_assets: frozenset[str] = frozenset()
+        self.pjx_trigger: dict[str, Any] | None = None
 
     def emit_rendered(self, component: "BaseComponent", level: "RenderedLevel") -> None:
         """Notify subscribers that ``component``'s subtree finished rendering.

--- a/pyjinhx/session.py
+++ b/pyjinhx/session.py
@@ -123,7 +123,9 @@ class RenderSession:
             Callable[[BaseComponent, RenderedLevel, RenderSession], None]
         ] = []
         # The Starlette request object for this render, set by middleware and
-        # read by PjxContext to expose request.state manifests and app context.
+        # read by PjxContext to expose app context. Manifests live on the
+        # session itself (pjx_mounted/pjx_assets/pjx_trigger below), not on
+        # request.state.
         self.pjx_request: Any = None
         # The parsed pjx request headers. They live on the session, not on
         # request.state, because the response composer is framework-free: it

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -139,16 +139,20 @@ def test_scope_exits_when_the_handler_raises():
     assert current_session() is None
 
 
-def test_manifests_are_parsed_onto_request_state():
+def test_manifests_are_parsed_onto_the_session():
     app = FastAPI()
     apply_setup(app, _settings())
     captured: dict[str, object] = {}
 
     @app.get("/state")
     def state(request: Request):
-        captured["mounted"] = request.state.pjx_mounted
-        captured["assets"] = request.state.pjx_assets
-        captured["trigger"] = request.state.pjx_trigger
+        from pyjinhx.session import current_session
+
+        session = current_session()
+        assert session is not None
+        captured["mounted"] = session.pjx_mounted
+        captured["assets"] = session.pjx_assets
+        captured["trigger"] = session.pjx_trigger
         return {"ok": True}
 
     with TestClient(app) as client:

--- a/tests/pyjinhx/integrations/test_reactive_request_cycle.py
+++ b/tests/pyjinhx/integrations/test_reactive_request_cycle.py
@@ -153,11 +153,13 @@ def test_request_scope_contextvars_reset_after_response():
     @app.post("/dirty")
     def dirty_endpoint(request: Request):
         dirty(Keys.CYCLE)
+        session = current_session()
+        assert session is not None
         seen.append(
             {
-                "session": current_session(),
+                "session": session,
                 "dirtied": set(get_dirtied()),
-                "mounted": request.state.pjx_mounted,
+                "mounted": session.pjx_mounted,
             }
         )
         return {"ok": True}

--- a/tests/pyjinhx/test_context.py
+++ b/tests/pyjinhx/test_context.py
@@ -58,7 +58,7 @@ def test_current_outside_a_request_scope_raises_no_active_request_scope():
         PjxContext.current()
 
 
-def test_manifest_accessors_read_request_state():
+def test_manifest_accessors_read_the_session():
     request = FakeRequest(
         pjx_mounted="mounted-manifest",
         pjx_assets="loaded-assets",
@@ -66,6 +66,9 @@ def test_manifest_accessors_read_request_state():
     )
     with request_scope() as session:
         session.pjx_request = request
+        session.pjx_mounted = "mounted-manifest"
+        session.pjx_assets = "loaded-assets"
+        session.pjx_trigger = "trigger-manifest"
         ctx = PjxContext.current()
         assert ctx.request is request
         assert ctx.mounted == "mounted-manifest"
@@ -73,12 +76,12 @@ def test_manifest_accessors_read_request_state():
         assert ctx.trigger == "trigger-manifest"
 
 
-def test_manifest_accessors_are_none_without_a_request():
+def test_manifest_accessors_default_without_a_request():
     with request_scope():
         ctx = PjxContext.current()
         assert ctx.request is None
-        assert ctx.mounted is None
-        assert ctx.assets is None
+        assert ctx.mounted == []
+        assert ctx.assets == frozenset()
         assert ctx.trigger is None
 
 
@@ -110,3 +113,22 @@ def test_app_context_is_the_same_object_the_session_accessor_returns():
     sentinel = object()
     with request_scope(load_context=sentinel):
         assert PjxContext.current().app_context is get_load_context()
+
+
+def test_manifest_accessors_read_the_session_not_the_request():
+    with request_scope() as session:
+        session.pjx_mounted = [{"id": "a", "type": "Card", "load": {}, "hash": "h"}]
+        session.pjx_assets = frozenset({"tok"})
+        session.pjx_trigger = {"id": "a"}
+        ctx = PjxContext.current()
+        assert ctx.mounted == [{"id": "a", "type": "Card", "load": {}, "hash": "h"}]
+        assert ctx.assets == frozenset({"tok"})
+        assert ctx.trigger == {"id": "a"}
+
+
+def test_manifest_accessors_default_to_empty_outside_a_parsed_request():
+    with request_scope():
+        ctx = PjxContext.current()
+        assert ctx.mounted == []
+        assert ctx.assets == frozenset()
+        assert ctx.trigger is None

--- a/tests/pyjinhx/test_context.py
+++ b/tests/pyjinhx/test_context.py
@@ -64,16 +64,19 @@ def test_manifest_accessors_read_the_session():
         pjx_assets="loaded-assets",
         pjx_trigger="trigger-manifest",
     )
+    mounted = [{"id": "a", "type": "Card", "load": {}, "hash": "h"}]
+    assets = frozenset({"tok"})
+    trigger = {"id": "a"}
     with request_scope() as session:
         session.pjx_request = request
-        session.pjx_mounted = "mounted-manifest"
-        session.pjx_assets = "loaded-assets"
-        session.pjx_trigger = "trigger-manifest"
+        session.pjx_mounted = mounted
+        session.pjx_assets = assets
+        session.pjx_trigger = trigger
         ctx = PjxContext.current()
         assert ctx.request is request
-        assert ctx.mounted == "mounted-manifest"
-        assert ctx.assets == "loaded-assets"
-        assert ctx.trigger == "trigger-manifest"
+        assert ctx.mounted == mounted
+        assert ctx.assets == assets
+        assert ctx.trigger == trigger
 
 
 def test_manifest_accessors_default_without_a_request():


### PR DESCRIPTION
## Summary

- Moves parsed pjx manifests (pjx_mounted, pjx_assets, pjx_trigger) from `request.state` onto the `RenderSession` itself
- Updates PjxContext properties to read manifests from session instead of request.state
- Middleware now parses manifests onto session rather than request during request_scope initialization
- Fixes stale documentation that referenced the old request.state location

This enables the response composer to access manifests without requiring a Starlette request object, making it truly framework-free.

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)