### PR TITLE
docs: reformat jinja setup() example for ruff format compliance

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -94,7 +94,11 @@ Pass a settings object via `settings=`, or override individual fields with expli
 ```python
 from pyjinhx import setup
 
-setup(app, jinja_globals={"site_name": "Acme"}, jinja_filters={"money": lambda cents: f"${cents / 100:,.2f}"})
+setup(
+    app,
+    jinja_globals={"site_name": "Acme"},
+    jinja_filters={"money": lambda cents: f"${cents / 100:,.2f}"},
+)
 ```
 
 Templates then read `{{ site_name }}` and `{{ total | money }}` with no per-component wiring.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -28,7 +28,9 @@ Sidebar = component("Sidebar", template_dir="./widgets")  # reads ./widgets/side
 
 ### Passing a Pre-Built Session
 
-For full control over the underlying Jinja environment — or to attach `on_rendered` hooks before the session goes live — construct a `RenderSession` yourself and bind it for the scope:
+Prefer `jinja_globals` and `jinja_filters` on `setup()` for adding names to templates — see [Jinja globals and filters](#jinja-globals-and-filters). Building the session by hand is for the two cases `setup(app)` does not cover: pyjinhx has no backend integration for the framework you are on, or you need to attach `on_rendered` hooks to the session before it goes live.
+
+In those cases, construct a `RenderSession` yourself and bind it for the scope:
 
 ```python
 from pyjinhx import RenderSession
@@ -42,13 +44,11 @@ with request_scope(session=session):
     ...
 ```
 
-`RenderSession()` takes two optional keyword arguments, `jinja_globals=` and `jinja_filters=`, and `request_scope()` takes only `session=` and `load_context=`.
+`RenderSession()` takes two optional keyword arguments, `jinja_globals=` and `jinja_filters=`, and `request_scope()` takes only `session=` and `load_context=`. A session you build yourself is used as-is: `request_scope()` reads `PjxSettings` for the Jinja mappings only when it has to construct the session itself.
 
 !!! note "Not yet public"
     `RenderSession` is exported from `pyjinhx`; `request_scope` is not — it lives in
-    `pyjinhx.session`, outside `pyjinhx.__all__`. Under `setup(app)` you never open the
-    scope yourself, so reach for this only when you are wiring a framework pyjinhx has no
-    backend for.
+    `pyjinhx.session`, outside `pyjinhx.__all__`.
 
 ## Logging
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -82,8 +82,26 @@ setup(app, context_factory=lambda req: AppLoadContext(db=get_db(req)))
 - `inject_htmx` — recorded only today; nothing reads it, so the vendored htmx runtime ships with `pjx.js` either way (default `True`)
 - `components_root` — path to scan for classless components; setting it triggers component discovery (default `None`)
 - `static_root` — path to serve static assets from (default `None`)
+- `jinja_globals` — extra names to expose to every template, as a mapping of name to value (default `None`)
+- `jinja_filters` — extra filters to expose to every template, as a mapping of filter name to callable (default `None`)
 
 Pass a settings object via `settings=`, or override individual fields with explicit `setup()` keyword arguments. Explicit `setup()` kwargs take precedence over values from `settings=`.
+
+### Jinja globals and filters
+
+`jinja_globals` and `jinja_filters` are the supported way to register names app-wide. Pass them to `setup()` and every request's Jinja environment gets them:
+
+```python
+from pyjinhx import setup
+
+setup(app, jinja_globals={"site_name": "Acme"}, jinja_filters={"money": lambda cents: f"${cents / 100:,.2f}"})
+```
+
+Templates then read `{{ site_name }}` and `{{ total | money }}` with no per-component wiring.
+
+Both default to `None`, which means "nothing extra to add" — not "start from an empty environment". Jinja seeds its own globals and filters (`range`, `dict`, `|upper`, `|length`, and the rest of the standard library) into every environment first, and these settings are merged on top. Passing `jinja_globals={...}` adds to that seed; it does not replace it. A name that collides with a builtin wins.
+
+There is no environment variable for either field: `PjxSettings.from_env()` reads only the four `PJX_*` variables listed below.
 
 ### Environment variables
 


### PR DESCRIPTION
## Summary
- Reformatted embedded Python code fences in markdown to comply with ruff format (line-length rule)
- Added documentation for jinja_globals and jinja_filters settings
- Scoped pre-built session route documentation

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)