### PR TITLE
fix: skip whitespace-prologue segments in _root_instance_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- `stamp_root_attrs` now locates the root opening tag when whitespace-only segments precede it, rebasing the absolute `root_span` offset instead of slicing `segments[0]` blindly.
+
 ## 1.6.3 — PJXPageLoader namespace collision with core's pjx.loader.page (2026-08-08)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- `PJXToastHost`'s wiring guard checked `pjx.toast`, the same key the host itself assigns as
+  its public API, so the guard always tripped and the host's `window` listener never attached.
+  It now guards on a private `pjx.__toastHostWired` flag instead (#963).
+- `pjx.toast()` dispatched a non-bubbling event on `document`, which never reached the toast
+  host's `window`-level listener. The event now bubbles, so both `pjx.toast()` calls and the
+  HX-Trigger path deliver toasts to the host (#963).
+
 ## 1.6.3 — PJXPageLoader namespace collision with core's pjx.loader.page (2026-08-08)
 
 ### Fixed

--- a/pyjinhx/builtins/ui/pjx_toast_host/pjx_toast_host.js
+++ b/pyjinhx/builtins/ui/pjx_toast_host/pjx_toast_host.js
@@ -1,6 +1,9 @@
 (function () {
     window.pjx = window.pjx || {};
-    if (pjx.toast) return;
+    // Private wiring flag: pjx.toast is this file's public API, so guarding on
+    // it would trip on core's own pjx.toast and skip wiring entirely.
+    if (pjx.__toastHostWired) return;
+    pjx.__toastHostWired = true;
 
     const wiredEvents = new Set();
 

--- a/pyjinhx/client/pjx.js
+++ b/pyjinhx/client/pjx.js
@@ -259,9 +259,12 @@
 
   // The dispatch half of the toast API. Rendering belongs to an L4 toast-host
   // builtin listening for this event, so core stays DOM-template-free.
+  // Dispatched with bubbles: true so it reaches the window-level listener
+  // the toast host builtin registers, matching the HX-Trigger toast path
+  // which already fires on the triggering element and bubbles to window.
   function pjxToast(payload) {
     document.dispatchEvent(
-      new CustomEvent("pjx:toast", { detail: payload || {}, bubbles: false })
+      new CustomEvent("pjx:toast", { detail: payload || {}, bubbles: true })
     );
   }
 

--- a/pyjinhx/reactive/fanout.py
+++ b/pyjinhx/reactive/fanout.py
@@ -247,10 +247,17 @@ def _root_instance_id(level: RenderedLevel) -> str | None:
     RenderedLevel and the authored ``id`` attr goes with it, so the stamped root
     tag is the only place a nested level's instance identity still lives.
     """
-    root = level.segments[0] if level.segments else ""
+    skipped = 0
+    root: object = None
+    for segment in level.segments:
+        if isinstance(segment, str) and not segment.strip():
+            skipped += len(segment)
+            continue
+        root = segment
+        break
     if not isinstance(root, str):
         return None
-    start, end = level.root_span
+    start, end = (offset - skipped for offset in level.root_span)
     match = RE_ROOT_PJX_ID.search(root[start:end])
     if match is None:
         return None

--- a/pyjinhx/root_attrs.py
+++ b/pyjinhx/root_attrs.py
@@ -53,23 +53,36 @@ def _override_tag(tag_text: str, attrs: dict[str, str]) -> str:
 def stamp_root_attrs(level: RenderedLevel, attrs: dict[str, str]) -> RenderedLevel:
     """Splice ``attrs`` into ``level``'s root opening tag at ``level.root_span``.
 
-    No-op (identity) when ``attrs`` is empty. Otherwise replaces the
-    ``root_span`` substring of ``level.segments[0]`` with the stamped tag
-    text and updates ``root_span`` to match the new tag's length. Mutates
+    No-op (identity) when ``attrs`` is empty. Otherwise walks ``segments``
+    past any leading whitespace-only ``str`` segments to find the root
+    segment, replaces the ``root_span`` substring of it with the stamped tag
+    text, and updates ``root_span`` to match the new tag's length. Mutates
     ``level`` in place and returns it, matching the ``splice()`` convention
     in ``pyjinhx.segments``.
 
+    ``root_span`` is an absolute offset into the raw source that produced
+    ``segments``, so it is rebased by the summed length of the skipped
+    whitespace prologue before slicing the located segment.
+
     When a component's whole template is one child tag, the renderer has
-    already replaced ``segments[0]`` with that child's own RenderedLevel by
-    the time this runs, so the root tag to stamp lives one level down: the
-    call recurses into it and the outer ``level.root_span`` is left alone,
-    since in that shape it bounds nothing this module owns and nothing reads
-    it. The returned object is still the outer ``level``, so the
+    already replaced that segment with the child's own RenderedLevel by the
+    time this runs, so the root tag to stamp lives one level down: the call
+    recurses into it and the outer ``level.root_span`` is left alone, since
+    in that shape it bounds nothing this module owns and nothing reads it.
+    The returned object is still the outer ``level``, so the
     mutate-and-return contract holds at every depth.
     """
     if not attrs:
         return level
-    root = level.segments[0]
+    skipped = 0
+    index = 0
+    for position, segment in enumerate(level.segments):
+        if isinstance(segment, str) and not segment.strip():
+            skipped += len(segment)
+            continue
+        index = position
+        break
+    root = level.segments[index]
     if isinstance(root, RenderedLevel):
         stamp_root_attrs(root, attrs)
         return level
@@ -77,8 +90,8 @@ def stamp_root_attrs(level: RenderedLevel, attrs: dict[str, str]) -> RenderedLev
         "stamp_root_attrs needs a str or RenderedLevel root segment, "
         f"got {type(root).__name__}"
     )
-    start, end = level.root_span
+    start, end = (offset - skipped for offset in level.root_span)
     new_tag = _override_tag(root[start:end], attrs)
-    level.segments[0] = root[:start] + new_tag + root[end:]
+    level.segments[index] = root[:start] + new_tag + root[end:]
     level.root_span = (start, start + len(new_tag))
     return level

--- a/pyjinhx/root_attrs.py
+++ b/pyjinhx/root_attrs.py
@@ -75,13 +75,18 @@ def stamp_root_attrs(level: RenderedLevel, attrs: dict[str, str]) -> RenderedLev
     if not attrs:
         return level
     skipped = 0
-    index = 0
+    index = None
     for position, segment in enumerate(level.segments):
         if isinstance(segment, str) and not segment.strip():
             skipped += len(segment)
             continue
         index = position
         break
+    if index is None:
+        raise ValueError(
+            "stamp_root_attrs found no non-whitespace root segment in "
+            f"{level.segments!r}"
+        )
     root = level.segments[index]
     if isinstance(root, RenderedLevel):
         stamp_root_attrs(root, attrs)
@@ -93,5 +98,5 @@ def stamp_root_attrs(level: RenderedLevel, attrs: dict[str, str]) -> RenderedLev
     start, end = (offset - skipped for offset in level.root_span)
     new_tag = _override_tag(root[start:end], attrs)
     level.segments[index] = root[:start] + new_tag + root[end:]
-    level.root_span = (start, start + len(new_tag))
+    level.root_span = (start + skipped, start + skipped + len(new_tag))
     return level

--- a/pyjinhx/segments.py
+++ b/pyjinhx/segments.py
@@ -34,9 +34,10 @@ class RenderedLevel:
     """One component's rendered output: its own markup cut into ordered segments.
 
     Children enter ``segments`` as whole RenderedLevel objects, never as text.
-    ``root_span`` is the (start, end) offset of the root tag inside ``segments[0]``,
-    recorded by the parse that produced the cut — later attr stamping is a splice
-    at that offset, never a re-parse.
+    ``root_span`` is the (start, end) offset of the root tag in the raw source
+    markup that produced ``segments`` — absolute, not relative to any one
+    segment — recorded by the parse that produced the cut. Later attr stamping
+    is a splice at that offset, never a re-parse.
     """
 
     segments: list["str | ChildRef | RenderedLevel"]

--- a/tests/pyjinhx/client/test_pjx_toast.py
+++ b/tests/pyjinhx/client/test_pjx_toast.py
@@ -40,7 +40,10 @@ def test_toast_event_bubbles_from_document_to_window(pjx_page):
         "})"
     )
     page.evaluate("pjx.toast({ message: 'hi' })")
-    assert page.evaluate("window.__seen") == {"onWindow": True, "targetIsDocument": True}
+    assert page.evaluate("window.__seen") == {
+        "onWindow": True,
+        "targetIsDocument": True,
+    }
 
 
 def test_toast_without_a_listener_does_not_throw(pjx_page):

--- a/tests/pyjinhx/client/test_pjx_toast.py
+++ b/tests/pyjinhx/client/test_pjx_toast.py
@@ -62,3 +62,12 @@ def test_toast_renders_a_toast_element_in_the_host(pjx_page):
     toast = page.locator("[data-pjx-toast-host] .pjx-toast")
     assert toast.count() == 1
     assert "saved" in toast.inner_text()
+
+
+def test_loading_the_toast_host_twice_renders_one_toast(pjx_page):
+    page = pjx_page("<div data-pjx-toast-host data-event-name='pjx:toast'></div>")
+    source = TOAST_HOST_JS_PATH.read_text(encoding="utf-8")
+    page.add_script_tag(content=source)
+    page.add_script_tag(content=source)
+    page.evaluate("window.pjx.toast('once')")
+    assert page.locator("[data-pjx-toast-host] .pjx-toast").count() == 1

--- a/tests/pyjinhx/client/test_pjx_toast.py
+++ b/tests/pyjinhx/client/test_pjx_toast.py
@@ -19,14 +19,16 @@ def test_toast_dispatches_a_pjx_toast_event_carrying_the_payload(pjx_page):
     ]
 
 
-def test_toast_event_is_dispatched_on_document(pjx_page):
+def test_toast_event_bubbles_from_document_to_window(pjx_page):
     page = pjx_page("<div></div>")
     page.evaluate(
-        "window.__target = null;"
-        "document.addEventListener('pjx:toast', (e) => { window.__target = e.target === document; })"
+        "window.__seen = null;"
+        "window.addEventListener('pjx:toast', (e) => {"
+        "  window.__seen = { onWindow: true, targetIsDocument: e.target === document };"
+        "})"
     )
     page.evaluate("pjx.toast({ message: 'hi' })")
-    assert page.evaluate("window.__target") is True
+    assert page.evaluate("window.__seen") == {"onWindow": True, "targetIsDocument": True}
 
 
 def test_toast_without_a_listener_does_not_throw(pjx_page):

--- a/tests/pyjinhx/client/test_pjx_toast.py
+++ b/tests/pyjinhx/client/test_pjx_toast.py
@@ -2,6 +2,18 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pyjinhx
+
+TOAST_HOST_JS_PATH = (
+    Path(pyjinhx.__file__).parent
+    / "builtins"
+    / "ui"
+    / "pjx_toast_host"
+    / "pjx_toast_host.js"
+)
+
 LISTEN = """
 () => {
   window.__toasts = [];
@@ -41,3 +53,12 @@ def test_toast_with_no_payload_dispatches_an_empty_detail(pjx_page):
     page.evaluate(LISTEN)
     page.evaluate("pjx.toast()")
     assert page.evaluate("window.__toasts") == [{}]
+
+
+def test_toast_renders_a_toast_element_in_the_host(pjx_page):
+    page = pjx_page("<div data-pjx-toast-host data-event-name='pjx:toast'></div>")
+    page.add_script_tag(content=TOAST_HOST_JS_PATH.read_text(encoding="utf-8"))
+    page.evaluate("window.pjx.toast('saved', { level: 'success' })")
+    toast = page.locator("[data-pjx-toast-host] .pjx-toast")
+    assert toast.count() == 1
+    assert "saved" in toast.inner_text()

--- a/tests/pyjinhx/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx/reactive/test_reactive_fanout.py
@@ -1617,3 +1617,25 @@ def test_walk_manifest_stats_shared_template_only_once(monkeypatch):
 
     assert STAT_CALLS == [str(shared_template)]
     assert len(STAT_CALLS) != len(candidates)
+
+
+def test_root_instance_id_reads_a_root_stamped_behind_a_whitespace_prologue():
+    """The inverse of stamp_root_attrs must skip the same whitespace segments.
+
+    A level whose root has a whitespace prologue gets its tag stamped into
+    segments[1..] by stamp_root_attrs, with root_span rebased absolute past
+    the prologue. `_root_instance_id` must walk the same skip to land on the
+    same segment, or extraction silently returns None.
+    """
+    from pyjinhx.root_attrs import stamp_root_attrs
+
+    prologue = "\n  "
+    tag = '<div class="root">hi</div>'
+    level = RenderedLevel(
+        segments=[prologue, tag],
+        root_span=(len(prologue), len(prologue) + 18),
+        descriptor=None,
+    )
+    stamp_root_attrs(level, {"data-pjx-id": "abc123"})
+
+    assert fanout._root_instance_id(level) == "abc123"

--- a/tests/pyjinhx/reactive/test_reactive_root_attrs.py
+++ b/tests/pyjinhx/reactive/test_reactive_root_attrs.py
@@ -18,7 +18,7 @@ from pyjinhx.reactive.component import ReactiveComponent
 from pyjinhx.reactive.root_attrs import stamp_reactive_root_attrs
 from pyjinhx.rendering import render_level
 from pyjinhx.root_attrs import serialize_attr, stamp_root_attrs
-from pyjinhx.segments import ChildRef, RenderedLevel, serialize
+from pyjinhx.segments import ChildRef, RenderedLevel, VerbatimParser, serialize
 from pyjinhx.session import RenderSession
 
 _TEMPLATE_DIR = Path(__file__).parent.parent.parent / "templates"
@@ -112,6 +112,15 @@ BuiltinRootWidget.__pjx_descriptor__ = _descriptor_for(
 )
 DoubleBuiltinRootWidget.__pjx_descriptor__ = _descriptor_for(
     DoubleBuiltinRootWidget, "reactive_double_root.html"
+)
+
+
+class PrologueRootWidget(ReactiveComponent):
+    pass
+
+
+PrologueRootWidget.__pjx_descriptor__ = _descriptor_for(
+    PrologueRootWidget, "reactive_prologue_root.html"
 )
 
 
@@ -401,3 +410,45 @@ def test_stamping_the_parent_does_not_move_the_childs_attrs(
         f'<span data-pjx-id="inner2" data-pjx-type="reactive_widget"'
         f' data-pjx-hash="{child.state_hash()}">widget</span>' in html
     )
+
+
+def test_whitespace_prologue_before_component_root(
+    session: RenderSession, registered_children
+):
+    component = PrologueRootWidget(id="pro1")
+
+    html = serialize(render_level(component, session))
+
+    assert 'data-pjx-id="pro1"' in html
+    assert html.lstrip().startswith("<b ")
+    assert 'class="badge"' in html
+    assert html.strip().endswith("</b>")
+
+
+def test_whitespace_prologue_before_plain_div_root():
+    source = '\n  <div class="card">body</div>\n'
+    parser = VerbatimParser()
+    parser.feed(source)
+    parser.close()
+    assert parser.root_span is not None
+    level = RenderedLevel(
+        segments=list(parser.segments),
+        root_span=parser.root_span,
+        descriptor=None,
+    )
+
+    html = serialize(stamp_root_attrs(level, {"data-x": "1", "class": "stamped"}))
+
+    assert html == '\n  <div class="stamped" data-x="1">body</div>\n'
+
+
+def test_multiple_whitespace_prologue_segments_before_root():
+    level = RenderedLevel(
+        segments=["\n", "   ", '<div id="d">x</div>'],
+        root_span=(4, 16),
+        descriptor=None,
+    )
+
+    html = serialize(stamp_root_attrs(level, {"data-y": "2"}))
+
+    assert html == '\n   <div id="d" data-y="2">x</div>'

--- a/tests/pyjinhx/test_root_attrs.py
+++ b/tests/pyjinhx/test_root_attrs.py
@@ -97,3 +97,49 @@ def test_stamp_root_attrs_multiple_attrs_via_rendered_level():
     start, end = level.root_span
     assert level.segments[0][start:end] == ('<div class="root" data-a="1" data-b="2">')  # type: ignore[index]
     assert level.segments[0][end:] == "hi</div>"  # type: ignore[index]
+
+
+def test_stamp_root_attrs_with_whitespace_prologue_keeps_root_span_absolute():
+    # segments[0] is a whitespace-only prologue segment; the real root tag
+    # lives in segments[1], and root_span is absolute over the raw source
+    # (i.e. offset as if segments[0] and segments[1] were concatenated).
+    prologue = "\n  "
+    tag = '<div class="root">hi</div>'
+    level = RenderedLevel(
+        segments=[prologue, tag],
+        root_span=(len(prologue) + 0, len(prologue) + 18),
+        descriptor=None,
+    )
+    stamp_root_attrs(level, {"data-x": "1"})
+    start, end = level.root_span
+    # root_span must still be absolute (rebased past the prologue), so a
+    # caller slicing segments[1] with root_span - len(prologue) gets the tag.
+    local_start, local_end = start - len(prologue), end - len(prologue)
+    assert level.segments[1][local_start:local_end] == (  # type: ignore[index]
+        '<div class="root" data-x="1">'
+    )
+
+
+def test_stamp_root_attrs_with_whitespace_prologue_is_idempotent_across_two_calls():
+    # A second stamp call (e.g. re-stamping via oob_swaps) must not re-subtract
+    # the prologue's length from an already-rebased root_span.
+    prologue = "\n  "
+    tag = '<div class="root">hi</div>'
+    level = RenderedLevel(
+        segments=[prologue, tag],
+        root_span=(len(prologue), len(prologue) + 18),
+        descriptor=None,
+    )
+    stamp_root_attrs(level, {"data-a": "1"})
+    stamp_root_attrs(level, {"data-b": "2"})
+    start, end = level.root_span
+    local_start, local_end = start - len(prologue), end - len(prologue)
+    assert level.segments[1][local_start:local_end] == (  # type: ignore[index]
+        '<div class="root" data-a="1" data-b="2">'
+    )
+
+
+def test_stamp_root_attrs_all_whitespace_segments_raises():
+    level = RenderedLevel(segments=["   ", "\n"], root_span=(0, 0), descriptor=None)
+    with pytest.raises(ValueError):
+        stamp_root_attrs(level, {"data-x": "1"})

--- a/tests/templates/reactive_prologue_root.html
+++ b/tests/templates/reactive_prologue_root.html
@@ -1,0 +1,2 @@
+
+  <InnerBadge/>


### PR DESCRIPTION
## Summary

- Fixes root_instance_id to skip whitespace-prologue segments, matching stamp_root_attrs's behavior
- Ensures root_span stays absolute across repeated stamp_root_attrs calls (fixes re-stamp corruption)
- Corrects RenderedLevel.root_span docstring
- Adds regression tests for whitespace-prologue root stamping

Closes #965

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxwB6LvymhekN1iFNoNbqu