### PR TITLE
fix: skip and log unpicklable values instead of raising from put()

### DIFF
--- a/pyjinhx/integrations/diskcache.py
+++ b/pyjinhx/integrations/diskcache.py
@@ -8,6 +8,8 @@ so installing the extra stays optional.
 
 from __future__ import annotations
 
+import logging
+import pickle
 from collections.abc import Iterable
 from pathlib import Path
 from typing import cast
@@ -15,6 +17,11 @@ from typing import cast
 from diskcache import FanoutCache
 
 from pyjinhx.reactive.backend import MISS
+
+logger = logging.getLogger("pyjinhx")
+
+_PICKLING_ERRORS = (pickle.PicklingError, TypeError, AttributeError)
+"""What a value that will not pickle raises, across pickle's several ways of saying so."""
 
 _KEYS_OF_TAG = "pjx:diskcache:keys-of-tag:"
 """Prefix of the entry holding the set of keys carrying one tag."""
@@ -64,6 +71,7 @@ class DiskCacheBackend:
                 giving up on that operation.
         """
         self._cache = FanoutCache(str(directory), shards=shards, timeout=timeout)
+        self._unpicklable: set[str] = set()
 
     def get(self, key: str) -> object:
         """Return the value stored under ``key``, or ``MISS``."""
@@ -74,8 +82,23 @@ class DiskCacheBackend:
     def put(
         self, key: str, value: object, *, tags: Iterable[str], ttl: float | None
     ) -> None:
-        """Store ``value`` under ``key``, replacing any entry already there."""
-        self._cache.set(key, value, expire=ttl)
+        """Store ``value`` under ``key``, replacing any entry already there.
+
+        A value that will not pickle is logged and skipped rather than raised
+        over: once a backend is configured, every component's load() result
+        passes through here, and one holding a socket or a lock is a normal
+        thing to meet, not an authoring error worth failing a request for.
+        """
+        try:
+            self._cache.set(key, value, expire=ttl)
+        except _PICKLING_ERRORS as exc:
+            # Caught here rather than left to component.py's generic handler:
+            # that one logs once per backend, class-blind, so the first
+            # unpicklable class would hide every later one. Narrow exception
+            # types on purpose - a lock timeout or a disk error still belongs
+            # to the caller, which degrades the backend over it.
+            self._note_unpicklable(value, exc)
+            return
         # A replacement may hang off different tags than the entry it replaces,
         # so its old memberships go before the new ones land - merging them
         # would leave the new value evictable by a tag it never claimed.
@@ -143,4 +166,25 @@ class DiskCacheBackend:
         return cast(
             "frozenset[str]",
             self._cache.get(_TAGS_OF_KEY + key, default=frozenset()),
+        )
+
+    def _note_unpicklable(self, value: object, exc: BaseException) -> None:
+        """Warn the first time this backend meets a class that will not pickle."""
+        cls = type(value)
+        name = f"{cls.__module__}.{cls.__qualname__}"
+        # One warning per class, not per call: a load() returning this type
+        # fails on every request, and a line per request buries the first. The
+        # qualified name rather than the class object, so this set does not
+        # keep a class alive for the life of the process.
+        if name in self._unpicklable:
+            return
+        self._unpicklable.add(name)
+        logger.warning(
+            "pyjinhx cache backend %s could not pickle a value of type %s "
+            "(%s: %s); it is not being cached. Further values of this type "
+            "are not logged.",
+            type(self).__name__,
+            name,
+            type(exc).__name__,
+            exc,
         )

--- a/pyjinhx/integrations/diskcache.py
+++ b/pyjinhx/integrations/diskcache.py
@@ -10,10 +10,17 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from pathlib import Path
+from typing import cast
 
 from diskcache import FanoutCache
 
 from pyjinhx.reactive.backend import MISS
+
+_KEYS_OF_TAG = "pjx:diskcache:keys-of-tag:"
+"""Prefix of the entry holding the set of keys carrying one tag."""
+
+_TAGS_OF_KEY = "pjx:diskcache:tags-of-key:"
+"""Prefix of the entry holding the set of tags one key sits under."""
 
 
 class DiskCacheBackend:
@@ -32,6 +39,11 @@ class DiskCacheBackend:
 
     Values are pickled on the way in, so what ``get()`` answers is a copy of
     what ``put()`` was handed rather than the same object.
+
+    Tag membership is kept as entries of the cache's own, under reserved
+    ``pjx:diskcache:`` key prefixes, rather than diskcache's native one-tag
+    ``tag=`` field: an entry may carry several tags, and an index held in this
+    process would be invisible to the worker that evicts next.
     """
 
     def __init__(
@@ -63,17 +75,25 @@ class DiskCacheBackend:
         self, key: str, value: object, *, tags: Iterable[str], ttl: float | None
     ) -> None:
         """Store ``value`` under ``key``, replacing any entry already there."""
