### PR TITLE
fix: raise instead of clobbering a nested reactive root's identity

### DIFF
--- a/pyjinhx/root_attrs.py
+++ b/pyjinhx/root_attrs.py
@@ -11,6 +11,12 @@ it only slices and concatenates strings.
 Port of v1 pyjinhx/root_attrs.py's `apply_root_attrs` / `_override_tag`
 behavior, scoped to L0: only pass-through attrs land here. `data-pjx-*` /
 `hx-swap-oob` stamping (L2/L3) reuses this same splice at the same span.
+
+Stamping across a component boundary (the nested-root recursion) refuses to
+overwrite an identity another component already wrote: a tag already carrying
+data-pjx-id/-type/-hash raises RootStampCollisionError instead. Detection is a
+string sniff of the tag text, not a type check, so this module stays import-pure
+and never learns what "reactive" means.
 """
 
 import re
@@ -50,7 +56,32 @@ def _override_tag(tag_text: str, attrs: dict[str, str]) -> str:
     return body
 
 
-def stamp_root_attrs(level: RenderedLevel, attrs: dict[str, str]) -> RenderedLevel:
+# The three attrs a reactive stamp always writes. data-pjx-load is deliberately
+# absent: it is only stamped when the component declares a key field, so its
+# presence says nothing about whether the tag was already stamped.
+_REACTIVE_STAMP_KEYS = ("data-pjx-id", "data-pjx-type", "data-pjx-hash")
+
+
+class RootStampCollisionError(ValueError):
+    """Two components tried to claim the same root tag's reactive identity."""
+
+
+def _reactive_stamps(tag_text: str) -> dict[str, str]:
+    """Read back whichever of the reactive identity attrs the tag already carries."""
+    found: dict[str, str] = {}
+    for name in _REACTIVE_STAMP_KEYS:
+        match = re.search(
+            r"\s" + re.escape(name) + r"\s*=\s*(\"[^\"]*\"|'[^']*'|[^\s/>]*)",
+            tag_text,
+        )
+        if match:
+            found[name] = match.group(1).strip("\"'")
+    return found
+
+
+def stamp_root_attrs(
+    level: RenderedLevel, attrs: dict[str, str], *, nested: bool = False
+) -> RenderedLevel:
     """Splice ``attrs`` into ``level``'s root opening tag at ``level.root_span``.
 
     No-op (identity) when ``attrs`` is empty. Otherwise walks ``segments``
@@ -71,6 +102,14 @@ def stamp_root_attrs(level: RenderedLevel, attrs: dict[str, str]) -> RenderedLev
     in that shape it bounds nothing this module owns and nothing reads it.
     The returned object is still the outer ``level``, so the
     mutate-and-return contract holds at every depth.
+
+    Recursing into a nested level crosses a component boundary, so the splice
+    there is no longer this component's to make unconditionally: if the nested
+    root already carries all of data-pjx-id/-type/-hash and this call would
+    rewrite those same keys, it raises RootStampCollisionError rather than
+    clobbering the inner component's identity. Same-level re-stamping (the
+    ``str`` root branch reached without recursion) still overrides, since
+    there the identity being replaced is the component's own.
     """
     if not attrs:
         return level
@@ -89,14 +128,28 @@ def stamp_root_attrs(level: RenderedLevel, attrs: dict[str, str]) -> RenderedLev
         )
     root = level.segments[index]
     if isinstance(root, RenderedLevel):
-        stamp_root_attrs(root, attrs)
+        stamp_root_attrs(root, attrs, nested=True)
         return level
     assert isinstance(root, str), (
         "stamp_root_attrs needs a str or RenderedLevel root segment, "
         f"got {type(root).__name__}"
     )
     start, end = (offset - skipped for offset in level.root_span)
-    new_tag = _override_tag(root[start:end], attrs)
+    tag_text = root[start:end]
+    if nested:
+        existing = _reactive_stamps(tag_text)
+        if len(existing) == len(_REACTIVE_STAMP_KEYS) and any(
+            name in attrs for name in _REACTIVE_STAMP_KEYS
+        ):
+            raise RootStampCollisionError(
+                "cannot stamp a reactive root tag that another reactive "
+                "component already stamped: this component's whole template is "
+                "a single reactive child tag, so both want the same element. "
+                f"already stamped: {existing}; stamping: "
+                f"{ {k: v for k, v in attrs.items() if k in _REACTIVE_STAMP_KEYS} }. "
+                "Wrap the child in an element of your own."
+            )
+    new_tag = _override_tag(tag_text, attrs)
     level.segments[index] = root[:start] + new_tag + root[end:]
     level.root_span = (start + skipped, start + skipped + len(new_tag))
     return level

