### PR TITLE
docs: warn that render() skips runtime injection under FastAPI

### DIFF
--- a/docs/api/base-component.md
+++ b/docs/api/base-component.md
@@ -44,6 +44,11 @@ The template is auto-discovered based on the component class name: a colocated `
 
 **Returns:** The component's rendered markup as a finished HTML string.
 
+!!! warning "Inside a pjx-adapted FastAPI route, return the component — not `.render()`"
+    `render()` returns markup only; it never injects the htmx/pjx.js runtime. In a route wired with `setup(app)`, return the component instance itself so the backend's response composer can fan out and inject the runtime. Calling `.render()` and returning the resulting string bypasses that path — `FastAPIBackend.to_response()` only calls `inject_runtime()` when the result `isinstance(..., BaseComponent)`, so a `str` return is assumed to be a fragment of an already-booted page and the page ships with no runtime. See [Response composition](responses.md#the-four-return-shapes) and #938.
+
+    `render()` remains correct everywhere else — tests, non-FastAPI usage, fragments, and any other integration that doesn't route handler returns through the composer.
+
 ## component
 
 ```python

--- a/docs/integrations/fastapi.md
+++ b/docs/integrations/fastapi.md
@@ -228,4 +228,4 @@ hands back one component's markup and nothing else. See
 ## Tips
 
 - **Component assets**: Components with adjacent `.js` and `.css` files — same snake_case stem as the `.pjx`, e.g. `todo_counter.py` / `todo_counter.pjx` / `todo_counter.js` — have their assets auto-injected. See [Asset Collection](../guide/assets.md).
-- **Response types**: FastAPI's `HTMLResponse` works directly with `render()`, which returns a plain `str`. Under `setup(app)` you can also just return the component (or a plain string) and let the composer build the response — see [Response composition](../api/responses.md).
+- **Response types**: FastAPI's `HTMLResponse` works directly with `render()`, which returns a plain `str`. Under `setup(app)` you can also just return the component (or a plain string) and let the composer build the response — see [Response composition](../api/responses.md). Prefer returning the component for full-page/cold routes: a `str`/`Markup` return skips runtime injection (see [`render()`](../api/base-component.md#render) and #938), so only use it for fragments where the page has already booted.


### PR DESCRIPTION
## Summary
- Adds documentation warning about render() skipping runtime injection under FastAPI
- Closes #943

## Test plan
- Documentation change only; no functional test changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)