### PR TITLE
fix: resolve basedpyright error in test_reactive_fanout and format docs

### DIFF
--- a/docs/api/responses.md
+++ b/docs/api/responses.md
@@ -105,6 +105,7 @@ Detection is duck-typed on that shape, not on `RedirectResponse`, so hand-built 
 ```python
 from starlette.responses import RedirectResponse
 
+
 @app.post("/todos")
 def create(title: str):
     ...

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -180,8 +180,7 @@ def load(cls, todo_id: int | str, ctx: TodoAppContext | None = None) -> "ItemRow
 
 # AFTER (1.2.0)
 @classmethod
-def load(cls, todo_id: int, ctx: TodoAppContext | None = None) -> "ItemRow":
-    ...
+def load(cls, todo_id: int, ctx: TodoAppContext | None = None) -> "ItemRow": ...
 ```
 
 A value that will not validate is passed through untouched rather than raised on — `load()`

--- a/docs/superpowers/rebuild/adr/0013-absence-is-proved-by-a-failed-load.md
+++ b/docs/superpowers/rebuild/adr/0013-absence-is-proved-by-a-failed-load.md
@@ -11,7 +11,7 @@ The L3.5 implementation read that miss as evidence of absence:
 ```python
 resolved, found = _resolve_registry_entry(cls, instance_id)
 if not found:
-    status = "missing"      # -> <div hx-swap-oob="delete:[data-pjx-id='...']">
+    status = "missing"  # -> <div hx-swap-oob="delete:[data-pjx-id='...']">
 ```
 
 Compose E6 and E7 and that reading collapses. In production the registry is written only by `register_rendered_instance`, subscribed to `on_rendered`, so it contains exactly the regions the *current* request rendered. A T2 request renders its primary and nothing else. Every region outside the primary tree — which is precisely the set fan-out exists to refresh — therefore misses the registry as a matter of course.

--- a/pyjinhx/builtins/ui/pjx_confirm_dialog/__init__.py
+++ b/pyjinhx/builtins/ui/pjx_confirm_dialog/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx.builtins.ui.pjx_confirm_dialog.pjx_confirm_dialog import PJXConfirmDialog
+
+__all__ = ["PJXConfirmDialog"]

--- a/pyjinhx/builtins/ui/pjx_confirm_dialog/pjx_confirm_dialog.css
+++ b/pyjinhx/builtins/ui/pjx_confirm_dialog/pjx_confirm_dialog.css
@@ -1,0 +1,54 @@
+:where(:root) {
+  --pjx-confirm-dialog-bg:       var(--surface);
+  --pjx-confirm-dialog-border:   var(--border);
+  --pjx-confirm-dialog-radius:   var(--radius-md);
+  --pjx-confirm-dialog-shadow:   var(--shadow-md);
+  --pjx-confirm-dialog-backdrop: rgb(0 0 0 / 0.5);
+  --pjx-confirm-dialog-danger:   #b3261e;
+}
+
+.pjx-confirm-dialog::backdrop {
+  background: var(--pjx-confirm-dialog-backdrop);
+}
+
+.pjx-confirm-dialog[open] {
+  margin: auto;
+  padding: 0;
+  border: 1px solid var(--pjx-confirm-dialog-border);
+  border-radius: var(--pjx-confirm-dialog-radius);
+  background: var(--pjx-confirm-dialog-bg);
+  box-shadow: var(--pjx-confirm-dialog-shadow);
+  max-width: min(28rem, calc(100vw - 2rem));
+}
+
+.pjx-confirm-dialog__card {
+  padding: 1.25rem 1.5rem;
+}
+
+.pjx-confirm-dialog__message {
+  margin: 0 0 1rem;
+  color: var(--text);
+}
+
+.pjx-confirm-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.pjx-confirm-dialog__ok,
+.pjx-confirm-dialog__cancel {
+  padding: 0.4rem 0.9rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--pjx-confirm-dialog-border);
+  background: var(--surface-alt);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+}
+
+.pjx-confirm-dialog__ok--danger {
+  background: var(--pjx-confirm-dialog-danger);
+  border-color: var(--pjx-confirm-dialog-danger);
+  color: #fff;
+}

