### PR TITLE
docs: complete ReactiveResponse removal with migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased
+
+### Removed
+- **Breaking:** `ReactiveResponse`. Response composition is no longer something a handler
+  constructs — return the body itself and the composer does the rest. Migrating:
+  - `return ReactiveResponse(primary=c.render(), mounted=request)` → `return c`
+  - `return ReactiveResponse(mounted=request)` → `return None`
+  - `return ReactiveResponse(redirect="/login")` → return your framework's own
+    `RedirectResponse("/login", status_code=303)`
+
+### Added
+- Native redirect support: a handler return whose `status_code` is in 300–399 and that
+  carries a `Location` header is translated to `204` + `HX-Redirect` for htmx requests, so
+  the browser really navigates. Non-htmx requests get the real `3xx` untouched. The check
+  is duck-typed on shape, so hand-built and third-party redirect responses work too.
+
+### Changed
+- Response composition moved to `pyjinhx.responses.compose()`, which every backend funnels
+  handler returns through. It recognizes a `BaseComponent` (rendered as the primary),
+  `None` (empty primary, `HX-Reswap: none`), and a `str`/`Markup`/`__html__`-bearing object
+  (used verbatim); anything else passes through untouched.
+
+### Fixed
+- Returning a bare component from a handler shipped zero OOB fragments, despite the docs
+  claiming fan-out rode along with any render. Fan-out is now attached on every
+  body-producing return, since the dirtied keys belong to the request rather than to the
+  spelling the handler chose.
+
 ## 1.0.0 — pyjinhx v2 (2026-08-03)
 
 pyjinhx 1.0 is the v2 rebuild, shipped under the `pyjinhx` import path. The 0.36.x engine has

--- a/docs/integrations/htmx.md
+++ b/docs/integrations/htmx.md
@@ -287,14 +287,14 @@ extension docs, and render the streamed fragments with PyJinHx components as usu
 ## Dependency-aware updates (reactive OOB)
 
 The patterns above use manual `hx-target` / `hx-swap` for each interaction. With
-PyJinHx reactivity, a mutation route simply returns `Cls.render()` and every
+PyJinHx reactivity, a mutation route simply returns `Cls(...)` and every
 dependent region rides along as an `hx-swap-oob` fragment — no per-swap wiring.
 This is the path to reach for when **one mutation updates multiple regions**
 (counter, list, totals):
 
 - Declare `react={...}` + `load()` on `ReactiveComponent` subclasses
-- Construct the primary and `return <instance>.render()` from mutation routes — dependent regions ride along as `hx-swap-oob` fragments
-- Wire [IntegrationBackend](../api/client-backend.md) via `setup()` so routes call `.render()` with no framework kwargs
+- Construct the primary and `return <instance>` from mutation routes — dependent regions ride along as `hx-swap-oob` fragments
+- Wire [IntegrationBackend](../api/client-backend.md) via `setup()` so routes return components with no framework kwargs
 
 See [Reactivity](../reactivity.md) and [Usage tiers](../guide/usage-tiers.md).
 
@@ -302,11 +302,11 @@ See [Reactivity](../reactivity.md) and [Usage tiers](../guide/usage-tiers.md).
 
 ### Reactive triggers don't need `hx-swap="none"`
 
-A `ReactiveResponse` with no primary HTML is OOB-only: htmx applies the
-out-of-band swaps, then swaps the empty leftover into the trigger's target —
-clearing it. pyjinhx removes this footgun automatically: when a request produces
-an OOB-only `ReactiveResponse`, the middleware emits `HX-Reswap: none`, so the
-trigger keeps its content with no extra attribute:
+A response with no primary HTML is OOB-only: htmx applies the out-of-band swaps,
+then swaps the empty leftover into the trigger's target — clearing it. pyjinhx
+removes this footgun automatically: when a handler returns `None` (or an empty
+primary), the composer emits `HX-Reswap: none`, so the trigger keeps its content
+with no extra attribute:
 
 ```html
 <!-- no hx-swap="none" needed -->
@@ -319,28 +319,45 @@ This is always on and requires the pyjinhx middleware (installed by
 ### Making redirects navigate under htmx
 
 htmx AJAX-follows a `3xx` and swaps the destination page into a fragment instead
-of navigating. To make a redirect trigger a real browser navigation, pass
-`redirect=` (and optionally `redirect_mode=`) to `ReactiveResponse` instead of
-returning a framework `RedirectResponse`:
+of navigating. You do not need a pyjinhx-specific response for this: return your
+framework's own redirect and pyjinhx translates it.
 
 ```python
