### PR TITLE
perf: skip the render cache for components too cheap to be worth it

### DIFF
--- a/pyjinhx/render_cache.py
+++ b/pyjinhx/render_cache.py
@@ -4,6 +4,7 @@
 
 import hashlib
 import json
+import os
 from typing import TYPE_CHECKING, Any, cast
 
 from pyjinhx._component import BaseComponent
@@ -17,6 +18,24 @@ from pyjinhx.segments import ChildRef, RenderedLevel
 
 if TYPE_CHECKING:
     from pyjinhx.session import RenderSession
+
+# A cache hit is not free: the key, the backend read, the unpickle and the asset
+# replay come to roughly 20us for a small component. Caching a render cheaper
+# than that costs more than it saves, and every builtin this repo ships renders
+# in 30-105us with only a fraction of that spent on the template. The default
+# sits well clear of them, so what gets cached is a template doing real work.
+_DEFAULT_MIN_SAVING_US = 150.0
+
+# Qualified names, not classes: see _too_cheap_key. Process-wide because the
+# measurement is a property of the template, not of any one request.
+_too_cheap: set[str] = set()
+_decided: set[str] = set()
+
+
+def reset_render_cost_decisions() -> None:
+    """Forget every measured class. For tests, which must not inherit a verdict."""
+    _too_cheap.clear()
+    _decided.clear()
 
 
 def _holds_component(value: object) -> bool:
@@ -154,6 +173,68 @@ def render_cache_key(component: BaseComponent) -> str:
     # would clear it.
     template_mtime = descriptor.template_path.stat().st_mtime
     return f"{identity}:{fields_digest}:{template_mtime}"
