### PR TITLE
fix: warn when a subclass redeclares id with a literal default (#972)

### DIFF
--- a/pyjinhx/_component.py
+++ b/pyjinhx/_component.py
@@ -12,6 +12,7 @@ import graph is enforced statically by tests/pyjinhx/test_import_graph.py.
 
 import itertools
 import json
+import logging
 import re
 import sys
 import types
@@ -28,6 +29,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+from pydantic.fields import FieldInfo
 
 from pyjinhx.descriptor import ClassDescriptor
 
@@ -36,12 +38,46 @@ if TYPE_CHECKING:
     # with rendering.py.
     from pyjinhx.session import RenderSession
 
+logger = logging.getLogger("pyjinhx")
+
 _auto_id_counter = itertools.count(1)
 
 
 def _auto_id() -> str:
     """Generate a process-unique component id (``pjx-<n>``)."""
     return f"pjx-{next(_auto_id_counter)}"
+
+
+def _warn_on_literal_id_default(
+    cls: "type[BaseComponent]", id_field: FieldInfo
+) -> None:
+    """Complain when ``cls`` gives ``id`` one fixed value instead of a factory.
+
+    The base field's ``default_factory`` is the whole reason two components of
+    the same class never share an id. A literal default replaces it with one
+    value every instance of the class carries, so a template that renders the
+    class twice registers both under the same key and the first instance is
+    quietly dropped from the request's instance registry. Nothing else in the
+    render path notices — the markup still comes out right and only a later
+    resolve()-by-id returns the wrong instance — so the class definition is the
+    last honest place to say something.
+
+    Silent for ``auto_id = False`` classes: those already refuse to construct
+    without an explicit id, so the declared default never reaches an instance
+    and the opt-out is deliberate and loud on its own.
+    """
+    if not cls.auto_id:
+        return
+    if id_field.default_factory is not None or id_field.is_required():
+        return
+    logger.warning(
+        "%s declares id = %r, a single literal shared by every instance instead "
+        "of the per-instance auto-id. Two of these rendered in one request "
+        "collide in the instance registry and the first one is lost. Use "
+        "Field(default_factory=...) or require callers to pass a distinct id.",
+        cls.__name__,
+        id_field.default,
+    )
 
 
 _ATTR_NAME_RE = re.compile(r"[A-Za-z@:][A-Za-z0-9_.:@-]*")
@@ -628,6 +664,7 @@ class BaseComponent(BaseModel):
                 f"{id_field.annotation}; id must remain typed str so "
                 f"_validate_id and _require_explicit_id keep their meaning."
             )
+        _warn_on_literal_id_default(cls, id_field)
         rebuild_class_descriptor(cls)
 
     @model_validator(mode="before")

--- a/tests/pyjinhx/test_component.py
+++ b/tests/pyjinhx/test_component.py
@@ -1,5 +1,6 @@
 import ast
 import inspect
+import logging
 from typing import ClassVar
 
 import pytest
@@ -467,6 +468,93 @@ class TestReservedNameCollisions:
         assert FixedId(id="custom").id == "custom"
         # the inherited _validate_id lineage still applies
         assert FixedId(id="").id.startswith("pjx-")