-from pyjinhx.reactive import ReactiveResponse
+from fastapi.responses import RedirectResponse
 
 
 @app.post("/logout")
 def logout():
-    return ReactiveResponse(redirect="/login")  # emits HX-Redirect
+    return RedirectResponse("/login", status_code=303)
 ```
 
-`redirect_mode="location"` emits `HX-Location` instead, for htmx's client-side
-ajax navigation rather than a full browser redirect.
+For an **htmx** request, any handler return whose `status_code` falls in 300–399 and
+that carries a `Location` header becomes `204 No Content` with `HX-Redirect: /login`,
+which htmx turns into a real browser navigation. The check is duck-typed on that shape,
+so hand-built and third-party redirect responses translate too. A **plain** (non-htmx)
+navigation gets the real `3xx` back, untouched — the same route serves both.
+
+`HX-Location` — htmx's client-side ajax navigation — has no status-code spelling, so
+there is nothing for pyjinhx to translate from. Ask for it directly:
+
+```python
+from starlette.responses import Response
+
+
+@app.post("/logout")
+def logout():
+    return Response(status_code=204, headers={"HX-Location": "/login"})
+```
+
+A framework `Response` is not a shape `compose()` adapts, so it takes the `PASSTHROUGH`
+path and reaches the client exactly as written.
 
 ### The `HX-Reswap: none` mechanism
 
-The automatic `HX-Reswap: none` behavior described above is implemented on
-`ReactiveResponse.headers` (in `pyjinhx/reactive/response.py`): it's emitted
-whenever a response has no primary markup. There's no pluggable backend hook
-for this — it's a fixed property of `ReactiveResponse` itself. Framework glue
+The automatic `HX-Reswap: none` behavior described above is implemented in
+`pyjinhx/responses.py`: `compose()` emits it whenever the composed body has no
+primary markup. There's no pluggable backend hook for this — it's a fixed
+property of composition, so every backend agrees about it. Framework glue
 (mounting static files, request scoping, adapting a pjx return into a native
 response) is the seam that *is* pluggable, via the
 [`IntegrationBackend`](../api/client-backend.md) protocol that `setup()` wires

--- a/docs/reactivity.md
+++ b/docs/reactivity.md
@@ -148,83 +148,96 @@ The runtime attaches these headers to htmx requests:
 
 Wire `FastAPIBackend` via `setup(app, ...)` — see the
 [canonical snippet](integrations/fastapi.md#middleware-recommended) and
-[Integration Backend](api/client-backend.md). Mutation routes then construct the primary
-and call `.render()` with no extra kwargs — headers are read from the backend after
-`@mutates`. Full-page routes call `.render()` plainly; boosted navigations skip
-re-injecting `pjx.js` when `X-PJX-Mounted` is present.
+[Integration Backend](api/client-backend.md). Mutation routes then **return** the primary
+component and the adapter composes the response — headers are read from the request scope
+after `@mutates`. Full-page routes return their component the same way; boosted navigations
+skip re-injecting `pjx.js` when `X-PJX-Mounted` is present.
 
 ## Emit OOB swaps from your route
 
-A mutation route does exactly one thing: **`return <component>.render()`**. You
-never call `load()` yourself and never assemble swaps by hand. For a **reactive**
-primary, construct the instance (its `PjxKey` field set, if it has one) and call
-`.render()` — it auto-`load()`s the instance for you before the render. The
-dependent regions ride along as out-of-band swaps:
+A mutation route does exactly one thing: **`return <component>`**. You never call
+`load()` yourself, never call `.render()`, and never assemble swaps by hand. For a
+**reactive** primary, construct the instance (its `PjxKey` field set, if it has one) and
+return it — the composer auto-`load()`s it before rendering. The dependent regions ride
+along as out-of-band swaps:
 
 ```python
 @app.post("/todos/toggle")
 def toggle():
     db.toggle_all()
