### PR TITLE
feat: add square, hexagon, diamond, and triangle shapes to PJXAvatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.7.1 — Avatar shapes (2026-08-23)
+
+### Added
+- `PJXAvatar(shape=...)` accepts `"square"`, `"hexagon"`, `"diamond"`, and `"triangle"` in
+  addition to the existing circle. `"circle"` stays the implicit default and emits no
+  modifier class; the others emit `pjx-avatar--{shape}`. `hexagon`/`diamond`/`triangle` are
+  cut with `clip-path`, so their border comes out straight-edged rather than rounded.
+
 ## 1.7.0 — Tooltip backdrop, drawer slide-in, and a literal-id-default warning (2026-08-19)
 
 ### Added

--- a/docs/components.md
+++ b/docs/components.md
@@ -391,9 +391,18 @@ Image or initials in a circle. **Assets:** `pjx_avatar.css` only.
     | `alt` | `str` | `""` | `img` alt text; also used as `title` on initials. |
     | `initials` | `str` | `""` | Up to two characters (trimmed/capped in validation). |
     | `size` | `str \| int` | `"md"` | Named token (`sm`, `md`, `lg`) **or** an arbitrary pixel size (`int`) or CSS length string (`"36px"`, `"2.5rem"`). Named tokens emit the BEM modifier class; an int/CSS length renders `width`/`height` inline. |
+    | `shape` | `Literal["circle", "square", "hexagon", "diamond", "triangle"]` | `"circle"` | `"circle"` is the implicit default and emits no modifier class; the others emit `pjx-avatar--{shape}`. |
     | `color` | `str` | `""` | Inline `background` color (e.g. `"#4f46e5"`, `"hsl(240 60% 50%)"` ). |
 
     **Arbitrary pixel sizing:** pass an `int` for a pixel size or any CSS length string for a custom size. This bypasses the named-token classes so the avatar can be sized by data rather than the three design-system tokens.
+
+    **Non-circle shapes:** `hexagon`, `diamond`, and `triangle` are cut with `clip-path`, which clips the border along with the shape — expect a straight-edged border on those, not a rounded one.
+
+<!-- demo: PJXAvatarShapes -->
+
+```html
+<PJXAvatar initials="JD" size="lg" shape="hexagon" alt="Hexagon"/>
+```
 
 ??? note "Style tokens"
 
@@ -410,12 +419,13 @@ Image or initials in a circle. **Assets:** `pjx_avatar.css` only.
 
     Root `.pjx-avatar`; no JS API.
 
-    **Classes:** `pjx-avatar`, `pjx-avatar--sm|md|lg` (named tokens only), `pjx-avatar__img`, `pjx-avatar__initials`.
+    **Classes:** `pjx-avatar`, `pjx-avatar--sm|md|lg` (named tokens only), `pjx-avatar--square|hexagon|diamond|triangle` (non-circle shapes only), `pjx-avatar__img`, `pjx-avatar__initials`.
 
 ??? note "Python"
 
     ```python
     PJXAvatar(initials="JD", size="sm", alt="Jane Doe")
+    PJXAvatar(initials="JD", size="lg", shape="hexagon", alt="Jane Doe")
     ```
 
 ### PJXAvatarStack

--- a/docs/demos/static.py
+++ b/docs/demos/static.py
@@ -93,6 +93,16 @@ def avatar():
     ]
 
 
