### PR TITLE
Recurse into included sub-routers when adapting pjx routes

### DIFF
--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 import inspect
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
@@ -297,8 +297,18 @@ def _install_route_adaptation(backend: FastAPIBackend, app: Starlette) -> None:
                 kwargs["response_model"] = None
             super().__init__(path, _adapt_endpoint(backend, endpoint), **kwargs)
 
+    def patch_routes(routes: Iterable[Any]) -> None:
+        for route in routes:
+            if isinstance(route, APIRoute):
+                if route.dependant.call is not None:
+                    route.dependant.call = _adapt_endpoint(backend, route.dependant.call)
+                    route.app = request_response(route.get_route_handler())
+                continue
+            # fastapi >= 0.137 keeps included routes under a sentinel route
+            # instead of flattening them into app.router.routes.
+            included = getattr(route, "original_router", None)
+            if included is not None:
+                patch_routes(included.routes)
+
     app.router.route_class = PjxRoute  # pyright: ignore[reportAttributeAccessIssue]
-    for route in app.router.routes:
-        if isinstance(route, APIRoute) and route.dependant.call is not None:
-            route.dependant.call = _adapt_endpoint(backend, route.dependant.call)
-            route.app = request_response(route.get_route_handler())
+    patch_routes(app.router.routes)

--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -301,7 +301,9 @@ def _install_route_adaptation(backend: FastAPIBackend, app: Starlette) -> None:
         for route in routes:
             if isinstance(route, APIRoute):
                 if route.dependant.call is not None:
-                    route.dependant.call = _adapt_endpoint(backend, route.dependant.call)
+                    route.dependant.call = _adapt_endpoint(
+                        backend, route.dependant.call
+                    )
                     route.app = request_response(route.get_route_handler())
                 continue
             # fastapi >= 0.137 keeps included routes under a sentinel route

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -623,3 +623,14 @@ def test_included_router_routes_are_adapted_two_levels_deep():
     apply_setup(app, _settings())
 
     assert inner.dependant.call is not original_call
+
+
+def test_nested_route_without_a_dependant_call_is_left_alone():
+    app = FastAPI()
+    inner = _real_api_route("/unguarded")
+    inner.dependant.call = None
+    app.router.routes.append(_FakeIncludedRoute([inner]))
+
+    apply_setup(app, _settings())
+
+    assert inner.dependant.call is None

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -1,7 +1,7 @@
 """The FastAPI adapter: request scope, header parsing, T1/T2 response adaptation."""
 
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
@@ -18,6 +18,9 @@ from pyjinhx.config import PjxSettings
 from pyjinhx.descriptor import ClassDescriptor
 from pyjinhx.integrations.fastapi import apply_setup
 from pyjinhx.session import request_scope
+
+if TYPE_CHECKING:
+    from starlette.routing import BaseRoute
 
 
 class Greeting(BaseComponent):
@@ -607,7 +610,7 @@ def test_included_router_routes_are_adapted_one_level_deep():
     app = FastAPI()
     inner = _real_api_route()
     original_call = inner.dependant.call
-    app.router.routes.append(_FakeIncludedRoute([inner]))
+    app.router.routes.append(cast("BaseRoute", _FakeIncludedRoute([inner])))
 
     apply_setup(app, _settings())
 
@@ -618,7 +621,9 @@ def test_included_router_routes_are_adapted_two_levels_deep():
     app = FastAPI()
     inner = _real_api_route("/deeper")
     original_call = inner.dependant.call
-    app.router.routes.append(_FakeIncludedRoute([_FakeIncludedRoute([inner])]))
+    app.router.routes.append(
+        cast("BaseRoute", _FakeIncludedRoute([_FakeIncludedRoute([inner])]))
+    )
 
     apply_setup(app, _settings())
 
@@ -629,7 +634,7 @@ def test_nested_route_without_a_dependant_call_is_left_alone():
     app = FastAPI()
     inner = _real_api_route("/unguarded")
     inner.dependant.call = None
-    app.router.routes.append(_FakeIncludedRoute([inner]))
+    app.router.routes.append(cast("BaseRoute", _FakeIncludedRoute([inner])))
 
     apply_setup(app, _settings())
 
