### PR TITLE
feat: add per-class load()-cost verdict for fan-out threading

### DIFF
--- a/pyjinhx/reactive/fanout.py
+++ b/pyjinhx/reactive/fanout.py
@@ -22,6 +22,7 @@ before calling ``load()``.
 """
 
 import re
+import time
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextvars import copy_context
@@ -34,6 +35,7 @@ from pyjinhx import discovery, registry
 from pyjinhx.reactive.cache import cache_get, cache_has
 from pyjinhx.reactive.component import ReactiveComponent, coerce_load_arg
 from pyjinhx.reactive.keys import coerce_load_key_str
+from pyjinhx.reactive.load_cost import note_load_cost
 from pyjinhx.rendering import render_level
 from pyjinhx.root_attrs import stamp_root_attrs
 from pyjinhx.segments import ChildRef, RenderedLevel, serialize
@@ -165,6 +167,11 @@ def _build_dirty(
         LookupError: ``load()`` cannot build this region any more — the one
             honest signal that a region the client still shows is gone
             server-side. ``walk_manifest`` turns it into a "missing" candidate.
+
+    The load is timed around the call that already happens — never a second,
+    synthetic one — so the verdict prices the author's real work. Recording it
+    here only writes the decision; what reads it is the build pass's choice of
+    threading, which lands separately.
     """
     key_args: dict[str, Any] = {}
     if cls._pjx_key_field is not None:
