### PR TITLE
feat: add jinja_globals/jinja_filters fields to PjxSettings

### DIFF
--- a/docs/api/responses.md
+++ b/docs/api/responses.md
@@ -105,6 +105,7 @@ Detection is duck-typed on that shape, not on `RedirectResponse`, so hand-built 
 ```python
 from starlette.responses import RedirectResponse
 
+
 @app.post("/todos")
 def create(title: str):
     ...

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -42,7 +42,7 @@ with request_scope(session=session):
     ...
 ```
 
-`RenderSession()` takes no arguments, and `request_scope()` takes only `session=` and `load_context=`.
+`RenderSession()` takes two optional keyword arguments, `jinja_globals=` and `jinja_filters=`, and `request_scope()` takes only `session=` and `load_context=`.
 
 !!! note "Not yet public"
     `RenderSession` is exported from `pyjinhx`; `request_scope` is not — it lives in

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -180,8 +180,7 @@ def load(cls, todo_id: int | str, ctx: TodoAppContext | None = None) -> "ItemRow
 
 # AFTER (1.2.0)
 @classmethod
-def load(cls, todo_id: int, ctx: TodoAppContext | None = None) -> "ItemRow":
-    ...
+def load(cls, todo_id: int, ctx: TodoAppContext | None = None) -> "ItemRow": ...
 ```
 
 A value that will not validate is passed through untouched rather than raised on — `load()`

--- a/docs/superpowers/rebuild/adr/0013-absence-is-proved-by-a-failed-load.md
+++ b/docs/superpowers/rebuild/adr/0013-absence-is-proved-by-a-failed-load.md
@@ -11,7 +11,7 @@ The L3.5 implementation read that miss as evidence of absence:
 ```python
 resolved, found = _resolve_registry_entry(cls, instance_id)
 if not found:
