### PR TITLE
style: fix ruff formatting in documentation files

### DIFF
--- a/docs/api/responses.md
+++ b/docs/api/responses.md
@@ -105,6 +105,7 @@ Detection is duck-typed on that shape, not on `RedirectResponse`, so hand-built 
 ```python
 from starlette.responses import RedirectResponse
 
+
 @app.post("/todos")
 def create(title: str):
     ...

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -180,8 +180,7 @@ def load(cls, todo_id: int | str, ctx: TodoAppContext | None = None) -> "ItemRow
 
 # AFTER (1.2.0)
 @classmethod
-def load(cls, todo_id: int, ctx: TodoAppContext | None = None) -> "ItemRow":
-    ...
+def load(cls, todo_id: int, ctx: TodoAppContext | None = None) -> "ItemRow": ...
 ```
 
 A value that will not validate is passed through untouched rather than raised on — `load()`

--- a/docs/superpowers/rebuild/adr/0013-absence-is-proved-by-a-failed-load.md
+++ b/docs/superpowers/rebuild/adr/0013-absence-is-proved-by-a-failed-load.md
@@ -11,7 +11,7 @@ The L3.5 implementation read that miss as evidence of absence:
 ```python
 resolved, found = _resolve_registry_entry(cls, instance_id)
 if not found:
-    status = "missing"      # -> <div hx-swap-oob="delete:[data-pjx-id='...']">
+    status = "missing"  # -> <div hx-swap-oob="delete:[data-pjx-id='...']">
 ```
 
 Compose E6 and E7 and that reading collapses. In production the registry is written only by `register_rendered_instance`, subscribed to `on_rendered`, so it contains exactly the regions the *current* request rendered. A T2 request renders its primary and nothing else. Every region outside the primary tree — which is precisely the set fan-out exists to refresh — therefore misses the registry as a matter of course.

--- a/pyjinhx/_component.py
+++ b/pyjinhx/_component.py
@@ -108,6 +108,13 @@ def _is_slot_field(cls: type, field_name: str) -> bool:
     children field, it carries a :class:`PjxSlot` marker in its ``Annotated``
     metadata, or its annotation names a component (see
     :func:`_is_component_typed_annotation`). Unknown field names are not slots.
+
+    The marker is looked for in two places. Pydantic hoists metadata into
+    ``field.metadata`` only from the outermost ``Annotated``, so a field spelled
+    ``Slot | None`` arrives with empty metadata and the marker still nested
+    inside the union; unwrapping the annotation the way
+    :func:`_is_component_typed_annotation` does recovers it. A union that keeps
+    more than one non-``None`` type is too ambiguous to read a marker out of.
     """
     if field_name == getattr(cls, "_pjx_children_field", None):
         return True
@@ -117,6 +124,13 @@ def _is_slot_field(cls: type, field_name: str) -> bool:
         return False
     if any(isinstance(m, PjxSlot) for m in field.metadata):
         return True
+    annotation = field.annotation
+    if get_origin(annotation) in (Union, types.UnionType):
+        args = [a for a in get_args(annotation) if a is not type(None)]
+        if len(args) == 1:
+            inner_metadata = getattr(args[0], "__metadata__", ())
+            if any(isinstance(m, PjxSlot) for m in inner_metadata):
+                return True
     return _is_component_typed_annotation(field.annotation)
 
 

--- a/tests/pyjinhx/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx/reactive/test_reactive_fanout.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 import re
-from typing import Annotated
+from typing import Annotated, cast
 
 import pytest
 
@@ -994,4 +994,4 @@ def test_a_string_load_arg_reaches_load_as_the_declared_int(tmp_path):
     assert INT_KEY_LOAD_ARGS == [1]
     assert candidate.status == "dirty"
     assert candidate.instance is not None
-    assert candidate.instance.title == "first"
+    assert cast(IntKeyedWidget, candidate.instance).title == "first"


### PR DESCRIPTION
## Summary
- Fix ruff formatting violations in documentation files
- Add type cast for IntKeyedWidget in test_reactive_fanout.py to resolve type checking issues
- Fix detection of PjxSlot through a nullable union in _is_slot_field

## Test plan
- All existing tests pass
- Ruff formatting and linting checks pass (0.16.0)

Closes #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)