+def avatar_shapes():
+    return [
+        PJXAvatar(initials="JD", size="lg", shape="circle", alt="Circle").render(),
+        PJXAvatar(initials="JD", size="lg", shape="square", alt="Square").render(),
+        PJXAvatar(initials="JD", size="lg", shape="hexagon", alt="Hexagon").render(),
+        PJXAvatar(initials="JD", size="lg", shape="diamond", alt="Diamond").render(),
+        PJXAvatar(initials="JD", size="lg", shape="triangle", alt="Triangle").render(),
+    ]
+
+
 def avatar_stack():
     return PJXAvatarStack(
         avatars=[
@@ -232,6 +242,7 @@ DEMOS = {
     "PJXDivider": (divider, 120),
     "PJXSpinner": (spinner, 140),
     "PJXAvatar": (avatar, 140),
+    "PJXAvatarShapes": (avatar_shapes, 140),
     "PJXAvatarStack": (avatar_stack, 120),
     "PJXBreadcrumb": (breadcrumb, 120),
     "PJXSkeleton": (skeleton, 150),

--- a/pyjinhx/builtins/ui/pjx_avatar/pjx_avatar.css
+++ b/pyjinhx/builtins/ui/pjx_avatar/pjx_avatar.css
@@ -41,6 +41,25 @@
   font-size: var(--pjx-avatar-font-size-lg);
 }
 
+.pjx-avatar--square {
+  border-radius: var(--radius-md, 6px);
+}
+
+.pjx-avatar--hexagon {
+  border-radius: 0;
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+}
+
+.pjx-avatar--diamond {
+  border-radius: 0;
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+}
+
+.pjx-avatar--triangle {
+  border-radius: 0;
+  clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+}
+
 .pjx-avatar__img {
   width: 100%;
   height: 100%;

--- a/pyjinhx/builtins/ui/pjx_avatar/pjx_avatar.pjx
+++ b/pyjinhx/builtins/ui/pjx_avatar/pjx_avatar.pjx
@@ -1,5 +1,5 @@
 <div id="{{ id }}"
-     class="pjx-avatar{% if size_is_token %} pjx-avatar--{{ size }}{% endif %}{% if class_name %} {{ class_name }}{% endif %}"{% if not size_is_token %} style="width:{{ size_css }};height:{{ size_css }};{% if color %}background:{{ color }};{% endif %}"{% elif color %} style="background:{{ color }};"{% endif %}{% for name, value in extra_attrs.items() %} {{ name }}="{{ value }}"{% endfor %}>
+     class="pjx-avatar{% if size_is_token %} pjx-avatar--{{ size }}{% endif %}{% if shape != "circle" %} pjx-avatar--{{ shape }}{% endif %}{% if class_name %} {{ class_name }}{% endif %}"{% if not size_is_token %} style="width:{{ size_css }};height:{{ size_css }};{% if color %}background:{{ color }};{% endif %}"{% elif color %} style="background:{{ color }};"{% endif %}{% for name, value in extra_attrs.items() %} {{ name }}="{{ value }}"{% endfor %}>
   {% if src %}
   <img class="pjx-avatar__img" src="{{ src }}" alt="{{ alt }}" loading="lazy" decoding="async" />
   {% else %}

--- a/pyjinhx/builtins/ui/pjx_avatar/pjx_avatar.py
+++ b/pyjinhx/builtins/ui/pjx_avatar/pjx_avatar.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import Field, computed_field, field_validator
 
 from pyjinhx._component import AttrValue, BaseComponent, ExtraAttrs
@@ -6,7 +8,7 @@ _NAMED_SIZES = {"sm", "md", "lg"}
 
 
 class PJXAvatar(BaseComponent):
-    """A circular avatar showing an image when ``src`` is set, initials otherwise."""
+    """An avatar showing an image when ``src`` is set, initials otherwise."""
 
     src: str = ""
     alt: str = ""
@@ -15,6 +17,8 @@ class PJXAvatar(BaseComponent):
     # An int (px) or any other CSS length string (e.g. "36px", "2.5rem")
     # renders inline width/height instead and omits the modifier class.
     size: str | int = "md"
+    # "circle" is the implicit default and emits no modifier class.
+    shape: Literal["circle", "square", "hexagon", "diamond", "triangle"] = "circle"
     class_name: AttrValue = ""
     color: AttrValue = ""
     extra_attrs: ExtraAttrs = Field(default_factory=dict)

--- a/tests/pyjinhx/builtins/pjx_avatar/test_pjx_avatar.py
+++ b/tests/pyjinhx/builtins/pjx_avatar/test_pjx_avatar.py
@@ -127,6 +127,23 @@ def test_extra_attrs_surface_on_the_root(avatar_session):
     assert 'class="pjx-avatar pjx-avatar--md"' in html
 
 
+def test_default_shape_is_circle_and_emits_no_modifier_class(avatar_session):
+    html = _html(avatar_session)
+    assert 'class="pjx-avatar pjx-avatar--md"' in html
+    assert "pjx-avatar--circle" not in html
+
+
+@pytest.mark.parametrize("shape", ["square", "hexagon", "diamond", "triangle"])
+def test_non_circle_shapes_emit_modifier_class(avatar_session, shape):
+    html = _html(avatar_session, shape=shape)
+    assert f"pjx-avatar--{shape}" in html
+
+
+def test_invalid_shape_is_rejected():
+    with pytest.raises(ValidationError):
+        PJXAvatar(id="a", shape="octagon")  # pyright: ignore[reportArgumentType]
+
+
 def test_stylesheet_is_auto_discovered_by_snake_case_filename():
     """The descriptor probes "<snake_case class name>.css" next to the module,
     so the v0.x kebab-case filename had to be renamed on the way in.


### PR DESCRIPTION
## Summary
- `PJXAvatar` gains a `shape` prop: `"circle"` (default, unchanged output), `"square"`, `"hexagon"`, `"diamond"`, `"triangle"`.
- `circle` stays implicit and emits no modifier class; the rest emit `pjx-avatar--{shape}`, non-circle shapes cut via `clip-path`.
- Showcased in the docs Components gallery (`PJXAvatarShapes` demo).

## Test plan
- [x] `pytest tests/pyjinhx` — 3455 passed
- [x] `ruff format` / `ruff check` on changed files — clean