### PR TITLE
style: ruff lint fixes and typecheck cleanup for #808

### DIFF
--- a/pyjinhx/reactive/backend_health.py
+++ b/pyjinhx/reactive/backend_health.py
@@ -1,0 +1,115 @@
+"""Per-backend failure state: what a raising tier-2 backend is allowed to cost.
+
+A cache is an optimization, so a backend that raises must not take a request
+down with it. What the failure costs differs by operation: a dropped get() or
+put() costs speed, while a dropped eviction risks serving stale data, so an
+evict failure marks the backend degraded and its reads stop being trusted until
+a write lands again.
+
+State is keyed on ``id(backend)`` because a backend is anything satisfying a
+structural protocol - it need not be hashable, so keying a dict on the backend
+itself is not available. Each entry carries a weak reference so a recycled id
+cannot hand a fresh backend a dead one's flags.
+"""
+
+from __future__ import annotations
+
+import logging
+import weakref
+from dataclasses import dataclass
+
+logger = logging.getLogger("pyjinhx")
+
+
+@dataclass
+class _Health:
+    """One backend instance's failure state for the life of this process."""
+
+    ref: weakref.ref[object] | None = None
+    logged: bool = False
+    degraded: bool = False
+
+
+_health: dict[int, _Health] = {}
+
+
+def is_degraded(backend: object) -> bool:
+    """Whether this backend's reads are currently not to be trusted."""
+    state = _health.get(id(backend))
+    return state is not None and _is_same(state, backend) and state.degraded
+
+
+def note_failure(
+    backend: object, operation: str, exc: BaseException, *, degrade: bool
+) -> None:
+    """Record a backend call that raised, warning at most once per backend.
+
+    Args:
+        backend: The backend instance whose call raised.
+        operation: The method that raised, named for the log line.
+        exc: What it raised, summarized in the log line.
+        degrade: Whether this failure means the backend's entries can no longer
+            be trusted - true for a failed eviction, false for a read or write.
+    """
+    state = _state(backend)
+    if degrade:
+        state.degraded = True
+    # One warning per backend, not one per failing call: a backend that is down
+    # fails on every request, and a log line per request buries the first one.
+    if state.logged:
+        return
+    state.logged = True
+    logger.warning(
+        "pyjinhx cache backend %s failed on %s (%s: %s); the cache is being "
+        "bypassed. Further failures from this backend are not logged.",
+        type(backend).__name__,
+        operation,
+        type(exc).__name__,
+        exc,
+    )
+
+
+def note_write_success(backend: object) -> None:
+    """Record a write that landed, clearing any degraded flag."""
+    # Deliberately does not create an entry: a backend that has never failed
+    # needs no state, and this runs on every successful tier-2 write.
+    state = _health.get(id(backend))
+    if state is not None and _is_same(state, backend):
+        state.degraded = False
+
+
+def reset_backend_health() -> None:
+    """Drop every backend's recorded failure state.
+
+    Exists for tests, which need one test's failing backend to leave nothing
+    behind for the next.
+    """
+    _health.clear()
+
+
+def _state(backend: object) -> _Health:
+    """This backend's state, fresh if the id was never used or was recycled."""
+    existing = _health.get(id(backend))
+    if existing is not None and _is_same(existing, backend):
+        return existing
+    fresh = _Health(ref=_weak_ref(backend))
+    _health[id(backend)] = fresh
+    return fresh
+
+
+def _is_same(state: _Health, backend: object) -> bool:
+    """Whether this state was recorded for this very backend object."""
+    # No reference means the object could not be weakly referenced, so the id
+    # is all there is to go on - the same position this module would be in
+    # without weakrefs at all, rather than a new risk.
+    if state.ref is None:
+        return True
+    return state.ref() is backend
+
+
+def _weak_ref(backend: object) -> weakref.ref[object] | None:
+    """A weak reference to this backend, or None if it does not support one."""
+    try:
+        return weakref.ref(backend)
+    except TypeError:
+        return None

--- a/pyjinhx/reactive/cache.py
+++ b/pyjinhx/reactive/cache.py
@@ -151,7 +151,10 @@ def invalidate(dirtied_keys: Iterable[str]) -> None:
         # second index to maintain and nothing to translate here.
         try:
             backend.evict(dirtied)
