### PR TITLE
fix: keep an auto-generated id out of the render-cache key

### DIFF
--- a/pyjinhx/render_cache.py
+++ b/pyjinhx/render_cache.py
@@ -77,6 +77,41 @@ def holds_spliced_components(component: BaseComponent) -> bool:
     return bool(_spliced_fields(component))
 
 
+def has_auto_id(component: BaseComponent) -> bool:
+    """Whether this instance's ``id`` came from the default factory.
+
+    Pydantic records the names the caller actually passed in ``model_fields_set``,
+    so an absent ``id`` there is one ``_auto_id()`` minted — ``pjx-1``, ``pjx-2``,
+    and so on, a fresh value per instance.
+    """
+    return "id" not in component.model_fields_set
+
+
+def auto_id_in_output(component: BaseComponent, output: str) -> bool:
+    """Whether an auto-generated ``id`` was interpolated into this render.
+
+    The key deliberately ignores an auto id, so a template that prints one — via
+    ``{{ id }}``, or an attribute built from it — would bake ``pjx-1`` into an
+    entry later served to ``pjx-2``. Such an instance is declined rather than
+    cached wrong, the same way ``holds_spliced_components`` declines one whose
+    slot tokens cannot outlive their render.
+
+    Tested against the finished output rather than by parsing the template for
+    an ``id`` reference: the output is the ground truth about what actually got
+    printed, it is already in hand at the point this is asked, and a substring
+    scan costs far less than a second parse. An author-supplied id is not
+    checked at all — it is in the key, so an entry can only ever be served back
+    to the same value.
+
+    Args:
+        component: The instance that produced ``output``.
+        output: The template's rendered text, before parsing.
+    """
+    if not has_auto_id(component):
+        return False
+    return component.id in output
+
+
 def render_cache_key(component: BaseComponent) -> str:
     """Return the render-cache key for ``component``.
 
@@ -85,6 +120,13 @@ def render_cache_key(component: BaseComponent) -> str:
     children values left out (a string on the same field stays in, since it is
     baked into the cached output rather than spliced back in), and the
     modification time of the template the class resolved to.
+
+    An auto-generated ``id`` is left out of the digest too. It counts up per
+    instance, so keeping it would give two structurally identical components two
+    different keys and the cache could never hit at all. An id the author passed
+    explicitly stays in: that one names something about the instance, and two
+    values of it are two different renders. This mirrors reactive's
+    ``state_hash_exclude``, which drops ``id`` for the same reason.
     """
     cls = type(component)
     descriptor = cls.__pjx_descriptor__
@@ -97,6 +139,8 @@ def render_cache_key(component: BaseComponent) -> str:
     # a ChildRef, so that value has to stay in the key or two different
     # strings on the same field would collide on one entry.
     spliced_fields = _spliced_fields(component)
