### PR TITLE
test: pin silence for recognized {#def#} names and single warning for nested ones

### DIFF
--- a/pyjinhx/props_header.py
+++ b/pyjinhx/props_header.py
@@ -34,17 +34,22 @@ _TYPES: dict[str, Any] = {
 }
 
 
-def _resolve_annotation(node: ast.expr | None) -> Any:
+def _resolve_annotation(node: ast.expr | None, field_name: str) -> Any:
     if node is None:
         return Any
     if isinstance(node, ast.Name):
-        return _TYPES.get(node.id, Any)
+        if node.id not in _TYPES:
+            # The only emission point: None and the union wrappers are handled
+            # by the branches below, so nesting never double-reports one prop.
+            logger.warning(_UNRECOGNIZED_ANNOTATION_WARNING, field_name, node.id)
+            return Any
+        return _TYPES[node.id]
     if isinstance(node, ast.Constant) and node.value is None:
         return type(None)
     # T | None  ->  Optional[T]
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        left = _resolve_annotation(node.left)
-        right = _resolve_annotation(node.right)
+        left = _resolve_annotation(node.left, field_name)
+        right = _resolve_annotation(node.right, field_name)
         if right is type(None):
             return left | None
         if left is type(None):
@@ -56,7 +61,7 @@ def _resolve_annotation(node: ast.expr | None) -> Any:
         and isinstance(node.value, ast.Name)
         and node.value.id == "Optional"
     ):
-        return _resolve_annotation(node.slice) | None
+        return _resolve_annotation(node.slice, field_name) | None
     return Any
 
 
@@ -107,7 +112,7 @@ def parse_props_header(source: str) -> list[tuple[str, Any, Any]] | None:
         if name in seen:
             raise ValueError(f"{{#def#}} header has duplicate prop {name!r}")
         seen.add(name)
-        annotation = _resolve_annotation(arg.annotation)
+        annotation = _resolve_annotation(arg.annotation, name)
         if index >= offset:
             default_node = defaults[index - offset]
             try:
@@ -183,6 +188,12 @@ def template_has_props_header(template_path: Path) -> bool:
 _STALE_DEF_HEADER_WARNING = (
     "<%s>: a {#def#} header is present but a Python class is registered — "
     "the header is ignored. Remove the header (or the class)."
+)
+
+_UNRECOGNIZED_ANNOTATION_WARNING = (
+    "<%s>: {#def#} annotation %r is not a recognized type — the prop falls back "
+    "to Any. A header cannot import names; use a builtin type or drop the "
+    "annotation."
 )
 
 

--- a/tests/pyjinhx/test_props_header_parse.py
+++ b/tests/pyjinhx/test_props_header_parse.py
@@ -62,6 +62,39 @@ def test_unrecognized_annotation_falls_back_to_any(caplog):
 
 
 @pytest.mark.parametrize(
+    "annotation",
+    ["str", "int", "float", "bool", "list", "dict", "Any", "Slot", "Children"],
+)
+def test_recognized_annotations_do_not_warn(annotation: str, caplog):
+    """A name in the closed vocabulary resolved fine — warning about it would
+    train authors to ignore the warning that matters."""
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        parse_props_header(f"{{#def value: {annotation} #}}")
+
+    assert [
+        r.getMessage()
+        for r in caplog.records
+        if "is not a recognized type" in r.getMessage()
+    ] == []
+
+
+@pytest.mark.parametrize(
+    "annotation", ["SomeModel | None", "None | SomeModel", "Optional[SomeModel]"]
+)
+def test_unrecognized_inside_optional_warns_exactly_once(annotation: str, caplog):
+    """The Name branch is the sole emission point, so wrapping an unresolved
+    name in a union reports it once, not once per recursive descent."""
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        parse_props_header(f"{{#def value: {annotation} #}}")
+
+    warnings = [
+        r for r in caplog.records if "is not a recognized type" in r.getMessage()
+    ]
+    assert len(warnings) == 1, [r.getMessage() for r in warnings]
+    assert "SomeModel" in warnings[0].getMessage()
+
+
+@pytest.mark.parametrize(
     "annotation, expected_children",
     [("Slot", False), ("Children", True)],
 )

--- a/tests/pyjinhx/test_props_header_parse.py
+++ b/tests/pyjinhx/test_props_header_parse.py
@@ -4,6 +4,7 @@ Parsing only — building a model class from the parsed spec belongs to #376,
 so nothing here exercises class generation.
 """
 
+import logging
 from typing import Any
 
 import pytest
@@ -44,9 +45,20 @@ def test_each_supported_annotation_resolves_to_its_type(
     ]
 
 
-def test_unrecognized_annotation_falls_back_to_any():
+def test_unrecognized_annotation_falls_back_to_any(caplog):
     """The vocabulary is deliberately closed: a header cannot import names."""
-    assert parse_props_header("{#def value: SomeModel #}") == [("value", Any, ...)]
+    with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+        fields = parse_props_header("{#def value: SomeModel #}")
+
+    assert fields == [("value", Any, ...)]
+    warnings = [
+        r for r in caplog.records if "is not a recognized type" in r.getMessage()
+    ]
+    assert len(warnings) == 1, [r.getMessage() for r in caplog.records]
+    assert warnings[0].levelno == logging.WARNING
+    message = warnings[0].getMessage()
+    assert "value" in message
+    assert "SomeModel" in message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Adds warning when a {#def#} annotation is not a recognized type
- Ensures the warning is emitted exactly once, even for nested optional annotations
- Adds comprehensive tests to verify recognized types are silent and unrecognized types warn once

Closes #983

## Test plan

- 2 commits: 1 fix + 1 test
- 49 lines of test code added
- 23 lines of implementation changes in props_header.py
- All existing tests pass
- New tests verify warning behavior for recognized and unrecognized annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)