-    return Counter().render()
+    return Counter()
 ```
 
 With `@mutates` on the store method, pending dirtied keys drive OOB swaps automatically.
 
-The primary's `.render()` runs its `load()` (populating `self` from the current
-world), renders it as the main-target response, then appends OOB swaps for every
-*other* mounted reactive region whose `react` keys intersect pending mutations from
-`@mutates`. Only the primary id is excluded (htmx swaps it as the main-target response);
-the region that *initiated* the request still updates out-of-band if it depends on the
-dirtied keys — e.g. a "Clear completed (N)" button updates its own count.
+The composer runs the primary's `load()` (populating it from the current world), renders
+it as the main-target response, then attaches an OOB swap for every *other* mounted
+reactive region whose `react` keys intersect pending mutations from `@mutates`. Only the primary id
+is excluded (htmx swaps it as the main-target response); the region that *initiated* the
+request still updates out-of-band if it depends on the dirtied keys — e.g. a "Clear
+completed (N)" button updates its own count.
 
 `X-PJX-Trigger` is **client-only**: `pjx.js` reads it to drive loading indicators (which
-region the user clicked). The server reactive walk (`render` / `oob_swaps`) never reads it —
-it excludes only the primary id and gates everything else on `react` keys and hashes.
+region the user clicked). The server reactive walk (`walk_manifest` / `oob_swaps`) never
+reads it — it excludes only the primary id and gates everything else on `react` keys and
+hashes.
 
-A **plain, non-reactive** primary has no `load()` to call, so you build it and render
-the instance: `MyFragment(id=..., ...).render()`.
+A **plain, non-reactive** primary has no `load()` to call, so you build it and return it:
+`return MyFragment(id=..., ...)`.
 
-### OOB swaps ride along any render
+### What the composer accepts, and where fan-out comes from
 
-The fan-out is not exclusive to `ReactiveComponent.render()`. **Any** component's
-`.render()` appends OOB swaps for dirtied mounted reactive regions when a client
-backend is active and mutations occurred in the request — including a non-reactive
-command-result view. Fan-out happens once per request scope and never double-swaps a
-region already present in the response body.
+Fan-out is **not** a property of `.render()`. `.render()` returns one component's markup
+and nothing else; it always has. Fan-out belongs to `pyjinhx.responses.compose()`, which
+every backend funnels handler returns through, and it is attached on **every** return that
+produces a body — because the dirtied keys belong to the request, not to whichever
+spelling the handler reached for.
+
+`compose()` recognizes exactly three shapes:
+
+| Handler returns | Primary body |
+|-----------------|--------------|
+| a `BaseComponent` | that component, rendered |
+| `None` | empty (OOB-only response, carries `HX-Reswap: none`) |
+| a `str`, a `Markup`, or any object with `__html__` | that markup verbatim |
+
+Anything else — a framework `Response`, a `RedirectResponse`, a dict destined for JSON —
+is `PASSTHROUGH`: pyjinhx does not touch it and the backend keeps its own value.
+
+So a non-reactive command-result view fans out just by being returned:
 
 ```python
 @app.post("/generate")
 def generate():
     report = controller.generate()  # @mutates dirties "reports", "quota"
-    return ReportSummary(report=report).render()  # non-reactive; counters fan out OOB
+    return ReportSummary(report=report)  # non-reactive; counters fan out OOB
 ```
 
-For a response that renders no component at all (a raw string, a `204`), use `from pyjinhx import ReactiveResponse` to attach the same fan-out:
+And a route with no component to show returns `None`:
 
 ```python
-from pyjinhx import ReactiveResponse
-
-
 @app.post("/dismiss")
 def dismiss():
     controller.dismiss()  # @mutates dirties mounted regions
-    return ReactiveResponse()  # no primary; dependents still fan out OOB
+    return None  # no primary; dependents still fan out OOB
 ```
 
-`ReactiveResponse` never dirties anything itself. Its full signature is `ReactiveResponse(primary=None, mounted=None, redirect=None, redirect_mode="redirect", assets=None)` — all keyword arguments, all about *what to send*. Dirty the keys first with `dirty(...)` (or `@mutates` on the store method), then build the response:
+Composing never dirties anything itself. Dirty the keys first — with `@mutates` on the
+store method, or `dirty(...)` inline — then return the body:
 
 ```python
