### PR TITLE
docs: rewrite the sqlite integration page and the migration note it made stale

### DIFF
--- a/docs/api/cache-backends.md
+++ b/docs/api/cache-backends.md
@@ -58,14 +58,61 @@ Eviction is by tag rather than through a reverse index the caller keeps, because
 
 ## Turning it on
 
+Three steps: install the extra, hand `setup()` a backend, and give it a directory that starts empty on every deployment.
+
+**1. Install the extra.** `diskcache` is not a runtime dependency, so it has to be asked for:
+
+```bash
+uv add "pyjinhx[diskcache]"      # or: pip install "pyjinhx[diskcache]"
+```
+
+**2. Construct a backend and pass it to `setup()`:**
+
 ```python
+from fastapi import FastAPI
+
 from pyjinhx import setup
 from pyjinhx.integrations.diskcache import DiskCacheBackend
+
+app = FastAPI()
 
 setup(app, cache_backend=DiskCacheBackend("/cache/pjx"))
 ```
 
-The directory must be ephemeral per deployment — see [The cache is volatile](#the-cache-is-volatile) for why, and for the mount that gives you one on each platform.
+That is the whole surface an app touches: this call and the `cache=` class keyword below.
+
+**3. Make `/cache` ephemeral.** This step is configuration, not code, and skipping it is the one mistake with real consequences — a directory that survives a deploy serves output built by the previous version of your code:
+
+```yaml
+# Kubernetes: an emptyDir is new and empty per pod
+volumes:
+  - name: pjx-cache
+    emptyDir: {}
+volumeMounts:
+  - name: pjx-cache
+    mountPath: /cache
+```
+
+```bash
+# Docker: a new tmpfs per container
+docker run --tmpfs /cache myapp
+```
+
+```ini
+# systemd: created at start, removed at stop — gives you /run/myapp
+RuntimeDirectory=myapp
+```
+
+See [The cache is volatile](#the-cache-is-volatile) for why enforcing this is the platform's job rather than pyjinhx's, and for the full per-platform table.
+
+### Checking it works
+
+Two things to confirm on the first deployment:
+
+- **Every worker shares one directory.** If each gets its own, the cross-worker eviction that keeps this safe is gone — one worker's `@mutates` will not reach the others, and they will serve stale data until the TTL expires.
+- **Nothing is being silently declined.** A component holding something unpicklable — a database handle, an open file, a lambda in a field — logs `could not pickle a value of type ...` once per class and then renders live every time. Nothing breaks, but that component gains nothing, and `cache=False` is how to say so deliberately.
+
+`scripts/bench_cross_request_load.py` shows the shape to expect: its `load() ran` column should settle at one execution per distinct key and stay flat as requests repeat.
 
 `PjxSettings.cache_backend` defaults to `None`: no backend, no behaviour change, no new dependency. The backend is constructed by the app rather than named by a string in an environment variable — it needs a path or a connection, and the app is the only thing that knows them. `shutdown_pyjinhx()` calls `close()` on it if it has one.
 

--- a/docs/api/integrations-sqlite.md
+++ b/docs/api/integrations-sqlite.md
@@ -1,7 +1,12 @@
-# SQLite invalidation integration
+# SQLite cache backend
 
-**Not yet implemented.** There is currently no `pyjinhx.integrations.sqlite` module and no `SqliteInvalidationBackend` class in pyjinhx.
+**There is no separate SQLite integration, because SQLite is already how the shipped one works.** `DiskCacheBackend` (`pyjinhx.integrations.diskcache`, installed with `pyjinhx[diskcache]`) stores its entries in SQLite — a `FanoutCache`, which spreads them over several databases so N workers writing do not queue behind one database-level write lock.
 
-Cross-process invalidation fan-out today lives entirely in-process, in `pyjinhx.reactive.fanout`: each worker walks its own request's `X-PJX-Mounted` manifest against that request's dirtied keys and re-renders the regions that need it. There is no shared-database or other mechanism yet for fanning a mutation's dirtied keys out to other worker processes on the same host.
+That also settles what an older version of this page called missing. Cross-process invalidation is not a second mechanism waiting to be built: every worker of a deployment opens the same directory, so an `evict()` in one is visible to the rest on their next read. It falls out of sharing a store rather than riding a channel beside it.
 
-See [Cache & Invalidation](cache-invalidation.md) for the fan-out mechanism that does exist today.
+Two boundaries, both inherited from SQLite:
+
+- **Local disk only.** Its locking is unreliable over NFS and other network filesystems, and a cache that corrupts under concurrency is worse than no cache. Documented rather than detected, because the check would be a guess about a mount point.
+- **One machine, not one cluster.** A shared filesystem covers the workers inside a pod or container; four pods hold four independent caches. That is where a [Redis backend](integrations-redis.md) would earn its place.
+
+See [Cache Backends](cache-backends.md) for the `CacheBackend` protocol, the per-class policy knobs, and the ephemeral-directory contract the disk backend expects.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -18,11 +18,17 @@ uv add pyjinhx
 
 ## Optional extras
 
-The `redis` extra pulls in the dependencies for the Redis invalidation backend (used across multiple workers; configuring it also enables cross-request caching):
+The `diskcache` extra pulls in the dependencies for `DiskCacheBackend`, which lets a `load()` result or a rendered shell be reused across requests instead of being rebuilt every time. Every worker on the machine shares one store, so a mutation in one is seen by the rest:
 
 ```bash
-pip install pyjinhx[redis]
+pip install "pyjinhx[diskcache]"
 ```
+
+```bash
+uv add "pyjinhx[diskcache]"
+```
+
+Optional in both directions: pyjinhx imports and runs without it, and installing it changes nothing until you pass a backend to `setup()`. See [Cache Backends](../api/cache-backends.md) for what it does and the directory it needs.
 
 ## Dependencies
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -440,15 +440,28 @@ nesting structure exactly. Anywhere the heuristic and the structure disagreed, t
 is right — so the only expected difference is fewer redundant swaps, never a missing one.
 Nothing to change in your code.
 
-### Cross-request `InvalidationBackend` is not in 1.0 yet (deferred)
+### Cross-request `InvalidationBackend` — deferred at 1.0, landed in 1.4.0
 
-> **Deferred, not removed.** The cross-request invalidation backends (Redis, SQLite) are
-> not part of the 1.0 release and are planned for a post-1.0 version (ADR 0011).
+> **Superseded.** This was deferred from the 1.0 release (ADR 0011). The capability
+> arrived in 1.4.0, in a different shape — see
+> [Cache Backends](api/cache-backends.md).
 
-The **per-request** load cache ships in 1.0 and is unchanged — single-process apps see no
-difference. If you configured a Redis or SQLite backend to share invalidation across
-processes, that configuration has no 1.0 equivalent yet; stay on 0.36 until it lands if you
-depend on it.
+The **per-request** load cache ships in 1.0 and is unchanged, so single-process apps see no
+difference either way.
+
+If you configured a 0.x Redis or SQLite backend to share invalidation across processes,
+1.4.0 is where that capability returns — but it is not a rename, and there is no drop-in
+equivalent to port to:
+
+- 0.x split **invalidation** (pub/sub of dirtied keys) from **storage**. 1.4.0 does not:
+  workers share one store, so an eviction in one is visible to the rest without a channel
+  beside it. Configure a `CacheBackend` and the invalidation comes with it.
+- `DiskCacheBackend` (`pyjinhx[diskcache]`) is the shipped implementation. It is SQLite
+  underneath, so it replaces the old SQLite backend's role, though not its API.
+- There is no Redis backend yet. The `redis` extra a 0.x app installed no longer exists —
+  a future one would implement the same `CacheBackend` protocol.
+- The store must live on a directory that is **ephemeral per deployment**. This is new, and
+  it is a deployment requirement rather than a setting.
 
 ### Still removed from earlier versions
 


### PR DESCRIPTION
Follow-up to #852, which flagged `docs/api/integrations-sqlite.md` as out of scope there.

## The page was worse than stale — it was wrong

> Cross-process invalidation fan-out today lives entirely in-process... There is no shared-database or other mechanism yet for fanning a mutation's dirtied keys out to other worker processes on the same host.

That stopped being true when `DiskCacheBackend` shipped (#802): it *is* SQLite, spread across shards, and cross-worker invalidation is exactly what it does — an `evict()` in one worker is visible to the rest on their next read of the shared directory. Rewritten to the same shape as the redis page: says plainly there's no separate `sqlite` integration because SQLite is already how the shipped one works, and points at `DiskCacheBackend` and its two real boundaries (local disk only, one machine not one cluster).

## Same bug, one more place: `docs/migration.md`

Grepping for other references to the old invalidation backends turned up the 1.0 migration guide, which still told 0.36 upgraders:

> If you configured a Redis or SQLite backend to share invalidation across processes, that configuration has no 1.0 equivalent yet; stay on 0.36 until it lands if you depend on it.

It landed, in 1.4.0 — so this was telling people to stay on an old release for a capability that already shipped. Replaced with what actually changed for that upgrade path, since it isn't a drop-in:

- 0.x split invalidation (pub/sub) from storage; 1.4.0 doesn't — sharing the store *is* the invalidation.
- `DiskCacheBackend` takes the old SQLite backend's role, not its API.
- No Redis backend exists yet; the `redis` extra a 0.x app installed is gone.
- The cache directory must now be ephemeral per deployment — new, and a deployment requirement rather than a setting.

## Left alone

`docs/api/integrations-redis.md` is untouched — "not yet implemented" is still accurate there, since no Redis backend exists. Both pages stay out of `mkdocs.yml` nav, same as before; that's not new to this PR.

`mkdocs build --strict` passes; `3223 passed, 1 skipped`; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxwB6LvymhekN1iFNoNbqu