-        # TODO(#813): diskcache carries one tag per entry while the protocol
-        # takes many; the fan-out that makes every tag evictable is that
-        # ticket's, and until then only the first tag is recorded.
-        tag = next(iter(tags), None)
-        self._cache.set(key, value, expire=ttl, tag=tag)
+        self._cache.set(key, value, expire=ttl)
+        # A replacement may hang off different tags than the entry it replaces,
+        # so its old memberships go before the new ones land - merging them
+        # would leave the new value evictable by a tag it never claimed.
+        self._unindex(key)
+        self._index(key, tags)
 
     def evict(self, tags: Iterable[str]) -> None:
         """Drop every entry carrying any of these tags."""
-        # TODO(#813): matches what put() recorded - the first tag only.
+        doomed: set[str] = set()
         for tag in tags:
-            self._cache.evict(tag)
+            doomed |= self._keys_of(tag)
+        # A set, so a key reachable from two of the given tags is deleted once.
+        for key in doomed:
+            self._cache.delete(key)
+            # Un-index every tag the entry sat under, not just the matched ones:
+            # the entry is gone, so a surviving membership would name a key
+            # nothing can look up.
+            self._unindex(key)
 
     def clear(self) -> None:
         """Drop every entry and every tag, whatever its ttl."""
@@ -86,3 +106,41 @@ class DiskCacheBackend:
         name on whatever backend is configured.
         """
         self._cache.close()
+
+    def _index(self, key: str, tags: Iterable[str]) -> None:
+        """Record ``key`` as carrying every one of ``tags``."""
+        # diskcache's native tag= is one tag per entry, which the protocol's
+        # Iterable[str] does not fit, so the index is entries of its own. They
+        # live in the cache rather than in a dict on self because the whole
+        # point of this backend is that another worker's evict() finds them.
+        carried = frozenset(tags)
+        if not carried:
+            return
+        self._cache.set(_TAGS_OF_KEY + key, carried)
+        for tag in carried:
+            self._cache.set(_KEYS_OF_TAG + tag, self._keys_of(tag) | {key})
+
+    def _unindex(self, key: str) -> None:
+        """Remove ``key`` from every tag bucket holding it."""
+        # The forward index names exactly the buckets this key sits in, so the
+        # cost is the entry's own tag count rather than the whole tag index.
+        for tag in self._tags_of(key):
+            self._cache.set(_KEYS_OF_TAG + tag, self._keys_of(tag) - {key})
+        self._cache.delete(_TAGS_OF_KEY + key)
+
+    def _keys_of(self, tag: str) -> frozenset[str]:
+        """Every key currently recorded under ``tag``."""
+        # self._cache.get() is untyped in diskcache and its inferred return
+        # includes types (bytes, a BufferedReader, ...) this store never
+        # actually produces, so the cast - not the bare call - is what the
+        # rest of the module reads as the true type.
+        return cast(
+            "frozenset[str]", self._cache.get(_KEYS_OF_TAG + tag, default=frozenset())
+        )
+
+    def _tags_of(self, key: str) -> frozenset[str]:
+        """Every tag currently recorded as carried by ``key``."""
+        return cast(
+            "frozenset[str]",
+            self._cache.get(_TAGS_OF_KEY + key, default=frozenset()),
+        )

--- a/tests/pyjinhx/integrations/test_diskcache_wiring.py
+++ b/tests/pyjinhx/integrations/test_diskcache_wiring.py
@@ -1,5 +1,6 @@
 """The diskcache-backed tier-2 cache: extra wiring and CacheBackend conformance."""
 
+import logging
 import subprocess
 import sys
 import textwrap
@@ -8,10 +9,25 @@ import time
 import pytest
 
 from pyjinhx.reactive.backend import MISS, CacheBackend
+from pyjinhx.reactive.backend_health import is_degraded
 
 diskcache = pytest.importorskip("diskcache")
 
 from pyjinhx.integrations.diskcache import DiskCacheBackend
+
+
+class Unpicklable:
+    """A value whose instances refuse to pickle, the way a live handle would."""
+
+    def __reduce__(self):
+        raise TypeError("Unpicklable does not pickle")
+
+
+class AlsoUnpicklable:
+    """A second such class, so log-once-per-class is distinguishable from once-ever."""
+
+    def __reduce__(self):
+        raise TypeError("AlsoUnpicklable does not pickle")
 
 
 def test_importing_bare_pyjinhx_does_not_need_the_extra():
@@ -206,3 +222,50 @@ def test_close_is_callable_the_way_shutdown_calls_it(tmp_path):
     close = getattr(backend, "close", None)
     assert close is not None
     close()
+
+
+def test_putting_an_unpicklable_value_does_not_raise(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("summary", Unpicklable(), tags=("todos",), ttl=None)
+
+
+def test_putting_an_unpicklable_value_leaves_the_key_unset(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("summary", Unpicklable(), tags=("todos",), ttl=None)
+    assert backend.get("summary") is MISS
+
+
+def test_putting_an_unpicklable_value_logs_once_per_class(tmp_path, caplog):
+    backend = DiskCacheBackend(tmp_path)
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        backend.put("first", Unpicklable(), tags=("todos",), ttl=None)
+        backend.put("second", Unpicklable(), tags=("todos",), ttl=None)
+    assert len(caplog.records) == 1
+    assert "Unpicklable" in caplog.records[0].getMessage()
+
+
+def test_putting_two_different_unpicklable_classes_each_logs_once(tmp_path, caplog):
+    backend = DiskCacheBackend(tmp_path)
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        backend.put("first", Unpicklable(), tags=("todos",), ttl=None)
+        backend.put("second", AlsoUnpicklable(), tags=("todos",), ttl=None)
+        backend.put("third", AlsoUnpicklable(), tags=("todos",), ttl=None)
+    assert len(caplog.records) == 2
+    logged = [record.getMessage() for record in caplog.records]
+    # Module-qualified, and with the trailing space: "AlsoUnpicklable" contains
+    # "Unpicklable", so a bare substring check would pass on the wrong record.
+    for cls in (Unpicklable, AlsoUnpicklable):
+        name = f"{cls.__module__}.{cls.__qualname__} "
+        assert any(name in message for message in logged), name
+
+
+def test_an_unpicklable_value_does_not_mark_the_backend_degraded(tmp_path):
+    # A value that will not pickle is a fact about that value, not a backend
+    # that is down - degradation is backend_health.py's separate mechanism.
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("summary", Unpicklable(), tags=("todos",), ttl=None)
+    assert is_degraded(backend) is False
+    backend.put("todos", [1], tags=("todos",), ttl=None)
+    assert backend.get("todos") == [1]
+    backend.evict(("todos",))
+    assert backend.get("todos") is MISS

--- a/tests/pyjinhx/integrations/test_diskcache_wiring.py
+++ b/tests/pyjinhx/integrations/test_diskcache_wiring.py
@@ -114,6 +114,82 @@ def test_evicting_a_tag_that_matches_nothing_is_a_no_op(tmp_path):
     assert backend.get("todos") == [1]
 
 
+def test_an_entry_with_several_tags_is_evicted_by_any_one_of_them(tmp_path):
+    # A fresh directory per case: an entry evicted by its first tag proves
+    # nothing about the second unless the second is tried on a live entry.
+    for tag in ("todos", "users"):
+        backend = DiskCacheBackend(tmp_path / tag)
+        backend.put("summary", [1], tags=("todos", "users"), ttl=None)
+        backend.evict((tag,))
+        assert backend.get("summary") is MISS
+
+
+def test_evict_drops_every_entry_matching_any_given_tag(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("todos", [1], tags=("todos",), ttl=None)
+    backend.put("users", [2], tags=("users",), ttl=None)
+    backend.put("orders", [3], tags=("orders",), ttl=None)
+    backend.evict(("todos", "users"))
+    assert backend.get("todos") is MISS
+    assert backend.get("users") is MISS
+    assert backend.get("orders") == [3]
+
+
+def test_an_entry_reachable_from_two_evicted_tags_is_dropped_once(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("summary", [1], tags=("todos", "users"), ttl=None)
+    backend.evict(("todos", "users"))
+    assert backend.get("summary") is MISS
+    # Whatever bookkeeping the double match left behind must not resurrect the
+    # key or poison the tags for the next entry stored under them.
+    backend.put("summary", [2], tags=("todos", "users"), ttl=None)
+    assert backend.get("summary") == [2]
+
+
+def test_re_putting_a_key_drops_its_old_tags(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("summary", [1], tags=("todos",), ttl=None)
+    backend.put("summary", [2], tags=("users",), ttl=None)
+    backend.evict(("todos",))
+    assert backend.get("summary") == [2]
+    backend.evict(("users",))
+    assert backend.get("summary") is MISS
+
+
+def test_evict_with_no_tags_is_a_no_op(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("summary", [1], tags=("todos", "users"), ttl=None)
+    backend.evict(())
+    assert backend.get("summary") == [1]
+
+
+def test_put_with_no_tags_is_never_evicted_by_a_later_evict_call(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("summary", [1], tags=(), ttl=None)
+    backend.evict(("todos", "users", ""))
+    assert backend.get("summary") == [1]
+
+
+def test_a_multi_tag_entry_still_expires_on_its_ttl(tmp_path):
+    backend = DiskCacheBackend(tmp_path)
+    backend.put("summary", [1], tags=("todos", "users"), ttl=0.05)
+    assert backend.get("summary") == [1]
+    time.sleep(0.1)
+    assert backend.get("summary") is MISS
+
+
+def test_multi_tag_semantics_hold_across_two_backend_instances_sharing_a_directory(
+    tmp_path,
+):
+    # The tag index has to live in the cache directory, not in either instance's
+    # memory: that is what makes an eviction in one worker visible in the next.
+    writer = DiskCacheBackend(tmp_path)
+    evictor = DiskCacheBackend(tmp_path)
+    writer.put("summary", [1], tags=("todos", "users"), ttl=None)
+    evictor.evict(("users",))
+    assert writer.get("summary") is MISS
+
+
 def test_clear_empties_the_cache(tmp_path):
     backend = DiskCacheBackend(tmp_path)
     backend.put("todos", [1], tags=("todos",), ttl=None)


### PR DESCRIPTION
## Summary

- Fix DiskCacheBackend to honor every tag an entry was put with
- Fix DiskCacheBackend to skip and log unpicklable values instead of raising from put()
- Add comprehensive test coverage for multi-tag eviction semantics
- Add test coverage for the log-once-and-skip policy for unpicklable values

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)