### PR TITLE
fix: adapt included sub-router routes end-to-end (#861)

### DIFF
--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -266,6 +266,7 @@ def _adapt_endpoint(
             result = await result
         return backend.to_response(result, _request_from(kwargs))
 
+    setattr(adapted, "__pjx_adapted__", True)  # noqa: B010
     return adapted
 
 
@@ -300,10 +301,14 @@ def _install_route_adaptation(backend: FastAPIBackend, app: Starlette) -> None:
     def patch_routes(routes: Iterable[Any]) -> None:
         for route in routes:
             if isinstance(route, APIRoute):
-                if route.dependant.call is not None:
-                    route.dependant.call = _adapt_endpoint(
-                        backend, route.dependant.call
-                    )
+                call = route.dependant.call
+                if call is not None and not getattr(call, "__pjx_adapted__", False):
+                    adapted = _adapt_endpoint(backend, call)
+                    route.dependant.call = adapted
+                    # An included sub-router is dispatched through effective
+                    # route contexts that fastapi rebuilds from ``endpoint``,
+                    # not from the dependant we just patched.
+                    route.endpoint = adapted
                     route.app = request_response(route.get_route_handler())
                 continue
             # fastapi >= 0.137 keeps included routes under a sentinel route
@@ -312,5 +317,19 @@ def _install_route_adaptation(backend: FastAPIBackend, app: Starlette) -> None:
             if included is not None:
                 patch_routes(included.routes)
 
-    app.router.route_class = PjxRoute  # pyright: ignore[reportAttributeAccessIssue]
-    patch_routes(app.router.routes)
+    app_router: Any = app.router
+    app_router.route_class = PjxRoute
+    patch_routes(app_router.routes)
+
+    # Routers included after setup never see PjxRoute: fastapi keeps the
+    # sub-router's own APIRoute objects instead of rebuilding them with the
+    # app's route_class, so adaptation has to happen at include time.
+    include_router = app_router.include_router
+
+    @functools.wraps(include_router)
+    def adapting_include_router(router: Any, **kwargs: Any) -> Any:
+        result = include_router(router, **kwargs)
+        patch_routes(router.routes)
+        return result
+
+    app_router.include_router = adapting_include_router

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -687,7 +687,10 @@ def test_include_router_after_setup_is_adapted():
         response = client.get("/sub-after")
 
     assert response.status_code == 200
-    assert "after" in response.text
+    # Asserting on the rendered fragment, not just the name: an unadapted route
+    # also answers 200 with the name in it, as pydantic-serialized JSON.
+    assert response.headers["content-type"].startswith("text/html")
+    assert "<div>hello after</div>" in response.text
 
 
 def test_include_router_before_setup_is_adapted():
@@ -707,4 +710,29 @@ def test_include_router_before_setup_is_adapted():
         response = client.get("/sub-before")
 
     assert response.status_code == 200
-    assert "before" in response.text
+    assert response.headers["content-type"].startswith("text/html")
+    assert "<div>hello before</div>" in response.text
+
+
+def test_nested_include_router_is_adapted_end_to_end():
+    from fastapi import APIRouter
+
+    app = FastAPI()
+    apply_setup(app, _settings())
+
+    inner = APIRouter()
+
+    @inner.get("/nested-deep")
+    def nested_deep() -> Greeting:
+        return Greeting(name="deep")
+
+    outer = APIRouter()
+    outer.include_router(inner)
+    app.include_router(outer)
+
+    with TestClient(app) as client:
+        response = client.get("/nested-deep")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "<div>hello deep</div>" in response.text


### PR DESCRIPTION
Closes #861.

Included sub-routers were adapted only in name: `patch_routes` mutated `route.dependant.call`, but fastapi >= 0.137 dispatches an included router through `_IncludedRouter.effective_candidates()`, which rebuilds each effective route from `route.endpoint`. A component-returning handler on an included router therefore answered `application/json` with the raw pydantic body instead of the rendered pjx fragment — verified on master for both include-before-setup and include-after-setup.

- adapt `route.endpoint` alongside `route.dependant.call`, with an idempotency marker so a router included twice is not double-wrapped
- wrap `app.router.include_router` so routers included *after* `apply_setup()` are adapted too (they never see `route_class = PjxRoute`; fastapi keeps the sub-router's own `APIRoute` objects)
- strengthen the two existing regression tests to assert `text/html` and the rendered fragment (they previously passed against unadapted code, since the JSON body also contained the checked substring), and add `test_nested_include_router_is_adapted_end_to_end`

All three end-to-end tests fail against master's `_install_route_adaptation` and pass with this change. Full suite 3252 passed / 1 skipped; ruff check + format clean; basedpyright 0 errors.