### PR TITLE
fix: PJXDrawer right/bottom slide-in animation not moving

### DIFF
--- a/pyjinhx/builtins/ui/pjx_drawer/pjx_drawer.css
+++ b/pyjinhx/builtins/ui/pjx_drawer/pjx_drawer.css
@@ -31,8 +31,11 @@
   background: transparent;
   z-index: var(--pjx-drawer-z);
   /* Clip the box while it slides in from off-screen so the page never gets a
-     transient scrollbar during the open/close animation. */
-  overflow: hidden;
+     transient scrollbar during the open/close animation. Must be `clip`, not
+     `hidden`: `hidden` makes this a scroll container, and showModal()'s focus
+     of the first control inside the still-off-screen box scrolls it back into
+     view — pinning scrollLeft to max and cancelling the slide entirely. */
+  overflow: clip;
   animation: pjx-drawer-root-in 200ms ease forwards;
 }
 
@@ -146,6 +149,8 @@
   to { transform: translateY(100%); }
 }
 
+/* Percentages here resolve against the box's own border box, so the offset
+   stays exact even though `width` is the content-box width token. */
 .pjx-drawer--left .pjx-drawer__box {
   --pjx-drawer-slide-from: -100%;
 }


### PR DESCRIPTION
## Summary
- `.pjx-drawer[open] { overflow: hidden }` made the dialog a scroll container; `showModal()` auto-focusing the close button inside the still off-screen box triggered a focus-scroll-into-view that pinned `scrollLeft`/`scrollTop` to max every animation frame, exactly cancelling the slide transform — the right/bottom drawer appeared to fade in place instead of sliding in.
- Left-side drawers were unaffected: `scrollLeft` can't go negative in LTR, so there was nothing to cancel.
- Fix: `overflow: hidden` → `overflow: clip` on the dialog root. `clip` still prevents the transient scrollbar during the slide, but doesn't create a scroll container, so there's no scroll position to fight the animation.
- Also reverted an intermediate `--pjx-drawer-slide-from` experiment (driving the offset from the `--pjx-drawer-width` token) back to the original `100%`/`-100%` — percentages resolve against the box's border box, which is exact; the width token undershoots by the border width and isn't the actual root cause.

## Test plan
- [x] `uv run pytest tests/pyjinhx/builtins/pjx_drawer/ tests/pyjinhx/builtins/pjx_drawer_header/ tests/pyjinhx/builtins/pjx_drawer_body/ tests/pyjinhx/builtins/pjx_drawer_footer/ -q` — 51 passed
- [x] Verified via real automatic-playback sampling (not animation-scrubbing) that right/left/bottom drawers now slide the full distance into place with `scrollLeft`/`scrollTop` staying at 0 throughout
- [x] Manually confirmed in-browser: right, left, and bottom drawers all slide correctly; close animation unaffected; `prefers-reduced-motion: reduce` still opens/closes instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)