### PR TITLE
test: update ClassDescriptor shape guards for json_coercible_fields

### DIFF
--- a/pyjinhx/_component.py
+++ b/pyjinhx/_component.py
@@ -308,6 +308,19 @@ def _resolve_slot_fields(cls: type) -> frozenset[str]:
     return frozenset(name for name in fields if _is_slot_field(cls, name))
 
 
+def _resolve_json_coercible_fields(cls: type) -> frozenset[str]:
+    """The declared fields of ``cls`` whose annotation is a JSON-coercion
+    candidate, resolved once per class at registration alongside
+    ``slot_fields`` — see :func:`_is_json_coercible_annotation`.
+    """
+    fields = getattr(cls, "model_fields", {})
+    return frozenset(
+        name
+        for name, field in fields.items()
+        if _is_json_coercible_annotation(field.annotation)
+    )
+
+
 def _resolve_children_field(cls: type) -> str | None:
     """The declared field a PascalCase tag's body content lands on, or ``None``.
 
@@ -433,6 +446,7 @@ def _resolve_class_descriptor(cls: type[BaseModel]) -> ClassDescriptor:
         if owner is not None
     }
     slot_fields = _resolve_slot_fields(cls)
+    json_coercible_fields = _resolve_json_coercible_fields(cls)
     children_field = _resolve_children_field(cls)
     declared_fields = getattr(cls, "model_fields", {})
     # A children_field reached via the override or the flagged-field branch is
@@ -452,6 +466,7 @@ def _resolve_class_descriptor(cls: type[BaseModel]) -> ClassDescriptor:
     return ClassDescriptor(
         template_path=template_path,
         slot_fields=slot_fields,
+        json_coercible_fields=json_coercible_fields,
         children_field=children_field,
         css_paths=() if css_path is None else (css_path,),
         js_paths=() if js_path is None else (js_path,),
@@ -627,14 +642,14 @@ class BaseComponent(BaseModel):
         strict core keeps its promise that undeclared keys are never walked."""
         if not isinstance(data, dict):
             return data
-        for name, field in cls.model_fields.items():
+        for name in cls.model_fields:
             value = data.get(name)
             if not isinstance(value, str):
                 continue
             text = value.strip()
             if not text or text[0] not in "{[":
                 continue
-            if not _is_json_coercible_annotation(field.annotation):
+            if name not in cls.__pjx_descriptor__.json_coercible_fields:
                 continue
             try:
                 data[name] = json.loads(text)

--- a/pyjinhx/descriptor.py
+++ b/pyjinhx/descriptor.py
@@ -30,3 +30,7 @@ class ClassDescriptor:
     """Whether the resolved template still carries a ``{#def#}`` header this
     class-based component ignores. Answered once, when ``template_path`` is
     resolved, so no render pays for the probe."""
+    json_coercible_fields: frozenset[str] = frozenset()
+    """Declared fields whose annotation makes them JSON-coercion candidates —
+    see :func:`pyjinhx._component._is_json_coercible_annotation`. Resolved
+    once per class at registration, mirroring ``slot_fields``."""

--- a/scripts/bench_field_count.py
+++ b/scripts/bench_field_count.py
@@ -31,7 +31,11 @@ import time
 from pathlib import Path
 
 from pyjinhx import discovery
-from pyjinhx._component import BaseComponent, _pascal_to_snake
+from pyjinhx._component import (
+    BaseComponent,
+    _pascal_to_snake,
+    _resolve_json_coercible_fields,
+)
 from pyjinhx.descriptor import ClassDescriptor
 from pyjinhx.rendering import render
 from pyjinhx.session import RenderSession
@@ -51,6 +55,7 @@ def _descriptor(
     return ClassDescriptor(
         template_path=template_dir / template,
         slot_fields=frozenset(),
+        json_coercible_fields=_resolve_json_coercible_fields(cls),
         children_field=None,
         css_paths=(),
         js_paths=(),

--- a/tests/pyjinhx/reactive/test_reactive_mount.py
+++ b/tests/pyjinhx/reactive/test_reactive_mount.py
@@ -14,7 +14,11 @@ import pytest
 from pydantic import Field
 
 from pyjinhx import discovery
-from pyjinhx._component import BaseComponent, _pascal_to_snake
+from pyjinhx._component import (
+    BaseComponent,
+    _pascal_to_snake,
+    _resolve_json_coercible_fields,
+)
 from pyjinhx.descriptor import ClassDescriptor
 from pyjinhx.reactive.component import PjxKey, ReactiveComponent
 from pyjinhx.rendering import render, render_level
@@ -41,6 +45,7 @@ def _descriptor_for(cls: type[BaseComponent], template: str) -> ClassDescriptor:
     return ClassDescriptor(
         template_path=_TEMPLATE_DIR / template,
         slot_fields=frozenset(),
+        json_coercible_fields=_resolve_json_coercible_fields(cls),
         children_field=None,
         css_paths=(),
         js_paths=(),

--- a/tests/pyjinhx/test_descriptor.py
+++ b/tests/pyjinhx/test_descriptor.py
@@ -58,7 +58,7 @@ class TestClassDescriptorShape:
         assert descriptor.strict is True
         assert descriptor.provenance == {"template": Child, "css": Base, "js": Base}
 
-    def test_exposes_exactly_the_eight_declared_fields(self):
+    def test_exposes_exactly_the_nine_declared_fields(self):
         names = [field.name for field in dataclasses.fields(ClassDescriptor)]
         assert names == [
             "template_path",
@@ -69,17 +69,21 @@ class TestClassDescriptorShape:
             "strict",
             "provenance",
             "has_stale_def_header",
+            "json_coercible_fields",
         ]
 
     def test_no_field_has_a_default_except_the_stale_header_flag(self):
         # Construction is always a resolver's job (#272-#276); a bare
-        # ClassDescriptor() must never be a legal call. has_stale_def_header is
-        # the sole deliberate exception: it is a defaulted, keyword-friendly
-        # field appended last so every existing call site keeps constructing
-        # without edits.
+        # ClassDescriptor() must never be a legal call. has_stale_def_header and
+        # json_coercible_fields are the deliberate exceptions: defaulted,
+        # keyword-friendly fields appended last so every existing call site
+        # keeps constructing without edits.
         for field in dataclasses.fields(ClassDescriptor):
             if field.name == "has_stale_def_header":
                 assert field.default is False
+                continue
+            if field.name == "json_coercible_fields":
+                assert field.default == frozenset()
                 continue
             assert field.default is dataclasses.MISSING
             assert field.default_factory is dataclasses.MISSING


### PR DESCRIPTION
## Summary
- Adds json_coercible_fields to ClassDescriptor for tracking which fields support JSON coercion
- Resolves json_coercible_fields once per class instead of per instance (performance optimization)
- Populates json_coercible_fields in manual descriptors for bench_field_count and reactive-mount
- Updates test shape guards to account for the new defaulted field

## Test plan
- [x] All existing tests pass
- [x] ClassDescriptor shape tests updated to include json_coercible_fields
- [x] No ruff lint or format issues

Closes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)