-    status = "missing"      # -> <div hx-swap-oob="delete:[data-pjx-id='...']">
+    status = "missing"  # -> <div hx-swap-oob="delete:[data-pjx-id='...']">
 ```
 
 Compose E6 and E7 and that reading collapses. In production the registry is written only by `register_rendered_instance`, subscribed to `on_rendered`, so it contains exactly the regions the *current* request rendered. A T2 request renders its primary and nothing else. Every region outside the primary tree — which is precisely the set fan-out exists to refresh — therefore misses the registry as a matter of course.

--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -1,9 +1,12 @@
 """App-level configuration for pyjinhx: the settings object and the setup() entrypoint.
 
 config sits above the render spine and may read from it; nothing in the spine,
-in reactive/ or in client/ may import this module back. Siblings that do not
-exist yet (dev, integrations.fastapi) are imported lazily inside functions so
-importing this module never depends on them.
+in reactive/ or in client/ may import this module back — except session.py's
+request_scope(), which reads current_settings() through a function-local
+import to seed a default session's Jinja globals/filters, never at module
+scope (test_session_only_imports_config_inside_a_function_body pins that).
+Siblings that do not exist yet (dev, integrations.fastapi) are imported
+lazily inside functions so importing this module never depends on them.
 """
 
 from __future__ import annotations

--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, fields, replace
 from importlib.util import find_spec as _find_spec
 from pathlib import Path
@@ -53,13 +53,19 @@ class PjxSettings:
     """The app-level knobs pyjinhx reads once at startup.
 
     ``inject_htmx`` is stored only; how it maps onto the session's asset modes
-    is pending design.
+    is pending design. ``jinja_globals`` and ``jinja_filters`` are registered
+    onto each request's Jinja environment by the session that reads them.
     """
 
     reactive_dev: bool = False
     inject_htmx: bool = True
     components_root: Path | str | None = None
     static_root: Path | str | None = None
+    # None rather than an empty dict: the dataclass is frozen and a mutable
+    # default is disallowed outright, and "nothing to add" is exactly what a
+    # missing mapping should mean to the session that applies these.
+    jinja_globals: Mapping[str, Any] | None = None
+    jinja_filters: Mapping[str, Any] | None = None
 
     @classmethod
     def from_env(cls) -> PjxSettings:

--- a/pyjinhx/session.py
+++ b/pyjinhx/session.py
@@ -1,6 +1,6 @@
 """RenderSession, the per-request ContextVars, and the request_scope that owns them."""
 
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
@@ -77,8 +77,13 @@ class AbsolutePathLoader(BaseLoader):
 class RenderSession:
     """Session providing Jinja environment with autoescape enabled."""
 
-    def __init__(self):
-        """Initialize render session."""
+    def __init__(
+        self,
+        *,
+        jinja_globals: Mapping[str, Any] | None = None,
+        jinja_filters: Mapping[str, Any] | None = None,
+    ):
+        """Initialize render session, optionally with extra Jinja globals and filters."""
         self.jinja_env = Environment(
             loader=AbsolutePathLoader(),
             autoescape=True,
@@ -86,6 +91,14 @@ class RenderSession:
             # hook swaps in a placeholder the render pipeline resolves later.
             finalize=finalize_slot_node,
         )
+        # update(), never assignment: Jinja seeds both mappings with its own
+        # builtins (range, dict, |upper, |length ...) and replacing the mapping
+        # outright would take a template's whole standard library with it.
+        # None is "nothing to add", not "clear".
+        if jinja_globals is not None:
+            self.jinja_env.globals.update(jinja_globals)
+        if jinja_filters is not None:
+            self.jinja_env.filters.update(jinja_filters)
         # Generic per-request asset slot from the #423 ContextVar model
         # (predates L2.2.1's descriptor accumulator below); no producer in
         # this codebase writes to it yet, so it stays as-is for whatever

--- a/pyjinhx/session.py
+++ b/pyjinhx/session.py
@@ -289,7 +289,18 @@ def request_scope(
         The RenderSession bound for this scope.
     """
     if session is None:
-        session = RenderSession()
+        # Function-local by necessity: config sits above the render spine and
+        # imports it at import time, so a module-scope edge back would be a
+        # real cycle. Same escape hatch _component.py uses for rendering.py.
+        # Only the branch that builds the session consults the settings: a
+        # caller that supplied one already chose its environment.
+        from pyjinhx.config import current_settings
+
+        settings = current_settings()
+        session = RenderSession(
+            jinja_globals=settings.jinja_globals,
+            jinja_filters=settings.jinja_filters,
+        )
     session_token = _render_session.set(session)
     instances_token = _instances.set({})
     dirtied_token = _dirtied.set(set())

--- a/tests/pyjinhx/integrations/test_reactive_request_cycle.py
+++ b/tests/pyjinhx/integrations/test_reactive_request_cycle.py
@@ -508,11 +508,20 @@ def test_lower_layers_do_not_import_the_wiring_layer():
         )
     ]
 
+    # session.request_scope() reads current_settings() through a function-local
+    # import (never at module scope) to seed a default session's Jinja
+    # globals/filters; test_import_graph.py's
+    # test_session_only_imports_config_inside_a_function_body pins that it
+    # stays function-local, so it is not a real upward edge here.
+    allowed_edges = {("pyjinhx.session", "pyjinhx.config")}
+
     offenders: list[tuple[str, str]] = []
     for name in lower:
         source = Path(importlib.import_module(name).__file__ or "").read_text()
         imported = imported_module_names(source)
         for upper_name in upper:
+            if (name, upper_name) in allowed_edges:
+                continue
             if upper_name in imported or any(
                 mod.startswith(f"{upper_name}.") for mod in imported
             ):

--- a/tests/pyjinhx/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx/reactive/test_reactive_fanout.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 import re
-from typing import Annotated
+from typing import Annotated, cast
 
 import pytest
 
@@ -994,4 +994,4 @@ def test_a_string_load_arg_reaches_load_as_the_declared_int(tmp_path):
     assert INT_KEY_LOAD_ARGS == [1]
     assert candidate.status == "dirty"
     assert candidate.instance is not None
-    assert candidate.instance.title == "first"
+    assert cast(IntKeyedWidget, candidate.instance).title == "first"

--- a/tests/pyjinhx/test_config_v2.py
+++ b/tests/pyjinhx/test_config_v2.py
@@ -26,6 +26,17 @@ def test_defaults():
     assert settings.inject_htmx is True
     assert settings.components_root is None
     assert settings.static_root is None
+    assert settings.jinja_globals is None
+    assert settings.jinja_filters is None
+
+
+def test_jinja_globals_and_filters_are_stored_as_given():
+    def shout(value: str) -> str:
+        return value.upper()
+
+    settings = PjxSettings(jinja_globals={"x": 1}, jinja_filters={"shout": shout})
+    assert settings.jinja_globals == {"x": 1}
+    assert settings.jinja_filters == {"shout": shout}
 
 
 def test_settings_are_frozen():
@@ -231,7 +242,14 @@ def test_setup_delegates_an_asgi_app_to_the_fastapi_integration(
 def test_deferred_cache_machinery_is_not_ported():
     """ADR 0009/0011: no invalidation backend, hub or cache scope in v2."""
     names = {field.name for field in dataclasses.fields(PjxSettings)}
-    assert names == {"reactive_dev", "inject_htmx", "components_root", "static_root"}
+    assert names == {
+        "reactive_dev",
+        "inject_htmx",
+        "components_root",
+        "static_root",
+        "jinja_globals",
+        "jinja_filters",
+    }
 
 
 def test_static_root_is_stored_on_the_settings(tmp_path: Path):

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -520,12 +520,18 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # The on_rendered hook's signature names BaseComponent and RenderedLevel, but
     # both imports are TYPE_CHECKING-only. At runtime session also imports
     # AssetMode from assets, a real edge alongside markers.
+    # session owns the per-request ContextVars. The one upward edge is
+    # config, imported inside request_scope()'s body — never at module scope
+    # — so the default session can be seeded with the app's Jinja globals and
+    # filters without inverting the layering; see the function-local guard
+    # test below.
     "session": frozenset(
         {
             "pyjinhx.markers",
             "pyjinhx._component",
             "pyjinhx.segments",
             "pyjinhx.assets",
+            "pyjinhx.config",
         }
     ),
     # pjx_table family (#526): each component module imports only the core
@@ -647,6 +653,7 @@ def test_session_never_reaches_into_reactive():
         "pyjinhx._component",
         "pyjinhx.segments",
         "pyjinhx.assets",
+        "pyjinhx.config",
     }
 
 
@@ -659,13 +666,18 @@ def test_nothing_below_config_imports_config():
     chain the app's lifespan — the two modules' mutual edges are each lazy
     (config imports integrations.fastapi inside setup(), see its own entry
     above) so the runtime cycle never actually executes at import time.
+
+    session.py is the second exception, and a lazy one: request_scope() calls
+    current_settings() inside its own body to seed a default session's Jinja
+    environment. The edge never executes at import time, and
+    test_session_only_imports_config_inside_a_function_body pins it there.
     """
     importers = {
         module_name(path)
         for path in module_paths()
         if "pyjinhx.config" in internal_imports(path)
     }
-    assert importers == {"integrations.fastapi"}
+    assert importers == {"integrations.fastapi", "session"}
 
 
 def test_nothing_imports_context():
@@ -710,6 +722,16 @@ def test_component_only_imports_render_and_session_inside_a_method_body():
     module_level = module_level_internal_imports(PACKAGE_ROOT / "_component.py")
     assert "pyjinhx.rendering" not in module_level
     assert "pyjinhx.session" not in module_level
+
+
+def test_session_only_imports_config_inside_a_function_body():
+    """request_scope() reads current_settings() to seed a default session's
+    Jinja environment, but config sits above the render spine: a module-scope
+    edge would invert the layering and, because config imports the spine at
+    import time, would be a genuine cycle. The whole-file edge table can't see
+    where in the file an import lives, so pin it here."""
+    module_level = module_level_internal_imports(PACKAGE_ROOT / "session.py")
+    assert "pyjinhx.config" not in module_level
 
 
 def test_no_render_spine_module_declares_a_reactive_import():

--- a/tests/pyjinhx/test_session.py
+++ b/tests/pyjinhx/test_session.py
@@ -479,3 +479,35 @@ def test_render_session_still_constructs_with_no_arguments():
     assert session.jinja_env.autoescape is True
     assert "range" in session.jinja_env.globals
     assert "upper" in session.jinja_env.filters
+
+
+def test_request_scope_applies_the_configured_globals_and_filters():
+    """The default-construction branch is the only place settings are read, so
+    an app that never builds its own session still gets its Jinja extras."""
+    from pyjinhx.config import PjxSettings, configure_pyjinhx, shutdown_pyjinhx
+
+    configure_pyjinhx(
+        PjxSettings(jinja_globals={"x": 1}, jinja_filters={"shout": str.upper})
+    )
+    try:
+        with session_module.request_scope() as session:
+            assert session.jinja_env.globals["x"] == 1
+            assert session.jinja_env.filters["shout"] is str.upper
+            assert "range" in session.jinja_env.globals
+    finally:
+        shutdown_pyjinhx()
+
+
+def test_request_scope_leaves_a_caller_supplied_session_alone():
+    """A pre-built session is the caller's business — the FastAPI middleware
+    builds its own and attaches hooks to it before the scope opens."""
+    from pyjinhx.config import PjxSettings, configure_pyjinhx, shutdown_pyjinhx
+
+    configure_pyjinhx(PjxSettings(jinja_globals={"x": 1}))
+    prebuilt = session_module.RenderSession()
+    try:
+        with session_module.request_scope(session=prebuilt) as session:
+            assert session is prebuilt
+            assert "x" not in session.jinja_env.globals
+    finally:
+        shutdown_pyjinhx()

--- a/tests/pyjinhx/test_session.py
+++ b/tests/pyjinhx/test_session.py
@@ -455,3 +455,27 @@ def test_exception_inside_the_block_still_resets_load_context():
         pass
 
     assert session_module.get_load_context() is None
+
+
+def test_render_session_registers_jinja_globals_alongside_the_builtins():
+    def now() -> str:
+        return "noon"
+
+    session = session_module.RenderSession(jinja_globals={"now": now})
+    assert session.jinja_env.globals["now"] is now
+    # Updating rather than reassigning is the whole point: Jinja's own globals
+    # must survive the addition.
+    assert "range" in session.jinja_env.globals
+
+
+def test_render_session_registers_jinja_filters_alongside_the_builtins():
+    session = session_module.RenderSession(jinja_filters={"shout": str.upper})
+    assert session.jinja_env.filters["shout"] is str.upper
+    assert "upper" in session.jinja_env.filters
+
+
+def test_render_session_still_constructs_with_no_arguments():
+    session = session_module.RenderSession()
+    assert session.jinja_env.autoescape is True
+    assert "range" in session.jinja_env.globals
+    assert "upper" in session.jinja_env.filters


### PR DESCRIPTION
## Summary

- Add `jinja_globals` and `jinja_filters` fields to `PjxSettings` for configuring Jinja template globals and filters
- Let `RenderSession` register extra Jinja globals and filters at construction time
- Seed request_scope's default session from the configured Jinja globals/filters
- Correct documentation about `RenderSession` initialization
- Fix basedpyright type error and ruff formatting issues

## Test Results

New tests added covering the configuration and session behavior with custom globals and filters.

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxwB6LvymhekN1iFNoNbqu