### PR TITLE
feat(reactive): tier-2 cache backend wiring

### DIFF
--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -1,13 +1,14 @@
 """App-level configuration for pyjinhx: the settings object and the setup() entrypoint.
 
 config sits above the render spine and may read from it; nothing in the spine,
-in reactive/ or in client/ may import this module back — except session.py's
-request_scope(), which reads current_settings() through a function-local
-import to seed a default session's Jinja globals/filters, and reactive/
-component.py's _resolve_tier2(), which reads it the same way to find the
-process's cache backend. Never at module scope in either case
-(test_session_only_imports_config_inside_a_function_body and
-test_component_only_imports_config_inside_a_function_body pin that).
+in reactive/ or in client/ may import this module back — except three
+function-local reads of current_settings(): session.py's request_scope(),
+which seeds a default session's Jinja globals/filters, reactive/component.py's
+_resolve_tier2() and reactive/cache.py's invalidate(), which both find the
+process's cache backend. Never at module scope in any of the three
+(test_session_only_imports_config_inside_a_function_body,
+test_component_only_imports_config_inside_a_function_body and
+test_cache_only_imports_config_inside_a_function_body pin that).
 Siblings that do not exist yet (dev, integrations.fastapi) are imported
 lazily inside functions so importing this module never depends on them.
 """

--- a/pyjinhx/config.py
+++ b/pyjinhx/config.py
@@ -3,8 +3,11 @@
 config sits above the render spine and may read from it; nothing in the spine,
 in reactive/ or in client/ may import this module back — except session.py's
 request_scope(), which reads current_settings() through a function-local
-import to seed a default session's Jinja globals/filters, never at module
-scope (test_session_only_imports_config_inside_a_function_body pins that).
+import to seed a default session's Jinja globals/filters, and reactive/
+component.py's _resolve_tier2(), which reads it the same way to find the
+process's cache backend. Never at module scope in either case
+(test_session_only_imports_config_inside_a_function_body and
+test_component_only_imports_config_inside_a_function_body pin that).
 Siblings that do not exist yet (dev, integrations.fastapi) are imported
 lazily inside functions so importing this module never depends on them.
 """

--- a/pyjinhx/reactive/cache.py
+++ b/pyjinhx/reactive/cache.py
@@ -18,6 +18,12 @@ single entry sits under so un-indexing costs that entry's own key count instead
 of a walk over every bucket. Outside a request scope every function is a no-op:
 the session getters answer throwaway containers, so writes vanish and reads
 miss. A cache that does nothing is a correct cache, so nothing raises.
+
+``invalidate()`` is the one function here that looks past this request:
+``wrapped_load`` writes each cross-request entry under the same reactive keys
+this module reverse-indexes by, so the dirtied keys pass straight through to
+the configured backend's ``evict()`` as tags. Nothing else in this module knows
+that tier exists.
 """
 
 from collections.abc import Iterable
