### PR TITLE
chore: satisfy the lint gate

### DIFF
--- a/pyjinhx/integrations/diskcache.py
+++ b/pyjinhx/integrations/diskcache.py
@@ -1,0 +1,88 @@
+"""The disk-backed tier-2 cache: a CacheBackend over diskcache's FanoutCache.
+
+Reached only by a caller that imports it, which is why ``diskcache`` is imported
+outright rather than guarded - the same convention as the Starlette import in
+``integrations/fastapi.py``. Nothing in ``pyjinhx`` imports this module eagerly,
+so installing the extra stays optional.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from diskcache import FanoutCache
+
+from pyjinhx.reactive.backend import MISS
+
+
+class DiskCacheBackend:
+    """A ``CacheBackend`` storing entries in a SQLite-backed directory.
+
+    Entries survive process restarts and are shared by every worker on the
+    machine, which is the whole point: N gunicorn workers stop each paying for
+    the same load(). It is a one-machine cache, not a one-cluster one - two
+    hosts pointed at their own directories hold two independent caches, and an
+    eviction on one is invisible to the other.
+
+    ``directory`` must live on local disk. SQLite's locking is unreliable over
+    NFS and other network filesystems, and a cache that corrupts under
+    concurrency is worse than no cache; this is documented rather than detected
+    because the check would be a guess about a mount point.
+
+    Values are pickled on the way in, so what ``get()`` answers is a copy of
+    what ``put()`` was handed rather than the same object.
+    """
+
+    def __init__(
+        self,
+        directory: str | Path,
+        *,
+        shards: int = 8,
+        timeout: float = 0.010,
+    ) -> None:
+        """Open (or create) a cache under ``directory``.
+
+        Args:
+            directory: Where the cache's SQLite shards live. Local disk only.
+            shards: How many SQLite databases the entries are spread over.
+                More than one because a single database serializes every
+                worker behind its write lock.
+            timeout: Seconds a shard operation waits on the write lock before
+                giving up on that operation.
+        """
+        self._cache = FanoutCache(str(directory), shards=shards, timeout=timeout)
+
+    def get(self, key: str) -> object:
+        """Return the value stored under ``key``, or ``MISS``."""
+        # diskcache's own default is None, which a cached None is
+        # indistinguishable from; MISS is what the protocol's callers branch on.
+        return self._cache.get(key, default=MISS)
+
+    def put(
+        self, key: str, value: object, *, tags: Iterable[str], ttl: float | None
+    ) -> None:
+        """Store ``value`` under ``key``, replacing any entry already there."""
+        # TODO(#813): diskcache carries one tag per entry while the protocol
+        # takes many; the fan-out that makes every tag evictable is that
+        # ticket's, and until then only the first tag is recorded.
+        tag = next(iter(tags), None)
+        self._cache.set(key, value, expire=ttl, tag=tag)
+
+    def evict(self, tags: Iterable[str]) -> None:
+        """Drop every entry carrying any of these tags."""
+        # TODO(#813): matches what put() recorded - the first tag only.
+        for tag in tags:
+            self._cache.evict(tag)
+
+    def clear(self) -> None:
+        """Drop every entry and every tag, whatever its ttl."""
+        self._cache.clear()
+
+    def close(self) -> None:
+        """Release the SQLite connections this cache holds open.
+
+        Not part of ``CacheBackend`` - ``shutdown_pyjinhx()`` looks for it by
+        name on whatever backend is configured.
+        """
+        self._cache.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ extraPaths = ["docs"]
 [project.optional-dependencies]
 redis = ["redis>=5.0.0", "fakeredis>=2.26.0"]
 fastapi = ["fastapi>=0.115.0", "starlette>=0.40.0"]
+diskcache = ["diskcache>=5.6.0"]
 
 [dependency-groups]
 dev = [
@@ -56,5 +57,6 @@ dev = [
     "python-multipart>=0.0.9",
     "fakeredis>=2.26.0",
     "redis>=5.0.0",
+    "diskcache>=5.6.0",
     "pytest-playwright>=0.8.0",
 ]

--- a/tests/pyjinhx/integrations/test_diskcache_wiring.py
+++ b/tests/pyjinhx/integrations/test_diskcache_wiring.py
@@ -1,0 +1,132 @@
+"""The diskcache-backed tier-2 cache: extra wiring and CacheBackend conformance."""
+
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+from pyjinhx.reactive.backend import MISS, CacheBackend
+
+diskcache = pytest.importorskip("diskcache")
+
+from pyjinhx.integrations.diskcache import DiskCacheBackend  # noqa: E402
+
+
+def test_importing_bare_pyjinhx_does_not_need_the_extra():
+    # A subprocess with diskcache blocked at the import hook is the only honest
+    # check here: the dev environment installs the extra, so an in-process
+    # import would pass whether or not the eager-import rule is respected.
+    script = textwrap.dedent("""
+        import sys
+
+        class Blocker:
+            # find_spec(), not the deprecated find_module(): CPython's import
+            # machinery (3.12+) never calls find_module() on a meta_path entry
+            # that only defines it, so a Blocker built on find_module() is
+            # inert - the import succeeds either way and the test is honest
+            # only by accident. find_spec() is the hook actually consulted.
+            def find_spec(self, name, path=None, target=None):
+                if name == "diskcache" or name.startswith("diskcache."):
+                    raise ImportError("diskcache is not installed")
+                return None
+
+        sys.meta_path.insert(0, Blocker())
+        import pyjinhx
+        import pyjinhx.config
+        assert "diskcache" not in sys.modules
+        print("ok")
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_the_backend_satisfies_the_protocol(tmp_path):
+    assert isinstance(DiskCacheBackend(tmp_path), CacheBackend)
+
+
+def test_the_backend_wraps_a_fanout_cache_not_a_plain_cache(tmp_path):
+    # A single Cache means one SQLite write lock every worker queues behind,
+    # which is the thing the sharded FanoutCache exists to avoid.
+    backend = DiskCacheBackend(tmp_path)
+    assert isinstance(backend._cache, diskcache.FanoutCache)
+
+
+def test_get_on_an_empty_cache_returns_miss(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    result = backend.get("pjx:1:app.Widget:todos")
+    assert result is MISS
+    assert result is not None
+
+
+def test_put_then_get_round_trips_the_value(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("todos", [1, 2, 3], tags=(), ttl=None)
+    assert backend.get("todos") == [1, 2, 3]
+
+
+def test_a_cached_none_round_trips_as_none_not_miss(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("todos", None, tags=(), ttl=None)
+    assert backend.get("todos") is None
+
+
+def test_a_re_put_replaces_the_entry(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("todos", [1], tags=(), ttl=None)
+    backend.put("todos", [2], tags=(), ttl=None)
+    assert backend.get("todos") == [2]
+
+
+def test_an_entry_past_its_ttl_reads_as_a_miss(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("todos", [1, 2, 3], tags=(), ttl=0.05)
+    assert backend.get("todos") == [1, 2, 3]
+    time.sleep(0.1)
+    assert backend.get("todos") is MISS
+
+
+def test_a_none_ttl_never_expires_on_its_own(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("todos", [1, 2, 3], tags=(), ttl=None)
+    time.sleep(0.1)
+    assert backend.get("todos") == [1, 2, 3]
+
+
+def test_evicting_a_tag_drops_the_entries_carrying_it(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("todos", [1], tags=("todos",), ttl=None)
+    backend.put("users", [2], tags=("users",), ttl=None)
+    backend.evict(("todos",))
+    assert backend.get("todos") is MISS
+    assert backend.get("users") == [2]
+
+
+def test_evicting_a_tag_that_matches_nothing_is_a_no_op(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("todos", [1], tags=("todos",), ttl=None)
+    backend.evict(("nothing-has-this-tag",))
+    backend.evict(())
+    assert backend.get("todos") == [1]
+
+
+def test_clear_empties_the_cache(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("todos", [1], tags=("todos",), ttl=None)
+    backend.put("users", [2], tags=("users",), ttl=None)
+    backend.clear()
+    assert backend.get("todos") is MISS
+    assert backend.get("users") is MISS
+
+
+def test_close_is_callable_the_way_shutdown_calls_it(tmp_path):
+    # shutdown_pyjinhx() reaches for close() by name on whatever backend is
+    # configured, so the attribute has to be there on the instance.
+    backend = DiskCacheBackend(tmp_path)
+    close = getattr(backend, "close", None)
+    assert close is not None
+    close()

--- a/tests/pyjinhx/integrations/test_diskcache_wiring.py
+++ b/tests/pyjinhx/integrations/test_diskcache_wiring.py
@@ -11,7 +11,7 @@ from pyjinhx.reactive.backend import MISS, CacheBackend
 
 diskcache = pytest.importorskip("diskcache")
 
-from pyjinhx.integrations.diskcache import DiskCacheBackend  # noqa: E402
+from pyjinhx.integrations.diskcache import DiskCacheBackend
 
 
 def test_importing_bare_pyjinhx_does_not_need_the_extra():
@@ -39,7 +39,7 @@ def test_importing_bare_pyjinhx_does_not_need_the_extra():
         print("ok")
     """)
     result = subprocess.run(
-        [sys.executable, "-c", script], capture_output=True, text=True
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
     )
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -408,6 +408,11 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     # only touches session.py's request_scope() by documented contract, never
     # by import, so it has no internal edges of its own.
     "integrations.base": frozenset(),
+    # diskcache is only reached by a caller that imports it directly (the
+    # extra-free import guarantee); it wraps FanoutCache with the same
+    # MISS sentinel reactive.backend already defines, rather than inventing
+    # a second one.
+    "integrations.diskcache": frozenset({"pyjinhx.reactive.backend"}),
     "integrations.fastapi": frozenset(
         {
             "pyjinhx.client.inject",

--- a/uv.lock
+++ b/uv.lock
@@ -142,6 +142,15 @@ wheels = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
 name = "fakeredis"
 version = "2.36.2"
 source = { registry = "https://pypi.org/simple" }
@@ -671,6 +680,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+diskcache = [
+    { name = "diskcache" },
+]
 fastapi = [
     { name = "fastapi" },
     { name = "starlette" },
@@ -682,6 +694,7 @@ redis = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "diskcache" },
     { name = "fakeredis" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -696,6 +709,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "diskcache", marker = "extra == 'diskcache'", specifier = ">=5.6.0" },
     { name = "fakeredis", marker = "extra == 'redis'", specifier = ">=2.26.0" },
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.115.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -704,10 +718,11 @@ requires-dist = [
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
     { name = "starlette", marker = "extra == 'fastapi'", specifier = ">=0.40.0" },
 ]
-provides-extras = ["redis", "fastapi"]
+provides-extras = ["redis", "fastapi", "diskcache"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "diskcache", specifier = ">=5.6.0" },
     { name = "fakeredis", specifier = ">=2.26.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },


### PR DESCRIPTION
## Summary
- Add DiskCacheBackend integration over diskcache's FanoutCache
- Declare integrations.diskcache edge in import graph guard
- Add diskcache extra and dev dependency  
- Remove unused E402 noqa and fix subprocess.run check per PLW1510

## Test plan
- 1 integration test file added (132 lines)
- 1 import graph test updated
- All ruff checks passing

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)