-        except Exception as exc:
+        # Same rationale as component.py's get()/put() guards: a backend is a
+        # plugin, so any failure it raises degrades rather than only the
+        # subset this module could predict.
+        except Exception as exc:  # noqa: BLE001
             # Unlike a dropped read or write, an eviction that did not happen
             # leaves entries that are now known to be wrong, so the backend
             # stops being read from until a write proves it current again.

--- a/pyjinhx/reactive/cache.py
+++ b/pyjinhx/reactive/cache.py
@@ -28,6 +28,7 @@ that tier exists.
 
 from collections.abc import Iterable
 
+from pyjinhx.reactive.backend_health import note_failure
 from pyjinhx.session import get_cache_forward, get_cache_reverse, get_cache_store
 
 # Distinguishes "no entry" from an entry whose value happens to be None.
@@ -148,7 +149,13 @@ def invalidate(dirtied_keys: Iterable[str]) -> None:
         # The dirtied keys are the tags verbatim - wrapped_load wrote each entry
         # under the very tuple tier 1 reverse-indexes it by - so there is no
         # second index to maintain and nothing to translate here.
-        backend.evict(dirtied)
+        try:
+            backend.evict(dirtied)
+        except Exception as exc:
+            # Unlike a dropped read or write, an eviction that did not happen
+            # leaves entries that are now known to be wrong, so the backend
+            # stops being read from until a write proves it current again.
+            note_failure(backend, "evict", exc, degrade=True)
 
 
 def _unindex(

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -27,7 +27,11 @@ from pydantic.fields import FieldInfo
 from pyjinhx._component import BaseComponent
 from pyjinhx.app_context import resolve_load_context_param
 from pyjinhx.reactive.backend import MISS, CacheBackend, CachePolicy
-from pyjinhx.reactive.backend_health import is_degraded, note_failure, note_write_success
+from pyjinhx.reactive.backend_health import (
+    is_degraded,
+    note_failure,
+    note_write_success,
+)
 from pyjinhx.reactive.cache import cache_get, cache_has, cache_put
 from pyjinhx.reactive.keys import coerce_load_key_str, coerce_reactive_key
 from pyjinhx.session import get_load_context
@@ -501,7 +505,10 @@ def _wrap_load(
             if not is_degraded(backend):
                 try:
                     cached = backend.get(string_key)
-                except Exception as exc:
+                # A backend is a plugin implementing an arbitrary protocol, so
+                # its failure mode is unknowable in advance; the policy is to
+                # degrade on any of them rather than pick and miss some.
+                except Exception as exc:  # noqa: BLE001
                     # A cache is an optimization: a backend that cannot answer
                     # costs this request a real load, never an error.
                     note_failure(backend, "get", exc, degrade=False)
@@ -527,7 +534,9 @@ def _wrap_load(
             # one dirtied key reaches both stores without a second index here.
             try:
                 backend.put(string_key, result, tags=react_keys, ttl=ttl)
-            except Exception as exc:
+            # Same rationale as the get() guard above: any backend failure
+            # degrades rather than only the ones this module can predict.
+            except Exception as exc:  # noqa: BLE001
                 # The component is already loaded and already in tier 1: a
                 # dropped write costs the next request a load, nothing more.
                 note_failure(backend, "put", exc, degrade=False)

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -27,6 +27,7 @@ from pydantic.fields import FieldInfo
 from pyjinhx._component import BaseComponent
 from pyjinhx.app_context import resolve_load_context_param
 from pyjinhx.reactive.backend import MISS, CacheBackend, CachePolicy
+from pyjinhx.reactive.backend_health import is_degraded, note_failure, note_write_success
 from pyjinhx.reactive.cache import cache_get, cache_has, cache_put
 from pyjinhx.reactive.keys import coerce_load_key_str, coerce_reactive_key
 from pyjinhx.session import get_load_context
@@ -494,7 +495,16 @@ def _wrap_load(
             string_key = _string_cache_key(
                 bound_cls, supplied, protocol_mode=cache_key_protocol_mode
             )
-            cached = backend.get(string_key)
+            cached = MISS
+            # A degraded backend is one whose evict() raised: entries it still
+            # holds may be stale, so it is not read from until a write lands.
+            if not is_degraded(backend):
+                try:
+                    cached = backend.get(string_key)
+                except Exception as exc:
+                    # A cache is an optimization: a backend that cannot answer
+                    # costs this request a real load, never an error.
+                    note_failure(backend, "get", exc, degrade=False)
             # `is not MISS`, not truthiness: a load() may legitimately return a
             # falsy component, and a cached one is a hit like any other.
             if cached is not MISS:

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -525,7 +525,16 @@ def _wrap_load(
         if backend is not None:
             # The same tuple tier 1 reverse-indexes on becomes tier 2's tags, so
             # one dirtied key reaches both stores without a second index here.
-            backend.put(string_key, result, tags=react_keys, ttl=ttl)
+            try:
+                backend.put(string_key, result, tags=react_keys, ttl=ttl)
+            except Exception as exc:
+                # The component is already loaded and already in tier 1: a
+                # dropped write costs the next request a load, nothing more.
+                note_failure(backend, "put", exc, degrade=False)
+            else:
+                # A write that landed is the evidence a degraded backend is
+                # answering again, and that what it now holds is current.
+                note_write_success(backend)
         return result
 
     return wrapped_load

--- a/tests/pyjinhx/reactive/test_reactive_cache_backend_health.py
+++ b/tests/pyjinhx/reactive/test_reactive_cache_backend_health.py
@@ -1,0 +1,104 @@
+"""Per-backend failure state: log once, degrade on evict, heal on a write."""
+
+import logging
+
+import pytest
+
+from pyjinhx.reactive.backend_health import (
+    is_degraded,
+    note_failure,
+    note_write_success,
+    reset_backend_health,
+)
+
+
+class FakeBackend:
+    """A stand-in backend: health state never calls into it, only keys on it."""
+
+
+@pytest.fixture(autouse=True)
+def clean_health():
+    """Every test starts and ends with no recorded backend health."""
+    reset_backend_health()
+    yield
+    reset_backend_health()
+
+
+def test_a_fresh_backend_is_not_degraded():
+    assert is_degraded(FakeBackend()) is False
+
+
+def test_a_get_failure_does_not_degrade_the_backend():
+    backend = FakeBackend()
+
+    note_failure(backend, "get", RuntimeError("boom"), degrade=False)
+
+    assert is_degraded(backend) is False
+
+
+def test_an_evict_failure_degrades_the_backend():
+    backend = FakeBackend()
+
+    note_failure(backend, "evict", RuntimeError("boom"), degrade=True)
+
+    assert is_degraded(backend) is True
+
+
+def test_a_successful_write_clears_the_degraded_flag():
+    backend = FakeBackend()
+    note_failure(backend, "evict", RuntimeError("boom"), degrade=True)
+
+    note_write_success(backend)
+
+    assert is_degraded(backend) is False
+
+
+def test_a_successful_write_on_a_healthy_backend_is_a_no_op():
+    backend = FakeBackend()
+
+    note_write_success(backend)
+
+    assert is_degraded(backend) is False
+
+
+def test_only_the_first_failure_of_a_backend_is_logged(
+    caplog: pytest.LogCaptureFixture,
+):
+    backend = FakeBackend()
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        note_failure(backend, "get", RuntimeError("boom"), degrade=False)
+        note_failure(backend, "get", RuntimeError("boom again"), degrade=False)
+        note_failure(backend, "evict", RuntimeError("and again"), degrade=True)
+
+    assert len(caplog.records) == 1
+    assert "FakeBackend" in caplog.records[0].getMessage()
+    assert "get" in caplog.records[0].getMessage()
+
+
+def test_two_backend_instances_keep_independent_state(
+    caplog: pytest.LogCaptureFixture,
+):
+    first = FakeBackend()
+    second = FakeBackend()
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        note_failure(first, "evict", RuntimeError("boom"), degrade=True)
+        note_failure(second, "get", RuntimeError("boom"), degrade=False)
+
+    assert is_degraded(first) is True
+    assert is_degraded(second) is False
+    assert len(caplog.records) == 2
+
+
+def test_reset_clears_every_backends_state(caplog: pytest.LogCaptureFixture):
+    backend = FakeBackend()
+    note_failure(backend, "evict", RuntimeError("boom"), degrade=True)
+
+    reset_backend_health()
+
+    assert is_degraded(backend) is False
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        note_failure(backend, "evict", RuntimeError("boom"), degrade=True)
+    assert len(caplog.records) == 1

--- a/tests/pyjinhx/reactive/test_reactive_cache_failure_policy.py
+++ b/tests/pyjinhx/reactive/test_reactive_cache_failure_policy.py
@@ -16,7 +16,11 @@ class BrokenBackend(InMemoryCacheBackend):
     """An in-memory backend whose chosen methods raise instead of working."""
 
     def __init__(
-        self, *, fail_get: bool = False, fail_put: bool = False, fail_evict: bool = False
+        self,
+        *,
+        fail_get: bool = False,
+        fail_put: bool = False,
+        fail_evict: bool = False,
     ) -> None:
         super().__init__()
         self.fail_get = fail_get
@@ -54,7 +58,7 @@ def clean_health():
     reset_backend_health()
 
 
-def publish(backend: object):
+def publish[B](backend: B) -> B:
     """Publish a backend into the process settings and return it."""
     configure_pyjinhx(current_settings().merge(cache_backend=backend))
     return backend
@@ -68,7 +72,7 @@ def settings_restored():
     configure_pyjinhx(previous)
 
 
-def make_row_class(calls: list[int]) -> type[ReactiveComponent]:
+def make_row_class(calls: list[int]):
     """A reactive component whose load() records every call it really ran."""
 
     class Row(ReactiveComponent, react=("rows",)):
@@ -208,10 +212,9 @@ def test_a_raising_evict_degrades_the_backend_and_warns_once(
 
     from pyjinhx.reactive.cache import invalidate
 
-    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
-        with request_scope():
-            invalidate(["rows:7"])
-            invalidate(["rows:8"])
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"), request_scope():
+        invalidate(["rows:7"])
+        invalidate(["rows:8"])
 
     assert is_degraded(backend) is True
     assert len(caplog.records) == 1

--- a/tests/pyjinhx/reactive/test_reactive_cache_failure_policy.py
+++ b/tests/pyjinhx/reactive/test_reactive_cache_failure_policy.py
@@ -180,3 +180,83 @@ def test_a_landed_write_clears_the_degraded_flag(settings_restored: None):
         Row.load(7)
 
     assert is_degraded(backend) is False
+
+
+def test_a_raising_evict_still_clears_tier_one(settings_restored: None):
+    publish(BrokenBackend(fail_evict=True))
+    calls: list[int] = []
+    Row = make_row_class(calls)
+
+    from pyjinhx.reactive.cache import invalidate
+    from pyjinhx.reactive.component import _cache_key
+
+    with request_scope():
+        Row.load(7)
+        key = _cache_key(Row, {"row_id": 7}, protocol_mode=False)
+
+        invalidate(["rows:7"])
+
+        from pyjinhx.reactive.cache import cache_has
+
+        assert cache_has(Row, key) is False
+
+
+def test_a_raising_evict_degrades_the_backend_and_warns_once(
+    settings_restored: None, caplog: pytest.LogCaptureFixture
+):
+    backend = publish(BrokenBackend(fail_evict=True))
+
+    from pyjinhx.reactive.cache import invalidate
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        with request_scope():
+            invalidate(["rows:7"])
+            invalidate(["rows:8"])
+
+    assert is_degraded(backend) is True
+    assert len(caplog.records) == 1
+
+
+def test_a_successful_put_lets_a_degraded_backend_be_read_again(
+    settings_restored: None,
+):
+    backend = publish(BrokenBackend(fail_evict=True))
+    calls: list[int] = []
+    Row = make_row_class(calls)
+
+    from pyjinhx.reactive.cache import invalidate
+
+    with request_scope():
+        invalidate(["rows:7"])
+    assert is_degraded(backend) is True
+
+    # This request's write lands, which clears the flag...
+    with request_scope():
+        Row.load(7)
+    assert is_degraded(backend) is False
+
+    # ...so the next one consults the backend again and is served from it.
+    backend.gets.clear()
+    with request_scope():
+        Row.load(7)
+
+    assert backend.gets != []
+    assert calls == [7]
+
+
+def test_two_backends_degrade_independently(settings_restored: None):
+    first = BrokenBackend(fail_evict=True)
+    second = BrokenBackend()
+
+    from pyjinhx.reactive.cache import invalidate
+
+    publish(first)
+    with request_scope():
+        invalidate(["rows:7"])
+
+    publish(second)
+    with request_scope():
+        invalidate(["rows:7"])
+
+    assert is_degraded(first) is True
+    assert is_degraded(second) is False

--- a/tests/pyjinhx/reactive/test_reactive_cache_failure_policy.py
+++ b/tests/pyjinhx/reactive/test_reactive_cache_failure_policy.py
@@ -1,0 +1,133 @@
+"""A raising tier-2 backend degrades the cache instead of failing the request."""
+
+import logging
+from typing import Annotated
+
+import pytest
+
+from pyjinhx.config import configure_pyjinhx, current_settings
+from pyjinhx.reactive.backend import InMemoryCacheBackend
+from pyjinhx.reactive.backend_health import is_degraded, reset_backend_health
+from pyjinhx.reactive.component import PjxKey, ReactiveComponent
+from pyjinhx.session import request_scope
+
+
+class BrokenBackend(InMemoryCacheBackend):
+    """An in-memory backend whose chosen methods raise instead of working."""
+
+    def __init__(
+        self, *, fail_get: bool = False, fail_put: bool = False, fail_evict: bool = False
+    ) -> None:
+        super().__init__()
+        self.fail_get = fail_get
+        self.fail_put = fail_put
+        self.fail_evict = fail_evict
+        self.gets: list[str] = []
+        self.puts: list[str] = []
+        self.evicts: list[tuple[str, ...]] = []
+
+    def get(self, key: str) -> object:
+        self.gets.append(key)
+        if self.fail_get:
+            raise RuntimeError("get is down")
+        return super().get(key)
+
+    def put(self, key: str, value: object, *, tags, ttl) -> None:
+        self.puts.append(key)
+        if self.fail_put:
+            raise RuntimeError("put is down")
+        super().put(key, value, tags=tags, ttl=ttl)
+
+    def evict(self, tags) -> None:
+        collected = tuple(tags)
+        self.evicts.append(collected)
+        if self.fail_evict:
+            raise RuntimeError("evict is down")
+        super().evict(collected)
+
+
+@pytest.fixture(autouse=True)
+def clean_health():
+    """Backend health is process-wide: no test may inherit another's flags."""
+    reset_backend_health()
+    yield
+    reset_backend_health()
+
+
+def publish(backend: object):
+    """Publish a backend into the process settings and return it."""
+    configure_pyjinhx(current_settings().merge(cache_backend=backend))
+    return backend
+
+
+@pytest.fixture
+def settings_restored():
+    """Restore whatever settings the process had before this test."""
+    previous = current_settings()
+    yield
+    configure_pyjinhx(previous)
+
+
+def make_row_class(calls: list[int]) -> type[ReactiveComponent]:
+    """A reactive component whose load() records every call it really ran."""
+
+    class Row(ReactiveComponent, react=("rows",)):
+        row_id: Annotated[int, PjxKey()] = 0
+
+        @classmethod
+        def load(cls, row_id: int) -> "Row":
+            calls.append(row_id)
+            return cls(row_id=row_id)
+
+    return Row
+
+
+def test_a_raising_get_falls_through_to_the_real_load(settings_restored: None):
+    publish(BrokenBackend(fail_get=True))
+    calls: list[int] = []
+    Row = make_row_class(calls)
+
+    with request_scope():
+        loaded = Row.load(7)
+
+    assert loaded.row_id == 7
+    assert calls == [7]
+
+
+def test_a_raising_get_warns_once_across_many_requests(
+    settings_restored: None, caplog: pytest.LogCaptureFixture
+):
+    publish(BrokenBackend(fail_get=True))
+    calls: list[int] = []
+    Row = make_row_class(calls)
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        for _ in range(3):
+            with request_scope():
+                Row.load(7)
+
+    assert calls == [7, 7, 7]
+    assert len(caplog.records) == 1
+
+
+def test_a_degraded_backend_is_not_even_asked_for_a_get(settings_restored: None):
+    backend = publish(BrokenBackend(fail_evict=True))
+    calls: list[int] = []
+    Row = make_row_class(calls)
+
+    # A failed eviction is what degrades the backend.
+    with request_scope():
+        Row.load(7)
+    from pyjinhx.reactive.cache import invalidate
+
+    with request_scope():
+        invalidate(["rows:7"])
+
+    assert is_degraded(backend) is True
+    backend.gets.clear()
+
+    with request_scope():
+        Row.load(7)
+
+    assert backend.gets == []
+    assert calls == [7, 7]

--- a/tests/pyjinhx/reactive/test_reactive_cache_failure_policy.py
+++ b/tests/pyjinhx/reactive/test_reactive_cache_failure_policy.py
@@ -131,3 +131,52 @@ def test_a_degraded_backend_is_not_even_asked_for_a_get(settings_restored: None)
 
     assert backend.gets == []
     assert calls == [7, 7]
+
+
+def test_a_raising_put_drops_the_write_without_touching_the_result(
+    settings_restored: None,
+):
+    publish(BrokenBackend(fail_put=True))
+    calls: list[int] = []
+    Row = make_row_class(calls)
+
+    with request_scope():
+        loaded = Row.load(7)
+
+    assert loaded.row_id == 7
+    assert calls == [7]
+
+
+def test_a_raising_put_warns_once_and_never_degrades_the_backend(
+    settings_restored: None, caplog: pytest.LogCaptureFixture
+):
+    backend = publish(BrokenBackend(fail_put=True))
+    calls: list[int] = []
+    Row = make_row_class(calls)
+
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        for _ in range(3):
+            with request_scope():
+                Row.load(7)
+
+    assert len(caplog.records) == 1
+    # Only a failed eviction can degrade a backend: a dropped write costs
+    # speed, not correctness, so reads keep being tried.
+    assert is_degraded(backend) is False
+    assert backend.gets != []
+
+
+def test_a_landed_write_clears_the_degraded_flag(settings_restored: None):
+    backend = publish(BrokenBackend())
+    calls: list[int] = []
+    Row = make_row_class(calls)
+
+    from pyjinhx.reactive.backend_health import note_failure
+
+    note_failure(backend, "evict", RuntimeError("boom"), degrade=True)
+    assert is_degraded(backend) is True
+
+    with request_scope():
+        Row.load(7)
+
+    assert is_degraded(backend) is False

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -445,13 +445,20 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # both self-contained on stdlib. Nothing here reaches into tier 1 (cache.py)
     # or the render spine - wiring it in is a later subtask's edge to add.
     "reactive.backend": frozenset(),
+    # backend_health.py is the per-backend log-once/degraded state (#808): a
+    # leaf keyed on id(backend), stdlib only, so both cache.py and component.py
+    # can import it without creating a cycle back up into either.
+    "reactive.backend_health": frozenset(),
     # cache.py is a store over session's cache ContextVar and nothing else: it
     # owns no state, and it must not reach sideways into keys.py or up into the
     # render spine to key or evict anything. The one exception is lazy:
     # invalidate() reads current_settings() inside its own body to sweep the
-    # configured cross-request backend with the same dirtied keys.
+    # configured cross-request backend with the same dirtied keys. It also
+    # reaches into backend_health.py to record an evict() failure (#808).
     # test_cache_only_imports_config_inside_a_function_body pins it there.
-    "reactive.cache": frozenset({"pyjinhx.session", "pyjinhx.config"}),
+    "reactive.cache": frozenset(
+        {"pyjinhx.session", "pyjinhx.config", "pyjinhx.reactive.backend_health"}
+    ),
     # mutations.py records dirtied keys through session's public writer; it owns
     # no ContextVar of its own and never reaches sideways into cache.py.
     "reactive.mutations": frozenset({"pyjinhx.session", "pyjinhx.reactive.keys"}),
@@ -482,6 +489,7 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
             "pyjinhx._component",
             "pyjinhx.config",
             "pyjinhx.reactive.backend",
+            "pyjinhx.reactive.backend_health",
             "pyjinhx.reactive.cache",
             "pyjinhx.reactive.keys",
             "pyjinhx.session",


### PR DESCRIPTION
## Summary

Implements cache health degradation for the reactive backend, allowing the system to survive failing tier-2 evictions and writes by degrading to reduced-capacity operation:

- Per-backend cache health state tracking with degradation on failures
- Treat raising or degraded backend get operations as cache miss
- Drop failing tier-2 writes and heal on next successful write
- Survive tier-2 eviction failures by degrading the backend
- Import-graph guard declarations for backend_health dependencies
- Ruff lint fixes and typecheck cleanup

## Test plan

- All existing tests pass
- New health state transitions covered in test suite
- Ruff check and format both clean

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)