### PR TITLE
fix(select): make the chip summary self-sufficient without PJXChipInput

### DIFF
--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.css
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.css
@@ -82,3 +82,33 @@
 .pjx-select__option[aria-selected="true"] {
   background: var(--pjx-select-option-active);
 }
+
+/* ── Multi-select: chip summary + option checkboxes ──────────────────────────── */
+/* Colour, radius and spacing come from PJXChipInput's tokens on purpose: the
+   trigger summary is the same chip, so a theme retunes both at once. Only
+   layout lives here. */
+.pjx-select__chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--pjx-chip-input-gap);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.pjx-select__chips .pjx-chip-input__chip {
+  max-width: 100%;
+}
+
+.pjx-select__chips .pjx-chip-input__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pjx-select__checkbox {
+  flex: none;
+  margin-right: 0.5rem;
+  accent-color: var(--pjx-select-option-active);
+  pointer-events: none;
+}

--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.css
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.css
@@ -85,22 +85,37 @@
 
 /* ── Multi-select: chip summary + option checkboxes ──────────────────────────── */
 /* Colour, radius and spacing come from PJXChipInput's tokens on purpose: the
-   trigger summary is the same chip, so a theme retunes both at once. Only
-   layout lives here. */
+   trigger summary is the same chip, so a theme retunes both at once. But
+   pyjinhx resolves CSS per component with no cross-component dependency, so a
+   page can render PJXSelect(multiple=True) and never render PJXChipInput. Every
+   --pjx-chip-input-* reference below therefore carries the same fallback value
+   pjx_chip_input.css itself declares, and the chip's visuals (not just this
+   row's layout) are embedded here so the summary is never unstyled on its own. */
 .pjx-select__chips {
   display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--pjx-chip-input-gap);
+  gap: var(--pjx-chip-input-gap, 0.375rem);
   min-width: 0;
   overflow: hidden;
 }
 
 .pjx-select__chips .pjx-chip-input__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   max-width: 100%;
+  padding: 0.125rem 0.5rem;
+  background: var(--pjx-chip-input-chip-bg, var(--surface-alt));
+  color: var(--pjx-chip-input-chip-fg, var(--text));
+  border-radius: var(--pjx-chip-input-chip-radius, var(--radius-full));
+  border: 1px solid var(--pjx-chip-input-border, var(--border));
+  font-size: 0.875em;
+  line-height: 1.5;
 }
 
 .pjx-select__chips .pjx-chip-input__label {
+  max-width: 16rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.js
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.js
@@ -152,23 +152,94 @@
         if (parts.trigger) parts.trigger.setAttribute('aria-expanded', 'false');
     }
 
