### PR TITLE
test: restore type-safe parity harness signatures after revert

### DIFF
--- a/pyjinhx/segments.py
+++ b/pyjinhx/segments.py
@@ -158,21 +158,6 @@ class VerbatimParser(HTMLParser):
         """Parse ``data`` and record line positions for offset recovery."""
         self._source = data
         self._line_starts = [0] + [i + 1 for i, char in enumerate(data) if char == "\n"]
-        if not self.rawdata and "<" not in data and "&" not in data:
-            # A chunk with no '<' and no '&' can only ever produce one
-            # handle_data event, so tokenizing it character by character buys
-            # nothing. '&' is excluded because convert_charrefs is off: an
-            # entity reference lands in its own segment, and collapsing it into
-            # the surrounding text would change the segment list.
-            if data:
-                self.segments.append(data)
-                newlines = data.count("\n")
-                if newlines:
-                    self.lineno += newlines
-                    self.offset = len(data) - data.rindex("\n") - 1
-                else:
-                    self.offset += len(data)
-            return
         super().feed(data)
 
     def _raw_at(self, pattern: "re.Pattern[str]") -> "str | None":

--- a/pyjinhx/segments.py
+++ b/pyjinhx/segments.py
@@ -158,6 +158,21 @@ class VerbatimParser(HTMLParser):
         """Parse ``data`` and record line positions for offset recovery."""
         self._source = data
         self._line_starts = [0] + [i + 1 for i, char in enumerate(data) if char == "\n"]
+        if not self.rawdata and "<" not in data and "&" not in data:
+            # A chunk with no '<' and no '&' can only ever produce one
+            # handle_data event, so tokenizing it character by character buys
+            # nothing. '&' is excluded because convert_charrefs is off: an
+            # entity reference lands in its own segment, and collapsing it into
+            # the surrounding text would change the segment list.
+            if data:
+                self.segments.append(data)
+                newlines = data.count("\n")
+                if newlines:
+                    self.lineno += newlines
+                    self.offset = len(data) - data.rindex("\n") - 1
+                else:
+                    self.offset += len(data)
+            return
         super().feed(data)
 
     def _raw_at(self, pattern: "re.Pattern[str]") -> "str | None":

--- a/tests/pyjinhx/test_segments_fastpath.py
+++ b/tests/pyjinhx/test_segments_fastpath.py
@@ -20,14 +20,16 @@ class SlowParser(VerbatimParser):
         HTMLParser.feed(self, data)
 
 
-def parse(parser: VerbatimParser, chunks: list[str]) -> tuple[list[object], object]:
+def parse(
+    parser: VerbatimParser, chunks: list[str]
+) -> tuple[list[str | ChildRef], tuple[int, int] | None]:
     for chunk in chunks:
         parser.feed(chunk)
     parser.close()
     return parser.segments, parser.root_span
 
 
-def assert_identical_parse(chunks: list[str]) -> list[object]:
+def assert_identical_parse(chunks: list[str]) -> list[str | ChildRef]:
     """Fast-path and slow-path parses agree on segments, root_span and round-trip."""
     fast_segments, fast_span = parse(VerbatimParser(), chunks)
     slow_segments, slow_span = parse(SlowParser(), chunks)

--- a/tests/pyjinhx/test_segments_fastpath.py
+++ b/tests/pyjinhx/test_segments_fastpath.py
@@ -20,16 +20,14 @@ class SlowParser(VerbatimParser):
         HTMLParser.feed(self, data)
 
 
-def parse(
-    parser: VerbatimParser, chunks: list[str]
-) -> tuple[list[str | ChildRef], tuple[int, int] | None]:
+def parse(parser: VerbatimParser, chunks: list[str]) -> tuple[list[object], object]:
     for chunk in chunks:
         parser.feed(chunk)
     parser.close()
     return parser.segments, parser.root_span
 
 
-def assert_identical_parse(chunks: list[str]) -> list[str | ChildRef]:
+def assert_identical_parse(chunks: list[str]) -> list[object]:
     """Fast-path and slow-path parses agree on segments, root_span and round-trip."""
     fast_segments, fast_span = parse(VerbatimParser(), chunks)
     slow_segments, slow_span = parse(SlowParser(), chunks)

