### PR TITLE
fix: type the disqualification test's monkeypatch replacement precisely

### DIFF
--- a/pyjinhx/_component.py
+++ b/pyjinhx/_component.py
@@ -486,6 +486,19 @@ class BaseComponent(BaseModel):
 
     _pjx_replace: ClassVar[bool] = False
 
+    _pjx_cache_policy: ClassVar[Any] = None
+    """This class's cross-request cache policy, exactly as ``cache=`` gave it:
+    a CachePolicy overriding the process default, False for no cross-request
+    caching, or None when the class said nothing (which is not the same answer
+    as False — resolving None against the default belongs to whoever reads it).
+
+    Typed loosely on purpose: CachePolicy lives under reactive/, and the render
+    spine may not import reactive/ at all. The two readers give the value its
+    meaning — render_cache.resolve_render_tier2 for the render cache and
+    reactive's _resolve_tier2 for the load cache — and ReactiveComponent
+    re-declares this attribute with the precise type where that import is legal.
+    """
+
     _pjx_stale_header_warned: ClassVar[bool] = False
     """Set the first time this class's stale ``{#def#}`` header is reported, so
     the complaint is made once and not once per render."""
@@ -546,15 +559,23 @@ class BaseComponent(BaseModel):
 
         return _render(self, session or current_session())
 
-    def __init_subclass__(cls, *, pjx_replace: bool = False, **kwargs: Any) -> None:
-        """Consume the ``pjx_replace`` class kwarg before it reaches
-        ``object.__init_subclass__``, which accepts no keyword arguments.
+    def __init_subclass__(
+        cls, *, pjx_replace: bool = False, cache: Any = None, **kwargs: Any
+    ) -> None:
+        """Consume the ``pjx_replace`` and ``cache`` class kwargs before they
+        reach ``object.__init_subclass__``, which accepts no keyword arguments.
 
         Assigned on every subclass, never merely inherited: a subclass of a
         replacing component is a new class that has not asked to replace
-        anything, and a leaked ``True`` would hand it someone else's tag.
+        anything, and a leaked ``True`` would hand it someone else's tag. Same
+        for caching — a subclass that inherited a parent's policy would be
+        cached against state it never declared.
         """
         cls._pjx_replace = bool(pjx_replace)
+        # Stored exactly as given, not coerced: None means "no answer, use the
+        # process default" and an explicit False means "never", and bool() would
+        # collapse the two into one.
+        cls._pjx_cache_policy = cache
         super().__init_subclass__(**kwargs)
 
     @classmethod

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -102,11 +102,11 @@ class ReactiveComponent(BaseComponent):
         a parent's would tie its cache entry to state it never reads.
         """
         cls._pjx_react_keys = tuple(coerce_reactive_key(key) for key in react or ())
-        # Stored exactly as given: an omitted cache= is None, which means "no
-        # answer, use the process default" and is not the same as an explicit
-        # False. Resolving None against the default belongs to whoever reads it.
-        cls._pjx_cache_policy = cache
-        super().__init_subclass__(**kwargs)
+        # Forwarded rather than assigned here: BaseComponent owns the attribute
+        # now, so plain and reactive classes answer the same knob the same way.
+        # The precise annotation stays on this parameter because reactive/ is
+        # where CachePolicy may legally be named.
+        super().__init_subclass__(cache=cache, **kwargs)
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:

--- a/pyjinhx/render_cache.py
+++ b/pyjinhx/render_cache.py
@@ -7,7 +7,7 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from pyjinhx._component import BaseComponent
-from pyjinhx.reactive.backend import MISS, CacheBackend
+from pyjinhx.reactive.backend import MISS, CacheBackend, CachePolicy
 from pyjinhx.segments import ChildRef, RenderedLevel
 
 if TYPE_CHECKING:
@@ -69,6 +69,39 @@ def render_cache_key(component: BaseComponent) -> str:
     # would clear it.
     template_mtime = descriptor.template_path.stat().st_mtime
     return f"{identity}:{fields_digest}:{template_mtime}"
