### PR TITLE
docs: show the full diskcache setup, and fix the stale redis extra

### DIFF
--- a/docs/api/cache-backends.md
+++ b/docs/api/cache-backends.md
@@ -58,14 +58,61 @@ Eviction is by tag rather than through a reverse index the caller keeps, because
 
 ## Turning it on
 
+Three steps: install the extra, hand `setup()` a backend, and give it a directory that starts empty on every deployment.
+
+**1. Install the extra.** `diskcache` is not a runtime dependency, so it has to be asked for:
+
+```bash
+uv add "pyjinhx[diskcache]"      # or: pip install "pyjinhx[diskcache]"
+```
+
+**2. Construct a backend and pass it to `setup()`:**
+
 ```python
+from fastapi import FastAPI
+
 from pyjinhx import setup
 from pyjinhx.integrations.diskcache import DiskCacheBackend
+
+app = FastAPI()
 
 setup(app, cache_backend=DiskCacheBackend("/cache/pjx"))
 ```
 
-The directory must be ephemeral per deployment — see [The cache is volatile](#the-cache-is-volatile) for why, and for the mount that gives you one on each platform.
+That is the whole surface an app touches: this call and the `cache=` class keyword below.
+
+**3. Make `/cache` ephemeral.** This step is configuration, not code, and skipping it is the one mistake with real consequences — a directory that survives a deploy serves output built by the previous version of your code:
+
+```yaml
+# Kubernetes: an emptyDir is new and empty per pod
+volumes:
+  - name: pjx-cache
+    emptyDir: {}
+volumeMounts:
+  - name: pjx-cache
+    mountPath: /cache
+```
+
+```bash
+# Docker: a new tmpfs per container
+docker run --tmpfs /cache myapp
+```
+
+```ini
+# systemd: created at start, removed at stop — gives you /run/myapp
+RuntimeDirectory=myapp
+```
+
+See [The cache is volatile](#the-cache-is-volatile) for why enforcing this is the platform's job rather than pyjinhx's, and for the full per-platform table.
+
+### Checking it works
+
+Two things to confirm on the first deployment:
+
+- **Every worker shares one directory.** If each gets its own, the cross-worker eviction that keeps this safe is gone — one worker's `@mutates` will not reach the others, and they will serve stale data until the TTL expires.
+- **Nothing is being silently declined.** A component holding something unpicklable — a database handle, an open file, a lambda in a field — logs `could not pickle a value of type ...` once per class and then renders live every time. Nothing breaks, but that component gains nothing, and `cache=False` is how to say so deliberately.
+
+`scripts/bench_cross_request_load.py` shows the shape to expect: its `load() ran` column should settle at one execution per distinct key and stay flat as requests repeat.
 
 `PjxSettings.cache_backend` defaults to `None`: no backend, no behaviour change, no new dependency. The backend is constructed by the app rather than named by a string in an environment variable — it needs a path or a connection, and the app is the only thing that knows them. `shutdown_pyjinhx()` calls `close()` on it if it has one.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -18,11 +18,17 @@ uv add pyjinhx
 
 ## Optional extras
 
-The `redis` extra pulls in the dependencies for the Redis invalidation backend (used across multiple workers; configuring it also enables cross-request caching):
+The `diskcache` extra pulls in the dependencies for `DiskCacheBackend`, which lets a `load()` result or a rendered shell be reused across requests instead of being rebuilt every time. Every worker on the machine shares one store, so a mutation in one is seen by the rest:
 
 ```bash
-pip install pyjinhx[redis]
+pip install "pyjinhx[diskcache]"
 ```
+
+```bash
+uv add "pyjinhx[diskcache]"
+```
+
+Optional in both directions: pyjinhx imports and runs without it, and installing it changes nothing until you pass a backend to `setup()`. See [Cache Backends](../api/cache-backends.md) for what it does and the directory it needs.
 
 ## Dependencies
 


### PR DESCRIPTION
## The bug this turned up

`docs/getting-started/installation.md` still documented the `redis` extra:

> The `redis` extra pulls in the dependencies for the Redis invalidation backend…
> ```
> pip install pyjinhx[redis]
> ```

That extra was **removed in #816** along with the page describing a `RedisInvalidationBackend` that never existed. The command no longer installs anything. Replaced with the `diskcache` extra, which is the one that actually ships, plus a note that it is optional in both directions — pyjinhx runs without it, and installing it changes nothing until a backend reaches `setup()`.

## The example

"Turning it on" opened with a fragment: no install step, and an `app` that came from nowhere. It is now a three-step sequence — install the extra, pass a backend to `setup()`, make the directory ephemeral — with a complete importable snippet.

The platform mounts are inlined rather than left behind a link. The full table still lives in [The cache is volatile](https://github.com/paulomtts/pyjinhx/blob/master/docs/api/cache-backends.md#the-cache-is-volatile) and this links to it, but step 3 is configuration rather than code and is the step most likely to be skipped — and skipping it is the one mistake with real consequences.

Also adds a short "checking it works" section covering the two things worth confirming on a first deploy: that every worker shares one directory (otherwise cross-worker eviction is silently gone), and that nothing is being declined for being unpicklable.

## Noted, not fixed

`docs/api/integrations-sqlite.md` is in the same category as the redis page was — it documents a `SqliteInvalidationBackend` that does not exist. It is absent from the nav so nobody navigates to it, but it is still in the tree and still searchable. Left alone as out of scope here.

`mkdocs build --strict` passes; `3223 passed, 1 skipped`; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxwB6LvymhekN1iFNoNbqu