-from pyjinhx import ReactiveResponse, dirty
+from pyjinhx import dirty
 
 
 @app.post("/dismiss")
 def dismiss():
     controller.dismiss()  # plain mutation, no @mutates
-    dirty(Keys.TODOS)  # dirty TODOS
-    return ReactiveResponse(primary="")  # fan out dependents OOB
+    dirty(Keys.TODOS)
+    return "<p>dismissed</p>"  # str primary; dependents fan out OOB
 ```
 
-Pass a primary body through `primary=`, e.g. `ReactiveResponse(primary="<p>dismissed</p>")`.
+Fan-out happens once per request scope and never double-swaps a region the primary body
+already carries.
 
 !!! note "Without an integration backend"
     Wire `IntegrationBackend` in middleware (via `setup()`) so `render()` reads manifest and asset headers automatically. Without a backend, reactive OOB is skipped when mutations are pending.
@@ -282,7 +295,7 @@ def toggle(todo_id: int) -> Todo: ...
 @app.post("/rows/{todo_id}/toggle")
 def toggle_row(todo_id: int):
     store.toggle(todo_id)
-    return TodoItemRow.load(todo_id).render()
+    return TodoItemRow(todo_id=todo_id, id=f"row-{todo_id}")
 ```
 
 When a keyed entity is removed but still listed in the client's mounted manifest (e.g.
@@ -333,7 +346,7 @@ whose `message_id` is `"42"`.
 
 `@mutates` takes the same idea as a `key=` keyword instead of calling `reactive_key()` yourself:
 
