### PR TITLE
fix: merge into window.pjx instead of replacing it (#958)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Re-executing the `pjx.js` runtime bundle no longer wipes builtin state installed on
+  `window.pjx`. The final assignment now merges (`Object.assign(window.pjx || {}, pjx)`)
+  instead of replacing the namespace wholesale, so self-guarding builtins (popover, toast
+  host) that ran on a first execution survive a second (#958).
+
 ## 1.6.3 — PJXPageLoader namespace collision with core's pjx.loader.page (2026-08-08)
 
 ### Fixed

--- a/pyjinhx/client/pjx.js
+++ b/pyjinhx/client/pjx.js
@@ -311,7 +311,10 @@
   pjx.region = pjxRegion;
   pjx.loadingTargets = pjxLoadingTargets;
   pjx.loadingClass = pjxLoadingClass;
-  window.pjx = pjx;
+  // Merge, never replace: builtins (popover, toast host) install themselves on
+  // this same namespace and self-guard, so a second execution of the bundle
+  // must not throw away keys the first execution's builtins left behind.
+  window.pjx = Object.assign(window.pjx || {}, pjx);
 
   if (!window.htmx) {
     console.error(

--- a/tests/pyjinhx/client/test_pjx_namespace_merge.py
+++ b/tests/pyjinhx/client/test_pjx_namespace_merge.py
@@ -1,0 +1,27 @@
+"""pjx.js merges into window.pjx: re-running the bundle must not wipe builtins."""
+
+from __future__ import annotations
+
+from pyjinhx.client import read_pjx_runtime
+
+
+def test_second_execution_keeps_state_installed_by_a_builtin(pjx_page):
+    page = pjx_page("<div></div>")
+    # Stand in for a builtin (popover, toast host) that self-guards on the
+    # shared window.pjx namespace: pjx.js itself never defines this key, so it
+    # can only survive a second run if the final assignment merges.
+    page.evaluate("window.pjx.popover = { open: function () { return 'first'; } }")
+
+    page.add_script_tag(content=read_pjx_runtime())
+
+    assert page.evaluate("typeof window.pjx.popover") == "object"
+    assert page.evaluate("window.pjx.popover.open()") == "first"
+
+
+def test_second_execution_still_installs_the_core_api(pjx_page):
+    page = pjx_page("<div></div>")
+    page.add_script_tag(content=read_pjx_runtime())
+
+    assert page.evaluate("typeof window.pjx.manifest") == "function"
+    assert page.evaluate("typeof window.pjx.toast") == "function"
+    assert page.evaluate("typeof window.pjx.loader.page") == "function"


### PR DESCRIPTION
## Summary
Re-executing pjx.js's bundle previously clobbered builtin state (popover, toast host) by wholesale replacing `window.pjx`. The final assignment now merges via `Object.assign` instead, preserving self-guarded builtin keys across executions.

## Changes
- Modified pjx.js to merge into the namespace instead of replacing it
- Updated CHANGELOG with fix description
- Added 2 tests validating namespace merge behavior

## Test count
- Added 2 new tests: `test_second_execution_keeps_state_installed_by_a_builtin`, `test_second_execution_still_installs_the_core_api`

Closes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)