### PR TITLE
chore: opt-in cProfile wrapper for the bench_*.py suite

### DIFF
--- a/scripts/_bench_profiling.py
+++ b/scripts/_bench_profiling.py
@@ -1,0 +1,40 @@
+"""Opt-in cProfile wrapper shared by the bench_*.py scripts.
+
+Off by default: profiling overhead would distort the very wall-clock numbers
+these scripts exist to measure. Set PJX_BENCH_PROFILE to turn it on for a run.
+"""
+
+import cProfile
+import os
+import pstats
+import sys
+
+
+def run_with_optional_profile(main_fn) -> None:
+    """Run ``main_fn()``, profiling under cProfile when PJX_BENCH_PROFILE is set.
+
+    PJX_BENCH_PROFILE_SORT selects the pstats sort key (default "tottime").
+    PJX_BENCH_PROFILE_TOP caps how many rows print (default 25). The table
+    goes to stderr so it never lands in a redirected/diffed stdout baseline.
+    """
+    if not os.environ.get("PJX_BENCH_PROFILE"):
+        main_fn()
+        return
+
+    sort_key = os.environ.get("PJX_BENCH_PROFILE_SORT", "tottime")
+    top_n = int(os.environ.get("PJX_BENCH_PROFILE_TOP", "25"))
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+    try:
+        main_fn()
+    finally:
+        profiler.disable()
+
+    print(
+        f"\n{'=' * 88}\ncProfile ({sort_key}, top {top_n})\n{'=' * 88}",
+        file=sys.stderr,
+    )
+    stats = pstats.Stats(profiler, stream=sys.stderr)
+    stats.sort_stats(sort_key)
+    stats.print_stats(top_n)

--- a/scripts/bench_cross_request_cache.py
+++ b/scripts/bench_cross_request_cache.py
@@ -101,4 +101,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from _bench_profiling import run_with_optional_profile
+
+    run_with_optional_profile(main)

--- a/scripts/bench_cross_request_load.py
+++ b/scripts/bench_cross_request_load.py
@@ -115,4 +115,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from _bench_profiling import run_with_optional_profile
+
+    run_with_optional_profile(main)

--- a/scripts/bench_field_count.py
+++ b/scripts/bench_field_count.py
@@ -126,4 +126,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from _bench_profiling import run_with_optional_profile
+
+    run_with_optional_profile(main)

--- a/scripts/bench_mixed_reactive_tree.py
+++ b/scripts/bench_mixed_reactive_tree.py
@@ -199,4 +199,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from _bench_profiling import run_with_optional_profile
+
+    run_with_optional_profile(main)

--- a/scripts/bench_reactive_cache.py
+++ b/scripts/bench_reactive_cache.py
@@ -84,4 +84,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from _bench_profiling import run_with_optional_profile
+
+    run_with_optional_profile(main)

--- a/scripts/bench_reactive_fanout.py
+++ b/scripts/bench_reactive_fanout.py
@@ -410,4 +410,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from _bench_profiling import run_with_optional_profile
+
+    run_with_optional_profile(main)

--- a/scripts/bench_render_depth.py
+++ b/scripts/bench_render_depth.py
@@ -113,4 +113,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from _bench_profiling import run_with_optional_profile
+
+    run_with_optional_profile(main)

--- a/scripts/bench_render_scaling.py
+++ b/scripts/bench_render_scaling.py
@@ -76,4 +76,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from _bench_profiling import run_with_optional_profile
+
+    run_with_optional_profile(main)

--- a/scripts/bench_render_scaling_v2.py
+++ b/scripts/bench_render_scaling_v2.py
@@ -164,4 +164,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from _bench_profiling import run_with_optional_profile
+
+    run_with_optional_profile(main)

--- a/scripts/bench_slot_payload.py
+++ b/scripts/bench_slot_payload.py
@@ -210,4 +210,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from _bench_profiling import run_with_optional_profile
+
+    run_with_optional_profile(main)

--- a/scripts/bench_state_hash.py
+++ b/scripts/bench_state_hash.py
@@ -77,4 +77,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from _bench_profiling import run_with_optional_profile
+
+    run_with_optional_profile(main)


### PR DESCRIPTION
## Summary
- Every `scripts/bench_*.py` now runs through `_bench_profiling.run_with_optional_profile(main)` instead of calling `main()` directly.
- Off by default — behavior and output are identical to before.
- Set `PJX_BENCH_PROFILE=1` to wrap the run in `cProfile` and print a `pstats` table to stderr afterward (`PJX_BENCH_PROFILE_SORT` for sort key, default `tottime`; `PJX_BENCH_PROFILE_TOP` for row count, default 25).

Came out of manually profiling several bench scripts by hand this week (walk_manifest, the whole rendering path across modalities) — this makes that a one-line env var instead of a scratch script each time.

## Test plan
- [x] `uv run pytest tests/test_bench_scripts_smoke.py -q` — 23 passed
- [x] `uv run ruff format scripts/` / `ruff check scripts/` — clean
- [x] Manual: `PJX_BENCH_PROFILE=1 uv run python scripts/bench_state_hash.py` — normal output unchanged, profiled table appended
- [x] Manual: `PJX_BENCH_SMOKE=1 PJX_BENCH_PROFILE=1 uv run python scripts/bench_reactive_fanout.py` — both flags compose correctly