--- a/pyjinhx/builtins/ui/pjx_confirm_dialog/pjx_confirm_dialog.js
+++ b/pyjinhx/builtins/ui/pjx_confirm_dialog/pjx_confirm_dialog.js
@@ -1,0 +1,74 @@
+(function () {
+    window.pjx = window.pjx || {};
+    if (pjx.confirm) return;
+
+    function dialogEl() {
+        return document.querySelector('dialog[data-pjx-dialog="confirm"]');
+    }
+
+    function confirm(message, options) {
+        const opts = options || {};
+        const dialog = dialogEl();
+        if (!dialog) return Promise.resolve(window.confirm(message));
+        if (dialog.open) return Promise.resolve(false); // singleton busy: treat as declined
+
+        const messageEl = dialog.querySelector('.pjx-confirm-dialog__message');
+        const okBtn = dialog.querySelector('.pjx-confirm-dialog__ok');
+        const cancelBtn = dialog.querySelector('.pjx-confirm-dialog__cancel');
+        messageEl.textContent = message;
+        okBtn.classList.toggle('pjx-confirm-dialog__ok--danger', Boolean(opts.danger));
+        const prevOk = okBtn.textContent;
+        const prevCancel = cancelBtn.textContent;
+        if (opts.okLabel) okBtn.textContent = opts.okLabel;
+        if (opts.cancelLabel) cancelBtn.textContent = opts.cancelLabel;
+
+        dialog.showModal();
+
+        return new Promise((resolve) => {
+            const ac = new AbortController();
+            const done = (result) => {
+                okBtn.textContent = prevOk;
+                cancelBtn.textContent = prevCancel;
+                ac.abort();
+                if (dialog.open) dialog.close();
+                resolve(result);
+            };
+            okBtn.addEventListener('click', () => done(true), { signal: ac.signal });
+            cancelBtn.addEventListener('click', () => done(false), { signal: ac.signal });
+            // Esc / programmatic close resolves false.
+            dialog.addEventListener('close', () => done(false), { signal: ac.signal });
+        });
+    }
+
+    // Every plain hx-confirm="..." routes through the styled dialog.
+    document.addEventListener('htmx:confirm', (evt) => {
+        if (!evt.detail.question) return;
+        if (!dialogEl()) return; // no singleton mounted: htmx falls back to window.confirm
+        evt.preventDefault();
+        const elt = evt.detail.elt;
+        confirm(evt.detail.question, {
+            danger: Boolean(elt && elt.hasAttribute('data-pjx-confirm-danger')),
+            okLabel: elt ? elt.getAttribute('data-pjx-confirm-ok') : null,
+            cancelLabel: elt ? elt.getAttribute('data-pjx-confirm-cancel') : null,
+        }).then((confirmed) => {
+            if (confirmed) evt.detail.issueRequest(true);
+        });
+    });
+
+    // Non-htmx forms: <form data-confirm="...">.
+    document.addEventListener('submit', (evt) => {
+        if (evt.defaultPrevented) return; // htmx (or other code) already owns this submit
+        const question = evt.target.getAttribute && evt.target.getAttribute('data-confirm');
+        if (!question || !dialogEl()) return;
+        evt.preventDefault();
+        confirm(question, {
+            danger: evt.target.hasAttribute('data-pjx-confirm-danger'),
+            okLabel: evt.target.getAttribute('data-pjx-confirm-ok'),
+            cancelLabel: evt.target.getAttribute('data-pjx-confirm-cancel'),
+        }).then((confirmed) => {
+            if (confirmed) evt.target.submit();
+        });
+    });
+
+    pjx.confirm = confirm;
+}());