+
+
+class TestLiteralIdDefaultWarning:
+    """A literal ``id`` default is shared by every instance of the class, which
+    is the one thing the base field's factory exists to prevent."""
+
+    @staticmethod
+    def _id_warnings(caplog) -> list[str]:
+        return [
+            record.getMessage()
+            for record in caplog.records
+            if "shared by every instance" in record.getMessage()
+        ]
+
+    def test_literal_id_default_warns_at_class_definition(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+
+            class LiteralId(BaseComponent):
+                id: str = "section-card"
+
+        messages = self._id_warnings(caplog)
+        assert len(messages) == 1
+        assert "LiteralId" in messages[0]
+        assert "section-card" in messages[0]
+
+    def test_literal_id_default_via_field_warns(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+
+            class FieldLiteralId(BaseComponent):
+                id: str = Field(default="fixed", description="a fixed id")
+
+        assert len(self._id_warnings(caplog)) == 1
+
+    def test_inherited_literal_id_default_warns_for_the_grandchild_too(self, caplog):
+        class Parent(BaseComponent):
+            id: str = "shared"
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+
+            class Child(Parent):
+                pass
+
+        messages = self._id_warnings(caplog)
+        assert len(messages) == 1
+        assert "Child" in messages[0]
+
+    def test_untouched_id_does_not_warn(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+
+            class Untouched(BaseComponent):
+                name: str = ""
+
+        assert self._id_warnings(caplog) == []
+
+    def test_custom_factory_does_not_warn(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+
+            class CustomFactory(BaseComponent):
+                id: str = Field(default_factory=lambda: "x")
+
+        assert self._id_warnings(caplog) == []
+
+    def test_required_id_does_not_warn(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+
+            class RequiredId(BaseComponent):
+                auto_id = False
+                id: str  # pyright: ignore[reportGeneralTypeIssues]
+
+        assert self._id_warnings(caplog) == []
+
+    def test_auto_id_opt_out_does_not_warn(self, caplog):
+        # auto_id = False already requires an explicit id, loudly, at
+        # construction; the literal default is dead weight, not a silent trap.
+        with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+
+            class OptedOut(BaseComponent):
+                auto_id = False
+                id: str = "fixed"
+
+        assert self._id_warnings(caplog) == []
+
+    def test_base_component_itself_does_not_warn(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="pyjinhx"):
+            assert BaseComponent.model_fields["id"].default_factory is not None
+        assert self._id_warnings(caplog) == []
 
 
 FORBIDDEN_IMPORTS = ("pyjinhx.reactive",)


### PR DESCRIPTION
## Summary

- Detects, at class-definition time, a subclass that redeclares `id` with a literal default instead of the base field's `default_factory`
- Logs a warning on the `pyjinhx` logger naming the class, the shared value, and the fix
- 8 new tests in `tests/pyjinhx/test_component.py` covering the warn and no-warn cases

## What & Why

`BaseComponent.id` is declared with `default_factory=_auto_id`, which is the only reason two instances of one component class never share an id. A subclass that writes `id: str = "section-card"` replaces that factory with a single value carried by every instance — Pydantic accepts it as an ordinary default override, and nothing complains. Two such instances rendered in one request then collide in the request-scoped instance registry: the first entry is overwritten, the markup still looks right, and only a later `resolve()`-by-id returns the wrong instance.

`__pydantic_init_subclass__` already validates the reserved `id` field (present, typed `str`); it now also inspects the effective default provider on `cls.model_fields["id"]` — which Pydantic has already resolved to the most-derived declaration, so a grandchild that inherits the literal is flagged too. The class is reported when all three hold:

- `cls.auto_id` is True — an `auto_id = False` class already refuses to construct without an explicit id, so its declared default never reaches an instance; that opt-out is deliberate and loud on its own and must not be flagged here.
- `id_field.default_factory is None` — any factory, including a custom one, keeps the per-instance guarantee.
- `not id_field.is_required()` — `id: str` with no default at all is a required field, which is safe.

A warning rather than a raise: this is virtually never intentional, but a page-level singleton is a legitimate (if rare) reason to want it, and raising would break existing subclasses at import time. `logger.warning` on the `"pyjinhx"` logger matches the existing convention for footgun diagnostics (`registry.py`'s collision warning, `props_header.py`'s stale-header warning).

The registry half of this issue — suggestion #2, `InstanceKeyCollisionError` under reactive-dev strict mode — landed in #986 and is already covered by `tests/pyjinhx/test_instance_registry.py`; this PR does not touch it.

## Tests

`3577 passed, 1 skipped, 1 xpassed`. New cases: literal default warns (bare and via `Field(default=...)`), inherited literal warns for the grandchild, untouched `id` does not warn, custom `default_factory` does not warn, required `id` does not warn, `auto_id = False` does not warn, `BaseComponent` itself keeps its factory. `ruff format`/`ruff check` clean; `basedpyright` clean on both changed files.

Closes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)
