### PR TITLE
test: cover optional Slot annotations in {#def#} headers

### DIFF
--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -888,6 +888,18 @@ def test_config_names_the_cache_backend_type_without_importing_it():
     )
 
 
+def test_props_header_only_imports_component_inside_a_function_body():
+    """parse_props_header() resolves the Slot and Children aliases out of
+    _component.py, but both names are bound at the bottom of that module, after
+    _OpenComponent — whose __pydantic_init_subclass__ reenters this module. A
+    module-scope import would therefore read them before they exist, deadlocking
+    class definition. The whole-file edge table above already permits the
+    props_header -> pyjinhx._component edge and cannot see where in the file the
+    import lives, so pin the scope here."""
+    module_level = module_level_internal_imports(PACKAGE_ROOT / "props_header.py")
+    assert "pyjinhx._component" not in module_level
+
+
 def test_no_render_spine_module_declares_a_reactive_import():
     """FORBIDDEN per architecture-overview.md: anything in the render spine
     importing reactive/. pyjinhx/reactive/ doesn't exist yet (#288), so this

--- a/tests/pyjinhx/test_props_header_build.py
+++ b/tests/pyjinhx/test_props_header_build.py
@@ -172,3 +172,22 @@ def test_descriptor_template_path_is_provisional_until_relocated(tmp_path, monke
     cls.__module__ = fake_module.__name__
     rebuild_class_descriptor(cls)
     assert cls.__pjx_descriptor__.template_path == tmp_path / "card.pjx"
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    ["Slot | None", "Optional[Slot]"],
+    ids=["union", "optional"],
+)
+def test_header_declared_slot_union_is_detected_as_slot_on_the_built_class(
+    annotation: str,
+):
+    """Pydantic hoists metadata only from the outermost Annotated, so an
+    optional slot arrives with empty field metadata and the marker still nested
+    inside the union; detection has to unwrap it."""
+    from pyjinhx._component import _is_slot_field
+
+    fields = parse_props_header(f"{{#def value: {annotation} #}}")
+    assert fields is not None
+    cls = build_component_class(fields, "Card")
+    assert _is_slot_field(cls, "value") is True


### PR DESCRIPTION
## Summary

- Adds coverage for optional Slot annotations in template property headers ({#def#})
- Ensures _component imports are pinned to function bodies for correct scoping
- Validates that props_header correctly handles optional slot annotations and nested scenarios

## Changes

- **tests/pyjinhx/test_props_header_build.py**: Added 19 lines to test optional Slot annotations
- **tests/pyjinhx/test_import_graph.py**: Added 12 lines to validate import graph handling

**Total tests added**: 2 test files, 31 lines of new test code

Closes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)