### PR TITLE
test: json coercibility verdicts are scoped per class, not per field name

### DIFF
--- a/tests/pyjinhx/test_component.py
+++ b/tests/pyjinhx/test_component.py
@@ -55,6 +55,10 @@ class Slotted(BaseComponent):
     body: Slot = ""
 
 
+class CachedListHolder(BaseComponent):
+    data: list[str] = Field(default_factory=list)
+
+
 class StrictStructural(BaseComponent):
     auto_id = False
     sources: list = Field(default_factory=list)
@@ -293,6 +297,19 @@ class TestJsonCoercion:
             Structural(**{field_name: 123})  # pyright: ignore[reportArgumentType]
         assert [error["type"] for error in excinfo.value.errors()] == [error_type]
         assert "invalid JSON attribute value" not in str(excinfo.value)
+
+
+class TestJsonCoercibleFieldsCache:
+    def test_json_coercion_consistent_across_instances(self):
+        # The coercibility verdict is resolved once per class; repeated
+        # construction must keep producing the same coerced value as a
+        # directly-constructed Python value would.
+        instances = [
+            CachedListHolder(data='["a", "b"]')  # pyright: ignore[reportArgumentType]
+            for _ in range(3)
+        ]
+        assert [instance.data for instance in instances] == [["a", "b"]] * 3
+        assert instances[0].data == CachedListHolder(data=["a", "b"]).data
 
 
 class Anchor(BaseComponent):

--- a/tests/pyjinhx/test_component.py
+++ b/tests/pyjinhx/test_component.py
@@ -59,6 +59,11 @@ class CachedListHolder(BaseComponent):
     data: list[str] = Field(default_factory=list)
 
 
+class CachedStrHolder(BaseComponent):
+    data: str = ""
+    count: int = 0
+
+
 class StrictStructural(BaseComponent):
     auto_id = False
     sources: list = Field(default_factory=list)
@@ -310,6 +315,27 @@ class TestJsonCoercibleFieldsCache:
         ]
         assert [instance.data for instance in instances] == [["a", "b"]] * 3
         assert instances[0].data == CachedListHolder(data=["a", "b"]).data
+
+    def test_json_coercible_fields_scoped_per_class(self):
+        # Two classes share the field name `data` with different annotations,
+        # so a verdict cached by name alone would leak across them.
+        assert "data" in CachedListHolder.__pjx_descriptor__.json_coercible_fields
+        assert "data" not in CachedStrHolder.__pjx_descriptor__.json_coercible_fields
+
+        payload = '["a", "b"]'
+        assert CachedListHolder(data=payload).data == [  # pyright: ignore[reportArgumentType]
+            "a",
+            "b",
+        ]
+        assert CachedStrHolder(data=payload).data == payload
+
+    def test_non_coercible_annotation_untouched_by_cache(self):
+        # `count` is excluded from the frozenset, so the early-exit branch must
+        # leave it entirely to Pydantic — both for a good value and a bad one.
+        assert CachedStrHolder(count=3).count == 3
+        with pytest.raises(ValidationError) as excinfo:
+            CachedStrHolder(count="[1, 2]")  # pyright: ignore[reportArgumentType]
+        assert "invalid JSON attribute value" not in str(excinfo.value)
 
 
 class Anchor(BaseComponent):


### PR DESCRIPTION
## Summary

- Adds test to verify json coercibility verdicts are scoped per class, not per field name
- Adds test to verify json coercion stays identical across instances of a class
- Closes #914

Closes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxwB6LvymhekN1iFNoNbqu