@@ -172,7 +179,9 @@ def _build_dirty(
         # key declared `int` arrives as `"1"`; restore the declared type before
         # calling the author's load(), whose signature is written against it.
         key_args[cls._pjx_key_field] = coerce_load_arg(cls, load)
+    started = time.perf_counter()
     instance = cls.load(**key_args)
+    note_load_cost(cls, (time.perf_counter() - started) * 1_000_000)
     instance.id = instance_id
     return instance, render_level(instance, session)
 

--- a/pyjinhx/reactive/load_cost.py
+++ b/pyjinhx/reactive/load_cost.py
@@ -1,0 +1,80 @@
+"""Whether a ReactiveComponent's load() costs enough to be worth a fan-out thread."""
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyjinhx.reactive.component import ReactiveComponent
+
+# Handing one candidate to the threadpool is not free: the submit, the
+# copy_context() copy the worker runs under and the join come to roughly 50-100us
+# per item, which is why the bench's zero-cost load() row loses at 0.3-0.4x. The
+# floor sits clear above a load() that only touches memory and well below the
+# 0.5ms row that already wins 2.8x, so nothing that profits is demoted.
+_DEFAULT_MIN_COST_US = 200.0
+
+# Qualified names, not classes: see _too_cheap_key. Process-wide because the
+# measurement is a property of the load implementation, not of any one request.
+_too_cheap: set[str] = set()
+_decided: set[str] = set()
+
+
+def reset_load_cost_decisions() -> None:
+    """Forget every measured class. For tests, which must not inherit a verdict."""
+    _too_cheap.clear()
+    _decided.clear()
+
+
+def _min_cost_us() -> float:
+    """The load() cost, in microseconds, below which threading the build is a loss.
+
+    Read per call rather than captured at import so a test — or an app that sets
+    the variable after importing pyjinhx — is not fighting import order.
+    """
+    raw = os.environ.get("PJX_FANOUT_THREAD_MIN_US")
+    if raw is None or raw == "":
+        return _DEFAULT_MIN_COST_US
+    try:
+        return float(raw)
+    except ValueError:
+        raise ValueError(
+            f"PJX_FANOUT_THREAD_MIN_US={raw!r} is not a number of microseconds."
+        ) from None
+
+
+def is_too_cheap_to_thread(cls: "type[ReactiveComponent]") -> bool:
+    """Whether this class's load() was measured as cheaper than a thread costs.
+
+    False for a class nobody has measured yet: fan-out threads by default and a
+    class earns its way out, so the first build of an unseen class behaves the
+    same as it did before any of this existed.
+    """
+    return _too_cheap_key(cls) in _too_cheap
+
+
+def note_load_cost(cls: "type[ReactiveComponent]", cost_us: float) -> None:
+    """Record what this class's load() actually cost, and decide it once.
+
+    Per class rather than per instance: the same load() doing the same work costs
+    the same whether it is row 3 or row 197, so one measurement settles every
+    instance and the check afterwards is a set lookup.
+
+    Decided once and never revisited. A class that re-measured could flip between
+    requests on nothing but machine load, and a build pass that threads or does
+    not thread according to scheduling noise is one nobody can reason about.
+    """
+    key = _too_cheap_key(cls)
+    if key in _decided:
+        return
+    _decided.add(key)
+    if cost_us < _min_cost_us():
+        _too_cheap.add(key)
+
+
+def _too_cheap_key(cls: "type[ReactiveComponent]") -> str:
+    """The qualified name this class is remembered under.
+
+    A name rather than the class object, so the two sets cannot keep a class alive
+    for the life of the process.
+    """
+    return f"{cls.__module__}.{cls.__qualname__}"

--- a/tests/pyjinhx/conftest.py
+++ b/tests/pyjinhx/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pyjinhx.reactive.load_cost import reset_load_cost_decisions
 from pyjinhx.render_cache import reset_render_cost_decisions
 from pyjinhx.session import RenderSession
 
@@ -21,6 +22,19 @@ def render_cost_decisions():
     reset_render_cost_decisions()
     yield
     reset_render_cost_decisions()
+
+
+@pytest.fixture(autouse=True)
+def load_cost_decisions():
+    """Clear the per-class load-cost verdicts around every test.
+
+    Same rationale as render_cost_decisions: process-wide, decided once, so
+    without this the first test to build a class through fan-out would fix its
+    threading verdict for the rest of the session.
+    """
+    reset_load_cost_decisions()
+    yield
+    reset_load_cost_decisions()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/pyjinhx/reactive/test_load_cost.py
+++ b/tests/pyjinhx/reactive/test_load_cost.py
@@ -1,0 +1,58 @@
+"""The per-class `load()`-cost verdict that decides whether fan-out threads a build."""
+
+import pytest
+
+from pyjinhx.reactive.load_cost import (
+    _DEFAULT_MIN_COST_US,
+    is_too_cheap_to_thread,
+    note_load_cost,
+    reset_load_cost_decisions,
+)
+
+
+class CheapLoad:
+    pass
+
+
+class OtherCheapLoad:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _clean_decisions():
+    reset_load_cost_decisions()
+    yield
+    reset_load_cost_decisions()
+
+
+def test_unmeasured_class_is_not_too_cheap():
+    assert is_too_cheap_to_thread(CheapLoad) is False
+
+
+def test_cost_below_floor_marks_the_class_too_cheap():
+    note_load_cost(CheapLoad, _DEFAULT_MIN_COST_US - 1.0)
+    assert is_too_cheap_to_thread(CheapLoad) is True
+
+
+def test_cost_at_the_floor_stays_worth_threading():
+    note_load_cost(CheapLoad, _DEFAULT_MIN_COST_US)
+    assert is_too_cheap_to_thread(CheapLoad) is False
+
+
+def test_second_measurement_does_not_flip_the_verdict():
+    note_load_cost(CheapLoad, _DEFAULT_MIN_COST_US - 1.0)
+    note_load_cost(CheapLoad, _DEFAULT_MIN_COST_US * 100)
+    assert is_too_cheap_to_thread(CheapLoad) is True
+
+
+def test_reset_returns_a_class_to_the_unmeasured_state():
+    note_load_cost(CheapLoad, 0.0)
+    assert is_too_cheap_to_thread(CheapLoad) is True
+    reset_load_cost_decisions()
+    assert is_too_cheap_to_thread(CheapLoad) is False
+
+
+def test_verdicts_are_keyed_per_class_not_shared_by_shape():
+    note_load_cost(CheapLoad, 0.0)
+    assert is_too_cheap_to_thread(CheapLoad) is True
+    assert is_too_cheap_to_thread(OtherCheapLoad) is False

--- a/tests/pyjinhx/reactive/test_load_cost.py
+++ b/tests/pyjinhx/reactive/test_load_cost.py
@@ -10,6 +10,12 @@ from pyjinhx.reactive.load_cost import (
     reset_load_cost_decisions,
 )
 
+# These stand in for ReactiveComponent subclasses without paying Pydantic's
+# model-construction cost: the decision API only ever looks at __module__/
+# __qualname__ (see _too_cheap_key), so a plain class exercises it exactly the
+# same as a real component would. The pyright: ignore comments below accept
+# that looseness rather than widening the production signature to `type`.
+
 
 class CheapLoad:
     pass
@@ -27,36 +33,36 @@ def _clean_decisions():
 
 
 def test_unmeasured_class_is_not_too_cheap():
-    assert is_too_cheap_to_thread(CheapLoad) is False
+    assert is_too_cheap_to_thread(CheapLoad) is False  # pyright: ignore[reportArgumentType]
 
 
 def test_cost_below_floor_marks_the_class_too_cheap():
-    note_load_cost(CheapLoad, _DEFAULT_MIN_COST_US - 1.0)
-    assert is_too_cheap_to_thread(CheapLoad) is True
+    note_load_cost(CheapLoad, _DEFAULT_MIN_COST_US - 1.0)  # pyright: ignore[reportArgumentType]
+    assert is_too_cheap_to_thread(CheapLoad) is True  # pyright: ignore[reportArgumentType]
 
 
 def test_cost_at_the_floor_stays_worth_threading():
-    note_load_cost(CheapLoad, _DEFAULT_MIN_COST_US)
-    assert is_too_cheap_to_thread(CheapLoad) is False
+    note_load_cost(CheapLoad, _DEFAULT_MIN_COST_US)  # pyright: ignore[reportArgumentType]
+    assert is_too_cheap_to_thread(CheapLoad) is False  # pyright: ignore[reportArgumentType]
 
 
 def test_second_measurement_does_not_flip_the_verdict():
-    note_load_cost(CheapLoad, _DEFAULT_MIN_COST_US - 1.0)
-    note_load_cost(CheapLoad, _DEFAULT_MIN_COST_US * 100)
-    assert is_too_cheap_to_thread(CheapLoad) is True
+    note_load_cost(CheapLoad, _DEFAULT_MIN_COST_US - 1.0)  # pyright: ignore[reportArgumentType]
+    note_load_cost(CheapLoad, _DEFAULT_MIN_COST_US * 100)  # pyright: ignore[reportArgumentType]
+    assert is_too_cheap_to_thread(CheapLoad) is True  # pyright: ignore[reportArgumentType]
 
 
 def test_reset_returns_a_class_to_the_unmeasured_state():
-    note_load_cost(CheapLoad, 0.0)
-    assert is_too_cheap_to_thread(CheapLoad) is True
+    note_load_cost(CheapLoad, 0.0)  # pyright: ignore[reportArgumentType]
+    assert is_too_cheap_to_thread(CheapLoad) is True  # pyright: ignore[reportArgumentType]
     reset_load_cost_decisions()
-    assert is_too_cheap_to_thread(CheapLoad) is False
+    assert is_too_cheap_to_thread(CheapLoad) is False  # pyright: ignore[reportArgumentType]
 
 
 def test_verdicts_are_keyed_per_class_not_shared_by_shape():
-    note_load_cost(CheapLoad, 0.0)
-    assert is_too_cheap_to_thread(CheapLoad) is True
-    assert is_too_cheap_to_thread(OtherCheapLoad) is False
+    note_load_cost(CheapLoad, 0.0)  # pyright: ignore[reportArgumentType]
+    assert is_too_cheap_to_thread(CheapLoad) is True  # pyright: ignore[reportArgumentType]
+    assert is_too_cheap_to_thread(OtherCheapLoad) is False  # pyright: ignore[reportArgumentType]
 
 
 def test_min_cost_defaults_when_the_env_var_is_absent(monkeypatch):
@@ -89,8 +95,8 @@ def test_env_var_is_re_read_on_every_call(monkeypatch):
 
 def test_the_env_floor_decides_the_verdict(monkeypatch):
     monkeypatch.setenv("PJX_FANOUT_THREAD_MIN_US", "10")
-    note_load_cost(CheapLoad, 50.0)
-    assert is_too_cheap_to_thread(CheapLoad) is False
+    note_load_cost(CheapLoad, 50.0)  # pyright: ignore[reportArgumentType]
+    assert is_too_cheap_to_thread(CheapLoad) is False  # pyright: ignore[reportArgumentType]
 
 
 def test_build_dirty_records_a_verdict_for_the_loaded_class(monkeypatch):
@@ -106,6 +112,6 @@ def test_build_dirty_records_a_verdict_for_the_loaded_class(monkeypatch):
             return cls()
 
     monkeypatch.setattr(fanout, "render_level", lambda instance, session: "<div></div>")
-    fanout._build_dirty(Recorded, "pjx-1", None, object())
+    fanout._build_dirty(Recorded, "pjx-1", None, object())  # pyright: ignore[reportArgumentType]
 
-    assert is_too_cheap_to_thread(Recorded) is True
+    assert is_too_cheap_to_thread(Recorded) is True  # pyright: ignore[reportArgumentType]

--- a/tests/pyjinhx/reactive/test_load_cost.py
+++ b/tests/pyjinhx/reactive/test_load_cost.py
@@ -4,6 +4,7 @@ import pytest
 
 from pyjinhx.reactive.load_cost import (
     _DEFAULT_MIN_COST_US,
+    _min_cost_us,
     is_too_cheap_to_thread,
     note_load_cost,
     reset_load_cost_decisions,
@@ -56,3 +57,55 @@ def test_verdicts_are_keyed_per_class_not_shared_by_shape():
     note_load_cost(CheapLoad, 0.0)
     assert is_too_cheap_to_thread(CheapLoad) is True
     assert is_too_cheap_to_thread(OtherCheapLoad) is False
+
+
+def test_min_cost_defaults_when_the_env_var_is_absent(monkeypatch):
+    monkeypatch.delenv("PJX_FANOUT_THREAD_MIN_US", raising=False)
+    assert _min_cost_us() == _DEFAULT_MIN_COST_US
+
+
+def test_empty_env_var_falls_back_to_the_default(monkeypatch):
+    monkeypatch.setenv("PJX_FANOUT_THREAD_MIN_US", "")
+    assert _min_cost_us() == _DEFAULT_MIN_COST_US
+
+
+def test_env_var_overrides_the_floor(monkeypatch):
+    monkeypatch.setenv("PJX_FANOUT_THREAD_MIN_US", "42.5")
+    assert _min_cost_us() == 42.5
+
+
+def test_non_numeric_env_var_names_itself_and_the_value(monkeypatch):
+    monkeypatch.setenv("PJX_FANOUT_THREAD_MIN_US", "abc")
+    with pytest.raises(ValueError, match="PJX_FANOUT_THREAD_MIN_US.*abc"):
+        _min_cost_us()
+
+
+def test_env_var_is_re_read_on_every_call(monkeypatch):
+    monkeypatch.setenv("PJX_FANOUT_THREAD_MIN_US", "10")
+    assert _min_cost_us() == 10.0
+    monkeypatch.setenv("PJX_FANOUT_THREAD_MIN_US", "20")
+    assert _min_cost_us() == 20.0
+
+
+def test_the_env_floor_decides_the_verdict(monkeypatch):
+    monkeypatch.setenv("PJX_FANOUT_THREAD_MIN_US", "10")
+    note_load_cost(CheapLoad, 50.0)
+    assert is_too_cheap_to_thread(CheapLoad) is False
+
+
+def test_build_dirty_records_a_verdict_for_the_loaded_class(monkeypatch):
+    from pyjinhx.reactive import fanout
+
+    monkeypatch.setenv("PJX_FANOUT_THREAD_MIN_US", "1000000")
+
+    class Recorded:
+        _pjx_key_field = None
+
+        @classmethod
+        def load(cls):
+            return cls()
+
+    monkeypatch.setattr(fanout, "render_level", lambda instance, session: "<div></div>")
+    fanout._build_dirty(Recorded, "pjx-1", None, object())
+
+    assert is_too_cheap_to_thread(Recorded) is True

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -566,12 +566,20 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
             "pyjinhx.reactive.cache",
             "pyjinhx.reactive.component",
             "pyjinhx.reactive.keys",
+            "pyjinhx.reactive.load_cost",
             "pyjinhx.rendering",
             "pyjinhx.root_attrs",
             "pyjinhx.segments",
             "pyjinhx.session",
         }
     ),
+    # #894: a process-wide, decide-once verdict on whether a class's load() is
+    # cheap enough that fan-out threading it is a loss. Mirrors render_cache.py's
+    # is_too_cheap()/note_render_cost() pattern one level down, inside reactive/
+    # rather than at the render spine, since the thing it prices (load()) is a
+    # reactive/-only concept. component is imported only under TYPE_CHECKING for
+    # the annotation, so it carries no runtime edge.
+    "reactive.load_cost": frozenset({"pyjinhx.reactive.component"}),
     # The instance registry (ADR 0009) is read-only over session's ContextVar
     # store; it consumes get_instances() and nothing else in pyjinhx. The
     # register_rendered_instance signature also names RenderedLevel, but that


### PR DESCRIPTION
## Summary
- Add per-class load()-cost verdict for fan-out threading to track I/O and render cost during reactive fan-out passes
- Time load() in _build_dirty and record its fan-out cost verdict
- Add type checking exemptions for load_cost stand-in classes

## Test plan
- 13 new tests validate load cost tracking and fan-out cost verdicts

Closes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)