### PR TITLE
chore: ruff import ordering

### DIFF
--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -35,6 +35,7 @@ from pyjinhx.registry import register_rendered_instance
 from pyjinhx.responses import PASSTHROUGH, PjxResponse, compose
 from pyjinhx.session import (
     RenderSession,
+    _environment_for,
     accumulate_assets,
     current_session,
     request_scope,
@@ -199,10 +200,7 @@ class PjxScopeMiddleware(BaseHTTPMiddleware):
         # settings, but it leaves a caller-supplied one alone — so the same
         # seeding has to happen here, at the only call site that supplies one.
         settings = current_settings()
-        session = RenderSession(
-            jinja_globals=settings.jinja_globals,
-            jinja_filters=settings.jinja_filters,
-        )
+        session = RenderSession(jinja_env=_environment_for(settings))
         session.on_rendered.append(accumulate_assets)
         session.on_rendered.append(stamp_reactive_root_attrs)
         session.on_rendered.append(register_rendered_instance)

--- a/pyjinhx/session.py
+++ b/pyjinhx/session.py
@@ -145,25 +145,32 @@ class RenderSession:
     def __init__(
         self,
         *,
+        jinja_env: Environment | None = None,
         jinja_globals: Mapping[str, Any] | None = None,
         jinja_filters: Mapping[str, Any] | None = None,
     ):
-        """Initialize render session, optionally with extra Jinja globals and filters."""
-        self.jinja_env = Environment(
-            loader=AbsolutePathLoader(),
-            autoescape=True,
-            # Interpolating a component-valued slot must not stringify it; the
-            # hook swaps in a placeholder the render pipeline resolves later.
-            finalize=finalize_slot_node,
+        """Initialize render session, optionally with extra Jinja globals and filters.
+
+        ``jinja_env`` adopts an already-built environment: this is how the two
+        request paths hand in the process-wide cached one instead of paying for
+        a fresh environment — and a cold template cache — per request. It is
+        mutually exclusive with the two mappings, which build a private
+        environment for a session the caller assembles by hand.
+        """
+        if jinja_env is not None and (
+            jinja_globals is not None or jinja_filters is not None
+        ):
+            raise TypeError(
+                "pass jinja_env or jinja_globals/jinja_filters, not both: an "
+                "adopted environment is shared with every other session built "
+                "from the same settings, so updating it here would leak this "
+                "session's names into all of them."
+            )
+        self.jinja_env = (
+            jinja_env
+            if jinja_env is not None
+            else _build_environment(jinja_globals, jinja_filters)
         )
-        # update(), never assignment: Jinja seeds both mappings with its own
-        # builtins (range, dict, |upper, |length ...) and replacing the mapping
-        # outright would take a template's whole standard library with it.
-        # None is "nothing to add", not "clear".
-        if jinja_globals is not None:
-            self.jinja_env.globals.update(jinja_globals)
-        if jinja_filters is not None:
-            self.jinja_env.filters.update(jinja_filters)
         # Generic per-request asset slot from the #423 ContextVar model
         # (predates L2.2.1's descriptor accumulator below); no producer in
         # this codebase writes to it yet, so it stays as-is for whatever

--- a/pyjinhx/session.py
+++ b/pyjinhx/session.py
@@ -1,5 +1,6 @@
 """RenderSession, the per-request ContextVars, and the request_scope that owns them."""
 
+import threading
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -16,6 +17,11 @@ if TYPE_CHECKING:
     # them at runtime would point session at its own consumers.
     from pyjinhx._component import BaseComponent
     from pyjinhx.segments import RenderedLevel
+
+    # Type-only for the same reason config is imported inside request_scope()'s
+    # body and nowhere else: config sits above the render spine, so a runtime
+    # module-scope edge back would be a genuine cycle.
+    from pyjinhx.config import PjxSettings
 
 # The seven pieces of per-request mutable state. They live here rather than
 # beside their eventual consumers because the import rule runs one way only:
@@ -72,6 +78,65 @@ class AbsolutePathLoader(BaseLoader):
                 return False
 
         return source, str(path), uptodate
+
+
+def _build_environment(
+    jinja_globals: Mapping[str, Any] | None,
+    jinja_filters: Mapping[str, Any] | None,
+) -> Environment:
+    """A new Jinja environment with pyjinhx's loader, autoescape and slot finalize."""
+    env = Environment(
+        loader=AbsolutePathLoader(),
+        autoescape=True,
+        # Interpolating a component-valued slot must not stringify it; the
+        # hook swaps in a placeholder the render pipeline resolves later.
+        finalize=finalize_slot_node,
+    )
+    # update(), never assignment: Jinja seeds both mappings with its own
+    # builtins (range, dict, |upper, |length ...) and replacing the mapping
+    # outright would take a template's whole standard library with it.
+    # None is "nothing to add", not "clear".
+    if jinja_globals is not None:
+        env.globals.update(jinja_globals)
+    if jinja_filters is not None:
+        env.filters.update(jinja_filters)
+    return env
+
+
+# Keyed by id(settings) rather than by the settings object, because PjxSettings
+# is a frozen dataclass: two distinct instances with equal fields hash and
+# compare equal, and one carrying a plain dict in jinja_globals is not hashable
+# at all. Identity is what an environment's contents actually depend on. The
+# settings object is stored beside its environment so CPython cannot recycle
+# its id onto a different object while the entry is live.
+_environment_cache: dict[int, tuple["PjxSettings", Environment]] = {}
+# architecture-overview.md invariant 4: process-wide mutable state is either
+# built-then-swapped under a lock, or ContextVar-scoped - no third category.
+# This dict is mutated in place (not swapped), so the lock has to wrap every
+# read-or-build, matching classless.py's _build_lock / discovery.py's
+# _registry_lock shape. Without it, two threads racing the first lookup for
+# one settings instance could each build and store their own Environment,
+# and a session already handed the loser would render off a discarded one -
+# silently breaking "one environment per settings" under the exact
+# concurrency this cache exists to survive.
+_environment_cache_lock = threading.Lock()
+
+
+def _environment_for(settings: "PjxSettings") -> Environment:
+    """The process-wide Jinja environment for ``settings``, built on first use.
+
+    Every request served under one settings object shares one environment.
+    Building a fresh one per request threw away Jinja's template cache — which
+    lives on the environment — so every request re-read and re-compiled every
+    template it touched.
+    """
+    with _environment_cache_lock:
+        cached = _environment_cache.get(id(settings))
+        if cached is not None:
+            return cached[1]
+        env = _build_environment(settings.jinja_globals, settings.jinja_filters)
+        _environment_cache[id(settings)] = (settings, env)
+        return env
 
 
 class RenderSession:

--- a/pyjinhx/session.py
+++ b/pyjinhx/session.py
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
     # Type-only: the hook's signature names the spine's own types, but importing
     # them at runtime would point session at its own consumers.
     from pyjinhx._component import BaseComponent
-    from pyjinhx.segments import RenderedLevel
 
     # Type-only for the same reason config is imported inside request_scope()'s
     # body and nowhere else: config sits above the render spine, so a runtime
     # module-scope edge back would be a genuine cycle.
     from pyjinhx.config import PjxSettings
+    from pyjinhx.segments import RenderedLevel
 
 # The seven pieces of per-request mutable state. They live here rather than
 # beside their eventual consumers because the import rule runs one way only:

--- a/pyjinhx/session.py
+++ b/pyjinhx/session.py
@@ -369,10 +369,7 @@ def request_scope(
         from pyjinhx.config import current_settings
 
         settings = current_settings()
-        session = RenderSession(
-            jinja_globals=settings.jinja_globals,
-            jinja_filters=settings.jinja_filters,
-        )
+        session = RenderSession(jinja_env=_environment_for(settings))
     session_token = _render_session.set(session)
     instances_token = _instances.set({})
     dirtied_token = _dirtied.set(set())

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -549,3 +549,32 @@ def test_configured_jinja_globals_and_filters_reach_the_request_session():
 
     assert response.status_code == 200
     assert response.text == "pyjinhx|OK|B"
+
+
+def test_middleware_sessions_share_the_cached_environment():
+    """The middleware builds its own session so it can attach the render hooks,
+    so it is also the place that has to adopt the cached environment — two
+    requests must not each compile the app's templates from scratch."""
+    from pyjinhx.config import current_settings
+    from pyjinhx.session import _environment_for, current_session
+
+    seen: list[object] = []
+
+    app = FastAPI()
+    apply_setup(app, _settings(jinja_globals={"x": 1}))
+
+    @app.get("/render")
+    def render():
+        session = current_session()
+        assert session is not None
+        seen.append(session.jinja_env)
+        return PlainTextResponse(session.jinja_env.from_string("{{ x }}").render())
+
+    with TestClient(app) as client:
+        assert client.get("/render").text == "1"
+        assert client.get("/render").text == "1"
+        # Inside the client block: the lifespan's shutdown resets the process
+        # settings, and the cache keys on the settings instance that was live.
+        expected = _environment_for(current_settings())
+
+    assert seen == [expected, expected]

--- a/tests/pyjinhx/test_session.py
+++ b/tests/pyjinhx/test_session.py
@@ -704,3 +704,26 @@ def test_cached_environment_keeps_the_loader_autoescape_and_builtins():
         "{{ x }}|{{ 'ok'|shout }}|{{ 'b'|upper }}|{{ range(2)|list }}|{{ 'ab'|length }}"
     )
     assert template.render() == "1|OK|B|[0, 1]|2"
+
+
+def test_render_session_adopts_a_supplied_environment():
+    from pyjinhx.config import PjxSettings
+
+    env = session_module._environment_for(PjxSettings(jinja_globals={"x": 1}))
+    session = session_module.RenderSession(jinja_env=env)
+
+    assert session.jinja_env is env
+
+
+def test_render_session_rejects_an_adopted_environment_with_extras():
+    """An adopted environment is shared with every other session on the same
+    settings; updating it here would leak one session's names into all of them."""
+    from pyjinhx.config import PjxSettings
+
+    env = session_module._environment_for(PjxSettings())
+
+    with pytest.raises(TypeError):
+        session_module.RenderSession(jinja_env=env, jinja_globals={"x": 1})
+
+    with pytest.raises(TypeError):
+        session_module.RenderSession(jinja_env=env, jinja_filters={"shout": str.upper})

--- a/tests/pyjinhx/test_session.py
+++ b/tests/pyjinhx/test_session.py
@@ -590,3 +590,117 @@ def test_request_scope_with_unset_settings_still_renders_jinja_builtins():
             assert template.render() == "B[0, 1, 2]"
     finally:
         shutdown_pyjinhx()
+
+
+def test_environment_for_reuses_one_environment_per_settings_instance():
+    """The whole point of the hoist: every request served under one settings
+    object shares one environment, so Jinja's template cache survives the
+    request that filled it."""
+    from pyjinhx.config import PjxSettings
+
+    settings = PjxSettings(jinja_globals={"x": 1})
+
+    first = session_module._environment_for(settings)
+    second = session_module._environment_for(settings)
+
+    assert first is second
+
+
+def test_environment_for_does_not_share_across_value_equal_settings():
+    """PjxSettings is a frozen dataclass, so two distinct instances compare
+    equal — identity, not equality, is what the cache keys on. Two apps in one
+    process must never end up updating each other's environment."""
+    from pyjinhx.config import PjxSettings
+
+    one = PjxSettings()
+    two = PjxSettings()
+
+    assert one == two
+    assert session_module._environment_for(one) is not session_module._environment_for(
+        two
+    )
+
+
+def test_environment_for_keeps_each_settings_extras_to_itself():
+    from pyjinhx.config import PjxSettings
+
+    left = PjxSettings(jinja_globals={"left": 1}, jinja_filters={"lshout": str.upper})
+    right = PjxSettings(jinja_globals={"right": 2}, jinja_filters={"rshout": str.lower})
+
+    left_env = session_module._environment_for(left)
+    right_env = session_module._environment_for(right)
+
+    assert left_env.globals["left"] == 1
+    assert "right" not in left_env.globals
+    assert "rshout" not in left_env.filters
+    assert right_env.globals["right"] == 2
+    assert "left" not in right_env.globals
+    assert "lshout" not in right_env.filters
+
+
+def test_environment_for_does_not_reapply_the_extras_on_a_cache_hit():
+    """A cache hit must return the stored environment untouched: no second
+    construction, and no second .update() that would resurrect a name the app
+    deliberately removed after startup."""
+    from pyjinhx.config import PjxSettings
+
+    settings = PjxSettings(jinja_globals={"x": 1}, jinja_filters={"shout": str.upper})
+
+    env = session_module._environment_for(settings)
+    globals_before = env.globals
+    del env.globals["x"]
+    del env.filters["shout"]
+
+    again = session_module._environment_for(settings)
+
+    assert again is env
+    assert again.globals is globals_before
+    assert "x" not in again.globals
+    assert "shout" not in again.filters
+
+
+def test_environment_for_is_safe_under_concurrent_first_lookups():
+    """Two threads racing the first _environment_for(settings) call for the
+    same settings instance (e.g. two sync FastAPI handlers dispatched into
+    Starlette's threadpool) must not each build-and-store their own
+    Environment — the lock is what makes 'one environment per settings' hold
+    under real concurrency, not just in a single-threaded test."""
+    from pyjinhx.config import PjxSettings
+
+    settings = PjxSettings(jinja_globals={"x": 1})
+    start = threading.Barrier(8)
+    results: list[session_module.Environment] = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        start.wait(timeout=5)
+        env = session_module._environment_for(settings)
+        with lock:
+            results.append(env)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert len(results) == 8
+    assert len({id(env) for env in results}) == 1
+
+
+def test_cached_environment_keeps_the_loader_autoescape_and_builtins():
+    """Reuse changes nothing about how the environment is built: same loader,
+    same autoescape, and Jinja's own standard library still resolves next to
+    the configured extras."""
+    from pyjinhx.config import PjxSettings
+
+    settings = PjxSettings(jinja_globals={"x": 1}, jinja_filters={"shout": str.upper})
+
+    env = session_module._environment_for(settings)
+
+    assert isinstance(env.loader, session_module.AbsolutePathLoader)
+    assert env.autoescape is True
+    template = env.from_string(
+        "{{ x }}|{{ 'ok'|shout }}|{{ 'b'|upper }}|{{ range(2)|list }}|{{ 'ab'|length }}"
+    )
+    assert template.render() == "1|OK|B|[0, 1]|2"

--- a/tests/pyjinhx/test_session.py
+++ b/tests/pyjinhx/test_session.py
@@ -727,3 +727,28 @@ def test_render_session_rejects_an_adopted_environment_with_extras():
 
     with pytest.raises(TypeError):
         session_module.RenderSession(jinja_env=env, jinja_filters={"shout": str.upper})
+
+
+def test_request_scope_default_session_uses_the_cached_environment():
+    """Two requests under one configuration must land on one environment —
+    otherwise every request starts with an empty template cache."""
+    from pyjinhx.config import (
+        PjxSettings,
+        configure_pyjinhx,
+        current_settings,
+        shutdown_pyjinhx,
+    )
+
+    configure_pyjinhx(PjxSettings(jinja_globals={"x": 1}))
+    try:
+        expected = session_module._environment_for(current_settings())
+        with session_module.request_scope() as first:
+            pass
+        with session_module.request_scope() as second:
+            pass
+
+        assert first.jinja_env is expected
+        assert second.jinja_env is expected
+        assert first is not second
+    finally:
+        shutdown_pyjinhx()


### PR DESCRIPTION
## Summary

- Implement Jinja environment caching per settings instance to improve rendering performance
- Enable FastAPI middleware to reuse the cached environment
- Allow RenderSession and request_scope to adopt pre-built Jinja environments
- Version bump to 1.3.0 with comprehensive test coverage

## Tests

Added 10 new tests covering:
- Environment caching and reuse across middleware
- RenderSession with pre-built environments
- request_scope default session environment adoption
- FastAPI integration wiring

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)