+    function isMultiple(root) {
+        return root.hasAttribute('data-multiple');
+    }
+
+    function selectedOptions(root) {
+        return Array.prototype.slice.call(
+            root.querySelectorAll('[data-pjx-select-option][aria-selected="true"]')
+        );
+    }
+
+    function labelOf(option) {
+        return option.textContent.trim();
+    }
+
+    // The native <select> is the form's source of truth in both modes, so it is
+    // re-derived from the option buttons rather than patched incrementally.
+    function syncNative(root, parts) {
+        if (!parts.native) return;
+        const values = selectedOptions(root).map(function (opt) {
+            return opt.getAttribute('data-value');
+        });
+        Array.prototype.forEach.call(parts.native.options, function (nativeOption) {
+            nativeOption.selected = values.indexOf(nativeOption.value) !== -1;
+        });
+    }
+
+    // Mirrors the template's trigger branch: 2+ selections become a chip row,
+    // 0 or 1 stay plain text. Chips are built node-by-node with textContent so
+    // a label containing markup can never become markup.
+    function renderTrigger(root, parts) {
+        if (!parts.label) return;
+        const chosen = selectedOptions(root);
+        if (chosen.length < 2) {
+            parts.label.textContent = chosen.length
+                ? labelOf(chosen[0])
+                : root.getAttribute('data-placeholder') || '';
+            return;
+        }
+        const row = document.createElement('span');
+        row.className = 'pjx-select__chips';
+        chosen.forEach(function (option) {
+            const chip = document.createElement('span');
+            chip.className = 'pjx-chip-input__chip';
+            const label = document.createElement('span');
+            label.className = 'pjx-chip-input__label';
+            label.textContent = labelOf(option);
+            chip.appendChild(label);
+            row.appendChild(chip);
+        });
+        parts.label.textContent = '';
+        parts.label.appendChild(row);
+    }
+
+    function toggle(root, option) {
+        const parts = partsOf(root);
+        const next = option.getAttribute('aria-selected') !== 'true';
+        option.setAttribute('aria-selected', next ? 'true' : 'false');
+        const box = option.querySelector('.pjx-select__checkbox');
+        if (box) box.checked = next;
+        syncNative(root, parts);
+        renderTrigger(root, parts);
+    }
+
     function select(root, value) {
         const parts = partsOf(root);
-        if (parts.native) parts.native.value = value;
         root.querySelectorAll('[data-pjx-select-option]').forEach(function (opt) {
             const isIt = opt.getAttribute('data-value') === value;
             opt.setAttribute('aria-selected', isIt ? 'true' : 'false');
-            if (isIt && parts.label) parts.label.textContent = opt.textContent.trim();
         });
+        syncNative(root, parts);
+        renderTrigger(root, parts);
     }
 
     document.addEventListener('click', function (e) {
         const option = e.target.closest('[data-pjx-select-option]');
         if (option) {
             const root = rootOf(option);
-            if (root) {
-                select(root, option.getAttribute('data-value'));
-                close(root);
+            // A disabled select never opens its panel, so this branch is
+            // unreachable while disabled — the guard just makes that explicit.
+            if (root && !root.hasAttribute('data-disabled')) {
+                if (isMultiple(root)) {
+                    // Multi-select stays open: picking several values from one
+                    // opening is the whole point of the mode.
+                    toggle(root, option);
+                } else {
+                    select(root, option.getAttribute('data-value'));
+                    close(root);
+                }
             }
             return;
         }

--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.pjx
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.pjx
@@ -6,7 +6,12 @@
     {% endfor %}
   </select>
   <button type="button" class="pjx-select__trigger" data-pjx-select-trigger aria-haspopup="listbox" aria-expanded="false"{% if disabled %} disabled{% endif %}>
-    <span class="pjx-select__label">{{ selected_options[0].label if selected_options else placeholder }}</span>
+    {#- The chip row lives *inside* .pjx-select__label rather than replacing it,
+        so the JS keeps one node to rewrite in both modes. Chips reuse
+        PJXChipInput's classes but deliberately omit its remove button and
+        hidden input: this is a read-only summary, and the native <select>
+        already posts the values. -#}
+    <span class="pjx-select__label">{% if multiple and selected_options | length > 1 %}<span class="pjx-select__chips">{% for option in selected_options %}<span class="pjx-chip-input__chip"><span class="pjx-chip-input__label">{{ option.label }}</span></span>{% endfor %}</span>{% else %}{{ selected_options[0].label if selected_options else placeholder }}{% endif %}</span>
   </button>
   <div class="pjx-select__panel" data-pjx-select-panel hidden role="listbox">
     {% for option in options %}<button type="button" class="pjx-select__option" data-pjx-select-option data-value="{{ option.value }}" aria-selected="{{ 'true' if option.value in selected_values else 'false' }}" role="option">{% if multiple %}<input type="checkbox"{% if disabled %} disabled{% endif %}{% if option.value in selected_values %} checked{% endif %} class="pjx-select__checkbox" tabindex="-1" aria-hidden="true">{% endif %}{{ option.label }}</button>

--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.pjx
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.pjx
@@ -1,14 +1,15 @@
-{% set selected = (options | selectattr("value", "equalto", value) | list | first) -%}
-<div id="{{ id }}" class="pjx-select{% if class_name %} {{ class_name }}{% endif %}" data-pjx-select data-name="{{ name }}"{% if disabled %} data-disabled{% endif %}>
-  <select name="{{ name }}" hidden{% if disabled %} disabled{% endif %}>
-    {% for option in options %}<option value="{{ option.value }}"{% if option.value == value %} selected{% endif %}>{{ option.label }}</option>
+{% set selected_values = (value or []) if multiple else ([value] if value else []) -%}
+{% set selected_options = options | selectattr("value", "in", selected_values) | list -%}
+<div id="{{ id }}" class="pjx-select{% if class_name %} {{ class_name }}{% endif %}" data-pjx-select data-name="{{ name }}"{% if multiple %} data-multiple data-placeholder="{{ placeholder }}"{% endif %}{% if disabled %} data-disabled{% endif %}>
+  <select name="{{ name }}"{% if multiple %} multiple{% endif %} hidden{% if disabled %} disabled{% endif %}>
+    {% for option in options %}<option value="{{ option.value }}"{% if option.value in selected_values %} selected{% endif %}>{{ option.label }}</option>
     {% endfor %}
   </select>
   <button type="button" class="pjx-select__trigger" data-pjx-select-trigger aria-haspopup="listbox" aria-expanded="false"{% if disabled %} disabled{% endif %}>
-    <span class="pjx-select__label">{{ selected.label if selected else placeholder }}</span>
+    <span class="pjx-select__label">{{ selected_options[0].label if selected_options else placeholder }}</span>
   </button>
   <div class="pjx-select__panel" data-pjx-select-panel hidden role="listbox">
-    {% for option in options %}<button type="button" class="pjx-select__option" data-pjx-select-option data-value="{{ option.value }}" aria-selected="{{ 'true' if option.value == value else 'false' }}" role="option">{{ option.label }}</button>
+    {% for option in options %}<button type="button" class="pjx-select__option" data-pjx-select-option data-value="{{ option.value }}" aria-selected="{{ 'true' if option.value in selected_values else 'false' }}" role="option">{% if multiple %}<input type="checkbox"{% if disabled %} disabled{% endif %}{% if option.value in selected_values %} checked{% endif %} class="pjx-select__checkbox" tabindex="-1" aria-hidden="true">{% endif %}{{ option.label }}</button>
     {% endfor %}
   </div>
 </div>

--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.py
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel
+from typing import Self
+
+from pydantic import BaseModel, model_validator
 
 from pyjinhx._component import AttrValue, BaseComponent
 
@@ -11,17 +13,33 @@ class SelectOption(BaseModel):
 
 
 class PJXSelect(BaseComponent):
-    """A single-choice select styled to replace a bare ``<select>``.
+    """A select styled to replace a bare ``<select>``, single-choice or multi.
 
     The JS finds trigger and panel through ``data-pjx-select``, mirroring
     pjx_popover's trigger/panel split. A hidden native ``<select>`` carries the
     same options so a plain form submit still posts a value without JS. A
     ``value`` that matches no option renders unselected rather than raising.
+
+    With ``multiple``, ``value`` is a list, every option row gets a checkbox,
+    and the trigger summarises two or more selections as chips.
     """
 
     name: str
     options: list[SelectOption]
-    value: str | None = None
+    value: str | list[str] | None = None
+    multiple: bool = False
     placeholder: str = "Select…"
     disabled: bool = False
     class_name: AttrValue = ""
+
+    @model_validator(mode="after")
+    def _check_value_shape(self) -> Self:
+        # An unknown value is tolerated (renders unselected), but the wrong
+        # *shape* is a caller bug that would silently drop the selection.
+        if self.value is None:
+            return self
+        if self.multiple and not isinstance(self.value, list):
+            raise ValueError("value must be a list when multiple=True")
+        if not self.multiple and not isinstance(self.value, str):
+            raise ValueError("value must be a str when multiple=False")
+        return self

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
@@ -73,7 +73,7 @@ class TestMultipleMarkup:
 
     def test_multiple_checked_state_follows_the_value_list(self, session):
         html = _html(session, multiple=True, value=["a", "c"])
-        assert html.count("checkbox\" checked") == 2
+        assert html.count('checkbox" checked') == 2
         assert html.count('<option value="a" selected>') == 1
         assert html.count('<option value="c" selected>') == 1
         assert '<option value="b">' in html
@@ -82,7 +82,7 @@ class TestMultipleMarkup:
     def test_multiple_unknown_value_dropped(self, session):
         html = _html(session, multiple=True, value=["a", "zzz"])
         assert html.count('aria-selected="true"') == 1
-        assert html.count("checkbox\" checked") == 1
+        assert html.count('checkbox" checked') == 1
         assert "zzz" not in html
 
     def test_multiple_disabled_checkboxes_present_but_inert(self, session):
@@ -126,7 +126,9 @@ class TestChipSummary:
             SelectOption(value="a", label="<b>Ampersand & co</b>"),
             SelectOption(value="b", label="Banana"),
         ]
-        trigger = _trigger(_html(session, options=options, multiple=True, value=["a", "b"]))
+        trigger = _trigger(
+            _html(session, options=options, multiple=True, value=["a", "b"])
+        )
         assert "&lt;b&gt;Ampersand &amp; co&lt;/b&gt;" in trigger
         assert "<b>Ampersand" not in trigger
 

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
@@ -38,3 +38,55 @@ class TestMultipleFields:
             PJXSelect(id="s", name="fruit", options=OPTIONS, multiple=True, value="a")
         with pytest.raises(ValidationError):
             PJXSelect(id="s", name="fruit", options=OPTIONS, value=["a"])
+
+
+@pytest.fixture
+def session():
+    """Loader rooted at "/" so absolute descriptor template paths resolve.
+
+    Same fixture shape as the sibling builtin tests.
+    """
+    return RenderSession()
+
+
+def _html(session, **kwargs) -> str:
+    base = {"id": "s", "name": "fruit", "options": OPTIONS}
+    base.update(kwargs)
+    return render(PJXSelect(**base), session)  # type: ignore[arg-type]
+
+
+class TestMultipleMarkup:
+    def test_multiple_renders_checkboxes(self, session):
+        html = _html(session, multiple=True)
+        assert html.count('type="checkbox"') == 3
+        assert 'type="checkbox"' not in _html(session)
+
+    def test_multiple_native_select_has_multiple_attr(self, session):
+        assert '<select name="fruit" multiple hidden>' in _html(session, multiple=True)
+        assert "multiple" not in _html(session)
+
+    def test_multiple_root_carries_the_multiple_hook(self, session):
+        head = _html(session, multiple=True)
+        head = head[: head.index(">")]
+        assert "data-multiple" in head
+        assert 'data-placeholder="Select…"' in head
+
+    def test_multiple_checked_state_follows_the_value_list(self, session):
+        html = _html(session, multiple=True, value=["a", "c"])
+        assert html.count("checkbox\" checked") == 2
+        assert html.count('<option value="a" selected>') == 1
+        assert html.count('<option value="c" selected>') == 1
+        assert '<option value="b">' in html
+        assert html.count('aria-selected="true"') == 2
+
+    def test_multiple_unknown_value_dropped(self, session):
+        html = _html(session, multiple=True, value=["a", "zzz"])
+        assert html.count('aria-selected="true"') == 1
+        assert html.count("checkbox\" checked") == 1
+        assert "zzz" not in html
+
+    def test_multiple_disabled_checkboxes_present_but_inert(self, session):
+        html = _html(session, multiple=True, disabled=True)
+        assert html.count('type="checkbox"') == 3
+        assert html.count('type="checkbox" disabled') == 3
+        assert "data-disabled" in html[: html.index(">")]

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
@@ -153,3 +153,40 @@ class TestStylesheet:
         assert ".pjx-select__checkbox" in css
         assert "var(--pjx-chip-input-gap)" in css
         assert "--pjx-select-chip-" not in css
+
+
+class TestController:
+    """The controller is asserted structurally — there is no JS runtime in this suite.
+
+    These checks pin the contract the markup and the script share (hook names,
+    escaping discipline) so a rename on either side fails loudly.
+    """
+
+    @staticmethod
+    def _js() -> str:
+        from pathlib import Path
+
+        return (
+            Path(__file__).resolve().parents[4]
+            / "pyjinhx"
+            / "builtins"
+            / "ui"
+            / "pjx_select"
+            / "pjx_select.js"
+        ).read_text()
+
+    def test_controller_branches_on_the_multiple_hook(self):
+        js = self._js()
+        assert "data-multiple" in js
+        assert "data-placeholder" in js
+
+    def test_controller_builds_chips_without_innerhtml(self):
+        js = self._js()
+        assert "pjx-chip-input__chip" in js
+        assert "pjx-chip-input__label" in js
+        assert "innerHTML =" not in js
+
+    def test_controller_keeps_no_search_or_keyboard_handling(self):
+        js = self._js()
+        assert "keydown" not in js
+        assert 'type="search"' not in js

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
@@ -1,0 +1,40 @@
+"""PJXSelect multi-select mode (#866) — checkboxes, chip trigger summary, native multi.
+
+Single-select behaviour lives in test_pjx_select.py. Search (#867), keyboard nav
+(#868) and the exhaustive cross-cutting suite (#869) are separate subtasks;
+nothing here anticipates their markup.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from pyjinhx.builtins.ui.pjx_select import PJXSelect, SelectOption
+from pyjinhx.rendering import render
+from pyjinhx.session import RenderSession
+
+OPTIONS = [
+    SelectOption(value="a", label="Apple"),
+    SelectOption(value="b", label="Banana"),
+    SelectOption(value="c", label="Cherry"),
+]
+
+
+class TestMultipleFields:
+    def test_multiple_defaults_to_false(self):
+        assert PJXSelect(id="s", name="fruit", options=OPTIONS).multiple is False
+
+    def test_multi_mode_accepts_a_list_value(self):
+        sel = PJXSelect(
+            id="s", name="fruit", options=OPTIONS, multiple=True, value=["a", "b"]
+        )
+        assert sel.value == ["a", "b"]
+
+    def test_multi_mode_accepts_none(self):
+        sel = PJXSelect(id="s", name="fruit", options=OPTIONS, multiple=True)
+        assert sel.value is None
+
+    def test_multiple_value_type_mismatch_raises(self):
+        with pytest.raises(ValidationError):
+            PJXSelect(id="s", name="fruit", options=OPTIONS, multiple=True, value="a")
+        with pytest.raises(ValidationError):
+            PJXSelect(id="s", name="fruit", options=OPTIONS, value=["a"])

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
@@ -138,12 +138,19 @@ class TestChipSummary:
 
 
 class TestStylesheet:
-    """The chip summary must borrow PJXChipInput's tokens, not fork them."""
+    """The chip summary borrows PJXChipInput's tokens when available, but pyjinhx's
+    asset walk resolves CSS per-class with no cross-component dependency: a page
+    that renders PJXSelect(multiple=True) without ever rendering PJXChipInput only
+    ships pjx_select.css. So pjx_select.css must carry its own fallback values for
+    every PJXChipInput token it references, and the actual chip visuals (not just
+    layout), rather than assuming pjx_chip_input.css is also on the page.
+    """
 
-    def test_chip_layout_rules_exist_and_reuse_chip_input_tokens(self):
+    @staticmethod
+    def _css() -> str:
         from pathlib import Path
 
-        css = (
+        return (
             Path(__file__).resolve().parents[4]
             / "pyjinhx"
             / "builtins"
@@ -151,10 +158,37 @@ class TestStylesheet:
             / "pjx_select"
             / "pjx_select.css"
         ).read_text()
+
+    def test_chip_layout_rules_exist_and_reuse_chip_input_tokens(self):
+        css = self._css()
         assert ".pjx-select__chips" in css
         assert ".pjx-select__checkbox" in css
-        assert "var(--pjx-chip-input-gap)" in css
+        assert "var(--pjx-chip-input-gap" in css
         assert "--pjx-select-chip-" not in css
+
+    def test_chip_tokens_have_standalone_fallbacks(self):
+        """Every --pjx-chip-input-* var() reference needs a fallback value so
+        chips still render (with the right colours, not just layout) when
+        pjx_chip_input.css never ships on the page."""
+        css = self._css()
+        import re
+
+        refs = re.findall(r"var\(--pjx-chip-input-[\w-]+([^)]*)\)", css)
+        assert refs, "expected at least one --pjx-chip-input-* var() reference"
+        assert all("," in ref for ref in refs), (
+            "every --pjx-chip-input-* reference needs a fallback: "
+            f"{[r for r in refs if ',' not in r]}"
+        )
+
+    def test_chip_visuals_are_embedded_not_just_layout(self):
+        """The chip's own background/border/radius/font-size must be embedded
+        in pjx_select.css, not left to pjx_chip_input.css to supply."""
+        css = self._css()
+        chip_rule_start = css.index(".pjx-select__chips .pjx-chip-input__chip")
+        chip_rule = css[chip_rule_start : css.index("}", chip_rule_start)]
+        assert "background" in chip_rule
+        assert "border-radius" in chip_rule
+        assert "font-size" in chip_rule
 
 
 class TestController:

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
@@ -90,3 +90,46 @@ class TestMultipleMarkup:
         assert html.count('type="checkbox"') == 3
         assert html.count('type="checkbox" disabled') == 3
         assert "data-disabled" in html[: html.index(">")]
+
+
+def _trigger(html: str) -> str:
+    start = html.index("data-pjx-select-trigger")
+    return html[start : html.index("</button>", start)]
+
+
+class TestChipSummary:
+    def test_multiple_two_plus_selected_renders_chips(self, session):
+        trigger = _trigger(_html(session, multiple=True, value=["a", "c"]))
+        assert trigger.count('class="pjx-chip-input__chip"') == 2
+        assert trigger.count('class="pjx-chip-input__label"') == 2
+        assert 'class="pjx-select__chips"' in trigger
+        assert "Apple" in trigger
+        assert "Cherry" in trigger
+        assert "Banana" not in trigger
+
+    def test_trigger_chips_carry_no_remove_button(self, session):
+        trigger = _trigger(_html(session, multiple=True, value=["a", "c"]))
+        assert "pjx-chip-input__remove" not in trigger
+        assert "&#x2715;" not in trigger
+
+    def test_multiple_zero_or_one_selected_renders_plain_label(self, session):
+        none_selected = _trigger(_html(session, multiple=True))
+        assert "pjx-chip-input__chip" not in none_selected
+        assert "Select…" in none_selected
+
+        one_selected = _trigger(_html(session, multiple=True, value=["b"]))
+        assert "pjx-chip-input__chip" not in one_selected
+        assert "Banana" in one_selected
+
+    def test_multiple_chip_label_escaped(self, session):
+        options = [
+            SelectOption(value="a", label="<b>Ampersand & co</b>"),
+            SelectOption(value="b", label="Banana"),
+        ]
+        trigger = _trigger(_html(session, options=options, multiple=True, value=["a", "b"]))
+        assert "&lt;b&gt;Ampersand &amp; co&lt;/b&gt;" in trigger
+        assert "<b>Ampersand" not in trigger
+
+    def test_label_span_is_still_the_single_trigger_hook(self, session):
+        html = _html(session, multiple=True, value=["a", "c"])
+        assert html.count('class="pjx-select__label"') == 1

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
@@ -133,3 +133,23 @@ class TestChipSummary:
     def test_label_span_is_still_the_single_trigger_hook(self, session):
         html = _html(session, multiple=True, value=["a", "c"])
         assert html.count('class="pjx-select__label"') == 1
+
+
+class TestStylesheet:
+    """The chip summary must borrow PJXChipInput's tokens, not fork them."""
+
+    def test_chip_layout_rules_exist_and_reuse_chip_input_tokens(self):
+        from pathlib import Path
+
+        css = (
+            Path(__file__).resolve().parents[4]
+            / "pyjinhx"
+            / "builtins"
+            / "ui"
+            / "pjx_select"
+            / "pjx_select.css"
+        ).read_text()
+        assert ".pjx-select__chips" in css
+        assert ".pjx-select__checkbox" in css
+        assert "var(--pjx-chip-input-gap)" in css
+        assert "--pjx-select-chip-" not in css


### PR DESCRIPTION
## Summary
- Multi-select chip summary is now self-sufficient and does not depend on PJXChipInput
- Standalone chip styling contract pinned for pjx_select.css
- Multi-select checkbox and chip row styling implemented and tested
- Toggle, sync, and re-summarise selections in multi mode
- Complete multi-select support with native HTML multiple and per-option checkboxes

## Test plan
- All existing tests pass
- New multi-select tests validate checkbox behavior, chip rendering, and state synchronization
- Ruff formatting applied and verified

Closes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)