### PR TITLE
feat: find the FastAPI-injected Response among handler kwargs

### DIFF
--- a/pyjinhx/integrations/base.py
+++ b/pyjinhx/integrations/base.py
@@ -76,14 +76,19 @@ class IntegrationBackend(Protocol):
         """Run pyjinhx's shutdown step as ``app`` stops."""
         ...
 
-    def to_response(self, result: object, request: object | None) -> object:
+    def to_response(
+        self, result: object, request: object | None, response: object | None = None
+    ) -> object:
         """Adapt a pjx handler return into this framework's response type.
 
         A backend delegates the decision to ``pyjinhx.responses.compose`` and
         emits its ``PjxResponse``; a ``PASSTHROUGH`` answer means the result was
         never pyjinhx's and is returned untouched. Nothing about fan-out
         ordering, dedupe or htmx header names is decided here, so two backends
-        cannot drift apart on any of it.
+        cannot drift apart on any of it. ``response`` is the framework's own
+        dependency-injected response object, if the handler declared one and
+        the backend can discover it; a backend with no such concept passes
+        ``None``.
         """
         ...
 

--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -92,7 +92,9 @@ class FastAPIBackend:
     def on_shutdown(self, app: object) -> None:
         shutdown_pyjinhx()
 
-    def to_response(self, result: object, request: object | None) -> object:
+    def to_response(
+        self, result: object, request: object | None, response: Any = None
+    ) -> object:
         """Emit compose()'s answer, or hand back a result that is not pjx's.
 
         Composition — including whether this request fans out — is decided by
@@ -114,9 +116,8 @@ class FastAPIBackend:
                 result, request or getattr(session, "pjx_request", None)
             )
         assert isinstance(composed, PjxResponse)
-        return HTMLResponse(
-            composed.body, headers=composed.headers, status_code=composed.status
-        )
+        headers, status = _merge_injected(composed, response)
+        return HTMLResponse(composed.body, headers=headers, status_code=status)
 
     def chain_lifespan(self, app: Starlette) -> None:
         """Run the startup/shutdown hooks around whatever lifespan app has.
@@ -230,6 +231,31 @@ def _response_from(kwargs: dict[str, Any]) -> Any:
         if isinstance(value, StarletteResponse):
             return value
     return None
+
+
+def _merge_injected(
+    composed: PjxResponse, response: Any
+) -> tuple[dict[str, str], int]:
+    """Fold what the handler set on its injected ``Response`` into the composed one.
+
+    The injected object wins on collisions: setting a header there is an explicit
+    act by the handler, while the composed headers are pyjinhx's own defaults.
+    Starlette cannot say whether a status was assigned or left at its default, so
+    only a non-200 counts as deliberate. ``content-length`` is dropped because it
+    describes the injected object's empty body, not the composed one.
+    """
+    if response is None:
+        return composed.headers, composed.status
+    injected = {
+        key: value
+        for key, value in dict(response.headers).items()
+        if key.lower() != "content-length"
+    }
+    status = getattr(response, "status_code", None)
+    return (
+        {**composed.headers, **injected},
+        composed.status if status in (None, 200) else status,
+    )
 
 
 def _is_htmx(request: Any) -> bool:

