### PR TITLE
feat: keyboard navigation for PJXSelect (#868)

### DIFF
--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.js
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.js
@@ -279,4 +279,143 @@
         const root = rootOf(filter);
         if (root) applyFilter(root, filter.value);
     });
+
+    // --- keyboard navigation -------------------------------------------
+    // Option buttons are natively focusable, so focus moves with .focus()
+    // alone; no roving tabindex. A select panel is a transient popup whose
+    // only tab stop is the trigger, unlike a tablist that must stay in the
+    // page's tab order with exactly one active tab.
+
+    function visibleOptions(root) {
+        return Array.prototype.slice.call(
+            root.querySelectorAll('[data-pjx-select-option]:not([hidden]):not([disabled])')
+        );
+    }
+
+    function moveFocus(root, from, delta) {
+        const options = visibleOptions(root);
+        if (!options.length) return;
+        const at = options.indexOf(from);
+        // An unknown `from` (focus in the filter box, or a node the filter
+        // just hid) enters the list from whichever end the caller is heading.
+        const next = at === -1
+            ? (delta > 0 ? 0 : options.length - 1)
+            : (at + delta + options.length) % options.length;
+        options[next].focus();
+    }
+
+    function focusEdge(root, last) {
+        const options = visibleOptions(root);
+        if (!options.length) return;
+        options[last ? options.length - 1 : 0].focus();
+    }
+
+    let typeAhead = '';
+    let typeAheadTimer = null;
+
+    function pushTypeAhead(ch) {
+        typeAhead += ch;
+        if (typeAheadTimer) clearTimeout(typeAheadTimer);
+        // A pause means the next keystroke starts a new word, not a longer
+        // prefix of the old one.
+        typeAheadTimer = setTimeout(function () {
+            typeAhead = '';
+            typeAheadTimer = null;
+        }, 500);
+        return typeAhead;
+    }
+
+    function typeAheadTarget(root, from, needle) {
+        const options = visibleOptions(root);
+        if (!options.length) return null;
+        const start = options.indexOf(from);
+        const prefix = needle.toLowerCase();
+        // Search starts *after* the focused option so repeating a letter
+        // cycles through the options sharing that initial.
+        for (let step = 1; step <= options.length; step += 1) {
+            const option = options[(start + step + options.length) % options.length];
+            if (labelOf(option).toLowerCase().indexOf(prefix) === 0) return option;
+        }
+        return null;
+    }
+
+    function dismiss(root) {
+        const trigger = root.querySelector('[data-pjx-select-trigger]');
+        close(root);
+        if (trigger) trigger.focus();
+    }
+
+    function commitOption(root, option) {
+        if (isMultiple(root)) {
+            // Multi-select stays open and keeps focus put, so the next Enter
+            // lands on the option the user is still looking at.
+            toggle(root, option);
+            return;
+        }
+        select(root, option.getAttribute('data-value'));
+        dismiss(root);
+    }
+
+    function onTriggerKey(e, root) {
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            open(root);
+            const options = visibleOptions(root);
+            if (!options.length) return;
+            options[e.key === 'ArrowUp' ? options.length - 1 : 0].focus();
+        }
+    }
+
+    document.addEventListener('keydown', function (e) {
+        if (e.isComposing) return;
+        if (!e.target.closest) return;
+        const root = rootOf(e.target);
+        if (!root || root.hasAttribute('data-disabled')) return;
+
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            dismiss(root);
+            return;
+        }
+
+        const option = e.target.closest('[data-pjx-select-option]');
+        if (!option) {
+            // The filter box owns its own keystrokes: its `input` listener is
+            // the search, so type-ahead would only fight it.
+            if (e.target.closest('[data-pjx-select-filter]')) {
+                if (e.key === 'ArrowDown') {
+                    e.preventDefault();
+                    focusEdge(root, false);
+                }
+                return;
+            }
+            if (e.target.closest('[data-pjx-select-trigger]')) onTriggerKey(e, root);
+            return;
+        }
+
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+            e.preventDefault();
+            moveFocus(root, option, e.key === 'ArrowDown' ? 1 : -1);
+            return;
+        }
+        if (e.key === 'Home' || e.key === 'End') {
+            e.preventDefault();
+            focusEdge(root, e.key === 'End');
+            return;
+        }
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            commitOption(root, option);
+            return;
+        }
+        if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+            const target = typeAheadTarget(root, option, pushTypeAhead(e.key));
+            // No match leaves focus alone; the buffer still holds, so the
+            // user can back out of a typo by pausing.
+            if (target) {
+                e.preventDefault();
+                target.focus();
+            }
+        }
+    });
 }());

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_keyboard.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_keyboard.py
@@ -1,0 +1,137 @@
+"""PJXSelect — keyboard navigation of the option panel.
+
+There is no JS harness in this repo (see test_pjx_select_filter.py), so the
+browser behavior is pinned by source-shape guards over pjx_select.js: each
+test names one invariant that is cheap to break and expensive to notice.
+The exhaustive key-by-mode matrix belongs to the PJXSelect test/docs subtask.
+"""
+
+from pathlib import Path
+
+UI = Path(__file__).resolve().parents[4] / "pyjinhx" / "builtins" / "ui"
+CONTROLLER = UI / "pjx_select" / "pjx_select.js"
+
+
+def source() -> str:
+    return CONTROLLER.read_text()
+
+
+def body_of(name: str) -> str:
+    """Text of the named top-level function, from its `function` line to its close."""
+    src = source()
+    start = src.index(f"function {name}(")
+    return src[start : src.index("\n    }", start)]
+
+
+class TestWiring:
+    def test_a_keydown_listener_is_wired(self):
+        assert "addEventListener('keydown'" in source()
+
+    def test_the_listener_ignores_targets_outside_a_select_root(self):
+        # Chip-input convention: bail before touching the root at all.
+        handler = source()[source().index("addEventListener('keydown'") :]
+        assert "rootOf(" in handler
+        assert "if (!root" in handler
+
+    def test_disabled_roots_are_inert(self):
+        handler = source()[source().index("addEventListener('keydown'") :]
+        assert "data-disabled" in handler
+
+
+class TestVisibleOptions:
+    def test_the_option_list_skips_hidden_options(self):
+        assert "[data-pjx-select-option]:not([hidden])" in body_of("visibleOptions")
+
+    def test_the_option_list_skips_disabled_options(self):
+        assert ":not([disabled])" in body_of("visibleOptions")
+
+
+class TestArrowNavigation:
+    def test_arrows_home_and_end_are_all_handled(self):
+        handler = source()[source().index("addEventListener('keydown'") :]
+        for key in ("'ArrowDown'", "'ArrowUp'", "'Home'", "'End'"):
+            assert key in handler
+
+    def test_movement_wraps_at_both_ends(self):
+        body = body_of("moveFocus")
+        assert "% options.length" in body
+        assert "+ options.length" in body
+
+    def test_movement_is_a_no_op_on_an_empty_list(self):
+        assert "if (!options.length) return" in body_of("moveFocus")
+
+    def test_movement_preventsdefault_and_focuses(self):
+        handler = source()[source().index("addEventListener('keydown'") :]
+        assert "e.preventDefault()" in handler
+        assert ".focus()" in handler
+
+
+class TestOpeningFromTheTrigger:
+    def test_the_trigger_opens_on_arrow_enter_and_space(self):
+        body = body_of("onTriggerKey")
+        assert "open(root)" in body
+        assert "'Enter'" in body
+        assert "' '" in body
+
+    def test_arrowup_enters_at_the_last_option(self):
+        assert "options.length - 1" in body_of("onTriggerKey")
+
+
+class TestTypeAhead:
+    def test_the_buffer_resets_after_an_idle_window(self):
+        body = body_of("pushTypeAhead")
+        assert "500" in body
+        assert "setTimeout" in body
+
+    def test_matching_is_case_insensitive_and_prefix_based(self):
+        body = body_of("typeAheadTarget")
+        assert "toLowerCase()" in body
+        assert "indexOf(" in body and "=== 0" in body
+
+    def test_type_ahead_wraps_past_the_focused_option(self):
+        assert "% options.length" in body_of("typeAheadTarget")
+
+    def test_the_filter_input_keeps_ownership_of_its_own_typing(self):
+        # Type-ahead only fires when focus is on an option button, never while
+        # the search box has it — otherwise every keystroke would do both.
+        handler = source()[source().index("addEventListener('keydown'") :]
+        assert "data-pjx-select-filter" in handler
+
+    def test_only_single_printing_characters_start_a_buffer(self):
+        handler = source()[source().index("addEventListener('keydown'") :]
+        assert "e.key.length === 1" in handler
+        assert "e.ctrlKey" in handler and "e.metaKey" in handler
+
+
+class TestCommitAndDismiss:
+    def test_enter_branches_on_mode(self):
+        body = body_of("commitOption")
+        assert "isMultiple(root)" in body
+        assert "toggle(root, option)" in body
+        assert "select(root, option.getAttribute('data-value'))" in body
+
+    def test_single_select_closes_and_returns_focus_to_the_trigger(self):
+        # commitOption delegates to dismiss() for the close+refocus half;
+        # dismiss's own body is pinned separately below.
+        assert "dismiss(root)" in body_of("commitOption")
+
+    def test_escape_closes_and_returns_focus_to_the_trigger(self):
+        body = body_of("dismiss")
+        assert "close(root)" in body
+        assert "trigger.focus()" in body
+
+    def test_escape_is_scoped_to_select_roots(self):
+        # pjx_popover.js also closes on Escape; scoping keeps the two handlers
+        # from fighting over unrelated components.
+        handler = source()[source().index("addEventListener('keydown'") :]
+        assert "'Escape'" in handler
+
+
+class TestUntouchedNeighbours:
+    def test_the_position_primitive_is_still_verbatim(self):
+        primitive = (UI / "pjx_popover" / "pjx_popover_position.js").read_text()
+        assert primitive in source()
+
+    def test_no_new_markup_hooks_were_invented(self):
+        template = (UI / "pjx_select" / "pjx_select.pjx").read_text()
+        assert "tabindex" not in template.replace('tabindex="-1"', "")

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_multiple.py
@@ -222,7 +222,6 @@ class TestController:
         assert "pjx-chip-input__label" in js
         assert "innerHTML =" not in js
 
-    def test_controller_keeps_no_search_or_keyboard_handling(self):
+    def test_controller_never_builds_the_search_markup(self):
         js = self._js()
-        assert "keydown" not in js
         assert 'type="search"' not in js


### PR DESCRIPTION
## Summary
- Adds keyboard navigation support to PJXSelect component
- Implements arrow key handling for menu navigation
- Adds proper focus management and keyboard event handling

Closes #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)