-- `dirty(reactive_key(ChatKeys.MESSAGE, message_id))` dirties exactly one bubble; the caller already has the id, so no `key=` helper is needed. `ReactiveResponse` takes no keys at all — dirty first, then build the response.
+- `dirty(reactive_key(ChatKeys.MESSAGE, message_id))` dirties exactly one bubble; the caller already has the id, so no `key=` helper is needed. Composition takes no keys at all — dirty first, then return the body.
 - `@mutates(ChatKeys.MESSAGE, key=lambda message_id: message_id)` is `key=` as a
   *callable* instead, since `@mutates` runs at decoration time, before any call
   arguments exist — see [Mutation tracking](#mutation-tracking-mutates) below.
@@ -381,7 +394,7 @@ def toggle(todo_id: int) -> Todo: ...
 @app.post("/rows/{todo_id}/toggle")
 def toggle_row(todo_id):
     store.toggle(todo_id)
-    return TodoItemRow.load(todo_id).render()
+    return TodoItemRow(todo_id=todo_id, id=f"row-{todo_id}")
 ```
 
 This dirties `Keys.TODOS` on every call, so it reloads every mounted `TodoItemRow`
@@ -592,7 +605,7 @@ are stamped with `data-pjx-*` at render time, and `pjx.js` reads the already-sta
 on `htmx:configRequest` (it never watches for changes; a DOM mutation is the *effect* of
 a swap, not its cause).
 
-A mutation route returns `Cls.render()`. That invalidates the `load()` cache for the
+A mutation route returns `Cls(...)`. The composer invalidates the `load()` cache for the
 dirtied keys, renders the primary as the main response, then runs the `oob_swaps` walk
 (with `exclude_ids = {primary.id}`) over the mounted manifest — sending the primary plus
 every dependent swap back in one response:
@@ -607,7 +620,7 @@ sequenceDiagram
     Note over S: open request scope, @mutates recorded the dirtied keys
     S->>C: invalidate dirtied keys
 
-    Note over S: render the primary via Cls.render
+    Note over S: render the primary via compose
     S->>C: load primary
     C-->>S: state, a cache miss hits the DB then caches
     S->>S: render primary HTML

--- a/examples/todo/app.py
+++ b/examples/todo/app.py
@@ -7,7 +7,6 @@ methods read.
 """
 
 from fastapi import FastAPI, Form, HTTPException
-from starlette.requests import Request
 
 from examples.todo import store
 from examples.todo.components import App, ItemRow
@@ -35,24 +34,26 @@ def index():
 
 
 @app.post("/todos")
-def add_todo(request: Request, text: str = Form(...)):
-    """Add one todo and return its row, with the counters swapped out of band.
+def add_todo(text: str = Form(...)):
+    """Add one todo and return its row; the counters ride along out of band.
 
     The primary fragment is the row alone because the composer form targets
-    #list with hx-swap="beforeend"; the middleware adapter also refreshes the
-    mounted counters that store.add's @mutates just dirtied.
+    #list with hx-swap="beforeend". The counters refresh because store.add's
+    @mutates dirtied their keys for this request, not because this route asked
+    for them.
     """
     todo = store.add(text)
     return ItemRow(todo_id=todo.id, id=f"row-{todo.id}")
 
 
 @app.post("/rows/{todo_id}/toggle")
-def toggle_todo(request: Request, todo_id: int):
+def toggle_todo(todo_id: int):
     """Flip one todo and return its row.
 
     store.toggle raises KeyError on an id it has never seen — a stale row in a
     long-open tab is a client mistake, not a server fault, so it becomes a 404
-    rather than a 500.
+    rather than a 500. Every mounted region whose keys store.toggle's @mutates
+    dirtied is swapped out of band alongside the row.
     """
     try:
         store.toggle(todo_id)
@@ -62,11 +63,12 @@ def toggle_todo(request: Request, todo_id: int):
 
 
 @app.post("/todos/clear-completed")
-def clear_completed(request: Request):
+def clear_completed():
     """Delete every completed todo; the page updates entirely out of band.
 
-    No primary fragment: the clear button has nothing of its own to swap in, so
-    the response is the OOB fan-out that store.clear_completed's dirtied keys
-    imply, plus the HX-Reswap: none the empty primary carries.
+    Returning None means there is no primary fragment — the clear button has
+    nothing of its own to swap in. The response is the OOB fan-out implied by
+    the keys store.clear_completed's @mutates dirtied, plus the HX-Reswap: none
+    an empty primary carries.
     """
     store.clear_completed()

--- a/tests/examples/test_todo_app.py
+++ b/tests/examples/test_todo_app.py
@@ -155,3 +155,10 @@ class TestSourceGuard:
 
         assert "ReactiveResponse" not in doc
         assert "appends OOB swaps" not in doc
+
+    def test_the_htmx_doc_names_no_removed_response_api(self):
+        """docs/integrations/htmx.md must describe native 3xx translation."""
+        doc = Path("docs/integrations/htmx.md").read_text()
+
+        assert "ReactiveResponse" not in doc
+        assert "HX-Redirect" in doc

--- a/tests/examples/test_todo_app.py
+++ b/tests/examples/test_todo_app.py
@@ -133,3 +133,18 @@ class TestClearCompleted:
         client.post("/todos/clear-completed")
 
         assert todo_store.total() == 3
+
+
+class TestSourceGuard:
+    def test_the_example_names_no_removed_response_api(self):
+        """The example is the migration reference: nothing v1-shaped may survive in it."""
+        source = Path("examples/todo/app.py").read_text()
+
+        assert "ReactiveResponse" not in source
+        assert ".render()" not in source
+
+    def test_no_route_takes_an_unused_request_argument(self):
+        """Routes return components; none of them needs the Request object."""
+        source = Path("examples/todo/app.py").read_text()
+
+        assert "Request" not in source

--- a/tests/examples/test_todo_app.py
+++ b/tests/examples/test_todo_app.py
@@ -148,3 +148,10 @@ class TestSourceGuard:
         source = Path("examples/todo/app.py").read_text()
 
         assert "Request" not in source
+
+    def test_the_reactivity_doc_names_no_removed_response_api(self):
+        """docs/reactivity.md must describe compose(), not the deleted class."""
+        doc = Path("docs/reactivity.md").read_text()
+
+        assert "ReactiveResponse" not in doc
+        assert "appends OOB swaps" not in doc


### PR DESCRIPTION
## Summary
- Complete the ReactiveResponse removal started in #758 with comprehensive documentation
- Document the new `compose()` pattern for fan-out routing as the replacement
- Update integration docs with native 3xx to HX-Redirect translation in HTMX
- Update examples to remove unused Request parameters
- Add Unreleased changelog entry

## Test plan
- All ruff checks pass (format and lint)
- Review documentation updates for accuracy and completeness
- Verify examples run correctly with updated code

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)