### PR TITLE
feat: add PJXPromptDialog template and co-located css/js assets

### DIFF
--- a/pyjinhx/builtins/ui/pjx_prompt_dialog/__init__.py
+++ b/pyjinhx/builtins/ui/pjx_prompt_dialog/__init__.py
@@ -1,0 +1,3 @@
+from pyjinhx.builtins.ui.pjx_prompt_dialog.pjx_prompt_dialog import PJXPromptDialog
+
+__all__ = ["PJXPromptDialog"]

--- a/pyjinhx/builtins/ui/pjx_prompt_dialog/pjx_prompt_dialog.css
+++ b/pyjinhx/builtins/ui/pjx_prompt_dialog/pjx_prompt_dialog.css
@@ -1,0 +1,59 @@
+:where(:root) {
+  --pjx-prompt-dialog-bg:       var(--surface);
+  --pjx-prompt-dialog-border:   var(--border);
+  --pjx-prompt-dialog-radius:   var(--radius-md);
+  --pjx-prompt-dialog-shadow:   var(--shadow-md);
+  --pjx-prompt-dialog-backdrop: rgb(0 0 0 / 0.5);
+}
+
+.pjx-prompt-dialog::backdrop {
+  background: var(--pjx-prompt-dialog-backdrop);
+}
+
+.pjx-prompt-dialog[open] {
+  margin: auto;
+  padding: 0;
+  border: 1px solid var(--pjx-prompt-dialog-border);
+  border-radius: var(--pjx-prompt-dialog-radius);
+  background: var(--pjx-prompt-dialog-bg);
+  box-shadow: var(--pjx-prompt-dialog-shadow);
+  max-width: min(26rem, calc(100vw - 2rem));
+}
+
+.pjx-prompt-dialog__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.pjx-prompt-dialog__label {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.pjx-prompt-dialog__input {
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-alt);
+  color: var(--text);
+  font: inherit;
+}
+
+.pjx-prompt-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.pjx-prompt-dialog__ok,
+.pjx-prompt-dialog__cancel {
+  padding: 0.4rem 0.9rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+}

--- a/pyjinhx/builtins/ui/pjx_prompt_dialog/pjx_prompt_dialog.js
+++ b/pyjinhx/builtins/ui/pjx_prompt_dialog/pjx_prompt_dialog.js
@@ -1,0 +1,53 @@
+(function () {
+    window.pjx = window.pjx || {};
+    if (pjx.prompt) return;
+
+    function dialogEl() {
+        return document.querySelector('dialog[data-pjx-dialog="prompt"]');
+    }
+
+    function prompt(title, options) {
+        const opts = options || {};
+        const dialog = dialogEl();
+        if (!dialog) return Promise.resolve(window.prompt(title, opts.initial || ''));
+        if (dialog.open) return Promise.resolve(null); // singleton busy: treat as cancelled
+
+        const label = dialog.querySelector('.pjx-prompt-dialog__label');
+        const input = dialog.querySelector('.pjx-prompt-dialog__input');
+        const okBtn = dialog.querySelector('.pjx-prompt-dialog__ok');
+        const cancelBtn = dialog.querySelector('.pjx-prompt-dialog__cancel');
+        const form = dialog.querySelector('form');
+
+        label.textContent = title;
+        input.value = opts.initial || '';
+        input.placeholder = opts.placeholder || '';
+        const prevOk = okBtn.textContent;
+        const prevCancel = cancelBtn.textContent;
+        if (opts.okLabel) okBtn.textContent = opts.okLabel;
+        if (opts.cancelLabel) cancelBtn.textContent = opts.cancelLabel;
+
+        dialog.showModal();
+        // Defer focus so the dialog has rendered; select() lets the user
+        // type-replace a prefilled value immediately.
+        setTimeout(() => { input.focus(); input.select(); }, 0);
+
+        return new Promise((resolve) => {
+            const ac = new AbortController();
+            const done = (result) => {
+                okBtn.textContent = prevOk;
+                cancelBtn.textContent = prevCancel;
+                ac.abort();
+                if (dialog.open) dialog.close();
+                resolve(result);
+            };
+            form.addEventListener('submit', (e) => {
+                e.preventDefault();
+                done(input.value.trim() || null);
+            }, { signal: ac.signal });
+            cancelBtn.addEventListener('click', () => done(null), { signal: ac.signal });
+            dialog.addEventListener('close', () => done(null), { signal: ac.signal });
+        });
+    }
+
+    pjx.prompt = prompt;
+}());

--- a/pyjinhx/builtins/ui/pjx_prompt_dialog/pjx_prompt_dialog.pjx
+++ b/pyjinhx/builtins/ui/pjx_prompt_dialog/pjx_prompt_dialog.pjx
@@ -1,0 +1,10 @@
+<dialog id="{{ id }}" class="pjx-prompt-dialog{% if class_name %} {{ class_name }}{% endif %}" data-pjx-dialog="prompt" aria-modal="true" aria-labelledby="{{ id }}-label">
+    <form method="dialog" class="pjx-prompt-dialog__card">
+        <label id="{{ id }}-label" class="pjx-prompt-dialog__label" for="{{ id }}-input">{{ input_label }}</label>
+        <input id="{{ id }}-input" class="pjx-prompt-dialog__input" type="text" autocomplete="off" />
+        <div class="pjx-prompt-dialog__actions">
+            <button type="button" class="pjx-prompt-dialog__cancel">{{ cancel_label }}</button>
+            <button type="submit" class="pjx-prompt-dialog__ok">{{ submit_label }}</button>
+        </div>
+    </form>
+</dialog>

--- a/pyjinhx/builtins/ui/pjx_prompt_dialog/pjx_prompt_dialog.py
+++ b/pyjinhx/builtins/ui/pjx_prompt_dialog/pjx_prompt_dialog.py
@@ -1,0 +1,10 @@
+from pyjinhx._component import AttrValue, BaseComponent
+
+
+class PJXPromptDialog(BaseComponent):
+    """The prompt shell and its label/button text; the question, initial value and open/close are driven by pjx.prompt(), not by fields here."""
+
+    input_label: str = ""
+    submit_label: str = "OK"
+    cancel_label: str = "Cancel"
+    class_name: AttrValue = ""

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -148,6 +148,12 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "builtins.ui.pjx_confirm_dialog.pjx_confirm_dialog": frozenset(
         {"pyjinhx._component"}
     ),
+    "builtins.ui.pjx_prompt_dialog.__init__": frozenset(
+        {"pyjinhx.builtins.ui.pjx_prompt_dialog.pjx_prompt_dialog"}
+    ),
+    "builtins.ui.pjx_prompt_dialog.pjx_prompt_dialog": frozenset(
+        {"pyjinhx._component"}
+    ),
     # pjx_drawer family (#518): the slide-in dialog shell plus its
     # header/body/footer regions. Same shape as the modal family — each
     # component module reaches down into _component.py only; each __init__ just


### PR DESCRIPTION
## Summary
Adds the PJXPromptDialog component to v2, including the BaseComponent subclass, package exports, template, and co-located CSS/JS assets. Renames assets from dashed v0 filenames to snake_case per ADR 0007.

## Test plan
- [x] Import graph entries updated and verified in test_import_graph.py

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxwB6LvymhekN1iFNoNbqu