### PR TITLE
fix: suppress basedpyright on the lazy builtins module attribute check

### DIFF
--- a/pyjinhx/builtins/__init__.py
+++ b/pyjinhx/builtins/__init__.py
@@ -31,6 +31,7 @@ __all__ = [  # noqa: RUF022
     "PJXCarousel",
     "PJXCarouselSlide",
     "PJXChipInput",
+    "PJXConfirmDialog",
     "PJXDivider",
     "PJXDrawer",
     "PJXDrawerBody",
@@ -121,6 +122,10 @@ _lazy_imports = {
     "PJXChipInput": (
         "pyjinhx.builtins.ui.pjx_chip_input.pjx_chip_input",
         "PJXChipInput",
+    ),
+    "PJXConfirmDialog": (
+        "pyjinhx.builtins.ui.pjx_confirm_dialog.pjx_confirm_dialog",
+        "PJXConfirmDialog",
     ),
     "PJXDivider": ("pyjinhx.builtins.ui.pjx_divider.pjx_divider", "PJXDivider"),
     "PJXDrawer": ("pyjinhx.builtins.ui.pjx_drawer.pjx_drawer", "PJXDrawer"),

--- a/pyjinhx/builtins/__init__.py
+++ b/pyjinhx/builtins/__init__.py
@@ -54,6 +54,7 @@ __all__ = [  # noqa: RUF022
     "PJXPopoverPanel",
     "PJXPopoverTrigger",
     "PJXProgress",
+    "PJXPromptDialog",
     "PJXRegionLoader",
     "PJXResizableGroup",
     "PJXResizableHandle",
@@ -188,6 +189,10 @@ _lazy_imports = {
         "PJXPopoverTrigger",
     ),
     "PJXProgress": ("pyjinhx.builtins.ui.pjx_progress.pjx_progress", "PJXProgress"),
+    "PJXPromptDialog": (
+        "pyjinhx.builtins.ui.pjx_prompt_dialog.pjx_prompt_dialog",
+        "PJXPromptDialog",
+    ),
     "PJXRegionLoader": (
         "pyjinhx.builtins.pjx_region_loader.pjx_region_loader",
         "PJXRegionLoader",

--- a/tests/pyjinhx/builtins/pjx_confirm_dialog/test_pjx_confirm_dialog.py
+++ b/tests/pyjinhx/builtins/pjx_confirm_dialog/test_pjx_confirm_dialog.py
@@ -74,4 +74,4 @@ def test_undeclared_attr_is_rejected():
 def test_exported_from_the_builtins_namespace():
     """`from pyjinhx.builtins import PJXConfirmDialog` must resolve through the lazy export table."""
     assert "PJXConfirmDialog" in builtins.__all__
-    assert builtins.PJXConfirmDialog is PJXConfirmDialog
+    assert builtins.PJXConfirmDialog is PJXConfirmDialog  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/pyjinhx/builtins/pjx_confirm_dialog/test_pjx_confirm_dialog.py
+++ b/tests/pyjinhx/builtins/pjx_confirm_dialog/test_pjx_confirm_dialog.py
@@ -1,0 +1,77 @@
+"""PJXConfirmDialog renders the single-root <dialog> confirm shell; its message text and open/close come from pjx.confirm(), not from fields."""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx import builtins
+from pyjinhx.builtins.ui.pjx_confirm_dialog import PJXConfirmDialog
+from pyjinhx.rendering import render
+from pyjinhx.session import RenderSession
+
+EXPECTED_DEFAULT = (
+    '<dialog id="cd" class="pjx-confirm-dialog" data-pjx-dialog="confirm" aria-modal="true" aria-labelledby="cd-message">\n'
+    '    <div class="pjx-confirm-dialog__card">\n'
+    '        <p id="cd-message" class="pjx-confirm-dialog__message"></p>\n'
+    '        <div class="pjx-confirm-dialog__actions">\n'
+    '            <button type="button" class="pjx-confirm-dialog__cancel">Cancel</button>\n'
+    '            <button type="button" class="pjx-confirm-dialog__ok">Confirm</button>\n'
+    "        </div>\n"
+    "    </div>\n"
+    "</dialog>"
+)
+
+
+@pytest.fixture
+def confirm_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve."""
+    return RenderSession()
+
+
+def _html(session, **kw) -> str:
+    return render(PJXConfirmDialog(id="cd", **kw), session)
+
+
+def test_default_render_is_single_confirm_dialog(confirm_session):
+    assert _html(confirm_session) == EXPECTED_DEFAULT
+
+
+def test_id_renders_on_the_dialog(confirm_session):
+    html = _html(confirm_session)
+    assert '<dialog id="cd"' in html
+    assert 'data-pjx-dialog="confirm"' in html
+
+
+def test_class_name_appended_to_root(confirm_session):
+    assert 'class="pjx-confirm-dialog mine"' in _html(
+        confirm_session, class_name="mine"
+    )
+
+
+def test_empty_class_name_adds_nothing(confirm_session):
+    assert 'class="pjx-confirm-dialog"' in _html(confirm_session, class_name="")
+
+
+def test_confirm_label_renders_on_ok_button(confirm_session):
+    html = _html(confirm_session, confirm_label="Delete")
+    assert (
+        '<button type="button" class="pjx-confirm-dialog__ok">Delete</button>' in html
+    )
+
+
+def test_cancel_label_renders_on_cancel_button(confirm_session):
+    html = _html(confirm_session, cancel_label="Nope")
+    assert (
+        '<button type="button" class="pjx-confirm-dialog__cancel">Nope</button>' in html
+    )
+
+
+def test_undeclared_attr_is_rejected():
+    """v2 core is strict (extra="forbid"): v0.x's extra_attrs pass-through is gone."""
+    with pytest.raises(ValidationError):
+        PJXConfirmDialog(id="cd", extra_attrs={"data-k": "v"})  # pyright: ignore[reportCallIssue]
+
+
+def test_exported_from_the_builtins_namespace():
+    """`from pyjinhx.builtins import PJXConfirmDialog` must resolve through the lazy export table."""
+    assert "PJXConfirmDialog" in builtins.__all__
+    assert builtins.PJXConfirmDialog is PJXConfirmDialog

--- a/tests/pyjinhx/builtins/pjx_prompt_dialog/test_pjx_prompt_dialog.py
+++ b/tests/pyjinhx/builtins/pjx_prompt_dialog/test_pjx_prompt_dialog.py
@@ -79,4 +79,4 @@ def test_undeclared_attr_is_rejected():
 def test_exported_from_the_builtins_namespace():
     """`from pyjinhx.builtins import PJXPromptDialog` must resolve through the lazy export table."""
     assert "PJXPromptDialog" in builtins.__all__
-    assert builtins.PJXPromptDialog is PJXPromptDialog
+    assert builtins.PJXPromptDialog is PJXPromptDialog  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/pyjinhx/builtins/pjx_prompt_dialog/test_pjx_prompt_dialog.py
+++ b/tests/pyjinhx/builtins/pjx_prompt_dialog/test_pjx_prompt_dialog.py
@@ -1,0 +1,82 @@
+"""PJXPromptDialog renders the single-root <dialog> prompt shell; its question, initial value and open/close come from pjx.prompt(), not from fields."""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx import builtins
+from pyjinhx.builtins.ui.pjx_prompt_dialog import PJXPromptDialog
+from pyjinhx.rendering import render
+from pyjinhx.session import RenderSession
+
+EXPECTED_DEFAULT = (
+    '<dialog id="pd" class="pjx-prompt-dialog" data-pjx-dialog="prompt" aria-modal="true" aria-labelledby="pd-label">\n'
+    '    <form method="dialog" class="pjx-prompt-dialog__card">\n'
+    '        <label id="pd-label" class="pjx-prompt-dialog__label" for="pd-input"></label>\n'
+    '        <input id="pd-input" class="pjx-prompt-dialog__input" type="text" autocomplete="off" />\n'
+    '        <div class="pjx-prompt-dialog__actions">\n'
+    '            <button type="button" class="pjx-prompt-dialog__cancel">Cancel</button>\n'
+    '            <button type="submit" class="pjx-prompt-dialog__ok">OK</button>\n'
+    "        </div>\n"
+    "    </form>\n"
+    "</dialog>"
+)
+
+
+@pytest.fixture
+def prompt_session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve."""
+    return RenderSession()
+
+
+def _html(session, **kw) -> str:
+    return render(PJXPromptDialog(id="pd", **kw), session)
+
+
+def test_default_render_is_single_prompt_dialog(prompt_session):
+    assert _html(prompt_session) == EXPECTED_DEFAULT
+
+
+def test_id_renders_on_the_dialog(prompt_session):
+    html = _html(prompt_session)
+    assert '<dialog id="pd"' in html
+    assert 'data-pjx-dialog="prompt"' in html
+
+
+def test_class_name_appended_to_root(prompt_session):
+    assert 'class="pjx-prompt-dialog mine"' in _html(prompt_session, class_name="mine")
+
+
+def test_empty_class_name_adds_nothing(prompt_session):
+    assert 'class="pjx-prompt-dialog"' in _html(prompt_session, class_name="")
+
+
+def test_submit_label_renders_on_submit_button(prompt_session):
+    html = _html(prompt_session, submit_label="Rename")
+    assert '<button type="submit" class="pjx-prompt-dialog__ok">Rename</button>' in html
+
+
+def test_cancel_label_renders_on_cancel_button(prompt_session):
+    html = _html(prompt_session, cancel_label="Nope")
+    assert (
+        '<button type="button" class="pjx-prompt-dialog__cancel">Nope</button>' in html
+    )
+
+
+def test_input_label_renders_on_label(prompt_session):
+    html = _html(prompt_session, input_label="New name")
+    assert (
+        '<label id="pd-label" class="pjx-prompt-dialog__label" for="pd-input">New name</label>'
+        in html
+    )
+
+
+def test_undeclared_attr_is_rejected():
+    """v2 core is strict (extra="forbid"): v0.x's extra_attrs pass-through is gone."""
+    with pytest.raises(ValidationError):
+        PJXPromptDialog(id="pd", extra_attrs={"data-k": "v"})  # pyright: ignore[reportCallIssue]
+
+
+def test_exported_from_the_builtins_namespace():
+    """`from pyjinhx.builtins import PJXPromptDialog` must resolve through the lazy export table."""
+    assert "PJXPromptDialog" in builtins.__all__
+    assert builtins.PJXPromptDialog is PJXPromptDialog


### PR DESCRIPTION
## Summary

Suppress basedpyright static analysis on lazy module exports. The pyjinhx.builtins module uses a custom ModuleType subclass with `__getattr__` for lazy exports. basedpyright only recognizes PEP 562 module-level `__getattr__` functions, so it cannot statically resolve attribute access through the dynamically-swapped module. Same suppression pattern already used elsewhere in the test suite.

Closes #785

## Test coverage

- PJXConfirmDialog export and test coverage
- PJXPromptDialog export and test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)