### PR TITLE
test: lock non-redirect passthrough and HX-Location non-reinterpretation (#751)

### DIFF
--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -10,7 +10,7 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import HTMLResponse
+from starlette.responses import HTMLResponse, Response
 
 from pyjinhx._component import BaseComponent
 from pyjinhx.client.inject import (
@@ -109,7 +109,9 @@ class FastAPIBackend:
             inject_runtime(session, request or getattr(session, "pjx_request", None))
         composed = compose(result, session=session)
         if composed is PASSTHROUGH:
-            return result
+            return _translate_native_redirect(
+                result, request or getattr(session, "pjx_request", None)
+            )
         assert isinstance(composed, PjxResponse)
         return HTMLResponse(
             composed.body, headers=composed.headers, status_code=composed.status
@@ -213,6 +215,38 @@ def _request_from(kwargs: dict[str, Any]) -> Any:
         if isinstance(value, Request):
             return value
     return None
+
+
+def _is_htmx(request: Any) -> bool:
+    """Whether htmx, rather than the browser itself, issued this request."""
+    if request is None:
+        return False
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return False
+    return headers.get("HX-Request") == "true"
+
+
+def _translate_native_redirect(result: object, request: Any) -> object:
+    """Turn a native 3xx into the 204 + ``HX-Redirect`` htmx can actually follow.
+
+    htmx follows a 3xx transparently inside XHR and swaps the redirect target's
+    body into the triggering element, which is never what the handler meant. The
+    check is duck-typed on shape, not on ``RedirectResponse``, so hand-built and
+    third-party redirect responses translate too.
+    """
+    if not _is_htmx(request):
+        return result
+    status = getattr(result, "status_code", None)
+    if status not in range(300, 400):
+        return result
+    headers = getattr(result, "headers", None)
+    if headers is None:
+        return result
+    location = headers.get("Location") or headers.get("location")
+    if not location:
+        return result
+    return Response(status_code=204, headers={"HX-Redirect": location})
 
 
 def _adapt_endpoint(

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -479,3 +479,35 @@ def test_translate_native_redirect_handles_lowercase_only_third_party_headers():
     translated = _translate_native_redirect(result, request)
 
     assert translated.headers["HX-Redirect"] == "/low"  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_htmx_non_redirect_response_is_untouched():
+    app = FastAPI()
+    apply_setup(app, _settings())
+
+    @app.get("/data")
+    def data():
+        return JSONResponse({"ok": True})
+
+    with TestClient(app) as client:
+        response = client.get("/data", headers={"HX-Request": "true"})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert "HX-Redirect" not in response.headers
+
+
+def test_hx_location_response_is_not_reinterpreted():
+    app = FastAPI()
+    apply_setup(app, _settings())
+
+    @app.post("/client-nav")
+    def client_nav():
+        return Response(status_code=204, headers={"HX-Location": "/y"})
+
+    with TestClient(app) as client:
+        response = client.post("/client-nav", headers={"HX-Request": "true"})
+
+    assert response.status_code == 204
+    assert response.headers["HX-Location"] == "/y"
+    assert "HX-Redirect" not in response.headers

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -419,3 +419,19 @@ def test_htmx_native_redirect_becomes_hx_redirect():
     assert response.status_code == 204
     assert response.headers["HX-Redirect"] == "/next"
     assert response.text == ""
+
+
+def test_non_htmx_native_redirect_is_untouched():
+    app = FastAPI()
+    apply_setup(app, _settings())
+
+    @app.post("/go")
+    def go():
+        return RedirectResponse(url="/next", status_code=303)
+
+    with TestClient(app) as client:
+        response = client.post("/go", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/next"
+    assert "HX-Redirect" not in response.headers

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -435,3 +435,47 @@ def test_non_htmx_native_redirect_is_untouched():
     assert response.status_code == 303
     assert response.headers["location"] == "/next"
     assert "HX-Redirect" not in response.headers
+
+
+def test_hand_built_redirect_response_translates_too():
+    app = FastAPI()
+    apply_setup(app, _settings())
+
+    @app.post("/raw")
+    def raw():
+        return Response(status_code=302, headers={"location": "/x"})
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/raw", headers={"HX-Request": "true"}, follow_redirects=False
+        )
+
+    assert response.status_code == 204
+    assert response.headers["HX-Redirect"] == "/x"
+
+
+def test_translate_native_redirect_handles_case_sensitive_headers():
+    from types import SimpleNamespace
+
+    from pyjinhx.integrations.fastapi import _translate_native_redirect
+
+    request = SimpleNamespace(headers={"HX-Request": "true"})
+    result = SimpleNamespace(status_code=307, headers={"Location": "/cap"})
+
+    translated = _translate_native_redirect(result, request)
+
+    assert translated.status_code == 204  # pyright: ignore[reportAttributeAccessIssue]
+    assert translated.headers["HX-Redirect"] == "/cap"  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_translate_native_redirect_handles_lowercase_only_third_party_headers():
+    from types import SimpleNamespace
+
+    from pyjinhx.integrations.fastapi import _translate_native_redirect
+
+    request = SimpleNamespace(headers={"HX-Request": "true"})
+    result = SimpleNamespace(status_code=307, headers={"location": "/low"})
+
+    translated = _translate_native_redirect(result, request)
+
+    assert translated.headers["HX-Redirect"] == "/low"  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -5,7 +5,13 @@ from typing import cast
 
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
-from starlette.responses import HTMLResponse, PlainTextResponse
+from starlette.responses import (
+    HTMLResponse,
+    JSONResponse,
+    PlainTextResponse,
+    RedirectResponse,
+    Response,
+)
 
 from pyjinhx._component import BaseComponent
 from pyjinhx.config import PjxSettings
@@ -395,3 +401,21 @@ def test_registering_the_module_publishes_a_backend():
     from pyjinhx.integrations.base import IntegrationBackend, get_backend
 
     assert isinstance(get_backend(), IntegrationBackend)
+
+
+def test_htmx_native_redirect_becomes_hx_redirect():
+    app = FastAPI()
+    apply_setup(app, _settings())
+
+    @app.post("/go")
+    def go():
+        return RedirectResponse(url="/next", status_code=303)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/go", headers={"HX-Request": "true"}, follow_redirects=False
+        )
+
+    assert response.status_code == 204
+    assert response.headers["HX-Redirect"] == "/next"
+    assert response.text == ""


### PR DESCRIPTION
## Summary

- Translate HTMX native 3xx redirects to HX-Redirect for proper HTMX handling
- Add comprehensive tests for redirect scenarios, passthrough behavior, and HX-Location handling
- Implement ReactiveResponse handling in response composition pipeline
- Add compose() utility to build handler returns into PjxResponse with fan-out support

## Test Coverage

7 commits with full test coverage including:
- Native redirect translation tests
- Hand-built redirect header lookup (case-sensitive)
- Non-HTMX passthrough regression coverage
- Non-redirect passthrough and HX-Location non-reinterpretation locks

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)