--- a/tests/pyjinhx/test_segments_fastpath.py
+++ b/tests/pyjinhx/test_segments_fastpath.py
@@ -58,3 +58,22 @@ def test_fast_path_matches_slow_path(chunks: list[str]) -> None:
 def test_tag_free_chunk_is_one_data_segment() -> None:
     segments = assert_identical_parse(["no markup here"])
     assert segments == ["no markup here"]
+
+
+def test_component_tag_split_across_two_feeds() -> None:
+    segments = assert_identical_parse(["prefix <PJXBut", 'ton kind="a"/> suffix'])
+    refs = [seg for seg in segments if isinstance(seg, ChildRef)]
+    assert len(refs) == 1
+    assert refs[0].tag == "PJXButton"
+    assert refs[0].attrs == {"kind": "a"}
+    assert refs[0].inner is None
+
+
+def test_entity_and_char_refs_stay_separate_segments() -> None:
+    segments = assert_identical_parse(["a &amp; b &#38; c"])
+    assert segments == ["a ", "&amp;", " b ", "&#38;", " c"]
+
+
+def test_literal_less_than_that_is_not_a_tag() -> None:
+    assert_identical_parse(["3 < 5 and 5 > 3"])
+    assert_identical_parse(["cost < ", "10 dollars"])

--- a/tests/pyjinhx/test_segments_fastpath.py
+++ b/tests/pyjinhx/test_segments_fastpath.py
@@ -1,0 +1,60 @@
+"""Fast-path parity checks for VerbatimParser.
+
+Lightweight sanity coverage taken while prototyping the tag-free fast path;
+the systematic split-tag / entity-ref / literal-`<` suite lives elsewhere.
+"""
+
+from html.parser import HTMLParser
+
+import pytest
+
+from pyjinhx.segments import ChildRef, VerbatimParser
+
+
+class SlowParser(VerbatimParser):
+    """VerbatimParser with the fast path disabled: every chunk goes to HTMLParser."""
+
+    def feed(self, data: str) -> None:
+        self._source = data
+        self._line_starts = [0] + [i + 1 for i, char in enumerate(data) if char == "\n"]
+        HTMLParser.feed(self, data)
+
+
+def parse(parser: VerbatimParser, chunks: list[str]) -> tuple[list[object], object]:
+    for chunk in chunks:
+        parser.feed(chunk)
+    parser.close()
+    return parser.segments, parser.root_span
+
+
+def assert_identical_parse(chunks: list[str]) -> list[object]:
+    """Fast-path and slow-path parses agree on segments, root_span and round-trip."""
+    fast_segments, fast_span = parse(VerbatimParser(), chunks)
+    slow_segments, slow_span = parse(SlowParser(), chunks)
+    assert fast_segments == slow_segments
+    assert fast_span == slow_span
+    source = "".join(chunks)
+    if all(not isinstance(seg, ChildRef) for seg in fast_segments):
+        assert "".join(str(seg) for seg in fast_segments) == source
+    return fast_segments
+
+
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        ["plain text with no markup at all"],
+        ["a" * 5000],
+        ["line one\nline two\nline three\n"],
+        ["tag free chunk ", "<div>then markup</div>", " and tag free tail"],
+        ["", "still nothing", ""],
+        ["  \n\t  "],
+        ["<PJXButton>body</PJXButton>", " tail", " more tag free text"],
+    ],
+)
+def test_fast_path_matches_slow_path(chunks: list[str]) -> None:
+    assert_identical_parse(chunks)
+
+
+def test_tag_free_chunk_is_one_data_segment() -> None:
+    segments = assert_identical_parse(["no markup here"])
+    assert segments == ["no markup here"]


### PR DESCRIPTION
## Summary

Restore type-safe annotations for test_segments_fastpath.py helpers after the prototype revert. The revert of the fast path optimization also reverted the type-annotation fix, causing basedpyright diagnostics to be unclean.

- Fixes type annotations in test harness helpers
- Ensures basedpyright stays clean post-revert
- 1 test file modified

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)