--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -300,7 +300,9 @@ def _adapt_endpoint(
         result = endpoint(*args, **kwargs)
         if inspect.isawaitable(result):
             result = await result
-        return backend.to_response(result, _request_from(kwargs))
+        return backend.to_response(
+            result, _request_from(kwargs), _response_from(kwargs)
+        )
 
     setattr(adapted, "__pjx_adapted__", True)  # noqa: B010
     return adapted

--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -233,9 +233,7 @@ def _response_from(kwargs: dict[str, Any]) -> Any:
     return None
 
 
-def _merge_injected(
-    composed: PjxResponse, response: Any
-) -> tuple[dict[str, str], int]:
+def _merge_injected(composed: PjxResponse, response: Any) -> tuple[dict[str, str], int]:
     """Fold what the handler set on its injected ``Response`` into the composed one.
 
     The injected object wins on collisions: setting a header there is an explicit

--- a/pyjinhx/integrations/fastapi.py
+++ b/pyjinhx/integrations/fastapi.py
@@ -222,6 +222,16 @@ def _request_from(kwargs: dict[str, Any]) -> Any:
     return None
 
 
+def _response_from(kwargs: dict[str, Any]) -> Any:
+    """The ``Response`` argument FastAPI injected, if the handler declared one."""
+    from starlette.responses import Response as StarletteResponse
+
+    for value in kwargs.values():
+        if isinstance(value, StarletteResponse):
+            return value
+    return None
+
+
 def _is_htmx(request: Any) -> bool:
     """Whether htmx, rather than the browser itself, issued this request."""
     if request is None:

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -736,3 +736,16 @@ def test_nested_include_router_is_adapted_end_to_end():
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
     assert "<div>hello deep</div>" in response.text
+
+
+def test_response_from_finds_the_injected_response():
+    from pyjinhx.integrations.fastapi import _response_from
+
+    injected = Response()
+    assert _response_from({"x": 1, "response": injected}) is injected
+
+
+def test_response_from_returns_none_without_an_injected_response():
+    from pyjinhx.integrations.fastapi import _response_from
+
+    assert _response_from({"x": 1, "name": "world"}) is None

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -822,3 +822,23 @@ def test_untouched_injected_response_changes_nothing_for_the_client():
 
     assert injected.status_code == plain.status_code == 200
     assert injected.text == plain.text
+
+
+def test_native_redirect_still_translates_with_an_injected_response():
+    app = FastAPI()
+    apply_setup(app, _settings())
+
+    @app.post("/go")
+    def go(response: Response):
+        response.headers["X-Custom"] = "yes"
+        response.status_code = 201
+        return RedirectResponse(url="/next", status_code=303)
+
+    with TestClient(app) as client:
+        result = client.post(
+            "/go", headers={"HX-Request": "true"}, follow_redirects=False
+        )
+
+    assert result.status_code == 204
+    assert result.headers["HX-Redirect"] == "/next"
+    assert "X-Custom" not in result.headers

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -784,3 +784,41 @@ def test_to_response_leaves_status_alone_when_injected_response_is_untouched():
     assert untouched.status_code == baseline.status_code == 200
     assert untouched.body == baseline.body == b"<div>hi</div>"
     assert untouched.headers["content-length"] == baseline.headers["content-length"]
+
+
+def test_injected_response_headers_and_status_reach_the_client():
+    app = FastAPI()
+    apply_setup(app, _settings())
+
+    @app.get("/hello")
+    def hello(response: Response) -> Greeting:
+        response.headers["X-Custom"] = "yes"
+        response.status_code = 201
+        return Greeting(name="ana")
+
+    with TestClient(app) as client:
+        result = client.get("/hello")
+
+    assert result.status_code == 201
+    assert result.headers["X-Custom"] == "yes"
+    assert "ana" in result.text
+
+
+def test_untouched_injected_response_changes_nothing_for_the_client():
+    app = FastAPI()
+    apply_setup(app, _settings())
+
+    @app.get("/with")
+    def with_response(response: Response) -> Greeting:
+        return Greeting(name="ana")
+
+    @app.get("/without")
+    def without_response() -> Greeting:
+        return Greeting(name="ana")
+
+    with TestClient(app) as client:
+        injected = client.get("/with")
+        plain = client.get("/without")
+
+    assert injected.status_code == plain.status_code == 200
+    assert injected.text == plain.text

--- a/tests/pyjinhx/integrations/test_fastapi_wiring.py
+++ b/tests/pyjinhx/integrations/test_fastapi_wiring.py
@@ -749,3 +749,38 @@ def test_response_from_returns_none_without_an_injected_response():
     from pyjinhx.integrations.fastapi import _response_from
 
     assert _response_from({"x": 1, "name": "world"}) is None
+
+
+def test_to_response_merges_injected_headers_and_non_default_status():
+    from pyjinhx.integrations.fastapi import FastAPIBackend
+
+    backend = FastAPIBackend(_settings())
+    injected = Response()
+    injected.headers["X-Custom"] = "yes"
+    injected.status_code = 201
+    with request_scope():
+        adapted = cast(
+            HTMLResponse,
+            backend.to_response("<div>hi</div>", None, injected),
+        )
+    assert adapted.status_code == 201
+    assert adapted.headers["X-Custom"] == "yes"
+    assert adapted.body == b"<div>hi</div>"
+
+
+def test_to_response_leaves_status_alone_when_injected_response_is_untouched():
+    from pyjinhx.integrations.fastapi import FastAPIBackend
+
+    backend = FastAPIBackend(_settings())
+    with request_scope():
+        untouched = cast(
+            HTMLResponse,
+            backend.to_response("<div>hi</div>", None, Response()),
+        )
+        baseline = cast(
+            HTMLResponse,
+            backend.to_response("<div>hi</div>", None),
+        )
+    assert untouched.status_code == baseline.status_code == 200
+    assert untouched.body == baseline.body == b"<div>hi</div>"
+    assert untouched.headers["content-length"] == baseline.headers["content-length"]

--- a/tests/pyjinhx/integrations/test_registry.py
+++ b/tests/pyjinhx/integrations/test_registry.py
@@ -29,7 +29,9 @@ class StubBackend:
     def on_shutdown(self, app: object) -> None:
         return None
 
-    def to_response(self, result: object, request: object | None) -> object:
+    def to_response(
+        self, result: object, request: object | None, response: object | None = None
+    ) -> object:
         return result
 
 

--- a/tests/pyjinhx/test_setup_backend_dispatch.py
+++ b/tests/pyjinhx/test_setup_backend_dispatch.py
@@ -87,7 +87,9 @@ class _SentinelBackend:
 
     def on_shutdown(self, app: object) -> None: ...
 
-    def to_response(self, result: object, request: object | None) -> object:
+    def to_response(
+        self, result: object, request: object | None, response: object | None = None
+    ) -> object:
         return result
 
 


### PR DESCRIPTION
## Summary
- Implement FastAPI response injection capability by detecting the Response object in handler kwargs
- Merge injected response headers and status code into the composed HTML response
- Pass the injected response from the adapted endpoint to to_response method
- Add comprehensive test coverage for the FastAPI wiring integration

Closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)