@@ -105,18 +111,24 @@ def cache_put(
 def invalidate(dirtied_keys: Iterable[str]) -> None:
     """Evict every cache entry that depends on any of these reactive keys.
 
-    Outside a request scope there is nothing indexed and nothing to drop, so
-    this is a silent no-op like the rest of the module.
+    Both tiers are swept: this request's store, and the configured cross-request
+    backend, where the same keys are the tags its entries were written under.
+    Outside a request scope there is nothing indexed in tier 1 and nothing to
+    drop there, so that half is a silent no-op like the rest of the module.
 
     Args:
         dirtied_keys: Normalized string keys, as produced by
             coerce_reactive_keys() and collected by session.add_dirtied().
     """
+    # Materialized once because two independent stores read it: a caller that
+    # passes a generator would otherwise hand the backend an already-drained
+    # iterable and quietly evict from tier 1 only.
+    dirtied = tuple(dirtied_keys)
     reverse = get_cache_reverse()
     forward = get_cache_forward()
     store = get_cache_store()
     evicted: set[tuple[type, object]] = set()
-    for react_key in dirtied_keys:
+    for react_key in dirtied:
         evicted |= reverse.get(react_key, set())
     for cache_key in evicted:
         # An entry reachable from two dirtied keys is popped once; the second
@@ -126,6 +138,17 @@ def invalidate(dirtied_keys: Iterable[str]) -> None:
         # ones that matched: the entry is gone from the store, so any surviving
         # membership would name a cache_key nothing can look up.
         _unindex(reverse, forward, cache_key)
+    # Function-local by necessity: config sits above reactive/ and imports the
+    # render spine at import time, so a module-scope edge back would be a real
+    # cycle. Same escape hatch session.py's request_scope() uses.
+    from pyjinhx.config import current_settings
+
+    backend = current_settings().cache_backend
+    if backend is not None:
+        # The dirtied keys are the tags verbatim - wrapped_load wrote each entry
+        # under the very tuple tier 1 reverse-indexes it by - so there is no
+        # second index to maintain and nothing to translate here.
+        backend.evict(dirtied)
 
 
 def _unindex(

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -26,7 +26,7 @@ from pydantic.fields import FieldInfo
 
 from pyjinhx._component import BaseComponent
 from pyjinhx.app_context import resolve_load_context_param
-from pyjinhx.reactive.backend import CachePolicy
+from pyjinhx.reactive.backend import MISS, CacheBackend, CachePolicy
 from pyjinhx.reactive.cache import cache_get, cache_has, cache_put
 from pyjinhx.reactive.keys import coerce_load_key_str, coerce_reactive_key
 from pyjinhx.session import get_load_context
@@ -499,6 +499,33 @@ def _wrap_load(
         return result
 
     return wrapped_load
+
+
+def _resolve_tier2(
+    cls: type["ReactiveComponent"],
+) -> tuple["CacheBackend | None", float | None]:
+    """The cross-request backend this class caches through, and the ttl it writes at.
+
+    Answers ``(None, None)`` when tier 2 is off for ``cls`` - either because no
+    backend is configured for the process or because the class opted out with
+    ``cache=False``. Otherwise the configured backend and the seconds its
+    entries stay valid.
+    """
+    # Function-local by necessity: config sits above reactive/ and imports the
+    # render spine at import time, so a module-scope edge back would be a real
+    # cycle. Same escape hatch session.py's request_scope() uses.
+    from pyjinhx.config import current_settings
+
+    policy = cls._pjx_cache_policy
+    # `is False`, not falsiness: None is "the class said nothing", which means
+    # the process default applies, and it is not the same answer as an explicit
+    # opt-out.
+    if policy is False:
+        return None, None
+    backend = current_settings().cache_backend
+    if backend is None:
+        return None, None
+    return backend, (CachePolicy() if policy is None else policy).ttl
 
 
 def _cache_key(

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -473,6 +473,35 @@ def _wrap_load(
         key = _cache_key(bound_cls, supplied, protocol_mode=cache_key_protocol_mode)
         if cache_has(bound_cls, key):
             return cache_get(bound_cls, key)
+        # Index under both the static react keys (a bare "todos" dirties every
+        # instance) and, when this call has a load key, the per-instance
+        # "todos:1" composite reactive_key() produces — @mutates(key=...) and
+        # dirty(reactive_key(...)) dirty only the composite, so invalidate()
+        # needs both forms to find this entry. Derived before either tier is
+        # consulted: a tier-2 hit indexes its promotion under the same keys a
+        # fresh load would have.
+        react_keys = bound_cls._pjx_react_keys
+        field = bound_cls._pjx_key_field
+        load_key = coerce_load_key_str(supplied.get(field)) if field else None
+        if load_key is not None:
+            react_keys = (
+                *react_keys,
+                *(f"{rk}:{load_key}" for rk in bound_cls._pjx_react_keys),
+            )
+        backend, ttl = _resolve_tier2(bound_cls)
+        string_key = ""
+        if backend is not None:
+            string_key = _string_cache_key(
+                bound_cls, supplied, protocol_mode=cache_key_protocol_mode
+            )
+            cached = backend.get(string_key)
+            # `is not MISS`, not truthiness: a load() may legitimately return a
+            # falsy component, and a cached one is a hit like any other.
+            if cached is not MISS:
+                # Promoted, not merely returned: the rest of this request must
+                # answer from the dict rather than going back over the seam.
+                cache_put(bound_cls, key, cached, react_keys=react_keys)
+                return cached
         call_kwargs = dict(supplied)
         if context_param is not None:
             call_kwargs[context_param] = get_load_context()
@@ -482,20 +511,11 @@ def _wrap_load(
                 f"{bound_cls.__name__}.load must return an instance of "
                 f"{bound_cls.__name__}; got {type(result).__name__}."
             )
-        # Index under both the static react keys (a bare "todos" dirties every
-        # instance) and, when this call has a load key, the per-instance
-        # "todos:1" composite reactive_key() produces — @mutates(key=...) and
-        # dirty(reactive_key(...)) dirty only the composite, so invalidate()
-        # needs both forms to find this entry.
-        react_keys = bound_cls._pjx_react_keys
-        field = bound_cls._pjx_key_field
-        load_key = coerce_load_key_str(supplied.get(field)) if field else None
-        if load_key is not None:
-            react_keys = (
-                *react_keys,
-                *(f"{rk}:{load_key}" for rk in bound_cls._pjx_react_keys),
-            )
         cache_put(bound_cls, key, result, react_keys=react_keys)
+        if backend is not None:
+            # The same tuple tier 1 reverse-indexes on becomes tier 2's tags, so
+            # one dirtied key reaches both stores without a second index here.
+            backend.put(string_key, result, tags=react_keys, ttl=ttl)
         return result
 
     return wrapped_load

--- a/tests/pyjinhx/integrations/test_reactive_request_cycle.py
+++ b/tests/pyjinhx/integrations/test_reactive_request_cycle.py
@@ -512,8 +512,18 @@ def test_lower_layers_do_not_import_the_wiring_layer():
     # import (never at module scope) to seed a default session's Jinja
     # globals/filters; test_import_graph.py's
     # test_session_only_imports_config_inside_a_function_body pins that it
-    # stays function-local, so it is not a real upward edge here.
-    allowed_edges = {("pyjinhx.session", "pyjinhx.config")}
+    # stays function-local, so it is not a real upward edge here. The two
+    # reactive/ edges below are the same lazy pattern:
+    # reactive.component's _resolve_tier2() and reactive.cache's invalidate()
+    # each read current_settings() inside their own bodies to find the
+    # process's cache backend, never at module scope
+    # (test_component_only_imports_config_inside_a_function_body and
+    # test_cache_only_imports_config_inside_a_function_body pin those).
+    allowed_edges = {
+        ("pyjinhx.session", "pyjinhx.config"),
+        ("pyjinhx.reactive.component", "pyjinhx.config"),
+        ("pyjinhx.reactive.cache", "pyjinhx.config"),
+    }
 
     offenders: list[tuple[str, str]] = []
     for name in lower:

--- a/tests/pyjinhx/reactive/test_reactive_cache_tier2_wiring.py
+++ b/tests/pyjinhx/reactive/test_reactive_cache_tier2_wiring.py
@@ -14,7 +14,7 @@ from pyjinhx.reactive.component import (
     _resolve_tier2,
     _string_cache_key,
 )
-from pyjinhx.session import get_cache_forward, request_scope
+from pyjinhx.session import add_dirtied, get_cache_forward, get_dirtied, request_scope
 
 
 @pytest.fixture
@@ -411,3 +411,37 @@ def test_invalidate_with_no_backend_configured_is_a_tier1_only_no_op(
         invalidate(["rows:7"])
 
         assert cache_has(Row, key) is False
+
+
+def test_a_dirtied_key_recorded_through_the_session_clears_both_tiers(
+    backend: InMemoryCacheBackend,
+):
+    """The real path: a mutation records a key, the response fan-out invalidates
+    it, and the next request must not be served stale from tier 2."""
+    calls: list[int] = []
+
+    class Row(ReactiveComponent, react=("rows",)):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            calls.append(row_id)
+            return cls(row_id=row_id)
+
+    with request_scope():
+        Row.load(7)
+
+    with request_scope():
+        add_dirtied({"rows:7"})
+        invalidate(get_dirtied())
+
+    # Both tiers are clear right after invalidate() - before the next request
+    # writes a fresh entry back.
+    assert (
+        backend.get(_string_cache_key(Row, {"row_id": 7}, protocol_mode=False)) is MISS
+    )
+
+    with request_scope():
+        Row.load(7)
+
+    assert calls == [7, 7]

--- a/tests/pyjinhx/reactive/test_reactive_cache_tier2_wiring.py
+++ b/tests/pyjinhx/reactive/test_reactive_cache_tier2_wiring.py
@@ -325,3 +325,89 @@ def test_an_expired_tier2_entry_falls_through_to_the_real_load(
         Row.load(7)
 
     assert calls == [7, 7]
+
+
+def test_invalidate_evicts_the_backend_entry_too(backend: InMemoryCacheBackend):
+    calls: list[int] = []
+
+    class Row(ReactiveComponent, react=("rows",)):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            calls.append(row_id)
+            return cls(row_id=row_id)
+
+    with request_scope():
+        Row.load(7)
+
+    string_key = _string_cache_key(Row, {"row_id": 7}, protocol_mode=False)
+    assert backend.get(string_key) is not MISS
+
+    with request_scope():
+        invalidate(["rows:7"])
+
+    assert backend.get(string_key) is MISS
+
+    # The next request has to load for real: neither tier holds it any more.
+    with request_scope():
+        Row.load(7)
+
+    assert calls == [7, 7]
+
+
+def test_invalidate_hands_the_backend_the_dirtied_keys_verbatim(
+    recording_backend: RecordingBackend,
+):
+    with request_scope():
+        invalidate(["rows", "rows:7"])
+
+    assert recording_backend.evicts == [("rows", "rows:7")]
+
+
+def test_invalidate_survives_a_one_shot_iterator_of_dirtied_keys(
+    recording_backend: RecordingBackend,
+):
+    """Both tiers see the same keys: the first walk must not drain the second."""
+
+    class Row(ReactiveComponent, react=("rows",)):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            return cls(row_id=row_id)
+
+    with request_scope():
+        Row.load(7)
+        key = _cache_key(Row, {"row_id": 7}, protocol_mode=False)
+
+        invalidate(iter(["rows:7"]))
+
+        assert cache_has(Row, key) is False
+
+    assert recording_backend.evicts == [("rows:7",)]
+    assert (
+        recording_backend.get(
+            _string_cache_key(Row, {"row_id": 7}, protocol_mode=False)
+        )
+        is MISS
+    )
+
+
+def test_invalidate_with_no_backend_configured_is_a_tier1_only_no_op(
+    no_backend: None,
+):
+    class Row(ReactiveComponent, react=("rows",)):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            return cls(row_id=row_id)
+
+    with request_scope():
+        Row.load(7)
+        key = _cache_key(Row, {"row_id": 7}, protocol_mode=False)
+
+        invalidate(["rows:7"])
+
+        assert cache_has(Row, key) is False

--- a/tests/pyjinhx/reactive/test_reactive_cache_tier2_wiring.py
+++ b/tests/pyjinhx/reactive/test_reactive_cache_tier2_wiring.py
@@ -4,13 +4,17 @@ from typing import Annotated
 
 import pytest
 
-from pyjinhx.config import PjxSettings, configure_pyjinhx, current_settings
-from pyjinhx.reactive.backend import CachePolicy, InMemoryCacheBackend
+from pyjinhx.config import configure_pyjinhx, current_settings
+from pyjinhx.reactive.backend import MISS, CachePolicy, InMemoryCacheBackend
+from pyjinhx.reactive.cache import cache_get, cache_has, invalidate
 from pyjinhx.reactive.component import (
     PjxKey,
     ReactiveComponent,
+    _cache_key,
     _resolve_tier2,
+    _string_cache_key,
 )
+from pyjinhx.session import get_cache_forward, request_scope
 
 
 @pytest.fixture
@@ -117,3 +121,207 @@ def test_resolve_tier2_reads_the_settings_at_call_time(
     configure_pyjinhx(current_settings().merge(cache_backend=replacement))
 
     assert _resolve_tier2(Row)[0] is replacement
+
+
+class RecordingBackend(InMemoryCacheBackend):
+    """An in-memory backend that remembers which methods it was asked for."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.gets: list[str] = []
+        self.puts: list[str] = []
+        self.evicts: list[tuple[str, ...]] = []
+
+    def get(self, key: str) -> object:
+        self.gets.append(key)
+        return super().get(key)
+
+    def put(self, key: str, value: object, *, tags, ttl) -> None:
+        self.puts.append(key)
+        super().put(key, value, tags=tags, ttl=ttl)
+
+    def evict(self, tags) -> None:
+        self.evicts.append(tuple(tags))
+        super().evict(self.evicts[-1])
+
+
+@pytest.fixture
+def recording_backend():
+    """Publish a RecordingBackend for one test, then restore the settings."""
+    previous = current_settings()
+    published = RecordingBackend()
+    configure_pyjinhx(previous.merge(cache_backend=published))
+    yield published
+    configure_pyjinhx(previous)
+
+
+def test_a_miss_writes_through_to_both_tiers(backend: InMemoryCacheBackend):
+    calls: list[int] = []
+
+    class Row(ReactiveComponent, react=("rows",)):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            calls.append(row_id)
+            return cls(row_id=row_id)
+
+    with request_scope():
+        loaded = Row.load(7)
+
+        assert calls == [7]
+        assert cache_has(Row, _cache_key(Row, {"row_id": 7}, protocol_mode=False))
+        assert (
+            cache_get(Row, _cache_key(Row, {"row_id": 7}, protocol_mode=False))
+            is loaded
+        )
+
+    stored = backend.get(_string_cache_key(Row, {"row_id": 7}, protocol_mode=False))
+    assert stored is loaded
+
+
+def test_a_tier2_hit_is_promoted_into_tier1_and_skips_the_real_load(
+    backend: InMemoryCacheBackend,
+):
+    calls: list[int] = []
+
+    class Row(ReactiveComponent, react=("rows",)):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            calls.append(row_id)
+            return cls(row_id=row_id)
+
+    with request_scope():
+        first = Row.load(7)
+
+    # A fresh request: tier 1 is empty again, so only tier 2 can answer.
+    with request_scope():
+        key = _cache_key(Row, {"row_id": 7}, protocol_mode=False)
+        assert cache_has(Row, key) is False
+
+        second = Row.load(7)
+
+        assert second is first
+        assert calls == [7]
+        # Promotion, not a bare return: the rest of this request answers from
+        # the dict without consulting the backend again.
+        assert cache_has(Row, key) is True
+        assert cache_get(Row, key) is first
+
+
+def test_the_promoted_entry_carries_the_same_reactive_keys(
+    backend: InMemoryCacheBackend,
+):
+    class Row(ReactiveComponent, react=("rows",)):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            return cls(row_id=row_id)
+
+    with request_scope():
+        Row.load(7)
+
+    with request_scope():
+        promoted = Row.load(7)
+        key = _cache_key(Row, {"row_id": 7}, protocol_mode=False)
+
+        assert get_cache_forward()[(Row, key)] == {"rows", "rows:7"}
+
+        # And the keys actually bite: dirtying the composite drops the promoted
+        # entry from tier 1.
+        invalidate(["rows:7"])
+        assert cache_has(Row, key) is False
+        assert promoted is not None
+
+
+def test_tier2_is_tagged_with_the_same_reactive_keys_tier1_indexes_on(
+    recording_backend: RecordingBackend,
+):
+    class Row(ReactiveComponent, react=("rows",)):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            return cls(row_id=row_id)
+
+    with request_scope():
+        Row.load(7)
+
+    string_key = _string_cache_key(Row, {"row_id": 7}, protocol_mode=False)
+    assert recording_backend.puts == [string_key]
+
+    recording_backend.evict(["rows:7"])
+    assert recording_backend.get(string_key) is MISS
+
+
+def test_a_cache_false_class_never_touches_the_backend(
+    recording_backend: RecordingBackend,
+):
+    calls: list[int] = []
+
+    class Row(ReactiveComponent, react=("rows",), cache=False):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            calls.append(row_id)
+            return cls(row_id=row_id)
+
+    with request_scope():
+        Row.load(7)
+        Row.load(7)
+
+    with request_scope():
+        Row.load(7)
+
+    assert recording_backend.gets == []
+    assert recording_backend.puts == []
+    # Tier 1 still memoizes within a request, and still starts empty in the next.
+    assert calls == [7, 7]
+
+
+def test_with_no_backend_every_request_runs_the_real_load_once(no_backend: None):
+    calls: list[int] = []
+
+    class Row(ReactiveComponent, react=("rows",)):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            calls.append(row_id)
+            return cls(row_id=row_id)
+
+    with request_scope():
+        Row.load(7)
+        Row.load(7)
+
+    with request_scope():
+        Row.load(7)
+
+    assert calls == [7, 7]
+
+
+def test_an_expired_tier2_entry_falls_through_to_the_real_load(
+    backend: InMemoryCacheBackend,
+):
+    """ttl is honored per class: a policy that has run out is an ordinary miss."""
+    calls: list[int] = []
+
+    class Row(ReactiveComponent, cache=CachePolicy(ttl=0)):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            calls.append(row_id)
+            return cls(row_id=row_id)
+
+    with request_scope():
+        Row.load(7)
+
+    with request_scope():
+        Row.load(7)
+
+    assert calls == [7, 7]

--- a/tests/pyjinhx/reactive/test_reactive_cache_tier2_wiring.py
+++ b/tests/pyjinhx/reactive/test_reactive_cache_tier2_wiring.py
@@ -1,0 +1,119 @@
+"""The two-tier seam: wrapped_load reading/writing tier 2, invalidate evicting it."""
+
+from typing import Annotated
+
+import pytest
+
+from pyjinhx.config import PjxSettings, configure_pyjinhx, current_settings
+from pyjinhx.reactive.backend import CachePolicy, InMemoryCacheBackend
+from pyjinhx.reactive.component import (
+    PjxKey,
+    ReactiveComponent,
+    _resolve_tier2,
+)
+
+
+@pytest.fixture
+def backend():
+    """Publish a fresh in-memory backend for one test, then restore the settings.
+
+    configure_pyjinhx rather than shutdown_pyjinhx: the latter resets every
+    other setting too, and a test that only asked for a backend should not
+    also blow away whatever else the process was configured with.
+    """
+    previous = current_settings()
+    published = InMemoryCacheBackend()
+    configure_pyjinhx(previous.merge(cache_backend=published))
+    yield published
+    configure_pyjinhx(previous)
+
+
+@pytest.fixture
+def no_backend():
+    """Publish settings with no cache backend for one test, then restore."""
+    previous = current_settings()
+    configure_pyjinhx(previous.merge(cache_backend=None))
+    yield
+    configure_pyjinhx(previous)
+
+
+def test_resolve_tier2_is_off_when_no_backend_is_configured(no_backend: None):
+    class Widget(ReactiveComponent):
+        value: str = ""
+
+        @classmethod
+        def load(cls) -> "Widget":
+            return cls(value="loaded")
+
+    assert _resolve_tier2(Widget) == (None, None)
+
+
+def test_resolve_tier2_is_on_by_default_at_the_process_default_ttl(
+    backend: InMemoryCacheBackend,
+):
+    class Widget(ReactiveComponent):
+        value: str = ""
+
+        @classmethod
+        def load(cls) -> "Widget":
+            return cls(value="loaded")
+
+    resolved, ttl = _resolve_tier2(Widget)
+
+    assert resolved is backend
+    assert ttl == CachePolicy().ttl == 300
+
+
+def test_resolve_tier2_honors_an_explicit_policy_ttl(backend: InMemoryCacheBackend):
+    class Widget(ReactiveComponent, cache=CachePolicy(ttl=45)):
+        value: str = ""
+
+        @classmethod
+        def load(cls) -> "Widget":
+            return cls(value="loaded")
+
+    assert _resolve_tier2(Widget) == (backend, 45)
+
+
+def test_resolve_tier2_honors_a_never_expiring_policy(backend: InMemoryCacheBackend):
+    class Widget(ReactiveComponent, cache=CachePolicy(ttl=None)):
+        value: str = ""
+
+        @classmethod
+        def load(cls) -> "Widget":
+            return cls(value="loaded")
+
+    assert _resolve_tier2(Widget) == (backend, None)
+
+
+def test_resolve_tier2_is_off_for_a_class_that_opted_out(
+    backend: InMemoryCacheBackend,
+):
+    class Widget(ReactiveComponent, cache=False):
+        value: str = ""
+
+        @classmethod
+        def load(cls) -> "Widget":
+            return cls(value="loaded")
+
+    assert _resolve_tier2(Widget) == (None, None)
+
+
+def test_resolve_tier2_reads_the_settings_at_call_time(
+    backend: InMemoryCacheBackend,
+):
+    """The backend is looked up per call, not captured when the class is defined."""
+
+    class Row(ReactiveComponent):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            return cls(row_id=row_id)
+
+    assert _resolve_tier2(Row)[0] is backend
+
+    replacement = InMemoryCacheBackend()
+    configure_pyjinhx(current_settings().merge(cache_backend=replacement))
+
+    assert _resolve_tier2(Row)[0] is replacement

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -468,12 +468,16 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # The load() wrap resolves its app-context parameter through app_context and
     # reads the bound value out of session's ContextVar; both are strictly below
     # reactive/, so neither edge is a cycle.
-    # backend is a third, vocabulary-only edge: CachePolicy names the cache=
-    # class keyword's type. No call into a backend is made from here.
+    # backend supplies both the cache= keyword's vocabulary and the MISS
+    # sentinel the tier-2 read compares against.
+    # config is the one upward edge, and it is lazy: _resolve_tier2() reads
+    # current_settings() inside its own body to find the configured backend.
+    # test_component_only_imports_config_inside_a_function_body pins it there.
     "reactive.component": frozenset(
         {
             "pyjinhx.app_context",
             "pyjinhx._component",
+            "pyjinhx.config",
             "pyjinhx.reactive.backend",
             "pyjinhx.reactive.cache",
             "pyjinhx.reactive.keys",
@@ -694,13 +698,18 @@ def test_nothing_below_config_imports_config():
     current_settings() inside its own body to seed a default session's Jinja
     environment. The edge never executes at import time, and
     test_session_only_imports_config_inside_a_function_body pins it there.
+
+    reactive/component.py is the third, and lazy in the same way:
+    _resolve_tier2() calls current_settings() inside its own body to find the
+    process's cache backend. test_component_only_imports_config_inside_a_function_body
+    pins it there.
     """
     importers = {
         module_name(path)
         for path in module_paths()
         if "pyjinhx.config" in internal_imports(path)
     }
-    assert importers == {"integrations.fastapi", "session"}
+    assert importers == {"integrations.fastapi", "reactive.component", "session"}
 
 
 def test_nothing_imports_context():
@@ -754,6 +763,18 @@ def test_session_only_imports_config_inside_a_function_body():
     import time, would be a genuine cycle. The whole-file edge table can't see
     where in the file an import lives, so pin it here."""
     module_level = module_level_internal_imports(PACKAGE_ROOT / "session.py")
+    assert "pyjinhx.config" not in module_level
+
+
+def test_component_only_imports_config_inside_a_function_body():
+    """_resolve_tier2() reads current_settings() to find the process's cache
+    backend, but config sits above reactive/: a module-scope edge would invert
+    the layering and, because config imports the spine at import time, would be
+    a genuine cycle. The whole-file edge table can't see where in the file an
+    import lives, so pin it here."""
+    module_level = module_level_internal_imports(
+        PACKAGE_ROOT / "reactive" / "component.py"
+    )
     assert "pyjinhx.config" not in module_level
 
 

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -447,8 +447,11 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "reactive.backend": frozenset(),
     # cache.py is a store over session's cache ContextVar and nothing else: it
     # owns no state, and it must not reach sideways into keys.py or up into the
-    # render spine to key or evict anything.
-    "reactive.cache": frozenset({"pyjinhx.session"}),
+    # render spine to key or evict anything. The one exception is lazy:
+    # invalidate() reads current_settings() inside its own body to sweep the
+    # configured cross-request backend with the same dirtied keys.
+    # test_cache_only_imports_config_inside_a_function_body pins it there.
+    "reactive.cache": frozenset({"pyjinhx.session", "pyjinhx.config"}),
     # mutations.py records dirtied keys through session's public writer; it owns
     # no ContextVar of its own and never reaches sideways into cache.py.
     "reactive.mutations": frozenset({"pyjinhx.session", "pyjinhx.reactive.keys"}),
@@ -699,17 +702,23 @@ def test_nothing_below_config_imports_config():
     environment. The edge never executes at import time, and
     test_session_only_imports_config_inside_a_function_body pins it there.
 
-    reactive/component.py is the third, and lazy in the same way:
-    _resolve_tier2() calls current_settings() inside its own body to find the
-    process's cache backend. test_component_only_imports_config_inside_a_function_body
-    pins it there.
+    reactive/component.py and reactive/cache.py are the third and fourth, and
+    lazy in the same way: _resolve_tier2() and invalidate() call
+    current_settings() inside their own bodies to find the process's cache
+    backend. test_component_only_imports_config_inside_a_function_body and
+    test_cache_only_imports_config_inside_a_function_body pin them there.
     """
     importers = {
         module_name(path)
         for path in module_paths()
         if "pyjinhx.config" in internal_imports(path)
     }
-    assert importers == {"integrations.fastapi", "reactive.component", "session"}
+    assert importers == {
+        "integrations.fastapi",
+        "reactive.cache",
+        "reactive.component",
+        "session",
+    }
 
 
 def test_nothing_imports_context():
@@ -775,6 +784,16 @@ def test_component_only_imports_config_inside_a_function_body():
     module_level = module_level_internal_imports(
         PACKAGE_ROOT / "reactive" / "component.py"
     )
+    assert "pyjinhx.config" not in module_level
+
+
+def test_cache_only_imports_config_inside_a_function_body():
+    """invalidate() reads current_settings() to sweep the cross-request backend,
+    but config sits above reactive/: a module-scope edge would invert the
+    layering and, because config imports the spine at import time, would be a
+    genuine cycle. The whole-file edge table can't see where in the file an
+    import lives, so pin it here."""
+    module_level = module_level_internal_imports(PACKAGE_ROOT / "reactive" / "cache.py")
     assert "pyjinhx.config" not in module_level
 
 


### PR DESCRIPTION
## Summary

Implements tier-2 cache backend (L2) support for component caching:
- Adds `_resolve_tier2()` to determine backend and TTL for component classes
- Integrates L2 caching into wrapped_load() with read-through and write-behind
- Evicts cross-request backend entries in invalidate()
- Adds ~450 lines of integration tests covering tier-2 wiring

Closes #807

## Test plan

- [x] 447 new test lines covering tier-2 cache resolution and lifecycle
- [x] All ruff checks passing (v0.16.0)
- [x] Code formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)