--- a/pyjinhx/builtins/ui/pjx_confirm_dialog/pjx_confirm_dialog.pjx
+++ b/pyjinhx/builtins/ui/pjx_confirm_dialog/pjx_confirm_dialog.pjx
@@ -1,0 +1,9 @@
+<dialog id="{{ id }}" class="pjx-confirm-dialog{% if class_name %} {{ class_name }}{% endif %}" data-pjx-dialog="confirm" aria-modal="true" aria-labelledby="{{ id }}-message">
+    <div class="pjx-confirm-dialog__card">
+        <p id="{{ id }}-message" class="pjx-confirm-dialog__message"></p>
+        <div class="pjx-confirm-dialog__actions">
+            <button type="button" class="pjx-confirm-dialog__cancel">{{ cancel_label }}</button>
+            <button type="button" class="pjx-confirm-dialog__ok">{{ confirm_label }}</button>
+        </div>
+    </div>
+</dialog>

--- a/pyjinhx/builtins/ui/pjx_confirm_dialog/pjx_confirm_dialog.py
+++ b/pyjinhx/builtins/ui/pjx_confirm_dialog/pjx_confirm_dialog.py
@@ -1,0 +1,9 @@
+from pyjinhx._component import AttrValue, BaseComponent
+
+
+class PJXConfirmDialog(BaseComponent):
+    """The confirm shell and its button labels; the message text and open/close are driven by pjx.confirm(), not by fields here."""
+
+    confirm_label: str = "Confirm"
+    cancel_label: str = "Cancel"
+    class_name: AttrValue = ""

--- a/tests/pyjinhx/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx/reactive/test_reactive_fanout.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 import re
-from typing import Annotated
+from typing import Annotated, cast
 
 import pytest
 
@@ -994,4 +994,4 @@ def test_a_string_load_arg_reaches_load_as_the_declared_int(tmp_path):
     assert INT_KEY_LOAD_ARGS == [1]
     assert candidate.status == "dirty"
     assert candidate.instance is not None
-    assert candidate.instance.title == "first"
+    assert cast(IntKeyedWidget, candidate.instance).title == "first"

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -142,6 +142,10 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
         {"pyjinhx.builtins.ui.pjx_modal_footer.pjx_modal_footer"}
     ),
     "builtins.ui.pjx_modal_footer.pjx_modal_footer": frozenset({"pyjinhx._component"}),
+    "builtins.ui.pjx_confirm_dialog.__init__": frozenset(
+        {"pyjinhx.builtins.ui.pjx_confirm_dialog.pjx_confirm_dialog"}
+    ),
+    "builtins.ui.pjx_confirm_dialog.pjx_confirm_dialog": frozenset({"pyjinhx._component"}),
     # pjx_drawer family (#518): the slide-in dialog shell plus its
     # header/body/footer regions. Same shape as the modal family — each
     # component module reaches down into _component.py only; each __init__ just

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -145,7 +145,9 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "builtins.ui.pjx_confirm_dialog.__init__": frozenset(
         {"pyjinhx.builtins.ui.pjx_confirm_dialog.pjx_confirm_dialog"}
     ),
-    "builtins.ui.pjx_confirm_dialog.pjx_confirm_dialog": frozenset({"pyjinhx._component"}),
+    "builtins.ui.pjx_confirm_dialog.pjx_confirm_dialog": frozenset(
+        {"pyjinhx._component"}
+    ),
     # pjx_drawer family (#518): the slide-in dialog shell plus its
     # header/body/footer regions. Same shape as the modal family — each
     # component module reaches down into _component.py only; each __init__ just


### PR DESCRIPTION
## Summary
- Port PJXConfirmDialog shell to v2 conventions with reactive pattern
- Add PJXConfirmDialog stylesheet and confirm singleton for UI state management
- Ruff format pjx_confirm_dialog module for consistency
- Resolve basedpyright error in test_reactive_fanout and update docs

Closes #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)