### PR TITLE
fix: dispatch pjx:toast with bubbles so it reaches window listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- `PJXToastHost`'s wiring guard checked `pjx.toast`, the same key the host itself assigns as
+  its public API, so the guard always tripped and the host's `window` listener never attached.
+  It now guards on a private `pjx.__toastHostWired` flag instead (#963).
+- `pjx.toast()` dispatched a non-bubbling event on `document`, which never reached the toast
+  host's `window`-level listener. The event now bubbles, so both `pjx.toast()` calls and the
+  HX-Trigger path deliver toasts to the host (#963).
+
 ## 1.6.3 — PJXPageLoader namespace collision with core's pjx.loader.page (2026-08-08)
 
 ### Fixed

--- a/pyjinhx/builtins/ui/pjx_toast_host/pjx_toast_host.js
+++ b/pyjinhx/builtins/ui/pjx_toast_host/pjx_toast_host.js
@@ -1,6 +1,9 @@
 (function () {
     window.pjx = window.pjx || {};
-    if (pjx.toast) return;
+    // Private wiring flag: pjx.toast is this file's public API, so guarding on
+    // it would trip on core's own pjx.toast and skip wiring entirely.
+    if (pjx.__toastHostWired) return;
+    pjx.__toastHostWired = true;
 
     const wiredEvents = new Set();
 

--- a/pyjinhx/client/pjx.js
+++ b/pyjinhx/client/pjx.js
@@ -259,9 +259,12 @@
 
   // The dispatch half of the toast API. Rendering belongs to an L4 toast-host
   // builtin listening for this event, so core stays DOM-template-free.
+  // Dispatched with bubbles: true so it reaches the window-level listener
+  // the toast host builtin registers, matching the HX-Trigger toast path
+  // which already fires on the triggering element and bubbles to window.
   function pjxToast(payload) {
     document.dispatchEvent(
-      new CustomEvent("pjx:toast", { detail: payload || {}, bubbles: false })
+      new CustomEvent("pjx:toast", { detail: payload || {}, bubbles: true })
     );
   }
 

--- a/tests/pyjinhx/client/test_pjx_toast.py
+++ b/tests/pyjinhx/client/test_pjx_toast.py
@@ -40,7 +40,10 @@ def test_toast_event_bubbles_from_document_to_window(pjx_page):
         "})"
     )
     page.evaluate("pjx.toast({ message: 'hi' })")
-    assert page.evaluate("window.__seen") == {"onWindow": True, "targetIsDocument": True}
+    assert page.evaluate("window.__seen") == {
+        "onWindow": True,
+        "targetIsDocument": True,
+    }
 
 
 def test_toast_without_a_listener_does_not_throw(pjx_page):

--- a/tests/pyjinhx/client/test_pjx_toast.py
+++ b/tests/pyjinhx/client/test_pjx_toast.py
@@ -62,3 +62,12 @@ def test_toast_renders_a_toast_element_in_the_host(pjx_page):
     toast = page.locator("[data-pjx-toast-host] .pjx-toast")
     assert toast.count() == 1
     assert "saved" in toast.inner_text()
+
+
+def test_loading_the_toast_host_twice_renders_one_toast(pjx_page):
+    page = pjx_page("<div data-pjx-toast-host data-event-name='pjx:toast'></div>")
+    source = TOAST_HOST_JS_PATH.read_text(encoding="utf-8")
+    page.add_script_tag(content=source)
+    page.add_script_tag(content=source)
+    page.evaluate("window.pjx.toast('once')")
+    assert page.locator("[data-pjx-toast-host] .pjx-toast").count() == 1

--- a/tests/pyjinhx/client/test_pjx_toast.py
+++ b/tests/pyjinhx/client/test_pjx_toast.py
@@ -19,14 +19,16 @@ def test_toast_dispatches_a_pjx_toast_event_carrying_the_payload(pjx_page):
     ]
 
 
-def test_toast_event_is_dispatched_on_document(pjx_page):
+def test_toast_event_bubbles_from_document_to_window(pjx_page):
     page = pjx_page("<div></div>")
     page.evaluate(
-        "window.__target = null;"
-        "document.addEventListener('pjx:toast', (e) => { window.__target = e.target === document; })"
+        "window.__seen = null;"
+        "window.addEventListener('pjx:toast', (e) => {"
+        "  window.__seen = { onWindow: true, targetIsDocument: e.target === document };"
+        "})"
     )
     page.evaluate("pjx.toast({ message: 'hi' })")
-    assert page.evaluate("window.__target") is True
+    assert page.evaluate("window.__seen") == {"onWindow": True, "targetIsDocument": True}
 
 
 def test_toast_without_a_listener_does_not_throw(pjx_page):

--- a/tests/pyjinhx/client/test_pjx_toast.py
+++ b/tests/pyjinhx/client/test_pjx_toast.py
@@ -2,6 +2,18 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pyjinhx
+
+TOAST_HOST_JS_PATH = (
+    Path(pyjinhx.__file__).parent
+    / "builtins"
+    / "ui"
+    / "pjx_toast_host"
+    / "pjx_toast_host.js"
+)
+
 LISTEN = """
 () => {
   window.__toasts = [];
@@ -41,3 +53,12 @@ def test_toast_with_no_payload_dispatches_an_empty_detail(pjx_page):
     page.evaluate(LISTEN)
     page.evaluate("pjx.toast()")
     assert page.evaluate("window.__toasts") == [{}]
+
+
+def test_toast_renders_a_toast_element_in_the_host(pjx_page):
+    page = pjx_page("<div data-pjx-toast-host data-event-name='pjx:toast'></div>")
+    page.add_script_tag(content=TOAST_HOST_JS_PATH.read_text(encoding="utf-8"))
+    page.evaluate("window.pjx.toast('saved', { level: 'success' })")
+    toast = page.locator("[data-pjx-toast-host] .pjx-toast")
+    assert toast.count() == 1
+    assert "saved" in toast.inner_text()


### PR DESCRIPTION
## Summary
- Fixed toast event dispatching to use the `bubbles` flag so pjx:toast events reach window listeners
- Fixed toast host wiring guard to no longer collide with pjx.toast dispatcher
- Added idempotency check to prevent duplicate toast rendering when host is loaded multiple times
- Updated changelog

## Tests
Added 2 new tests for toast host rendering and idempotency (6 total in test suite).

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)