### PR TITLE
docs: reframe the redis page around the CacheBackend protocol (#816)

### DIFF
--- a/docs/api/integrations-redis.md
+++ b/docs/api/integrations-redis.md
@@ -1,7 +1,5 @@
-# Redis invalidation integration
+# Redis cache backend
 
-**Not yet implemented.** There is currently no `pyjinhx.integrations.redis` module and no `RedisInvalidationBackend` class in pyjinhx.
+**Not yet implemented.** There is no `pyjinhx.integrations.redis` module and no Redis backend class in pyjinhx. A future one would be an ordinary `CacheBackend` — the runtime-checkable protocol in `pyjinhx.reactive.backend`, four methods wide: `get`, `put`, `evict`, `clear`. Nothing above it would need a second mechanism: invalidation falls out of workers sharing one store, rather than riding a pub/sub channel beside it.
 
-Cross-process invalidation fan-out today lives entirely in-process, in `pyjinhx.reactive.fanout`: each worker walks its own request's `X-PJX-Mounted` manifest against that request's dirtied keys and re-renders the regions that need it. There is no mechanism yet for propagating a mutation's dirtied keys to *other* worker processes or hosts, Redis-backed or otherwise.
-
-See [Cache & Invalidation](cache-invalidation.md) for the fan-out mechanism that does exist today.
+`DiskCacheBackend` (`pyjinhx.integrations.diskcache`, installed with `pyjinhx[diskcache]`) is the shipped implementation of that protocol, and it is also where the boundary falls — a shared filesystem is one machine, not one cluster, so four pods have four independent caches. That is where a Redis backend would earn its place. See [Cache Backends](cache-backends.md) for the protocol, the policy knobs and what the disk backend does today.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ typeCheckingMode = "standard"
 extraPaths = ["docs"]
 
 [project.optional-dependencies]
-redis = ["redis>=5.0.0", "fakeredis>=2.26.0"]
 fastapi = ["fastapi>=0.115.0", "starlette>=0.40.0"]
 diskcache = ["diskcache>=5.6.0"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -687,10 +687,6 @@ fastapi = [
     { name = "fastapi" },
     { name = "starlette" },
 ]
-redis = [
-    { name = "fakeredis" },
-    { name = "redis" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -710,15 +706,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "diskcache", marker = "extra == 'diskcache'", specifier = ">=5.6.0" },
-    { name = "fakeredis", marker = "extra == 'redis'", specifier = ">=2.26.0" },
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.115.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "markupsafe", specifier = ">=3.0.3" },
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
     { name = "starlette", marker = "extra == 'fastapi'", specifier = ">=0.40.0" },
 ]
-provides-extras = ["redis", "fastapi", "diskcache"]
+provides-extras = ["fastapi", "diskcache"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Reframe the Redis documentation to align with the tier-2 cache backend design
- Remove the unused redis extra from pyproject.toml (v0.x residue)
- Clarify that a Redis backend would implement CacheBackend like DiskCacheBackend

The old documentation described a RedisInvalidationBackend and fan-out split that the tier-2 design deliberately does not have.

## Test plan
No new tests added; documentation and dependency cleanup only.

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)