+    if has_auto_id(component):
+        spliced_fields.add("id")
     # JSON-mode dump plus sorted, separator-pinned encoding so dict ordering
     # and non-JSON-native types can't perturb an unchanged set of props.
     canonical = json.dumps(

--- a/pyjinhx/rendering.py
+++ b/pyjinhx/rendering.py
@@ -17,6 +17,7 @@ from pyjinhx.discovery import get_class
 from pyjinhx.markers import SLOT_TOKEN_RE, collect_slot_tokens
 from pyjinhx.props_header import warn_stale_def_header
 from pyjinhx.render_cache import (
+    auto_id_in_output,
     holds_spliced_components,
     load_rendered_level,
     render_cache_key,
@@ -376,7 +377,7 @@ def render_level(
         root_span=parser.root_span or (0, 0),
         descriptor=descriptor,
     )
-    if backend is not None:
+    if backend is not None and not auto_id_in_output(component, output_string):
         # Written here, with every child hole still unresolved: what is worth
         # caching is this level's own shell, and a level whose children were
         # already spliced in would be a cache of one request's whole subtree.

--- a/scripts/bench_cross_request_cache.py
+++ b/scripts/bench_cross_request_cache.py
@@ -1,0 +1,104 @@
+"""Cross-request cache benchmark: does tier 2 actually save the second request?
+
+Every other bench script renders its tree once, inside one scope. That prices
+tier 2's write path with no read ever, which is the half of the story that makes
+a configured backend look like nothing but overhead — and it is why a render key
+that could never repeat went unnoticed: nothing here asked for the same thing
+twice.
+
+This script renders the same tree in a fresh request_scope() each time, so tier
+1 starts empty and only the process-wide backend can answer. A working render
+cache shows request 2 well under request 1; a broken one shows them equal, which
+is the shape to watch for.
+
+Not a CI test (timing-sensitive). Run manually before/after cache work:
+
+    uv run python scripts/bench_cross_request_cache.py
+    PJX_BENCH_BACKEND=diskcache uv run python scripts/bench_cross_request_cache.py
+"""
+
+import os
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from bench_render_scaling_v2 import (
+    BenchRoot,
+    setup_session,
+    tree_shape,
+    tree_size,
+)
+
+from pyjinhx.config import PjxSettings, configure_pyjinhx
+from pyjinhx.reactive.backend import InMemoryCacheBackend
+from pyjinhx.rendering import render
+from pyjinhx.session import RenderSession, request_scope
+
+COMPONENT_COUNTS = (50, 200, 1000, 5000)
+REQUESTS = 12
+
+if os.environ.get("PJX_BENCH_SMOKE"):
+    COMPONENT_COUNTS = COMPONENT_COUNTS[:1]
+    REQUESTS = 3
+
+
+def build_backend(name: str | None) -> object | None:
+    """The backend named by ``PJX_BENCH_BACKEND``, or None to leave tier 2 off.
+
+    ``diskcache`` is the one that costs a real pickle and a SQLite round-trip;
+    ``memory`` isolates the seam's own bookkeeping from that storage cost.
+    """
+    if name is None or name == "none":
+        return None
+    if name == "memory":
+        return InMemoryCacheBackend()
+    if name == "diskcache":
+        from pyjinhx.integrations.diskcache import DiskCacheBackend
+
+        return DiskCacheBackend(tempfile.mkdtemp(prefix="pjx-bench-"))
+    raise SystemExit(f"unknown PJX_BENCH_BACKEND {name!r}: none, memory or diskcache")
+
+
+def one_request(session: RenderSession, mids: int, leaves: int) -> float:
+    """Render the tree inside a fresh request scope; answer seconds elapsed.
+
+    A new scope per call is the whole point: it drops the request-scoped tier-1
+    store, so a repeat render can only be answered by the process-wide backend.
+    """
+    started = time.perf_counter()
+    with request_scope(session=session):
+        render(BenchRoot(mids=mids, leaves=leaves), session)
+    return time.perf_counter() - started
+
+
+def main() -> None:
+    name = os.environ.get("PJX_BENCH_BACKEND")
+    backend = build_backend(name)
+    if backend is not None:
+        configure_pyjinhx(PjxSettings(cache_backend=backend))
+
+    session = setup_session()
+    print(f"backend={name or 'none'}, {REQUESTS} requests per size, fresh scope each\n")
+    print(
+        f"{'n':>6}  {'request 1':>11}  {'request 2':>11}  {'median 3+':>11}  {'1/warm':>8}"
+    )
+    for requested in COMPONENT_COUNTS:
+        mids, leaves = tree_shape(requested)
+        n = tree_size(mids, leaves)
+        elapsed = [one_request(session, mids, leaves) for _ in range(REQUESTS)]
+        cold = elapsed[0] * 1000
+        second = elapsed[1] * 1000
+        # Median of the rest rather than the mean: one scheduler hiccup in a
+        # dozen requests should not decide the number this is read for.
+        warm = statistics.median(elapsed[2:]) * 1000
+        print(
+            f"{n:6d}  {cold:9.1f}ms  {second:9.1f}ms  {warm:9.1f}ms  {cold / warm:7.2f}x"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_cross_request_load.py
+++ b/scripts/bench_cross_request_load.py
@@ -1,0 +1,118 @@
+"""Cross-request load-cache benchmark: when does tier 2 pay for itself?
+
+The load cache's whole value is skipping the author's load() on a later request,
+so what it saves is whatever load() costs — which for any real app is a database
+round-trip, not a constructor call. Benchmarking it against a load() that does
+nothing measures the wrong thing twice over: it prices the backend's own
+overhead against approximately zero, and reports a wash where production would
+see a query disappear.
+
+So the simulated cost of load() is the swept variable here. Each row holds the
+component count fixed and asks the same question at a different load() cost:
+does routing through the backend beat re-running load() on the next request?
+The crossover is the number to read — under it, tier 2 costs more than it saves.
+
+time.sleep() stands in for the I/O. It releases the GIL the way a real socket
+wait does, so it models a query the process is blocked on rather than one it is
+burning CPU over.
+
+Not a CI test (timing-sensitive). Run manually before/after load-cache work:
+
+    uv run python scripts/bench_cross_request_load.py
+"""
+
+import os
+import statistics
+import tempfile
+import time
+from typing import Annotated
+
+from pyjinhx.config import PjxSettings, configure_pyjinhx
+from pyjinhx.reactive.component import PjxKey, ReactiveComponent
+from pyjinhx.session import request_scope
+
+# Milliseconds one load() call blocks for. 0.0 is the pure-overhead case: what
+# tier 2 costs when it saves nothing at all.
+LOAD_COSTS_MS = (0.0, 0.1, 0.5, 2.0, 10.0)
+# Distinct keys per request, so a request pays this many load() calls.
+ROWS = 20
+REQUESTS = 8
+
+if os.environ.get("PJX_BENCH_SMOKE"):
+    LOAD_COSTS_MS = LOAD_COSTS_MS[:1]
+    ROWS = 2
+    REQUESTS = 2
+
+_load_cost_s = 0.0
+_calls = 0
+
+
+class BenchRow(ReactiveComponent, react={"bench_rows"}):
+    """A keyed reactive component whose load() blocks like a query would."""
+
+    row_id: Annotated[int, PjxKey()]
+    title: str = ""
+
+    @classmethod
+    def load(cls, row_id: int) -> "BenchRow":
+        global _calls
+        _calls += 1
+        if _load_cost_s:
+            time.sleep(_load_cost_s)
+        return cls(row_id=row_id, title=f"row {row_id}")
+
+
+def one_request() -> float:
+    """Load every row inside a fresh request scope; answer seconds elapsed.
+
+    A new scope per call drops the request-scoped tier-1 store, so a repeat only
+    avoids load() if the process-wide backend answered.
+    """
+    started = time.perf_counter()
+    with request_scope():
+        for row_id in range(ROWS):
+            BenchRow.load(row_id=row_id)
+    return time.perf_counter() - started
+
+
+def measure(cost_ms: float, backend: object | None) -> tuple[float, int]:
+    """Median warm-request time in ms, and how many load() bodies actually ran."""
+    global _load_cost_s, _calls
+    _load_cost_s = cost_ms / 1000
+    configure_pyjinhx(PjxSettings(cache_backend=backend))
+    _calls = 0
+    # The first request is the cold one that fills the cache; the median of what
+    # follows is what a steady-state request costs.
+    elapsed = [one_request() for _ in range(REQUESTS)]
+    return statistics.median(elapsed[1:]) * 1000, _calls
+
+
+def main() -> None:
+    from pyjinhx.integrations.diskcache import DiskCacheBackend
+
+    print(f"{ROWS} load() calls per request, {REQUESTS} requests, fresh scope each")
+    print("warm = median of requests 2+\n")
+    header = (
+        f"{'load() cost':>12}  {'no backend':>11}  {'diskcache':>11}  "
+        f"{'saved':>8}  {'load() ran':>11}"
+    )
+    print(header)
+    for cost_ms in LOAD_COSTS_MS:
+        plain, plain_calls = measure(cost_ms, None)
+        # A fresh directory per row, so one row's warm entries can never answer
+        # the next row's cold measurement.
+        cached, cached_calls = measure(
+            cost_ms, DiskCacheBackend(tempfile.mkdtemp(prefix="pjx-bench-"))
+        )
+        saved = (plain - cached) / plain * 100 if plain else 0.0
+        print(
+            f"{cost_ms:10.1f}ms  {plain:9.2f}ms  {cached:9.2f}ms  "
+            f"{saved:6.0f}%  {plain_calls:5d} / {cached_calls:<5d}"
+        )
+    print()
+    print("load() ran: bodies executed without a backend / with one.")
+    print("A working tier 2 shows the second number at one per distinct key.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pyjinhx/test_render_cache_key.py
+++ b/tests/pyjinhx/test_render_cache_key.py
@@ -13,7 +13,7 @@ import pytest
 
 from pyjinhx._component import BaseComponent, Children, Slot
 from pyjinhx.descriptor import ClassDescriptor
-from pyjinhx.render_cache import render_cache_key
+from pyjinhx.render_cache import auto_id_in_output, has_auto_id, render_cache_key
 
 
 class _KeyPlain(BaseComponent):
@@ -142,3 +142,42 @@ def test_a_slot_field_holding_a_plain_string_stays_in_the_key(template: Path):
     assert render_cache_key(
         _KeySlotted(id="a", label="hi", body="hello world")
     ) != render_cache_key(_KeySlotted(id="a", label="hi", body="goodbye moon"))
+
+
+def test_two_instances_with_auto_ids_share_a_key(template: Path):
+    _attach(_KeyPlain, template)
+    first, second = _KeyPlain(label="hi"), _KeyPlain(label="hi")
+    assert first.id != second.id
+    assert render_cache_key(first) == render_cache_key(second)
+
+
+def test_two_explicit_ids_still_give_different_keys(template: Path):
+    _attach(_KeyPlain, template)
+    assert render_cache_key(_KeyPlain(id="a", label="hi")) != render_cache_key(
+        _KeyPlain(id="b", label="hi")
+    )
+
+
+def test_an_auto_id_and_an_explicit_id_do_not_collide(template: Path):
+    _attach(_KeyPlain, template)
+    assert render_cache_key(_KeyPlain(label="hi")) != render_cache_key(
+        _KeyPlain(id="a", label="hi")
+    )
+
+
+def test_has_auto_id_reports_how_the_id_was_set():
+    assert has_auto_id(_KeyPlain(label="hi"))
+    assert not has_auto_id(_KeyPlain(id="a", label="hi"))
+
+
+def test_auto_id_in_output_catches_an_interpolated_auto_id():
+    component = _KeyPlain(label="hi")
+    assert auto_id_in_output(component, f'<div id="{component.id}">hi</div>')
+    assert not auto_id_in_output(component, "<div>hi</div>")
+
+
+def test_an_explicit_id_in_the_output_is_not_declined():
+    # An explicit id is part of the key, so an entry can only ever be served
+    # back to the same value — printing it is safe.
+    component = _KeyPlain(id="a", label="hi")
+    assert not auto_id_in_output(component, '<div id="a">hi</div>')

--- a/tests/pyjinhx/test_render_cache_wiring.py
+++ b/tests/pyjinhx/test_render_cache_wiring.py
@@ -512,3 +512,65 @@ def test_a_corrupt_entry_propagates_out_of_render_level(box_template: Path):
             render_level(_CachedBox(id="a", label="hi"), RenderSession())
     finally:
         configure_pyjinhx(previous)
+
+
+class _AutoIdBox(BaseComponent):
+    label: str = "hi"
+
+
+class _IdPrinter(BaseComponent):
+    label: str = "hi"
+
+
+def test_two_instances_with_auto_ids_hit_the_same_entry(
+    backend: InMemoryCacheBackend, tmp_path: Path
+):
+    # The regression this file previously missed: every other render test names
+    # an explicit id, so an auto id counting up per instance never showed up as
+    # a key that could not repeat.
+    path = tmp_path / "auto_id_box.html"
+    path.write_text("<div>{{ label }}</div>", encoding="utf-8")
+    _attach(_AutoIdBox, path)
+    spy = SpyBackend()
+    configure_pyjinhx(current_settings().merge(cache_backend=spy))
+
+    first = serialize(render_level(_AutoIdBox(label="hi"), RenderSession()))
+    second = serialize(render_level(_AutoIdBox(label="hi"), RenderSession()))
+
+    assert first == second == "<div>hi</div>"
+    assert len(spy.puts) == 1
+
+
+def test_a_template_printing_its_auto_id_is_not_cached(
+    backend: InMemoryCacheBackend, tmp_path: Path
+):
+    # The auto id is out of the key, so an entry baking one in would be served
+    # back under a different id. Declined rather than cached wrong.
+    path = tmp_path / "id_printer.html"
+    path.write_text('<div id="{{ id }}">{{ label }}</div>', encoding="utf-8")
+    _attach(_IdPrinter, path)
+    spy = SpyBackend()
+    configure_pyjinhx(current_settings().merge(cache_backend=spy))
+
+    one = _IdPrinter(label="hi")
+    two = _IdPrinter(label="hi")
+    first = serialize(render_level(one, RenderSession()))
+    second = serialize(render_level(two, RenderSession()))
+
+    assert spy.puts == []
+    assert first == f'<div id="{one.id}">hi</div>'
+    assert second == f'<div id="{two.id}">hi</div>'
+
+
+def test_a_template_printing_an_explicit_id_is_still_cached(
+    backend: InMemoryCacheBackend, tmp_path: Path
+):
+    path = tmp_path / "explicit_id_printer.html"
+    path.write_text('<div id="{{ id }}">{{ label }}</div>', encoding="utf-8")
+    _attach(_IdPrinter, path)
+    spy = SpyBackend()
+    configure_pyjinhx(current_settings().merge(cache_backend=spy))
+
+    render_level(_IdPrinter(id="a", label="hi"), RenderSession())
+
+    assert len(spy.puts) == 1


### PR DESCRIPTION
Closes #848.

## The bug

`render_cache_key()` hashed the component's whole `model_dump()`, and `id` carries `default_factory=_auto_id` — `pjx-1`, `pjx-2`, one per instance. Two structurally identical components never shared a key, so the render cache **never hit**. It only wrote: every request added entries nothing would read, and the store grew until the TTL caught up.

```
BenchRoot(mids=2, leaves=2)  ->  ...BenchRoot:9608dbdf7ad8d562...
BenchRoot(mids=2, leaves=2)  ->  ...BenchRoot:afd863320c824f0d...
```

## The fix

An **explicit** id stays in the key — two values of it are two different renders. An **auto** id is dropped, which is what reactive's `state_hash_exclude` already does for the same reason. `model_fields_set` separates the two.

That leaves one hole: a template printing its own auto id would bake `pjx-1` into an entry later served to `pjx-2`. Those instances are declined rather than cached wrong — checked against the finished output rather than by re-parsing the template for an `id` reference, since the output is the ground truth about what actually got printed and it is already in hand at that point.

## Why the suite missed it

Every render-cache test names an explicit id, including `test_a_second_render_answers_from_the_cache_without_rendering_the_template` — so the one test that asserts a hit was passing the one input shape that could hit. Added tests cover the auto-id path both ways.

## Why the benches missed it

No bench script rendered the same thing twice across scopes; each renders its tree once, which prices tier 2's write path with no read ever. `scripts/bench_cross_request_cache.py` fills that gap — same tree, `REQUESTS` times, a fresh `request_scope()` each — so a cache that cannot hit shows up as request 2 costing what request 1 did.

Before (request 2 ≈ request 1, no reuse) and after:

| components | no backend | diskcache before | diskcache after |
|---:|---:|---:|---:|
| 50 | 1.7ms | 8.9ms | 2.1ms |
| 197 | 6.8ms | 36.2ms | 5.8ms |
| 993 | 33.4ms | 189.8ms | 31.0ms |
| 4971 | 162.2ms | 979.2ms | 154.7ms |

Cold/warm ratios go from ~1.0x (no reuse at all) to 1.34x–4.22x.

## Note on what this does not settle

Warm renders now land at roughly the no-backend baseline rather than well under it — for a tree of cheap leaf templates, a pickle plus SQLite round-trip costs about what rendering costs. Whether render tier 2 should be on by default, or whether per-component is the right granularity, is a separate question this does not answer.

`3210 passed, 1 skipped`; `ruff check` and `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxwB6LvymhekN1iFNoNbqu