@@ -646,16 +651,60 @@ def test_unknown_route_shapes_in_the_tree_are_skipped():
     inner = _real_api_route("/mixed")
     original_call = inner.dependant.call
     app.router.routes.append(
-        _FakeIncludedRoute(
-            [
-                Route("/plain", lambda request: PlainTextResponse("x")),
-                WebSocketRoute("/ws", endpoint),
-                _FakeIncludedRoute([]),
-                inner,
-            ]
+        cast(
+            "BaseRoute",
+            _FakeIncludedRoute(
+                [
+                    Route("/plain", lambda request: PlainTextResponse("x")),
+                    WebSocketRoute("/ws", endpoint),
+                    _FakeIncludedRoute([]),
+                    inner,
+                ]
+            ),
         )
     )
 
     apply_setup(app, _settings())
 
     assert inner.dependant.call is not original_call
+
+
+def test_include_router_after_setup_is_adapted():
+    from fastapi import APIRouter
+
+    app = FastAPI()
+    apply_setup(app, _settings())
+
+    sub = APIRouter()
+
+    @sub.get("/sub-after")
+    def sub_after() -> Greeting:
+        return Greeting(name="after")
+
+    app.include_router(sub)
+
+    with TestClient(app) as client:
+        response = client.get("/sub-after")
+
+    assert response.status_code == 200
+    assert "after" in response.text
+
+
+def test_include_router_before_setup_is_adapted():
+    from fastapi import APIRouter
+
+    app = FastAPI()
+    sub = APIRouter()
+
+    @sub.get("/sub-before")
+    def sub_before():
+        return Greeting(name="before")
+
+    app.include_router(sub)
+    apply_setup(app, _settings())
+
+    with TestClient(app) as client:
+        response = client.get("/sub-before")
+
+    assert response.status_code == 200
+    assert "before" in response.text

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -634,3 +634,28 @@ def test_nested_route_without_a_dependant_call_is_left_alone():
     apply_setup(app, _settings())
 
     assert inner.dependant.call is None
+
+
+def test_unknown_route_shapes_in_the_tree_are_skipped():
+    from starlette.routing import Route, WebSocketRoute
+
+    async def endpoint(websocket):  # pragma: no cover - never called
+        raise AssertionError
+
+    app = FastAPI()
+    inner = _real_api_route("/mixed")
+    original_call = inner.dependant.call
+    app.router.routes.append(
+        _FakeIncludedRoute(
+            [
+                Route("/plain", lambda request: PlainTextResponse("x")),
+                WebSocketRoute("/ws", endpoint),
+                _FakeIncludedRoute([]),
+                inner,
+            ]
+        )
+    )
+
+    apply_setup(app, _settings())
+
+    assert inner.dependant.call is not original_call

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -578,3 +578,37 @@ def test_middleware_sessions_share_the_cached_environment():
         expected = _environment_for(current_settings())
 
     assert seen == [expected, expected]
+
+
+class _FakeRouter:
+    """Stands in for the ``.original_router`` of fastapi's _IncludedRouter."""
+
+    def __init__(self, routes):
+        self.routes = routes
+
+
+class _FakeIncludedRoute:
+    """Duck-typed stand-in for fastapi>=0.137's routing._IncludedRouter."""
+
+    def __init__(self, routes):
+        self.original_router = _FakeRouter(routes)
+
+
+def _real_api_route(path: str = "/deep"):
+    from fastapi.routing import APIRoute
+
+    def handler() -> str:
+        return "hello"
+
+    return APIRoute(path, handler)
+
+
+def test_included_router_routes_are_adapted_one_level_deep():
+    app = FastAPI()
+    inner = _real_api_route()
+    original_call = inner.dependant.call
+    app.router.routes.append(_FakeIncludedRoute([inner]))
+
+    apply_setup(app, _settings())
+
+    assert inner.dependant.call is not original_call

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -612,3 +612,14 @@ def test_included_router_routes_are_adapted_one_level_deep():
     apply_setup(app, _settings())
 
     assert inner.dependant.call is not original_call
+
+
+def test_included_router_routes_are_adapted_two_levels_deep():
+    app = FastAPI()
+    inner = _real_api_route("/deeper")
+    original_call = inner.dependant.call
+    app.router.routes.append(_FakeIncludedRoute([_FakeIncludedRoute([inner])]))
+
+    apply_setup(app, _settings())
+
+    assert inner.dependant.call is not original_call


### PR DESCRIPTION
## Summary

- Fix route adaptation to recurse into included sub-routers (enabling routes added via include_router() to be properly adapted)
- Add comprehensive test coverage for sub-router adaptation with various edge cases
- Ensure route adaptation works correctly regardless of include_router() call timing

## Test Plan

- 6 new commits covering: red test case, sub-router recursion at one level, leaf guard verification, unknown route skipping, and ordering independence
- All existing tests continue to pass

Closes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)