+
+
+def _min_saving_us() -> float:
+    """The render-and-parse cost, in microseconds, below which caching is a loss.
+
+    Read per call rather than captured at import so a test — or an app that sets
+    the variable after importing pyjinhx — is not fighting import order.
+    """
+    raw = os.environ.get("PJX_RENDER_CACHE_MIN_US")
+    if raw is None or raw == "":
+        return _DEFAULT_MIN_SAVING_US
+    try:
+        return float(raw)
+    except ValueError:
+        raise ValueError(
+            f"PJX_RENDER_CACHE_MIN_US={raw!r} is not a number of microseconds."
+        ) from None
+
+
+def is_too_cheap(cls: type[BaseComponent]) -> bool:
+    """Whether this class was measured as costing less to render than to cache.
+
+    Answered from a process-wide set filled by ``note_render_cost``. Asked before
+    the key is built and before the backend is read, because a class that is not
+    worth caching should pay neither — skipping only the write would leave the
+    per-request half of the waste in place.
+    """
+    return _too_cheap_key(cls) in _too_cheap
+
+
+def note_render_cost(cls: type[BaseComponent], saving_us: float) -> None:
+    """Record what rendering this class actually cost, and decide it once.
+
+    ``saving_us`` is the template render plus the parse — the work a cache hit
+    replaces, not the whole of render_level. Timing the whole thing would fold in
+    validation, context building and child filling, none of which a hit avoids,
+    and would price a class as expensive for work the cache cannot save.
+
+    Per class rather than per instance: the same template doing the same work
+    costs the same whether it is row 3 or row 197, so one measurement settles
+    every instance and the check afterwards is a set lookup.
+
+    Decided once and never revisited. A class that re-measured could flip between
+    requests on nothing but machine load, which would make cache membership — and
+    so the store's contents — depend on scheduling noise.
+    """
+    key = _too_cheap_key(cls)
+    if key in _decided:
+        return
+    _decided.add(key)
+    if saving_us < _min_saving_us():
+        _too_cheap.add(key)
+
+
+def _too_cheap_key(cls: type[BaseComponent]) -> str:
+    """The qualified name this class is remembered under.
+
+    A name rather than the class object, so the two sets cannot keep a class
+    alive for the life of the process — the same reason the diskcache backend
+    remembers unpicklable types by name.
+    """
+    return f"{cls.__module__}.{cls.__qualname__}"
 
 
 def resolve_render_tier2(

--- a/pyjinhx/rendering.py
+++ b/pyjinhx/rendering.py
@@ -6,6 +6,7 @@ finished HTML string for a childless component (render, public API).
 """
 
 import html
+import time
 from typing import Any, cast
 
 import jinja2
@@ -19,7 +20,9 @@ from pyjinhx.props_header import warn_stale_def_header
 from pyjinhx.render_cache import (
     auto_id_in_output,
     holds_spliced_components,
+    is_too_cheap,
     load_rendered_level,
+    note_render_cost,
     render_cache_key,
     replay_asset_accumulation,
     resolve_render_tier2,
@@ -331,6 +334,16 @@ def render_level(
     cache_key = ""
     if getattr(component.__class__, "_pjx_key_field", _NO_KEY_FIELD) is _NO_KEY_FIELD:
         backend, ttl = resolve_render_tier2(component.__class__)
+    # Asked before the key is built and before the backend is read: a class that
+    # costs less to render than to cache must pay neither half. An explicit
+    # cache= is the author overriding the measurement, so it is never consulted
+    # for one — resolve_render_tier2 has already turned cache=False off.
+    if (
+        backend is not None
+        and component.__class__._pjx_cache_policy is None
+        and is_too_cheap(component.__class__)
+    ):
+        backend, ttl = None, None
     # holds_spliced_components reads the instance's own slot/children field
     # values off the descriptor, which is only ever safe to do for a class
     # tier 2 would otherwise cache — checked last, and only once tier 2 is
@@ -357,6 +370,16 @@ def render_level(
         raise jinja2.TemplateNotFound(
             err.name, message=f"{prefix}template file not found"
         ) from err
+    # Only the render and the parse are timed, because only they are what a
+    # cache hit replaces. Everything around them — validation, context build,
+    # child filling — is paid on a hit too, so folding it in would price a class
+    # as expensive for work the cache cannot save.
+    #
+    # This first render is also the one Jinja compiles the template on, so the
+    # figure runs high. Left uncorrected: the error points at caching a class
+    # that did not need it, which costs a hit's overhead, while the opposite
+    # error forfeits a saving measured at 3-9x on templates that do real work.
+    render_started = time.perf_counter()
     with collect_slot_tokens() as slot_table:
         output_string = template.render(context)
 
@@ -364,6 +387,7 @@ def render_level(
     parser = VerbatimParser()
     parser.feed(output_string)
     parser.close()
+    note_render_cost(component.__class__, (time.perf_counter() - render_started) * 1e6)
 
     # Validate single-root rule
     try:

--- a/tests/pyjinhx/conftest.py
+++ b/tests/pyjinhx/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pyjinhx.render_cache import reset_render_cost_decisions
 from pyjinhx.session import RenderSession
 
 
@@ -7,3 +8,28 @@ from pyjinhx.session import RenderSession
 def render_session():
     """Provide a RenderSession for tests."""
     return RenderSession()
+
+
+@pytest.fixture(autouse=True)
+def render_cost_decisions():
+    """Clear the per-class render-cost verdicts around every test.
+
+    They are process-wide and decided once, so without this the first test to
+    render a class would fix whether the render cache applies to it for the rest
+    of the session — and which test ran first would decide it.
+    """
+    reset_render_cost_decisions()
+    yield
+    reset_render_cost_decisions()
+
+
+@pytest.fixture(autouse=True)
+def cache_everything_by_default(monkeypatch: pytest.MonkeyPatch):
+    """Disarm the too-cheap heuristic for tests that are not about it.
+
+    The templates here are a few tags long and render in single-digit
+    microseconds, so in production the heuristic would rightly decline every one
+    of them. Tests covering the cache *mechanism* still need it to engage, so the
+    floor drops to zero unless a test sets its own.
+    """
+    monkeypatch.setenv("PJX_RENDER_CACHE_MIN_US", "0")

--- a/tests/pyjinhx/test_render_cache_wiring.py
+++ b/tests/pyjinhx/test_render_cache_wiring.py
@@ -574,3 +574,49 @@ def test_a_template_printing_an_explicit_id_is_still_cached(
     render_level(_IdPrinter(id="a", label="hi"), RenderSession())
 
     assert len(spy.puts) == 1
+
+
+class _TinyBox(BaseComponent):
+    label: str = "hi"
+
+
+class _TinyExplicit(BaseComponent, cache=CachePolicy(ttl=30)):
+    label: str = "hi"
+
+
+def test_a_class_measured_too_cheap_stops_touching_the_backend(
+    backend: InMemoryCacheBackend, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # A floor no real template clears, so the first render measures under it.
+    monkeypatch.setenv("PJX_RENDER_CACHE_MIN_US", "1000000")
+    path = tmp_path / "tiny_box.html"
+    path.write_text("<div>{{ label }}</div>", encoding="utf-8")
+    _attach(_TinyBox, path)
+    spy = SpyBackend()
+    configure_pyjinhx(current_settings().merge(cache_backend=spy))
+
+    render_level(_TinyBox(label="hi"), RenderSession())
+    first_gets, first_puts = len(spy.gets), len(spy.puts)
+    render_level(_TinyBox(label="hi"), RenderSession())
+
+    # The first render pays a lookup and a store — that is the price of
+    # measuring. Every render after it pays neither, reads included.
+    assert (len(spy.gets), len(spy.puts)) == (first_gets, first_puts)
+
+
+def test_an_explicit_cache_policy_overrides_the_too_cheap_verdict(
+    backend: InMemoryCacheBackend, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("PJX_RENDER_CACHE_MIN_US", "1000000")
+    path = tmp_path / "tiny_explicit.html"
+    path.write_text("<div>{{ label }}</div>", encoding="utf-8")
+    _attach(_TinyExplicit, path)
+    spy = SpyBackend()
+    configure_pyjinhx(current_settings().merge(cache_backend=spy))
+
+    render_level(_TinyExplicit(label="hi"), RenderSession())
+    render_level(_TinyExplicit(label="hi"), RenderSession())
+
+    # cache=CachePolicy(...) is the author saying "cache this"; a measurement
+    # must not quietly overrule it.
+    assert len(spy.gets) == 2

--- a/tests/pyjinhx/test_render_cost_threshold.py
+++ b/tests/pyjinhx/test_render_cost_threshold.py
@@ -1,0 +1,90 @@
+"""The too-cheap heuristic: which classes the render cache declines to touch.
+
+A cache hit costs a key, a backend read, an unpickle and an asset replay —
+around 20us for a small component. A template cheaper than that to render loses
+by being cached, so the render path measures each class once and remembers.
+"""
+
+import pytest
+
+from pyjinhx._component import BaseComponent
+from pyjinhx.reactive.backend import CachePolicy
+from pyjinhx.render_cache import (
+    is_too_cheap,
+    note_render_cost,
+    reset_render_cost_decisions,
+)
+
+
+class _Cheap(BaseComponent):
+    label: str = "hi"
+
+
+class _Pricey(BaseComponent):
+    label: str = "hi"
+
+
+class _Explicit(BaseComponent, cache=CachePolicy(ttl=30)):
+    label: str = "hi"
+
+
+@pytest.fixture(autouse=True)
+def own_threshold(monkeypatch: pytest.MonkeyPatch):
+    """This file sets its own floor; the suite-wide zero would disarm every test."""
+    monkeypatch.setenv("PJX_RENDER_CACHE_MIN_US", "150")
+    reset_render_cost_decisions()
+
+
+def test_a_render_under_the_floor_marks_the_class_too_cheap():
+    note_render_cost(_Cheap, 12.0)
+    assert is_too_cheap(_Cheap)
+
+
+def test_a_render_over_the_floor_leaves_the_class_cacheable():
+    note_render_cost(_Pricey, 900.0)
+    assert not is_too_cheap(_Pricey)
+
+
+def test_the_first_measurement_decides_and_later_ones_do_not_move_it():
+    # Re-measuring would let a class flip between requests on machine load
+    # alone, making the store's contents depend on scheduling noise.
+    note_render_cost(_Cheap, 12.0)
+    note_render_cost(_Cheap, 5000.0)
+    assert is_too_cheap(_Cheap)
+
+
+def test_an_unmeasured_class_is_not_too_cheap():
+    # Absence of a verdict is "cache it", so the first render is never skipped.
+    assert not is_too_cheap(_Pricey)
+
+
+def test_the_floor_is_read_from_the_environment(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PJX_RENDER_CACHE_MIN_US", "5")
+    note_render_cost(_Cheap, 12.0)
+    assert not is_too_cheap(_Cheap)
+
+
+def test_a_non_numeric_floor_is_rejected(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PJX_RENDER_CACHE_MIN_US", "soon")
+    with pytest.raises(ValueError, match="microseconds"):
+        note_render_cost(_Cheap, 12.0)
+
+
+def test_reset_forgets_every_verdict():
+    note_render_cost(_Cheap, 12.0)
+    reset_render_cost_decisions()
+    assert not is_too_cheap(_Cheap)
+
+
+def test_two_classes_are_judged_independently():
+    note_render_cost(_Cheap, 12.0)
+    note_render_cost(_Pricey, 900.0)
+    assert is_too_cheap(_Cheap)
+    assert not is_too_cheap(_Pricey)
+
+
+def test_an_explicit_policy_class_can_still_be_measured_as_cheap():
+    # The heuristic records what it saw; honoring the override is render_level's
+    # job, so the verdict itself stays a plain measurement.
+    note_render_cost(_Explicit, 12.0)
+    assert is_too_cheap(_Explicit)


### PR DESCRIPTION
Closes #850.

## Why

Benchmarking the diskcache backend against pyjinhx's own builtins found the render cache was a **net loss** on every one of them:

| component | no backend | cache hit | win |
|---|---:|---:|---:|
| PJXTableCell | 31.5us | 54.2us | 0.58x |
| PJXBadge | 33.3us | 55.1us | 0.61x |
| PJXTable | 33.4us | 56.5us | 0.59x |
| PJXModal | 40.4us | 62.7us | 0.64x |
| PJXButton | 45.2us | 46.1us | 0.98x |

Real builtins render in 31-105us (median 38us, 45 of 58 between 25-50us). A hit costs ~20us of key, backend read, unpickle and asset replay, against ~15us of template work to save.

## What

The render path times each class once and remembers the verdict process-wide. Under the floor, the class is skipped **before the key is built and before the backend is read** — skipping only the write would leave a lookup per render per request in place, which is the recurring half of the waste.

**What gets timed is the template render plus the parse**, not the whole of `render_level`. Validation, context building and child filling are paid on a hit too; folding them in would price a class as expensive for work the cache cannot save. This is also why the earlier "everything is 542us" reading was wrong — that harness built a fresh `RenderSession()` per iteration, which gets a cold template cache, so it was timing Jinja compilation.

Floor defaults to **150us**, overridable with `PJX_RENDER_CACHE_MIN_US`.

## Validation against the default

57 of 58 builtins declined. Templates doing real work admitted:

| rows | verdict | plain | cached | win |
|---:|---|---:|---:|---:|
| 1 | **TOO CHEAP** | 52.4us | 65.3us | 0.80x — would have lost |
| 3 | cached | 88.9us | 32.8us | 2.71x |
| 8 | cached | 187.6us | 40.8us | 4.60x |
| 20 | cached | 404.5us | 46.0us | 8.79x |
| 60 | cached | 1048.9us | 111.7us | 9.39x |

Every declined class would have lost; every admitted one wins.

## Decisions

**Explicit policy overrides the measurement.** `cache=CachePolicy(...)` is the author saying "cache this", so the field means one thing throughout: `False` never, a policy always, absent lets the measurement decide. A silently-ignored policy is the kind of thing that generates a bug report about the cache "not working".

**Decided once, never revisited.** A class that re-measured could flip between requests on machine load alone, making the store's contents depend on scheduling noise.

**The measured render includes Jinja's first-time compile,** so the figure runs high. Left uncorrected on purpose, and commented as such: the error points at caching a class that did not need it (costing a hit's overhead) rather than forfeiting a 3-9x saving.

## Tests

`tests/pyjinhx/test_render_cost_threshold.py` for the verdict logic, plus two wiring tests: a cheap class stops touching the backend entirely after its first render, and an explicit policy is not overruled.

Two autouse fixtures in `tests/pyjinhx/conftest.py` — one resets the process-wide verdicts around every test (they are decided once, so otherwise whichever test ran first would fix them for the session), one drops the floor to zero so tests covering the cache *mechanism* still engage it. The templates in those tests are a few tags long and would rightly be declined in production.

`3223 passed, 1 skipped`; `ruff check` and `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxwB6LvymhekN1iFNoNbqu