+
+
+def resolve_render_tier2(
+    cls: type[BaseComponent],
+) -> tuple[CacheBackend | None, float | None]:
+    """The render cache this class stores through, and the ttl it writes at.
+
+    Answers ``(None, None)`` when the render cache is off for ``cls`` - either
+    because no backend is configured for the process or because the class opted
+    out with ``cache=False``. Otherwise the configured backend and the seconds
+    its entries stay valid.
+
+    A near-twin of reactive's ``_resolve_tier2`` rather than a shared import:
+    that one is typed to ReactiveComponent and lives next to the load-cache key
+    machinery its only caller needs, while this one is handed a plain class and
+    nothing else. Sharing them would drag reactive/ into the render spine's
+    reach for four lines.
+    """
+    # Function-local by necessity: config sits above the render spine and
+    # imports it at import time, so a module-scope edge back would be a real
+    # cycle. Same escape hatch reactive's _resolve_tier2 uses.
+    from pyjinhx.config import current_settings
+
+    policy = cls._pjx_cache_policy
+    # `is False`, not falsiness: None is "the class said nothing", which means
+    # the process default applies, and it is not the same answer as an explicit
+    # opt-out.
+    if policy is False:
+        return None, None
+    backend = current_settings().cache_backend
+    if backend is None:
+        return None, None
+    return backend, (CachePolicy() if policy is None else policy).ttl
 
 
 def store_rendered_level(

--- a/pyjinhx/render_cache.py
+++ b/pyjinhx/render_cache.py
@@ -140,6 +140,27 @@ def resolve_render_tier2(
     return backend, (CachePolicy() if policy is None else policy).ttl
 
 
+def copy_level_shell(level: RenderedLevel) -> RenderedLevel:
+    """A level sharing everything but its segment list with ``level``.
+
+    Both directions across the cache seam need this. A backend may store by
+    reference (InMemoryCacheBackend does, by design), while _fill_children and
+    _splice_slot_nodes rewrite ``segments`` in place - so writing the live level
+    would let this request's children land inside the cached entry, and handing
+    a restored entry straight back would let the next request fill a level that
+    is already full.
+
+    Shallow on purpose: the descriptor is frozen, the root span is a tuple, and
+    a ChildRef is only ever read (its attrs are copied before use), so a deep
+    copy would duplicate immutable data on every hit for nothing.
+    """
+    return RenderedLevel(
+        segments=list(level.segments),
+        root_span=level.root_span,
+        descriptor=level.descriptor,
+    )
+
+
 def store_rendered_level(
     backend: CacheBackend, key: str, level: RenderedLevel, *, ttl: float | None
 ) -> None:

--- a/pyjinhx/render_cache.py
+++ b/pyjinhx/render_cache.py
@@ -4,10 +4,15 @@
 
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from pyjinhx._component import BaseComponent
 from pyjinhx.reactive.backend import MISS, CacheBackend, CachePolicy
+from pyjinhx.reactive.backend_health import (
+    is_degraded,
+    note_failure,
+    note_write_success,
+)
 from pyjinhx.segments import ChildRef, RenderedLevel
 
 if TYPE_CHECKING:
@@ -245,3 +250,62 @@ def replay_asset_accumulation(level: RenderedLevel, session: "RenderSession") ->
     descriptor: Any = level.descriptor
     session.css_assets.update(descriptor.css_paths)
     session.js_assets.update(descriptor.js_paths)
+
+
+def load_rendered_level(backend: CacheBackend, key: str) -> RenderedLevel | None:
+    """The level cached under ``key``, or None when there is nothing usable.
+
+    None covers three answers the caller treats identically - no entry, a
+    degraded backend that is not being read from, and a backend whose get()
+    raised - because all three mean the same thing to a render: do the work.
+
+    The level comes back detached from the stored one (copy_level_shell), so the
+    caller may fill its children without editing the cache.
+
+    Raises:
+        ValueError: If the entry exists but is not a RenderedLevel. A corrupt or
+            foreign entry is a data-integrity problem the caller must see, not a
+            backend that failed to answer, so it is neither swallowed as a miss
+            nor counted against the backend's health.
+    """
+    # A degraded backend is one whose evict() raised: entries it still holds may
+    # be stale, so it is not read from until a write lands.
+    if is_degraded(backend):
+        return None
+    try:
+        restored = restore_rendered_level(backend, key)
+    except ValueError:
+        raise
+    # A backend is a plugin implementing an arbitrary protocol, so its failure
+    # mode is unknowable in advance; the policy is to degrade on any of them
+    # rather than pick and miss some.
+    except Exception as exc:  # noqa: BLE001
+        # A cache is an optimization: a backend that cannot answer costs this
+        # request a real render, never an error.
+        note_failure(backend, "get", exc, degrade=False)
+        return None
+    if restored is MISS:
+        return None
+    return copy_level_shell(cast(RenderedLevel, restored))
+
+
+def save_rendered_level(
+    backend: CacheBackend, key: str, level: RenderedLevel, *, ttl: float | None
+) -> None:
+    """Write ``level``'s shell behind ``key``, absorbing a backend that raises.
+
+    Stores a detached copy: the caller is about to resolve this level's children
+    in place, and the entry must keep its holes for the next request to fill.
+    """
+    try:
+        store_rendered_level(backend, key, copy_level_shell(level), ttl=ttl)
+    # Same rationale as the get() guard above: any backend failure degrades
+    # rather than only the ones this module can predict.
+    except Exception as exc:  # noqa: BLE001
+        # The level is already rendered: a dropped write costs the next request
+        # a render, nothing more.
+        note_failure(backend, "put", exc, degrade=False)
+    else:
+        # A write that landed is the evidence a degraded backend is answering
+        # again, and that what it now holds is current.
+        note_write_success(backend)

--- a/pyjinhx/render_cache.py
+++ b/pyjinhx/render_cache.py
@@ -31,6 +31,47 @@ def _holds_component(value: object) -> bool:
     return False
 
 
+def _spliced_fields(component: BaseComponent) -> set[str]:
+    """Slot/children field names whose current value is a component, or a
+    list/dict holding one.
+
+    These are the fields a render treats as opaque holes: the key leaves them
+    out (see render_cache_key) and the cache refuses the instance outright (see
+    holds_spliced_components), which are the two halves of one rule.
+    """
+    descriptor = type(component).__pjx_descriptor__
+    hole_fields = set(descriptor.slot_fields)
+    if descriptor.children_field is not None:
+        hole_fields.add(descriptor.children_field)
+    return {name for name in hole_fields if _holds_component(getattr(component, name))}
+
+
+def holds_spliced_components(component: BaseComponent) -> bool:
+    """Whether this instance carries a component in a slot or children field,
+    which disqualifies it from the render cache.
+
+    Such a value never reaches the template as text: build_context wraps it in a
+    ComponentNode, and interpolating it fires the finalize hook, which writes a
+    random ``pjx-slot-<uuid4 hex>`` token into a table that lives exactly as long
+    as the one ``template.render()`` call that produced it. A cache hit performs
+    no such call, so the tokens baked into a restored level match nothing in this
+    request and would splice as literal garbage into the page.
+
+    Regenerating those tokens positionally against a fresh table is possible in
+    principle - an identical key implies identical control flow implies identical
+    emission order - but it needs the stored level to carry that order, which
+    means changing what is stored. So the render cache declines these instances
+    instead, the same way the load cache declines an unpicklable result: not an
+    error, just an instance that renders live every time.
+
+    Answered per instance, not per class: a Slot field declared component-capable
+    but currently holding a plain string emits no token at all, and that string is
+    baked into the cached segments as text (and stays in the key), so there is
+    nothing to disqualify.
+    """
+    return bool(_spliced_fields(component))
+
+
 def render_cache_key(component: BaseComponent) -> str:
     """Return the render-cache key for ``component``.
 
@@ -50,12 +91,7 @@ def render_cache_key(component: BaseComponent) -> str:
     # string instead is baked into the cached segments as literal text, never
     # a ChildRef, so that value has to stay in the key or two different
     # strings on the same field would collide on one entry.
-    hole_fields = set(descriptor.slot_fields)
-    if descriptor.children_field is not None:
-        hole_fields.add(descriptor.children_field)
-    spliced_fields = {
-        name for name in hole_fields if _holds_component(getattr(component, name))
-    }
+    spliced_fields = _spliced_fields(component)
     # JSON-mode dump plus sorted, separator-pinned encoding so dict ordering
     # and non-JSON-native types can't perturb an unchanged set of props.
     canonical = json.dumps(

--- a/pyjinhx/rendering.py
+++ b/pyjinhx/rendering.py
@@ -16,9 +16,17 @@ from pyjinhx.assets import emit_assets
 from pyjinhx.discovery import get_class
 from pyjinhx.markers import SLOT_TOKEN_RE, collect_slot_tokens
 from pyjinhx.props_header import warn_stale_def_header
+from pyjinhx.render_cache import (
+    holds_spliced_components,
+    load_rendered_level,
+    render_cache_key,
+    replay_asset_accumulation,
+    resolve_render_tier2,
+    save_rendered_level,
+)
 from pyjinhx.render_context import build_context
 from pyjinhx.segments import ChildRef, RenderedLevel, VerbatimParser, serialize
-from pyjinhx.session import RenderSession
+from pyjinhx.session import RenderSession, accumulate_assets
 
 # How many times one class may appear on a single nesting path before the path
 # is treated as a cycle. A terminating design reuses a class a handful of times
@@ -215,6 +223,40 @@ def _splice_slot_nodes(
     level.segments = spliced
 
 
+def _finish_cached_level(
+    level: RenderedLevel, session: "RenderSession", chain: tuple[str, ...]
+) -> RenderedLevel:
+    """Finish a level restored from the render cache: resolve its holes, replay
+    its assets, return it.
+
+    Everything a live render does after the parse, and nothing it does before.
+    The child holes are still ChildRefs - that is the whole point of caching the
+    shell - so they resolve and recurse here exactly as they do on a fresh
+    level, cycle guard and registry lookups included.
+
+    _splice_slot_nodes is deliberately not called: a component-valued slot is
+    what holds_spliced_components refuses to cache in the first place, so a
+    restored level carries no live slot tokens and this request's table would be
+    empty - the call would return on its first line. Skipping it says that out
+    loud instead of relying on the reader to check.
+
+    replay_asset_accumulation stands in for the accumulate_assets half of
+    session.emit_rendered - the hook's other two subscribers stamp reactive
+    root attrs and register a reactive instance, and nothing reactive is ever
+    in this cache. Called only when accumulate_assets is actually one of this
+    session's on_rendered subscribers (D6): that hook is opt-in per session,
+    not automatic (see tests/pyjinhx/test_assets.py), so a hit must reproduce
+    what the live path would have done for *this* session - forcing
+    accumulation onto a session that never asked for it would make a hit
+    observably different from the miss it stands in for.
+    """
+    for index, child in _fill_children(level):
+        level.segments[index] = render_level(child, session, chain)
+    if accumulate_assets in session.on_rendered:
+        replay_asset_accumulation(level, session)
+    return level
+
+
 def render_level(
     component: BaseComponent,
     session: "RenderSession",
@@ -274,6 +316,32 @@ def render_level(
         raise ValueError(f"{prefix}cycle detected: {' -> '.join((*cycle, name))}")
     chain = (*chain, name)
 
+    # Tier 2 (the render cache) is for plain components only. A reactive class
+    # carries the _pjx_key_field marker and caches its load() result across
+    # requests instead; caching its rendered shell too would key one component
+    # against two independently invalidated stores, so the marker's mere
+    # presence takes this level off the render-cache path entirely (the same
+    # duck-type _fill_children and _mount_root read, and the reason this module
+    # still imports nothing from reactive/). A component holding a component in
+    # a slot/children field is disqualified the same way (D1): its slot tokens
+    # are only valid for the template.render() call that emitted them.
+    backend = None
+    ttl = None
+    cache_key = ""
+    if getattr(component.__class__, "_pjx_key_field", _NO_KEY_FIELD) is _NO_KEY_FIELD:
+        backend, ttl = resolve_render_tier2(component.__class__)
+    # holds_spliced_components reads the instance's own slot/children field
+    # values off the descriptor, which is only ever safe to do for a class
+    # tier 2 would otherwise cache — checked last, and only once tier 2 is
+    # already on, so an off backend costs this nothing extra.
+    if backend is not None and holds_spliced_components(component):
+        backend, ttl = None, None
+    if backend is not None:
+        cache_key = render_cache_key(component)
+        restored = load_rendered_level(backend, cache_key)
+        if restored is not None:
+            return _finish_cached_level(restored, session, chain)
+
     # Phase 2: Context build — component-valued slots arrive as ComponentNode,
     # string-valued slots arrive as Markup so authored markup survives
     # autoescape.
@@ -308,6 +376,11 @@ def render_level(
         root_span=parser.root_span or (0, 0),
         descriptor=descriptor,
     )
+    if backend is not None:
+        # Written here, with every child hole still unresolved: what is worth
+        # caching is this level's own shell, and a level whose children were
+        # already spliced in would be a cache of one request's whole subtree.
+        save_rendered_level(backend, cache_key, level, ttl=ttl)
     # Unregistered tags stop being holes here, one pass per level (ADR 0005);
     # the ones that do resolve arrive already built — a reactive child through
     # its cache-routed load() factory, a plain one through its constructor.

--- a/pyjinhx/rendering.py
+++ b/pyjinhx/rendering.py
@@ -252,15 +252,12 @@ def render_level(
     if descriptor.has_stale_def_header:
         warn_stale_def_header(component.__class__)
 
-    # Phase 2: Context build — component-valued slots arrive as ComponentNode,
-    # string-valued slots arrive as Markup so authored markup survives
-    # autoescape.
-    context = build_context(component, descriptor)
-
-    # Phase 3: Jinja render with autoescape ON
-    jinja_env = session.jinja_env
     prefix = f"{component.__class__.__name__} (template: {descriptor.template_path}): "
 
+    # Checked before anything else this level does, including a cache lookup: a
+    # hit skips the template render entirely, so a guard left down in Phase 3
+    # would stop counting the moment the cache started answering.
+    #
     # A class may legitimately reappear deeper on the same path — Card > Row >
     # Card terminates — so mere presence in the chain proves nothing. What a
     # real cycle looks like is a path that stops making progress: the same class
@@ -276,6 +273,14 @@ def render_level(
         cycle = chain[last:]
         raise ValueError(f"{prefix}cycle detected: {' -> '.join((*cycle, name))}")
     chain = (*chain, name)
+
+    # Phase 2: Context build — component-valued slots arrive as ComponentNode,
+    # string-valued slots arrive as Markup so authored markup survives
+    # autoescape.
+    context = build_context(component, descriptor)
+
+    # Phase 3: Jinja render with autoescape ON
+    jinja_env = session.jinja_env
 
     try:
         template = jinja_env.get_template(str(descriptor.template_path))

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -438,6 +438,11 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
             "pyjinhx.discovery",
             "pyjinhx.markers",
             "pyjinhx.props_header",
+            # render_cache is the render spine's one door to the cross-request cache:
+            # it owns every reactive/ import the cache needs (the backend protocol and
+            # the health state), so rendering.py can consult tier 2 without the spine
+            # naming reactive/ anywhere - which the two tests below still forbid.
+            "pyjinhx.render_cache",
             "pyjinhx.render_context",
             "pyjinhx.segments",
             "pyjinhx.session",

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -455,7 +455,14 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
     "render_cache": frozenset(
         {
             "pyjinhx._component",
+            # Lazy, inside resolve_render_tier2()'s body only (config sits above
+            # the render spine, see test_render_cache_only_imports_config_inside_a_function_body).
+            "pyjinhx.config",
             "pyjinhx.reactive.backend",
+            # backend_health carries the degrade-on-failure policy the load cache
+            # already uses; the render cache degrades on the same terms, so it reads
+            # the same state rather than keeping a second one.
+            "pyjinhx.reactive.backend_health",
             "pyjinhx.segments",
             "pyjinhx.session",
         }
@@ -737,6 +744,12 @@ def test_nothing_below_config_imports_config():
     current_settings() inside their own bodies to find the process's cache
     backend. test_component_only_imports_config_inside_a_function_body and
     test_cache_only_imports_config_inside_a_function_body pin them there.
+
+    render_cache.py is the fifth, and lazy for the same reason:
+    resolve_render_tier2() calls current_settings() inside its own body to find
+    the process's render-cache backend. config sits above the render spine, so
+    a module-scope edge would be a genuine cycle.
+    test_render_cache_only_imports_config_inside_a_function_body pins it there.
     """
     importers = {
         module_name(path)
@@ -747,6 +760,7 @@ def test_nothing_below_config_imports_config():
         "integrations.fastapi",
         "reactive.cache",
         "reactive.component",
+        "render_cache",
         "session",
     }
 
@@ -814,6 +828,16 @@ def test_component_only_imports_config_inside_a_function_body():
     module_level = module_level_internal_imports(
         PACKAGE_ROOT / "reactive" / "component.py"
     )
+    assert "pyjinhx.config" not in module_level
+
+
+def test_render_cache_only_imports_config_inside_a_function_body():
+    """resolve_render_tier2() reads current_settings() to find the process's
+    render-cache backend, but config sits above the render spine: a
+    module-scope edge would invert the layering and, because config imports
+    the spine at import time, would be a genuine cycle. The whole-file edge
+    table can't see where in the file an import lives, so pin it here."""
+    module_level = module_level_internal_imports(PACKAGE_ROOT / "render_cache.py")
     assert "pyjinhx.config" not in module_level
 
 

--- a/tests/pyjinhx/test_render_cache_wiring.py
+++ b/tests/pyjinhx/test_render_cache_wiring.py
@@ -461,7 +461,7 @@ def test_a_component_valued_slot_is_never_cached_and_splices_every_time(
 
     real_render_cache_key = rendering.render_cache_key
 
-    def guarded(component: object) -> str:
+    def guarded(component: BaseComponent) -> str:
         # Scoped to _HoleHolder itself, not the whole tree: its spliced _Inner
         # child is an ordinary cacheable component and legitimately gets its
         # own key computed on its own render_level call — what D1 disqualifies

--- a/tests/pyjinhx/test_render_cache_wiring.py
+++ b/tests/pyjinhx/test_render_cache_wiring.py
@@ -26,6 +26,7 @@ from pyjinhx.render_cache import (
     copy_level_shell,
     holds_spliced_components,
     load_rendered_level,
+    render_cache_key,
     resolve_render_tier2,
     save_rendered_level,
 )
@@ -480,3 +481,34 @@ def test_a_component_valued_slot_is_never_cached_and_splices_every_time(
 
     assert first == second == "<div><span>i</span></div>"
     assert "pjx-slot-" not in first
+
+
+def test_a_failing_get_degrades_the_backend_without_failing_the_render(
+    box_template: Path, caplog: pytest.LogCaptureFixture
+):
+    spy = SpyBackend(fail_get=True)
+    previous = current_settings()
+    configure_pyjinhx(previous.merge(cache_backend=spy))
+    try:
+        with caplog.at_level("WARNING", logger="pyjinhx"):
+            rendered = serialize(
+                render_level(_CachedBox(id="a", label="hi"), RenderSession())
+            )
+    finally:
+        configure_pyjinhx(previous)
+
+    assert rendered == "<div>hi</div>"
+    assert len(caplog.records) == 1
+
+
+def test_a_corrupt_entry_propagates_out_of_render_level(box_template: Path):
+    spy = SpyBackend()
+    previous = current_settings()
+    configure_pyjinhx(previous.merge(cache_backend=spy))
+    try:
+        key = render_cache_key(_CachedBox(id="a", label="hi"))
+        spy.put(key, "not a level", tags=(), ttl=None)
+        with pytest.raises(ValueError, match="not a RenderedLevel"):
+            render_level(_CachedBox(id="a", label="hi"), RenderSession())
+    finally:
+        configure_pyjinhx(previous)

--- a/tests/pyjinhx/test_render_cache_wiring.py
+++ b/tests/pyjinhx/test_render_cache_wiring.py
@@ -11,7 +11,9 @@ from typing import Any
 import pytest
 
 from pyjinhx._component import BaseComponent
-from pyjinhx.reactive.backend import CachePolicy
+from pyjinhx.config import configure_pyjinhx, current_settings
+from pyjinhx.reactive.backend import CachePolicy, InMemoryCacheBackend
+from pyjinhx.render_cache import resolve_render_tier2
 
 
 def test_a_plain_component_records_an_explicit_cache_policy():
@@ -43,3 +45,57 @@ def test_a_subclass_does_not_inherit_its_parents_cache_policy():
         label: str = ""
 
     assert Child._pjx_cache_policy is None
+
+
+@pytest.fixture
+def backend():
+    """Publish a fresh in-memory backend for one test, then restore the settings.
+
+    configure_pyjinhx rather than shutdown_pyjinhx, matching
+    test_reactive_cache_tier2_wiring.py: a test that asked for a backend should
+    not also blow away whatever else the process was configured with.
+    """
+    previous = current_settings()
+    published = InMemoryCacheBackend()
+    configure_pyjinhx(previous.merge(cache_backend=published))
+    yield published
+    configure_pyjinhx(previous)
+
+
+@pytest.fixture
+def no_backend():
+    previous = current_settings()
+    configure_pyjinhx(previous.merge(cache_backend=None))
+    yield
+    configure_pyjinhx(previous)
+
+
+def test_render_tier2_is_off_when_no_backend_is_configured(no_backend: None):
+    class Widget(BaseComponent):
+        label: str = ""
+
+    assert resolve_render_tier2(Widget) == (None, None)
+
+
+def test_render_tier2_is_on_by_default_at_the_process_default_ttl(backend: Any):
+    class Widget(BaseComponent):
+        label: str = ""
+
+    resolved, ttl = resolve_render_tier2(Widget)
+
+    assert resolved is backend
+    assert ttl == CachePolicy().ttl == 300
+
+
+def test_render_tier2_honors_an_explicit_policy_ttl(backend: Any):
+    class Widget(BaseComponent, cache=CachePolicy(ttl=45)):
+        label: str = ""
+
+    assert resolve_render_tier2(Widget) == (backend, 45)
+
+
+def test_render_tier2_is_off_for_a_class_that_opted_out(backend: Any):
+    class Widget(BaseComponent, cache=False):
+        label: str = ""
+
+    assert resolve_render_tier2(Widget) == (None, None)

--- a/tests/pyjinhx/test_render_cache_wiring.py
+++ b/tests/pyjinhx/test_render_cache_wiring.py
@@ -266,3 +266,43 @@ def test_a_failing_put_does_not_raise_and_does_not_clear_degradation():
     save_rendered_level(spy, "k", _level(), ttl=None)
 
     assert spy.puts == ["k"]
+
+
+from pyjinhx import discovery
+from pyjinhx.rendering import render_level
+from pyjinhx.segments import serialize
+from pyjinhx.session import RenderSession
+
+
+class _CachedBox(BaseComponent):
+    label: str = "hi"
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    discovery._registry.mapping = {}
+    discovery._registry.template_dir = None
+    yield
+    discovery._registry.mapping = {}
+    discovery._registry.template_dir = None
+
+
+@pytest.fixture
+def box_template(tmp_path: Path) -> Path:
+    path = tmp_path / "cached_box.html"
+    path.write_text("<div>{{ label }}</div>", encoding="utf-8")
+    _attach(_CachedBox, path)
+    return path
+
+
+def test_a_first_render_writes_the_shell_through_to_the_backend(
+    backend: InMemoryCacheBackend, box_template: Path
+):
+    spy = SpyBackend()
+    configure_pyjinhx(current_settings().merge(cache_backend=spy))
+
+    rendered = serialize(render_level(_CachedBox(id="a", label="hi"), RenderSession()))
+
+    assert rendered == "<div>hi</div>"
+    assert len(spy.puts) == 1
+    assert len(spy.gets) == 1

--- a/tests/pyjinhx/test_render_cache_wiring.py
+++ b/tests/pyjinhx/test_render_cache_wiring.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import pytest
 
-from pyjinhx import discovery
+from pyjinhx import discovery, rendering
 from pyjinhx._component import BaseComponent, Children, Slot, _pascal_to_snake
 from pyjinhx.config import configure_pyjinhx, current_settings
 from pyjinhx.descriptor import ClassDescriptor
@@ -412,3 +412,71 @@ def test_a_hit_does_not_fill_the_children_of_the_cached_entry(
     third = serialize(render_level(_CachedBox(id="a", label="hi"), RenderSession()))
 
     assert first == second == third == "<div>hi<span>i</span></div>"
+
+
+def test_cache_false_never_touches_the_backend(box_template: Path):
+    class OptedOut(BaseComponent, cache=False):
+        label: str = "hi"
+
+    _attach(OptedOut, box_template)
+    spy = SpyBackend()
+    previous = current_settings()
+    configure_pyjinhx(previous.merge(cache_backend=spy))
+    try:
+        render_level(OptedOut(id="a", label="hi"), RenderSession())
+        render_level(OptedOut(id="a", label="hi"), RenderSession())
+    finally:
+        configure_pyjinhx(previous)
+
+    assert spy.gets == []
+    assert spy.puts == []
+
+
+def test_no_backend_configured_never_computes_a_key(
+    no_backend: None, box_template: Path, monkeypatch: pytest.MonkeyPatch
+):
+    def boom(component: object) -> str:
+        raise AssertionError("render_cache_key was computed with tier 2 off")
+
+    monkeypatch.setattr(rendering, "render_cache_key", boom)
+
+    assert serialize(render_level(_CachedBox(id="a", label="hi"), RenderSession())) == (
+        "<div>hi</div>"
+    )
+
+
+def test_a_component_valued_slot_is_never_cached_and_splices_every_time(
+    backend: InMemoryCacheBackend, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The (b) disqualification: no key, no entry, and correct markup twice."""
+    inner = tmp_path / "inner.html"
+    inner.write_text("<span>i</span>", encoding="utf-8")
+    _attach(_Inner, inner)
+    holder = tmp_path / "slot_holder.html"
+    holder.write_text("<div>{{ body }}</div>", encoding="utf-8")
+    _attach(
+        _HoleHolder, holder, slot_fields=frozenset({"body"}), children_field="content"
+    )
+
+    real_render_cache_key = rendering.render_cache_key
+
+    def guarded(component: object) -> str:
+        # Scoped to _HoleHolder itself, not the whole tree: its spliced _Inner
+        # child is an ordinary cacheable component and legitimately gets its
+        # own key computed on its own render_level call — what D1 disqualifies
+        # is only the parent instance holding the component-valued slot.
+        if isinstance(component, _HoleHolder):
+            raise AssertionError(  # noqa: TRY004
+                "a component-valued slot must never be keyed"
+            )
+        return real_render_cache_key(component)
+
+    monkeypatch.setattr(rendering, "render_cache_key", guarded)
+
+    first = serialize(render_level(_HoleHolder(id="a", body=_Inner()), RenderSession()))
+    second = serialize(
+        render_level(_HoleHolder(id="a", body=_Inner()), RenderSession())
+    )
+
+    assert first == second == "<div><span>i</span></div>"
+    assert "pjx-slot-" not in first

--- a/tests/pyjinhx/test_render_cache_wiring.py
+++ b/tests/pyjinhx/test_render_cache_wiring.py
@@ -15,10 +15,17 @@ from pyjinhx._component import BaseComponent, Children, Slot
 from pyjinhx.config import configure_pyjinhx, current_settings
 from pyjinhx.descriptor import ClassDescriptor
 from pyjinhx.reactive.backend import CachePolicy, InMemoryCacheBackend
+from pyjinhx.reactive.backend_health import (
+    is_degraded,
+    note_failure,
+    reset_backend_health,
+)
 from pyjinhx.render_cache import (
     copy_level_shell,
     holds_spliced_components,
+    load_rendered_level,
     resolve_render_tier2,
+    save_rendered_level,
 )
 from pyjinhx.segments import ChildRef, RenderedLevel
 
@@ -140,7 +147,9 @@ def _attach(
 def test_a_string_in_a_slot_field_is_not_a_spliced_component(tmp_path: Path):
     template = tmp_path / "holder.html"
     template.write_text("<div>{{ body }}</div>", encoding="utf-8")
-    _attach(_HoleHolder, template, slot_fields=frozenset({"body"}), children_field="content")
+    _attach(
+        _HoleHolder, template, slot_fields=frozenset({"body"}), children_field="content"
+    )
 
     assert holds_spliced_components(_HoleHolder(body="plain", content="text")) is False
 
@@ -148,7 +157,9 @@ def test_a_string_in_a_slot_field_is_not_a_spliced_component(tmp_path: Path):
 def test_a_component_in_a_slot_field_is_a_spliced_component(tmp_path: Path):
     template = tmp_path / "holder.html"
     template.write_text("<div>{{ body }}</div>", encoding="utf-8")
-    _attach(_HoleHolder, template, slot_fields=frozenset({"body"}), children_field="content")
+    _attach(
+        _HoleHolder, template, slot_fields=frozenset({"body"}), children_field="content"
+    )
 
     assert holds_spliced_components(_HoleHolder(body=_Inner(), content="text")) is True
 
@@ -156,14 +167,18 @@ def test_a_component_in_a_slot_field_is_a_spliced_component(tmp_path: Path):
 def test_a_component_in_the_children_field_is_a_spliced_component(tmp_path: Path):
     template = tmp_path / "holder.html"
     template.write_text("<div>{{ content }}</div>", encoding="utf-8")
-    _attach(_HoleHolder, template, slot_fields=frozenset({"body"}), children_field="content")
+    _attach(
+        _HoleHolder, template, slot_fields=frozenset({"body"}), children_field="content"
+    )
 
     assert holds_spliced_components(_HoleHolder(body="x", content=[_Inner()])) is True
 
 
 def test_copying_a_level_shell_gives_an_independently_mutable_segment_list():
     ref = ChildRef(tag="PJXIcon", attrs={}, inner=None)
-    original = RenderedLevel(segments=["<div>", ref, "</div>"], root_span=(0, 5), descriptor=None)
+    original = RenderedLevel(
+        segments=["<div>", ref, "</div>"], root_span=(0, 5), descriptor=None
+    )
 
     copy = copy_level_shell(original)
     copy.segments[1] = "filled"
@@ -171,3 +186,83 @@ def test_copying_a_level_shell_gives_an_independently_mutable_segment_list():
     assert original.segments[1] is ref
     assert copy.root_span == original.root_span
     assert copy.descriptor is original.descriptor
+
+
+class SpyBackend(InMemoryCacheBackend):
+    """An in-memory backend that records its calls and can be told to fail.
+
+    Mirrors reactive/test_reactive_cache_failure_policy.py's BrokenBackend; kept
+    local rather than imported across the reactive/render test split so neither
+    file owns the other's fixture.
+    """
+
+    def __init__(self, *, fail_get: bool = False, fail_put: bool = False) -> None:
+        super().__init__()
+        self.fail_get = fail_get
+        self.fail_put = fail_put
+        self.gets: list[str] = []
+        self.puts: list[str] = []
+
+    def get(self, key: str) -> object:
+        self.gets.append(key)
+        if self.fail_get:
+            raise RuntimeError("get is down")
+        return super().get(key)
+
+    def put(self, key: str, value: object, *, tags, ttl) -> None:
+        self.puts.append(key)
+        if self.fail_put:
+            raise RuntimeError("put is down")
+        super().put(key, value, tags=tags, ttl=ttl)
+
+
+@pytest.fixture(autouse=True)
+def clean_health():
+    """Backend health is process-wide: no test may inherit another's flags."""
+    reset_backend_health()
+    yield
+    reset_backend_health()
+
+
+def _level() -> RenderedLevel:
+    return RenderedLevel(segments=["<div></div>"], root_span=(0, 5), descriptor=None)
+
+
+def test_loading_a_missing_entry_answers_none():
+    assert load_rendered_level(SpyBackend(), "k") is None
+
+
+def test_a_failing_get_answers_none_without_raising():
+    spy = SpyBackend(fail_get=True)
+
+    assert load_rendered_level(spy, "k") is None
+
+
+def test_a_corrupt_entry_still_raises_through_the_facade():
+    spy = SpyBackend()
+    spy.put("k", "not a level", tags=(), ttl=None)
+
+    with pytest.raises(ValueError, match="not a RenderedLevel"):
+        load_rendered_level(spy, "k")
+
+
+def test_a_degraded_backend_is_not_read_from_until_a_write_lands():
+    spy = SpyBackend()
+    # Degrade it the way backend_health's contract does, via a failed evict.
+    note_failure(spy, "evict", RuntimeError("evict is down"), degrade=True)
+    assert load_rendered_level(spy, "k") is None
+    assert spy.gets == []
+
+    save_rendered_level(spy, "k", _level(), ttl=None)
+
+    assert is_degraded(spy) is False
+    load_rendered_level(spy, "k")
+    assert spy.gets == ["k"]
+
+
+def test_a_failing_put_does_not_raise_and_does_not_clear_degradation():
+    spy = SpyBackend(fail_put=True)
+
+    save_rendered_level(spy, "k", _level(), ttl=None)
+
+    assert spy.puts == ["k"]

--- a/tests/pyjinhx/test_render_cache_wiring.py
+++ b/tests/pyjinhx/test_render_cache_wiring.py
@@ -1,0 +1,45 @@
+"""The tier-2 render cache as render_level() actually uses it: the class-level
+off-switch, the resolve/read/write seam, and the slot-disqualification rule.
+
+Full behavioral coverage of the render cache is #821's; what is pinned here is
+the wiring — that render_level consults the backend at all, that it stops
+consulting it when told to, and that nothing it caches can splice wrong.
+"""
+
+from typing import Any
+
+import pytest
+
+from pyjinhx._component import BaseComponent
+from pyjinhx.reactive.backend import CachePolicy
+
+
+def test_a_plain_component_records_an_explicit_cache_policy():
+    class Widget(BaseComponent, cache=CachePolicy(ttl=45)):
+        label: str = ""
+
+    assert Widget._pjx_cache_policy == CachePolicy(ttl=45)
+
+
+def test_a_plain_component_records_an_explicit_opt_out():
+    class Widget(BaseComponent, cache=False):
+        label: str = ""
+
+    assert Widget._pjx_cache_policy is False
+
+
+def test_a_plain_component_that_says_nothing_records_none():
+    class Widget(BaseComponent):
+        label: str = ""
+
+    assert Widget._pjx_cache_policy is None
+
+
+def test_a_subclass_does_not_inherit_its_parents_cache_policy():
+    class Parent(BaseComponent, cache=False):
+        label: str = ""
+
+    class Child(Parent):
+        label: str = ""
+
+    assert Child._pjx_cache_policy is None

--- a/tests/pyjinhx/test_render_cache_wiring.py
+++ b/tests/pyjinhx/test_render_cache_wiring.py
@@ -15,7 +15,12 @@ from pyjinhx._component import BaseComponent, Children, Slot
 from pyjinhx.config import configure_pyjinhx, current_settings
 from pyjinhx.descriptor import ClassDescriptor
 from pyjinhx.reactive.backend import CachePolicy, InMemoryCacheBackend
-from pyjinhx.render_cache import holds_spliced_components, resolve_render_tier2
+from pyjinhx.render_cache import (
+    copy_level_shell,
+    holds_spliced_components,
+    resolve_render_tier2,
+)
+from pyjinhx.segments import ChildRef, RenderedLevel
 
 
 def test_a_plain_component_records_an_explicit_cache_policy():
@@ -154,3 +159,15 @@ def test_a_component_in_the_children_field_is_a_spliced_component(tmp_path: Path
     _attach(_HoleHolder, template, slot_fields=frozenset({"body"}), children_field="content")
 
     assert holds_spliced_components(_HoleHolder(body="x", content=[_Inner()])) is True
+
+
+def test_copying_a_level_shell_gives_an_independently_mutable_segment_list():
+    ref = ChildRef(tag="PJXIcon", attrs={}, inner=None)
+    original = RenderedLevel(segments=["<div>", ref, "</div>"], root_span=(0, 5), descriptor=None)
+
+    copy = copy_level_shell(original)
+    copy.segments[1] = "filled"
+
+    assert original.segments[1] is ref
+    assert copy.root_span == original.root_span
+    assert copy.descriptor is original.descriptor

--- a/tests/pyjinhx/test_render_cache_wiring.py
+++ b/tests/pyjinhx/test_render_cache_wiring.py
@@ -6,12 +6,14 @@ the wiring — that render_level consults the backend at all, that it stops
 consulting it when told to, and that nothing it caches can splice wrong.
 """
 
+import os
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from pyjinhx._component import BaseComponent, Children, Slot
+from pyjinhx import discovery
+from pyjinhx._component import BaseComponent, Children, Slot, _pascal_to_snake
 from pyjinhx.config import configure_pyjinhx, current_settings
 from pyjinhx.descriptor import ClassDescriptor
 from pyjinhx.reactive.backend import CachePolicy, InMemoryCacheBackend
@@ -27,7 +29,9 @@ from pyjinhx.render_cache import (
     resolve_render_tier2,
     save_rendered_level,
 )
-from pyjinhx.segments import ChildRef, RenderedLevel
+from pyjinhx.rendering import render_level
+from pyjinhx.segments import ChildRef, RenderedLevel, serialize
+from pyjinhx.session import RenderSession, accumulate_assets
 
 
 def test_a_plain_component_records_an_explicit_cache_policy():
@@ -268,12 +272,6 @@ def test_a_failing_put_does_not_raise_and_does_not_clear_degradation():
     assert spy.puts == ["k"]
 
 
-from pyjinhx import discovery
-from pyjinhx.rendering import render_level
-from pyjinhx.segments import serialize
-from pyjinhx.session import RenderSession
-
-
 class _CachedBox(BaseComponent):
     label: str = "hi"
 
@@ -306,3 +304,111 @@ def test_a_first_render_writes_the_shell_through_to_the_backend(
     assert rendered == "<div>hi</div>"
     assert len(spy.puts) == 1
     assert len(spy.gets) == 1
+
+
+def test_a_second_render_answers_from_the_cache_without_rendering_the_template(
+    backend: InMemoryCacheBackend, box_template: Path
+):
+    session = RenderSession()
+    first = serialize(render_level(_CachedBox(id="a", label="hi"), session))
+    mtime = box_template.stat().st_mtime
+    box_template.write_text("<div>REBUILT</div>", encoding="utf-8")
+    os.utime(box_template, (mtime, mtime))
+
+    second = serialize(render_level(_CachedBox(id="a", label="hi"), RenderSession()))
+
+    assert first == "<div>hi</div>"
+    assert second == first
+
+
+def _accumulating_session() -> RenderSession:
+    """A fresh RenderSession with the asset accumulator wired to on_rendered.
+
+    accumulate_assets is opt-in per session (see tests/pyjinhx/test_assets.py's
+    fixture of the same shape) — a bare RenderSession() never accumulates on a
+    live render either, so a test proving a hit "replays what a live render
+    would have done" has to compare against a session that actually would.
+    """
+    session = RenderSession()
+    session.on_rendered.append(accumulate_assets)
+    return session
+
+
+def test_a_hit_replays_the_assets_a_live_render_would_have_emitted(
+    backend: InMemoryCacheBackend, tmp_path: Path
+):
+    css = tmp_path / "box.css"
+    js = tmp_path / "box.js"
+    template = tmp_path / "asset_box.html"
+    template.write_text("<div>{{ label }}</div>", encoding="utf-8")
+    _CachedBox.__pjx_descriptor__ = ClassDescriptor(
+        template_path=template,
+        slot_fields=frozenset(),
+        children_field=None,
+        css_paths=(css,),
+        js_paths=(js,),
+        strict=True,
+        provenance={"template": _CachedBox},
+    )
+    render_level(_CachedBox(id="a", label="hi"), _accumulating_session())
+
+    warm = _accumulating_session()
+    render_level(_CachedBox(id="a", label="hi"), warm)
+
+    assert warm.css_assets == {css}
+    assert warm.js_assets == {js}
+
+
+def test_a_hit_accumulates_nothing_when_the_session_never_asked_for_it(
+    backend: InMemoryCacheBackend, tmp_path: Path
+):
+    """D6: a hit must not do more than the live path would for this session.
+
+    accumulate_assets is opt-in (see _accumulating_session above); a session
+    that never subscribed it gets nothing on a live render, so a cache hit on
+    an equivalent, un-wired session must also get nothing — not a forced
+    accumulation the caller never asked for.
+    """
+    css = tmp_path / "unwired_box.css"
+    template = tmp_path / "unwired_box.html"
+    template.write_text("<div>{{ label }}</div>", encoding="utf-8")
+    _CachedBox.__pjx_descriptor__ = ClassDescriptor(
+        template_path=template,
+        slot_fields=frozenset(),
+        children_field=None,
+        css_paths=(css,),
+        js_paths=(),
+        strict=True,
+        provenance={"template": _CachedBox},
+    )
+    # Primes the cache (a miss, on an un-wired session — nothing accumulates,
+    # which is the baseline this test is protecting).
+    priming = RenderSession()
+    render_level(_CachedBox(id="a", label="hi"), priming)
+    assert priming.css_assets == set()
+
+    # A hit, on a second un-wired session — must match the miss above, not
+    # force accumulation this session never subscribed to.
+    warm = RenderSession()
+    render_level(_CachedBox(id="a", label="hi"), warm)
+
+    assert warm.css_assets == set()
+
+
+def test_a_hit_does_not_fill_the_children_of_the_cached_entry(
+    backend: InMemoryCacheBackend, tmp_path: Path
+):
+    """The entry keeps its holes: filling the restored copy must not edit it."""
+    icon = tmp_path / "icon.html"
+    icon.write_text("<span>i</span>", encoding="utf-8")
+    _attach(_Inner, icon)
+    holder = tmp_path / "holder_tag.html"
+    holder.write_text("<div>{{ label }}<Inner/></div>", encoding="utf-8")
+    _attach(_CachedBox, holder)
+    discovery._registry.mapping = {_pascal_to_snake("Inner"): _Inner}
+
+    first = serialize(render_level(_CachedBox(id="a", label="hi"), RenderSession()))
+    second = serialize(render_level(_CachedBox(id="a", label="hi"), RenderSession()))
+    third = serialize(render_level(_CachedBox(id="a", label="hi"), RenderSession()))
+
+    assert first == second == third == "<div>hi<span>i</span></div>"

--- a/tests/pyjinhx/test_render_cache_wiring.py
+++ b/tests/pyjinhx/test_render_cache_wiring.py
@@ -6,14 +6,16 @@ the wiring — that render_level consults the backend at all, that it stops
 consulting it when told to, and that nothing it caches can splice wrong.
 """
 
+from pathlib import Path
 from typing import Any
 
 import pytest
 
-from pyjinhx._component import BaseComponent
+from pyjinhx._component import BaseComponent, Children, Slot
 from pyjinhx.config import configure_pyjinhx, current_settings
+from pyjinhx.descriptor import ClassDescriptor
 from pyjinhx.reactive.backend import CachePolicy, InMemoryCacheBackend
-from pyjinhx.render_cache import resolve_render_tier2
+from pyjinhx.render_cache import holds_spliced_components, resolve_render_tier2
 
 
 def test_a_plain_component_records_an_explicit_cache_policy():
@@ -99,3 +101,56 @@ def test_render_tier2_is_off_for_a_class_that_opted_out(backend: Any):
         label: str = ""
 
     assert resolve_render_tier2(Widget) == (None, None)
+
+
+class _HoleHolder(BaseComponent):
+    label: str = "hi"
+    body: Slot = ""
+    content: Children = ""
+
+
+class _Inner(BaseComponent):
+    pass
+
+
+def _attach(
+    cls: type[BaseComponent],
+    template_path: Path,
+    *,
+    slot_fields: frozenset[str] = frozenset(),
+    children_field: str | None = None,
+) -> None:
+    """Point a class at a tmp-path template, as test_render_cache_key.py does."""
+    cls.__pjx_descriptor__ = ClassDescriptor(
+        template_path=template_path,
+        slot_fields=slot_fields,
+        children_field=children_field,
+        css_paths=(),
+        js_paths=(),
+        strict=True,
+        provenance={"template": cls},
+    )
+
+
+def test_a_string_in_a_slot_field_is_not_a_spliced_component(tmp_path: Path):
+    template = tmp_path / "holder.html"
+    template.write_text("<div>{{ body }}</div>", encoding="utf-8")
+    _attach(_HoleHolder, template, slot_fields=frozenset({"body"}), children_field="content")
+
+    assert holds_spliced_components(_HoleHolder(body="plain", content="text")) is False
+
+
+def test_a_component_in_a_slot_field_is_a_spliced_component(tmp_path: Path):
+    template = tmp_path / "holder.html"
+    template.write_text("<div>{{ body }}</div>", encoding="utf-8")
+    _attach(_HoleHolder, template, slot_fields=frozenset({"body"}), children_field="content")
+
+    assert holds_spliced_components(_HoleHolder(body=_Inner(), content="text")) is True
+
+
+def test_a_component_in_the_children_field_is_a_spliced_component(tmp_path: Path):
+    template = tmp_path / "holder.html"
+    template.write_text("<div>{{ content }}</div>", encoding="utf-8")
+    _attach(_HoleHolder, template, slot_fields=frozenset({"body"}), children_field="content")
+
+    assert holds_spliced_components(_HoleHolder(body="x", content=[_Inner()])) is True


### PR DESCRIPTION
## Summary

- Implements tier-2 render-cache wiring with disqualification predicates and cache invalidation
- Adds render_level propagation through the render cache and component lifecycle
- Introduces degrade-aware load/save facades and cache key sealing logic
- Wires component-valued slots and children exclusion from cache keys

## Test plan

- 27 new test cases covering cache hit/miss paths, degradation propagation, corruption handling, asset replay, and D6 gating
- Existing test suite passes with no regressions

Closes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)