--- a/tests/pyjinhx/test_root_attrs.py
+++ b/tests/pyjinhx/test_root_attrs.py
@@ -1,6 +1,11 @@
 import pytest
 
-from pyjinhx.root_attrs import _override_tag, serialize_attr, stamp_root_attrs
+from pyjinhx.root_attrs import (
+    RootStampCollisionError,
+    _override_tag,
+    serialize_attr,
+    stamp_root_attrs,
+)
 from pyjinhx.segments import RenderedLevel
 
 
@@ -143,3 +148,86 @@ def test_stamp_root_attrs_all_whitespace_segments_raises():
     level = RenderedLevel(segments=["   ", "\n"], root_span=(0, 0), descriptor=None)
     with pytest.raises(ValueError):
         stamp_root_attrs(level, {"data-x": "1"})
+
+
+def test_stamp_root_attrs_nested_reactive_collision_raises():
+    """Stamping a nested reactive root that already carries all three reactive
+    identity attrs with attrs that include one of those keys raises
+    RootStampCollisionError, preventing silent overwrite of the child's id."""
+    # Inner level's tag with all three reactive stamps
+    inner_tag = (
+        '<div data-pjx-id="inner-123" data-pjx-type="inner_comp" data-pjx-hash="abc">'
+    )
+    inner_level = _level(inner_tag, (0, len(inner_tag)))
+
+    # Outer level whose root segment is the inner level (component template = another component)
+    outer_level = RenderedLevel(
+        segments=[inner_level], root_span=(0, len(inner_tag)), descriptor=None
+    )
+
+    # Attempting to stamp the outer component's reactive identity onto the nested root
+    # should raise, not silently overwrite the inner component's identity
+    with pytest.raises(RootStampCollisionError) as exc_info:
+        stamp_root_attrs(
+            outer_level,
+            {
+                "data-pjx-id": "outer-456",
+                "data-pjx-type": "outer_comp",
+                "data-pjx-hash": "def",
+            },
+        )
+
+    assert "cannot stamp a reactive root tag" in str(exc_info.value)
+    assert "inner-123" in str(exc_info.value)
+    assert "outer-456" in str(exc_info.value)
+
+
+def test_stamp_root_attrs_nested_partial_reactive_does_not_collide():
+    """A nested reactive root with only some of the identity attrs (not a
+    complete stamp) can still be stamped without collision, allowing partial
+    overwrites."""
+    # Inner level with only some reactive stamps (not all three)
+    inner_tag = '<div data-pjx-id="inner-123" data-pjx-type="inner_comp">'
+    inner_level = _level(inner_tag, (0, len(inner_tag)))
+
+    outer_level = RenderedLevel(
+        segments=[inner_level], root_span=(0, len(inner_tag)), descriptor=None
+    )
+
+    # Since the inner tag doesn't have all three stamps, this should not raise
+    stamp_root_attrs(
+        outer_level,
+        {
+            "data-pjx-id": "outer-456",
+            "data-pjx-type": "outer_comp",
+            "data-pjx-hash": "def",
+        },
+    )
+    # Should complete without error
+    assert outer_level is not None
+
+
+def test_stamp_root_attrs_nested_same_level_override_allowed():
+    """Stamping a nested RenderedLevel with no reactive stamps allows it,
+    and stamping the same level multiple times (re-stamping) overwrites."""
+    # Inner level with no reactive stamps
+    inner_tag = "<div>"
+    inner_level = _level(inner_tag, (0, len(inner_tag)))
+
+    outer_level = RenderedLevel(
+        segments=[inner_level], root_span=(0, len(inner_tag)), descriptor=None
+    )
+
+    # First stamp should work
+    stamp_root_attrs(
+        outer_level,
+        {"data-pjx-id": "first-id", "data-pjx-type": "first_type"},
+    )
+
+    # Re-stamping the same nested level should also work (it's own level override)
+    stamp_root_attrs(
+        outer_level,
+        {"data-pjx-id": "second-id", "data-pjx-type": "second_type"},
+    )
+
+    assert outer_level is not None


### PR DESCRIPTION
## Summary
- Detects and raises `RootStampCollisionError` when a nested reactive component's root already has stamping attributes
- Prevents silent overwriting of child reactive component identities by parent stamps
- Ensures nested reactive roots remain addressable for fanout/manifest lookups

## Test Plan
- Added 3 test cases covering full collision, partial stamps, and re-stamping scenarios
- Tests verify collision detection in nested reactive component stamping

Closes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)