### PR TITLE
subtask: splice hx-preserve for disjoint nested regions in oob_swaps

### DIFF
--- a/docs/api/renderer.md
+++ b/docs/api/renderer.md
@@ -62,6 +62,7 @@ def __init__(self) -> None
 | `pjx_mounted` | `list[dict[str, Any]]` | The client's parsed `X-PJX-Mounted` manifest, set by middleware and read by fan-out |
 | `pjx_assets` | `frozenset[str]` | The client's parsed `X-PJX-Assets` tokens — which assets it already holds |
 | `pjx_trigger` | `dict[str, Any] \| None` | The parsed htmx trigger header for this request, or `None` |
+| `nested_react_keys` | `dict[str, tuple[str, ...]]` | Reactive instance id → that class's reactive keys, written by `record_nested_react_keys` when a caller appends it to `on_rendered` |
 
 The three `pjx_*` manifest fields live on the session rather than on `request.state` because the response composer is framework-free: it has no `Request` to read them from.
 

--- a/docs/superpowers/plans/issue-1011.md
+++ b/docs/superpowers/plans/issue-1011.md
@@ -1,0 +1,238 @@
+<!-- task-pipeline: validated -->
+# Spec (verbatim)
+
+> The following is the spec this plan implements, copied verbatim from `docs/superpowers/specs/issue-1011-design.md`.
+
+---
+
+# Issue #1011 — declare `ReactiveComponent.retain_across_parent_swaps`
+
+Subtask 1 of 3 under story #1009 (`hx-preserve` retention for disjoint nested reactive regions, fixes #1008), milestone 18 "Nested reactive OOB ownership". Narrows the milestone design at `docs/superpowers/specs/2026-08-23-nested-reactive-oob-preserve-design.md:110-112` to its first slice: the declaration of the opt-out flag, with nothing reading it yet.
+
+## Scope
+
+In scope: one new public ClassVar on `ReactiveComponent` in `pyjinhx/reactive/component.py`, plus unit tests for it.
+
+```python
+retain_across_parent_swaps: ClassVar[bool] = True
+```
+
+It is placed in the existing ClassVar block in the class body (`pyjinhx/reactive/component.py:52-67`), next to `state_hash_exclude` (line 60), which is its closest sibling in both name and role — a public, subclass-overridable knob, as opposed to the `_pjx_`-prefixed derived facts around it. It carries a short prose docstring immediately below the assignment, matching the convention of every other ClassVar in that block (docstring, not an inline comment), saying what the flag means and that a subclass sets it `False` to opt out of ever being preserved against an ancestor's OOB swap — i.e. to declare itself fully owned by its parent.
+
+Out of scope, and explicitly owned by the sibling subtasks, which are still Backlog:
+
+- Recording nested react-keys during dirty rebuilds — `pyjinhx/reactive/root_attrs.py` and `pyjinhx/reactive/fanout.py` (#1012).
+- Reading this flag and splicing `hx-preserve="true"` in `oob_swaps()` — `pyjinhx/reactive/fanout.py` (#1013).
+
+#1011 must not touch `root_attrs.py` or `fanout.py`. No `__init_subclass__` / `__pydantic_init_subclass__` change is needed: unlike `react=(...)` and the cache kwargs, this flag has no consumption path at class-definition time. It is a plain inherited ClassVar that a subclass overrides by reassignment in its body, exactly the mechanism `state_hash_exclude` uses.
+
+## Observable behavior
+
+- `ReactiveComponent.retain_across_parent_swaps` exists and is `True`.
+- A subclass that says nothing inherits `True`; the value is visible on both the class and an instance.
+- A subclass that assigns `retain_across_parent_swaps = False` reads back `False` on that class and its own subclasses, while `ReactiveComponent` and unrelated sibling subclasses still read `True` — the override is per-class, never a mutation of the base.
+- Setting it changes no rendering, no OOB swap, no cache behavior in this subtask. The flag is inert until #1013 wires it as one of three AND-ed conditions for stamping `hx-preserve="true"` onto a nested root (react-keys disjoint from the dirtied set; the id not itself a dirty/missing candidate in the same walk; `retain_across_parent_swaps` True on the owning class).
+
+## Error paths
+
+None. There is no validation, no coercion, and no rejection at class-definition time — a non-bool assignment is a static typing concern only, consistent with how the neighbouring ClassVars behave. No new exception types, no new messages.
+
+## Tests
+
+Tier per the test-placement rule at `docs/superpowers/rebuild/implementation-overview.md:59` ("Tests mirror the package: `tests/pyjinhx/test_<module>.py` per module, `tests/pyjinhx/reactive/` for the cluster"): all of these are unit tests in the mirrored-package tree, in the existing `tests/pyjinhx/reactive/test_reactive_component.py`, beside the other `ReactiveComponent` ClassVar tests (e.g. the `_pjx_cache_policy` tests already there).
+
+1. `retain_across_parent_swaps` defaults to `True` on `ReactiveComponent` itself — `tests/pyjinhx/reactive/test_reactive_component.py`.
+2. A subclass that does not mention the flag inherits `True` — same file.
+3. A subclass assigning `retain_across_parent_swaps = False` reads back `False`, and `ReactiveComponent` still reads `True` (no base mutation) — same file.
+4. Two sibling subclasses set it independently: one `False`, one left alone, and each keeps its own value — same file.
+
+Not tested here: "a nested class with `retain_across_parent_swaps = False` -> no stamp, even when keys are disjoint" (milestone spec Testing section, lines 174-177). That is Story 1's end-to-end assertion and requires the wired `oob_swaps()` behavior, so it is owned by #1013.
+
+---
+
+# `ReactiveComponent.retain_across_parent_swaps` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Declare a public, per-class-overridable `retain_across_parent_swaps: ClassVar[bool] = True` on `ReactiveComponent`, with unit tests, and nothing reading it yet.
+
+**Architecture:** A single class-body declaration in `pyjinhx/reactive/component.py`, placed in the existing ClassVar block beside `state_hash_exclude`, documented with a prose docstring directly below the assignment like every other ClassVar there. Because it is a plain inherited ClassVar overridden by reassignment in a subclass body — the same mechanism `state_hash_exclude` uses — no `__init_subclass__` / `__pydantic_init_subclass__` change is required, and no other module is touched.
+
+**Tech Stack:** Python 3, pydantic (`BaseComponent` is a pydantic model base), pytest, ruff, basedpyright, uv.
+
+**Spec:** `docs/superpowers/specs/issue-1011-design.md` (reproduced verbatim at the top of this file). Milestone-level design: `docs/superpowers/specs/2026-08-23-nested-reactive-oob-preserve-design.md:110-112`.
+
+## Global Constraints
+
+- Branch `m18/task-1011`, worktree `/home/mtts/Code/libs/pyjinhx/.claude/worktrees/m18/task-1011`, cut fresh from `origin/master`. Assume no code from #1012 or #1013 exists.
+- Do NOT touch `pyjinhx/reactive/root_attrs.py` or `pyjinhx/reactive/fanout.py` — those are #1012 and #1013 territory.
+- Do NOT add an `__init_subclass__` / `__pydantic_init_subclass__` hook for this flag.
+- Exact new declaration, verbatim: `retain_across_parent_swaps: ClassVar[bool] = True`.
+- No validation, no coercion, no new exception types or messages. A non-bool assignment is a static typing concern only.
+- ClassVar convention in this file: `ClassVar[...]` annotation, class-level default, and a short prose docstring immediately below the assignment (a docstring, not an inline comment).
+- Tests go in the mirrored-package tree only: `tests/pyjinhx/reactive/test_reactive_component.py` (rule at `docs/superpowers/rebuild/implementation-overview.md:59`). Not `tests/unit/`, `tests/integration/`, `tests/reactivity/`, or `tests/ui/`.
+- Run each verification command as its own invocation; never chain them with `&&`.
+
+---
+
+### Task 1: Declare the `retain_across_parent_swaps` ClassVar
+
+**Files:**
+- Modify: `pyjinhx/reactive/component.py:60-62` (insert immediately after the `state_hash_exclude` docstring, before `_pjx_cache_policy` at line 64)
+- Test: `tests/pyjinhx/reactive/test_reactive_component.py` (append to the end of the file, after `test_cache_alone_does_not_disturb_the_react_keys` at line 769-773)
+
+**Interfaces:**
+- Consumes: `ReactiveComponent` from `pyjinhx.reactive.component` — already imported at the top of the test file (line 10: `from pyjinhx.reactive.component import PjxKey, ReactiveComponent`). No new imports are needed in the test file.
+- Note on the override syntax: a subclass reassigns the flag bare, with no re-annotation (`retain_across_parent_swaps = False`), because pydantic permits an un-annotated assignment when the name is an inherited ClassVar. That is exactly how `state_hash_exclude` is overridden today — see `tests/pyjinhx/reactive/test_reactive_state_hash.py:29` — so do not re-annotate it as `ClassVar[bool]` in the subclass bodies.
+- Produces: `ReactiveComponent.retain_across_parent_swaps: ClassVar[bool]`, default `True`. #1013 will read it as `type(component).retain_across_parent_swaps`; this task only guarantees the attribute exists, defaults to `True`, and is overridden per-class by plain reassignment in a subclass body.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these four tests to the end of `tests/pyjinhx/reactive/test_reactive_component.py`, after `test_cache_alone_does_not_disturb_the_react_keys`:
+
+```python
+def test_retain_across_parent_swaps_defaults_to_true():
+    assert ReactiveComponent.retain_across_parent_swaps is True
+
+
+def test_retain_across_parent_swaps_is_inherited_by_a_silent_subclass():
+    class Widget(ReactiveComponent):
+        pass
+
+    assert Widget.retain_across_parent_swaps is True
+    assert Widget().retain_across_parent_swaps is True
+
+
+def test_a_subclass_can_opt_out_of_retain_across_parent_swaps_without_mutating_the_base():
+    class Widget(ReactiveComponent):
+        retain_across_parent_swaps = False
+
+    class Child(Widget):
+        pass
+
+    assert Widget.retain_across_parent_swaps is False
+    assert Child.retain_across_parent_swaps is False
+    assert ReactiveComponent.retain_across_parent_swaps is True
+
+
+def test_sibling_subclasses_set_retain_across_parent_swaps_independently():
+    class OptedOut(ReactiveComponent):
+        retain_across_parent_swaps = False
+
+    class Silent(ReactiveComponent):
+        pass
+
+    assert OptedOut.retain_across_parent_swaps is False
+    assert Silent.retain_across_parent_swaps is True
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/pyjinhx/reactive/test_reactive_component.py -k retain_across_parent_swaps -v`
+
+Expected: all four FAIL with `AttributeError: type object 'ReactiveComponent' has no attribute 'retain_across_parent_swaps'` (or the same `AttributeError` named for the subclass).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `pyjinhx/reactive/component.py`, insert the new declaration between the `state_hash_exclude` docstring (ends line 62) and `_pjx_cache_policy` (line 64), so the block reads:
+
+```python
+    state_hash_exclude: ClassVar[frozenset[str]] = frozenset({"id"})
+    """Field names left out of the state hash. A subclass's value replaces this
+    one outright rather than adding to it."""
+
+    retain_across_parent_swaps: ClassVar[bool] = True
+    """Whether this class's rendered region survives an ancestor's OOB swap
+    untouched when nothing it depends on was dirtied. A subclass sets this to
+    False to declare itself fully owned by its parent, so a parent swap always
+    re-renders it rather than preserving what is on the page."""
+
+    _pjx_cache_policy: ClassVar[CachePolicy | Literal[False] | None] = None
+```
+
+`ClassVar` is already imported at `pyjinhx/reactive/component.py:16`; add no imports.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/pyjinhx/reactive/test_reactive_component.py -k retain_across_parent_swaps -v`
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Run the tier-1 suite**
+
+Run: `uv run pytest tests/pyjinhx/`
+
+Expected: PASS, no new failures.
+
+- [ ] **Step 6: Run the tier-2 suite**
+
+Run: `uv run pytest tests/`
+
+Expected: PASS, no new failures.
+
+- [ ] **Step 7: Run the type checker**
+
+Run: `uvx "basedpyright==1.39.9" pyjinhx/`
+
+Expected: no new errors relative to `master`. `retain_across_parent_swaps` is a `ClassVar[bool]`, so a subclass assigning `= False` type-checks; assigning a non-bool is the static error the spec intends and needs no runtime guard.
+
+- [ ] **Step 8: Format and lint**
+
+Run: `ruff format .`
+
+Then run: `ruff check .`
+
+Expected: formatter reports nothing to reformat in the two touched files; `ruff check` passes.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pyjinhx/reactive/component.py tests/pyjinhx/reactive/test_reactive_component.py
+git commit -m "feat: declare ReactiveComponent.retain_across_parent_swaps"
+```
+
+---
+
+### Task 2: Full verification sweep
+
+**Files:**
+- No source changes expected. If a tier fails, fix the cause in `pyjinhx/reactive/component.py` or `tests/pyjinhx/reactive/test_reactive_component.py` only — do not touch `pyjinhx/reactive/root_attrs.py` or `pyjinhx/reactive/fanout.py`.
+
+**Interfaces:**
+- Consumes: `ReactiveComponent.retain_across_parent_swaps: ClassVar[bool]` from Task 1.
+- Produces: nothing new; this task only proves the branch is green end to end.
+
+- [ ] **Step 1: Run the docs build**
+
+Run: `uv run mkdocs build --strict`
+
+Expected: build succeeds. This task adds no docs page; the flag stays undocumented until #1013 gives it observable behavior worth documenting.
+
+- [ ] **Step 2: Run the docs-field reference check**
+
+Run: `uv run pytest tests/pyjinhx/test_docs_reference_real_fields.py -q`
+
+Expected: PASS. This check flags docs that name fields which do not exist; adding a field cannot break it.
+
+- [ ] **Step 3: Run the package build**
+
+Run: `uvx --from build python -m build`
+
+Expected: sdist and wheel build successfully.
+
+- [ ] **Step 4: Confirm no out-of-scope files were touched**
+
+Run: `git diff --stat origin/master...HEAD`
+
+Expected: exactly two files — `pyjinhx/reactive/component.py` and `tests/pyjinhx/reactive/test_reactive_component.py`. If `pyjinhx/reactive/root_attrs.py` or `pyjinhx/reactive/fanout.py` appear, revert those changes; they belong to #1012 and #1013.
+
+- [ ] **Step 5: Commit anything the sweep fixed**
+
+Only if steps 1-4 required a change:
+
+```bash
+git add pyjinhx/reactive/component.py tests/pyjinhx/reactive/test_reactive_component.py
+git commit -m "fix: address verification failures for retain_across_parent_swaps"
+```
+
+If nothing changed, skip this step — the branch is already complete at Task 1's commit.

--- a/docs/superpowers/plans/issue-1012.md
+++ b/docs/superpowers/plans/issue-1012.md
@@ -1,0 +1,560 @@
+<!-- task-pipeline: validated -->
+# Subtask #1012 — `record_nested_react_keys` on_rendered subscriber
+
+Parent story: #1009 "hx-preserve retention for disjoint nested reactive regions" (milestone 18, "Nested reactive OOB ownership"). Canonical design: `docs/superpowers/specs/2026-08-23-nested-reactive-oob-preserve-design.md`, Story 1 (lines 74-227). This subtask narrows Story 1 step 1 to its first half only: build the per-request map. Nothing consumes it yet.
+
+## Scope
+
+Add one exported function, `record_nested_react_keys(component, level, session)`, to `pyjinhx/reactive/root_attrs.py`, placed beside `stamp_reactive_root_attrs` (currently root_attrs.py:19-52), plus the per-request map it writes into, plus tests.
+
+Signature is fixed by the `on_rendered` callback shape: `Callable[[BaseComponent, RenderedLevel, RenderSession], None]` (`RenderSession.on_rendered`, session.py:242-244; invoked by `emit_rendered`, session.py:267-268). The two existing subscribers of that shape — `stamp_reactive_root_attrs` and `registry.register_rendered_instance` (registry.py:108-124) — are the parity references for docstring shape and for the "unused `session` argument" convention where applicable; here `session` *is* used, as the map's home.
+
+The map's home is a new per-request attribute on `RenderSession`, declared and initialized in `__init__` alongside `css_assets`/`pjx_mounted` (session.py:206-255), suggested name `nested_react_keys: dict[str, tuple[str, ...]]`. This is the one open implementation decision the subtask body leaves to the implementer; #1013 reads whatever name lands here, so the attribute must be named clearly and carry an inline comment explaining what it holds and who consumes it. A per-request map keyed by instance id and scoped to the session is what ADR 0009 (minimal instance registry, reactivity-only) and ADR 0012 (fan-out follows the request, not the return value) require — it must not become module-global or process-lived state.
+
+Map contents: for every `ReactiveComponent` rendered — root and nested alike — `component.id -> type(component)._pjx_react_keys` (a `tuple[str, ...]`, set per class in `__init_subclass__`, component.py:49/104). The key must be the same instance-id string that `fanout.py` resolves through `ChildRef.attrs["id"]` / `_root_instance_id(RenderedLevel)` in `_contained` (fanout.py:267-291), since that is where #1013 cross-references it.
+
+The subtask body says the value is `_pjx_react_keys` alone. The parent story spec's step 1 describes `id -> (react_keys, load_key)`. The subtask body is authoritative for #1012: record react keys only, and flag the discrepancy explicitly in the PR description so #1013 can decide whether it needs `load_key` too.
+
+Explicitly out of scope: any change to `pyjinhx/reactive/fanout.py` (#1013 owns `_contained`, `oob_swaps` at fanout.py:665, the `hx-preserve` splice, and the wiring that attaches this subscriber to the session `_build_dirty` uses); any change to `ReactiveComponent.retain_across_parent_swaps` (#1011, already implemented on branch `m18/task-1011`, PR #1015 — do not re-add); any auto-registration of the new subscriber.
+
+## Observable behavior
+
+- Exported, not auto-registered. Like `stamp_reactive_root_attrs`, callers append it to a session's `on_rendered` list explicitly. A session that never attaches it leaves the map empty; no production code path changes behavior as a result of this subtask.
+- Rendering a `ReactiveComponent` with a session that has the subscriber attached leaves `session.nested_react_keys[component.id]` equal to that class's `_pjx_react_keys` tuple.
+- A class declared with no `react=(...)` records the empty tuple `()` under its id — an entry is still made. Presence in the map means "this id is a reactive component"; the value answers "on what keys".
+- Every reactive component in a tree gets an entry, at every nesting depth, because `emit_rendered` fires once per component. Nested entries are the point of the subtask.
+- Non-reactive components are a no-op that costs one `isinstance` check and nothing else, matching the guard at root_attrs.py:37-38. No entry is written for them.
+- The subscriber composes with the others: attaching it alongside `stamp_reactive_root_attrs` neither perturbs the stamped root attributes nor mutates `level` in any way. `record_nested_react_keys` performs no splice and no rendered-output mutation at all; it is read-only against `component` and `level`.
+- Repeated renders in one session: a second render of the same id overwrites its entry with the same value. This is deliberately silent — unlike `registry.register_instance` (registry.py:95-105), no collision error and no warning, because the value is class-derived and idempotent.
+
+## Error paths
+
+There are none of its own. The function raises nothing, catches nothing, and validates nothing: `component.id` and `_pjx_react_keys` are both guaranteed present on any `ReactiveComponent`. Should it ever raise, `emit_rendered`'s comment (session.py:265-266) applies — exceptions propagate, a half-written session is not swallowed.
+
+## Test list
+
+Test-placement rule for this repo: tests live flat under `tests/pyjinhx/`, one file per source module named `test_<module>.py`, colocated in the matching subpackage directory. There is no unit/integration/reactivity tier split in practice (`tests/unit`, `tests/integration`, `tests/reactivity`, `tests/ui` hold no test files). So every test below goes in the single tier that exists, in `tests/pyjinhx/reactive/test_reactive_root_attrs.py`, added beside the existing `stamp_reactive_root_attrs` coverage — not in `tests/pyjinhx/reactive/test_reactive_fanout.py`, which is #1013's territory.
+
+All tests exercise the subscriber through a real `render_level()` pass against a `RenderSession` with `record_nested_react_keys` appended to `on_rendered`, reusing the module's existing `ReactiveWidget`/`PlainWidget` fixtures and `_descriptor_for` helper.
+
+1. A single reactive component declared with `react=("a", "b")` records `{id: ("a", "b")}` — value equality against the class's normalized `_pjx_react_keys`, not against the raw kwarg.
+2. A reactive component declared with no `react` kwarg records an entry whose value is `()`; the id is present in the map.
+3. A nested tree (reactive parent containing a reactive child, each with distinct `react` keys and distinct ids) records one entry per component, at both depths, with each id mapped to its own class's keys.
+4. A tree of non-reactive components only leaves the map empty.
+5. A mixed tree records entries for the reactive nodes only; non-reactive ids never appear as keys.
+6. The recorded id matches the id `fanout` would resolve for that node — assert the map key equals the `data-pjx-id` stamped onto the level's root tag when `stamp_reactive_root_attrs` is attached to the same session, which is the identity channel `_contained` reads.
+7. Composition/non-interference: with both subscribers attached, the rendered string is byte-identical to the same render with only `stamp_reactive_root_attrs` attached.
+8. Isolation: two independent `RenderSession` instances rendering the same component class each hold their own map; one session's entries never appear in the other's.
+
+## Verification
+
+fullSuite: `uv run pytest tests/pyjinhx/ ; uv run pytest tests/ ; uv venv .venv-min && uv pip install --python .venv-min . pytest && .venv-min/bin/python -m pytest tests/minimal/ -q`
+
+typecheck: `uvx "basedpyright==1.39.9" pyjinhx/`
+
+lint: `ruff format . ; ruff check .`
+
+---
+
+# `record_nested_react_keys` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an exported `on_rendered` subscriber that records every rendered reactive component's `id -> _pjx_react_keys` into a new per-request `RenderSession.nested_react_keys` map, so #1013 can later decide which nested reactive regions a parent swap must retain.
+
+**Architecture:** Two source edits only. `RenderSession.__init__` gains one more per-request state slot (`nested_react_keys: dict[str, tuple[str, ...]]`), initialized empty beside `pjx_mounted`/`css_assets`. `pyjinhx/reactive/root_attrs.py` gains `record_nested_react_keys`, a sibling of `stamp_reactive_root_attrs` with the identical `(component, level, session)` callback shape and the identical `isinstance(component, ReactiveComponent)` early return; it writes one dict entry and mutates nothing else. It is exported but never auto-registered — callers append it to `session.on_rendered` themselves, exactly as `pyjinhx/integrations/fastapi.py:209` does for `stamp_reactive_root_attrs`. No `fanout.py` change, no `component.py` change.
+
+**Tech Stack:** Python 3.12+, Pydantic-based `BaseComponent`, pytest, `uv`, ruff, basedpyright.
+
+**Spec:** `docs/superpowers/specs/issue-1012-design.md` (reproduced verbatim above this plan).
+
+## Global Constraints
+
+- Branch `m18/task-1012` in worktree `/home/mtts/Code/libs/pyjinhx/.claude/worktrees/m18/task-1012`, cut from `origin/m18/task-1011`. Assume no other subtask's code exists here beyond that base.
+- Do **not** touch `pyjinhx/reactive/fanout.py`. `_contained` (fanout.py:267-291) and `oob_swaps` (fanout.py:665) belong to #1013.
+- Do **not** add, remove, or edit `ReactiveComponent.retain_across_parent_swaps`. It belongs to #1011 and is already on the base branch.
+- Do **not** auto-register the new subscriber anywhere (not in `pyjinhx/integrations/fastapi.py`, not in `pyjinhx/reactive/fanout.py`). Export only.
+- New session attribute name is exactly `nested_react_keys`, typed exactly `dict[str, tuple[str, ...]]`. #1013 reads this name.
+- Map value is `type(component)._pjx_react_keys` alone. Do **not** add `load_key`, even though the parent story spec mentions it; instead flag the discrepancy in the PR description (Task 5).
+- Request-scoped state only: the map lives on the `RenderSession` instance. No module-level dict, no `ContextVar`, no class attribute (ADR 0009, ADR 0012).
+- All new tests go in `tests/pyjinhx/reactive/test_reactive_root_attrs.py` — the repo's single de facto test tier, one test file per source module colocated in the matching subpackage directory.
+- Verification commands, each run as its own invocation, never chained with `&&`:
+  - `uv run pytest tests/pyjinhx/`
+  - `uv run pytest tests/`
+  - `uv venv .venv-min && uv pip install --python .venv-min . pytest && .venv-min/bin/python -m pytest tests/minimal/ -q`
+  - `uvx "basedpyright==1.39.9" pyjinhx/`
+  - `ruff format .`
+  - `ruff check .`
+
+---
+
+### Task 1: The per-request map on `RenderSession`
+
+**Files:**
+- Modify: `pyjinhx/session.py:255` (end of `RenderSession.__init__`, right after `self.pjx_trigger`)
+- Test: `tests/pyjinhx/reactive/test_reactive_root_attrs.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `RenderSession.nested_react_keys: dict[str, tuple[str, ...]]` — empty dict on a fresh session, one per instance. Task 2 writes into it; #1013 reads it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append at the end of `tests/pyjinhx/reactive/test_reactive_root_attrs.py`:
+
+```python
+def test_fresh_session_starts_with_an_empty_nested_react_keys_map():
+    """#1012's per-request map: empty until a subscriber writes into it."""
+    assert RenderSession().nested_react_keys == {}
+
+
+def test_each_session_owns_its_own_nested_react_keys_map():
+    """Per-request by construction: no shared class-level or module-level dict."""
+    first = RenderSession()
+    second = RenderSession()
+
+    first.nested_react_keys["w"] = ("a",)
+
+    assert second.nested_react_keys == {}
+    assert first.nested_react_keys is not second.nested_react_keys
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/pyjinhx/reactive/test_reactive_root_attrs.py -k nested_react_keys_map -v`
+Expected: FAIL, both tests, with `AttributeError: 'RenderSession' object has no attribute 'nested_react_keys'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `pyjinhx/session.py`, in `RenderSession.__init__`, immediately after the `self.pjx_trigger: dict[str, Any] | None = None` line (session.py:255):
+
+```python
+        # Per-request map of reactive instance id -> that class's
+        # _pjx_react_keys, written by reactive.root_attrs.record_nested_react_keys
+        # when a caller appends it to on_rendered above. #1013's fan-out reads it
+        # to decide which nested reactive regions a parent swap must retain, so
+        # the key is the same instance-id string fanout's _contained resolves
+        # (ChildRef.attrs["id"] / _root_instance_id). Lives on the session, not
+        # module-global: it must die with the request.
+        self.nested_react_keys: dict[str, tuple[str, ...]] = {}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/pyjinhx/reactive/test_reactive_root_attrs.py -k nested_react_keys_map -v`
+Expected: PASS, 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyjinhx/session.py tests/pyjinhx/reactive/test_reactive_root_attrs.py
+git commit -m "feat: add per-request RenderSession.nested_react_keys map"
+```
+
+---
+
+### Task 2: `record_nested_react_keys` records reactive components
+
+**Files:**
+- Modify: `pyjinhx/reactive/root_attrs.py` (append after `stamp_reactive_root_attrs`, which ends at root_attrs.py:52)
+- Test: `tests/pyjinhx/reactive/test_reactive_root_attrs.py`
+
+**Interfaces:**
+- Consumes: `RenderSession.nested_react_keys: dict[str, tuple[str, ...]]` from Task 1.
+- Produces: `record_nested_react_keys(component: BaseComponent, level: RenderedLevel, session: RenderSession) -> None` — an `on_rendered`-shaped subscriber, exported from `pyjinhx.reactive.root_attrs`, never auto-registered.
+
+- [ ] **Step 1: Add the test fixtures this task and Tasks 3-4 need**
+
+In `tests/pyjinhx/reactive/test_reactive_root_attrs.py`, add these class definitions and descriptors immediately after the `ReactiveShell.__pjx_descriptor__ = ClassDescriptor(...)` block (currently test file lines 81-89):
+
+```python
+class KeyedReactiveWidget(ReactiveComponent, react=("a", "b")):
+    pass
+
+
+class UnkeyedReactiveWidget(ReactiveComponent):
+    pass
+
+
+class KeyedReactiveShell(ReactiveComponent, react=("shell",)):
+    body: Slot = ""
+
+
+class PlainShell(BaseComponent):
+    body: Slot = ""
+
+
+KeyedReactiveWidget.__pjx_descriptor__ = _descriptor_for(
+    KeyedReactiveWidget, "reactive_widget.html"
+)
+UnkeyedReactiveWidget.__pjx_descriptor__ = _descriptor_for(
+    UnkeyedReactiveWidget, "reactive_widget.html"
+)
+KeyedReactiveShell.__pjx_descriptor__ = ClassDescriptor(
+    template_path=_TEMPLATE_DIR / "reactive_shell.html",
+    slot_fields=frozenset({"body"}),
+    children_field=None,
+    css_paths=(),
+    js_paths=(),
+    strict=True,
+    provenance={"template": KeyedReactiveShell},
+)
+PlainShell.__pjx_descriptor__ = ClassDescriptor(
+    template_path=_TEMPLATE_DIR / "reactive_shell.html",
+    slot_fields=frozenset({"body"}),
+    children_field=None,
+    css_paths=(),
+    js_paths=(),
+    strict=True,
+    provenance={"template": PlainShell},
+)
+```
+
+Then add this fixture immediately after the existing `session` fixture (test file lines 154-159):
+
+```python
+@pytest.fixture
+def recording_session() -> RenderSession:
+    """A session with only the nested-react-keys recorder attached."""
+    session = RenderSession()
+    session.on_rendered.append(record_nested_react_keys)
+    return session
+```
+
+And extend the existing import at test file line 18 to:
+
+```python
+from pyjinhx.reactive.root_attrs import (
+    record_nested_react_keys,
+    stamp_reactive_root_attrs,
+)
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append at the end of `tests/pyjinhx/reactive/test_reactive_root_attrs.py`:
+
+```python
+def test_records_a_reactive_components_declared_react_keys(
+    recording_session: RenderSession,
+):
+    """Spec test 1: the value is the class's normalized _pjx_react_keys tuple."""
+    component = KeyedReactiveWidget(id="k1")
+
+    render_level(component, recording_session)
+
+    assert recording_session.nested_react_keys == {
+        "k1": KeyedReactiveWidget._pjx_react_keys
+    }
+    assert recording_session.nested_react_keys["k1"] == ("a", "b")
+
+
+def test_reactive_component_without_react_kwarg_records_an_empty_tuple(
+    recording_session: RenderSession,
+):
+    """Spec test 2: presence means 'reactive'; the value answers 'on what keys'."""
+    render_level(UnkeyedReactiveWidget(id="u1"), recording_session)
+
+    assert "u1" in recording_session.nested_react_keys
+    assert recording_session.nested_react_keys["u1"] == ()
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/pyjinhx/reactive/test_reactive_root_attrs.py -k "records_a_reactive_components_declared or without_react_kwarg" -v`
+Expected: FAIL at collection/import time with `ImportError: cannot import name 'record_nested_react_keys' from 'pyjinhx.reactive.root_attrs'`.
+
+- [ ] **Step 4: Write the minimal implementation**
+
+Append to `pyjinhx/reactive/root_attrs.py`, after `stamp_reactive_root_attrs` (which ends at root_attrs.py:52):
+
+```python
+def record_nested_react_keys(
+    component: BaseComponent, level: RenderedLevel, session: RenderSession
+) -> None:
+    """Record a rendered reactive component's react keys under its instance id."""
+    session.nested_react_keys[component.id] = type(component)._pjx_react_keys  # pyright: ignore[reportAttributeAccessIssue]
+```
+
+Note: this deliberately has no `isinstance` guard yet and carries a temporary pyright suppression — Task 3 adds the guard and removes the suppression. Do not run the typecheck command against this intermediate state.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/pyjinhx/reactive/test_reactive_root_attrs.py -k "records_a_reactive_components_declared or without_react_kwarg" -v`
+Expected: PASS, 2 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyjinhx/reactive/root_attrs.py tests/pyjinhx/reactive/test_reactive_root_attrs.py
+git commit -m "feat: record reactive components' react keys on the render session"
+```
+
+---
+
+### Task 3: Non-reactive components are a no-op
+
+**Files:**
+- Modify: `pyjinhx/reactive/root_attrs.py` (the `record_nested_react_keys` body added in Task 2)
+- Test: `tests/pyjinhx/reactive/test_reactive_root_attrs.py`
+
+**Interfaces:**
+- Consumes: `record_nested_react_keys(component, level, session)` from Task 2; the `recording_session` fixture and the `PlainShell` / `KeyedReactiveShell` fixtures from Task 2 Step 1.
+- Produces: the final shape of `record_nested_react_keys` — an `isinstance(component, ReactiveComponent)` early return before any read, mirroring `stamp_reactive_root_attrs` (root_attrs.py:38-39), so a non-reactive tree pays one isinstance check per component and nothing else.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append at the end of `tests/pyjinhx/reactive/test_reactive_root_attrs.py`:
+
+```python
+def test_a_tree_of_plain_components_records_nothing(
+    recording_session: RenderSession,
+):
+    """Spec test 4: non-reactive components are a bare isinstance no-op."""
+    render_level(PlainShell(id="ps1", body=PlainWidget(id="pw1")), recording_session)
+
+    assert recording_session.nested_react_keys == {}
+
+
+def test_a_mixed_tree_records_only_its_reactive_nodes(
+    recording_session: RenderSession,
+):
+    """Spec test 5: a plain child of a reactive parent never becomes a key."""
+    render_level(
+        KeyedReactiveShell(id="mix1", body=PlainWidget(id="plain1")),
+        recording_session,
+    )
+
+    assert recording_session.nested_react_keys == {"mix1": ("shell",)}
+    assert "plain1" not in recording_session.nested_react_keys
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/pyjinhx/reactive/test_reactive_root_attrs.py -k "tree_of_plain_components or mixed_tree_records" -v`
+Expected: FAIL, both tests, with `AttributeError: type object 'PlainWidget' has no attribute '_pjx_react_keys'` (raised out of `emit_rendered`, which lets subscriber exceptions propagate).
+
+- [ ] **Step 3: Write the implementation**
+
+Replace the whole `record_nested_react_keys` body in `pyjinhx/reactive/root_attrs.py` with the final version, guard and full docstring included:
+
+```python
+def record_nested_react_keys(
+    component: BaseComponent, level: RenderedLevel, session: RenderSession
+) -> None:
+    """Record a rendered reactive component's react keys under its instance id.
+
+    Shaped for ``RenderSession.on_rendered`` and exported rather than
+    auto-registered: a session that never appends it keeps an empty
+    ``nested_react_keys`` map, so nothing in a normal render changes. A
+    non-reactive component returns before anything is read, so a tree with no
+    reactive nodes pays one isinstance check per component and nothing else.
+
+    ``emit_rendered`` fires once per component, so every reactive node lands an
+    entry at every nesting depth — the nested entries are what #1013's fan-out
+    needs to tell a disjoint nested reactive region from part of a parent's own
+    swap. A class declared without ``react=(...)`` records the empty tuple:
+    presence of an id means "this is a reactive component", the value answers
+    "on what keys". A repeat render of one id overwrites in silence — unlike
+    ``registry.register_instance``, there is nothing to collide over, since the
+    value is class-derived and every write for one id is identical.
+
+    Args:
+        component: The component that just finished rendering.
+        level: That component's RenderedLevel (unused; this subscriber splices
+            nothing and leaves the rendered output byte-identical).
+        session: The RenderSession this render ran against; its
+            ``nested_react_keys`` map is where the entry lands.
+    """
+    if not isinstance(component, ReactiveComponent):
+        return
+    session.nested_react_keys[component.id] = type(component)._pjx_react_keys
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/pyjinhx/reactive/test_reactive_root_attrs.py -k "tree_of_plain_components or mixed_tree_records" -v`
+Expected: PASS, 2 passed.
+
+- [ ] **Step 5: Run the whole module's tests to verify nothing regressed**
+
+Run: `uv run pytest tests/pyjinhx/reactive/test_reactive_root_attrs.py -v`
+Expected: PASS, all tests including the pre-existing `stamp_reactive_root_attrs` suite.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyjinhx/reactive/root_attrs.py tests/pyjinhx/reactive/test_reactive_root_attrs.py
+git commit -m "feat: skip non-reactive components in record_nested_react_keys"
+```
+
+---
+
+### Task 4: Lock in nesting, identity, composition and isolation
+
+**Files:**
+- Test: `tests/pyjinhx/reactive/test_reactive_root_attrs.py`
+
+**Interfaces:**
+- Consumes: the final `record_nested_react_keys` from Task 3; the `session` fixture (only `stamp_reactive_root_attrs` attached), the `recording_session` fixture, and the `KeyedReactiveWidget` / `KeyedReactiveShell` fixtures.
+- Produces: nothing new in `pyjinhx/`. These are the four remaining spec behaviors (spec tests 3, 6, 7, 8) that the Task 2/3 implementation already satisfies; they exist so #1013 cannot silently break them.
+
+**Important:** these tests must pass on their first run with **no** change to `pyjinhx/`. If one fails, that is a real defect in Task 2/3's implementation — stop, use `superpowers:systematic-debugging`, and fix the source rather than weakening the test.
+
+- [ ] **Step 1: Write the tests**
+
+Append at the end of `tests/pyjinhx/reactive/test_reactive_root_attrs.py`:
+
+```python
+def test_every_depth_of_a_nested_reactive_tree_gets_its_own_entry(
+    recording_session: RenderSession,
+):
+    """Spec test 3: nested entries are the point — one per component, per class."""
+    child = KeyedReactiveWidget(id="inner-k")
+    parent = KeyedReactiveShell(id="outer-k", body=child)
+
+    render_level(parent, recording_session)
+
+    assert recording_session.nested_react_keys == {
+        "outer-k": ("shell",),
+        "inner-k": ("a", "b"),
+    }
+
+
+def test_the_recorded_id_is_the_id_stamped_as_data_pjx_id():
+    """Spec test 6: the map key is the identity channel fanout's _contained reads."""
+    both = RenderSession()
+    both.on_rendered.append(stamp_reactive_root_attrs)
+    both.on_rendered.append(record_nested_react_keys)
+
+    html = serialize(render_level(KeyedReactiveWidget(id="ident1"), both))
+
+    assert list(both.nested_react_keys) == ["ident1"]
+    assert 'data-pjx-id="ident1"' in html
+
+
+def test_recording_leaves_the_rendered_markup_byte_identical():
+    """Spec test 7: the recorder splices nothing and perturbs no other stamp."""
+    stamp_only = RenderSession()
+    stamp_only.on_rendered.append(stamp_reactive_root_attrs)
+    both = RenderSession()
+    both.on_rendered.append(stamp_reactive_root_attrs)
+    both.on_rendered.append(record_nested_react_keys)
+
+    without = serialize(
+        render_level(
+            KeyedReactiveShell(id="bytes1", body=KeyedReactiveWidget(id="bytes2")),
+            stamp_only,
+        )
+    )
+    with_recorder = serialize(
+        render_level(
+            KeyedReactiveShell(id="bytes1", body=KeyedReactiveWidget(id="bytes2")),
+            both,
+        )
+    )
+
+    assert with_recorder == without
+    assert both.nested_react_keys == {"bytes1": ("shell",), "bytes2": ("a", "b")}
+    assert stamp_only.nested_react_keys == {}
+
+
+def test_two_sessions_never_see_each_others_entries():
+    """Spec test 8: request-scoped state, per ADR 0009/0012."""
+    first = RenderSession()
+    first.on_rendered.append(record_nested_react_keys)
+    second = RenderSession()
+    second.on_rendered.append(record_nested_react_keys)
+
+    render_level(KeyedReactiveWidget(id="s1"), first)
+    render_level(KeyedReactiveWidget(id="s2"), second)
+
+    assert first.nested_react_keys == {"s1": ("a", "b")}
+    assert second.nested_react_keys == {"s2": ("a", "b")}
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `uv run pytest tests/pyjinhx/reactive/test_reactive_root_attrs.py -k "every_depth_of_a_nested or recorded_id_is_the_id or byte_identical or two_sessions_never" -v`
+Expected: PASS, 4 passed, with no edit to `pyjinhx/`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/pyjinhx/reactive/test_reactive_root_attrs.py
+git commit -m "test: lock nesting, identity, composition and session isolation for record_nested_react_keys"
+```
+
+---
+
+### Task 5: Full verification and PR note
+
+**Files:**
+- Modify (only if `ruff format` rewrites them): `pyjinhx/session.py`, `pyjinhx/reactive/root_attrs.py`, `tests/pyjinhx/reactive/test_reactive_root_attrs.py`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4.
+- Produces: a clean tree against all five verification commands, plus the PR-description paragraph flagging the `load_key` scope discrepancy.
+
+- [ ] **Step 1: Confirm no out-of-scope file changed**
+
+Run: `git diff --stat origin/m18/task-1011...HEAD`
+Expected: exactly three files — `pyjinhx/session.py`, `pyjinhx/reactive/root_attrs.py`, `tests/pyjinhx/reactive/test_reactive_root_attrs.py`. If `pyjinhx/reactive/fanout.py` or `pyjinhx/reactive/component.py` appears, revert that file: it belongs to #1013 / #1011.
+
+- [ ] **Step 2: Format**
+
+Run: `ruff format .`
+Expected: reports only the files above as reformatted, or "0 files reformatted".
+
+- [ ] **Step 3: Lint**
+
+Run: `ruff check .`
+Expected: "All checks passed!".
+
+- [ ] **Step 4: Typecheck**
+
+Run: `uvx "basedpyright==1.39.9" pyjinhx/`
+Expected: 0 errors. In particular the temporary `# pyright: ignore[reportAttributeAccessIssue]` from Task 2 Step 4 must be gone (Task 3 Step 3 replaced that line); if basedpyright reports an unnecessary-ignore, delete the leftover comment.
+
+- [ ] **Step 5: Run tier 1**
+
+Run: `uv run pytest tests/pyjinhx/`
+Expected: PASS, no failures.
+
+- [ ] **Step 6: Run tier 2**
+
+Run: `uv run pytest tests/`
+Expected: PASS, no failures.
+
+- [ ] **Step 7: Run tier 3 (minimal-install suite)**
+
+Run: `uv venv .venv-min && uv pip install --python .venv-min . pytest && .venv-min/bin/python -m pytest tests/minimal/ -q`
+Expected: PASS, no failures.
+
+- [ ] **Step 8: Commit any formatting fallout**
+
+```bash
+git add -A
+git commit -m "chore: ruff format after record_nested_react_keys" || echo "nothing to commit"
+```
+
+- [ ] **Step 9: Record the PR-description note**
+
+Include this paragraph verbatim in the PR body when the PR for #1012 is opened:
+
+```markdown
+**Scope note for #1013:** the subtask body for #1012 specifies the per-request
+map's value as `_pjx_react_keys` alone, while the parent story spec
+(`docs/superpowers/specs/2026-08-23-nested-reactive-oob-preserve-design.md`,
+Story 1 step 1) describes `id -> (react_keys, load_key)`. This PR follows the
+subtask body and records react keys only. If #1013's `_contained`
+cross-reference turns out to need the load key too, widening
+`RenderSession.nested_react_keys`' value type is a one-line change in
+`record_nested_react_keys` — flagging it here rather than pre-building it.
+
+**Consumed by #1013:** the attribute name is `RenderSession.nested_react_keys`,
+typed `dict[str, tuple[str, ...]]`, keyed by the same instance-id string
+`fanout._contained` resolves via `ChildRef.attrs["id"]` / `_root_instance_id`.
+The subscriber is exported and **not** auto-registered: #1013 must append
+`record_nested_react_keys` to the session `_build_dirty` uses.
+```

--- a/docs/superpowers/specs/issue-1011-design.md
+++ b/docs/superpowers/specs/issue-1011-design.md
@@ -1,0 +1,42 @@
+# Issue #1011 — declare `ReactiveComponent.retain_across_parent_swaps`
+
+Subtask 1 of 3 under story #1009 (`hx-preserve` retention for disjoint nested reactive regions, fixes #1008), milestone 18 "Nested reactive OOB ownership". Narrows the milestone design at `docs/superpowers/specs/2026-08-23-nested-reactive-oob-preserve-design.md:110-112` to its first slice: the declaration of the opt-out flag, with nothing reading it yet.
+
+## Scope
+
+In scope: one new public ClassVar on `ReactiveComponent` in `pyjinhx/reactive/component.py`, plus unit tests for it.
+
+```python
+retain_across_parent_swaps: ClassVar[bool] = True
+```
+
+It is placed in the existing ClassVar block in the class body (`pyjinhx/reactive/component.py:52-67`), next to `state_hash_exclude` (line 60), which is its closest sibling in both name and role — a public, subclass-overridable knob, as opposed to the `_pjx_`-prefixed derived facts around it. It carries a short prose docstring immediately below the assignment, matching the convention of every other ClassVar in that block (docstring, not an inline comment), saying what the flag means and that a subclass sets it `False` to opt out of ever being preserved against an ancestor's OOB swap — i.e. to declare itself fully owned by its parent.
+
+Out of scope, and explicitly owned by the sibling subtasks, which are still Backlog:
+
+- Recording nested react-keys during dirty rebuilds — `pyjinhx/reactive/root_attrs.py` and `pyjinhx/reactive/fanout.py` (#1012).
+- Reading this flag and splicing `hx-preserve="true"` in `oob_swaps()` — `pyjinhx/reactive/fanout.py` (#1013).
+
+#1011 must not touch `root_attrs.py` or `fanout.py`. No `__init_subclass__` / `__pydantic_init_subclass__` change is needed: unlike `react=(...)` and the cache kwargs, this flag has no consumption path at class-definition time. It is a plain inherited ClassVar that a subclass overrides by reassignment in its body, exactly the mechanism `state_hash_exclude` uses.
+
+## Observable behavior
+
+- `ReactiveComponent.retain_across_parent_swaps` exists and is `True`.
+- A subclass that says nothing inherits `True`; the value is visible on both the class and an instance.
+- A subclass that assigns `retain_across_parent_swaps = False` reads back `False` on that class and its own subclasses, while `ReactiveComponent` and unrelated sibling subclasses still read `True` — the override is per-class, never a mutation of the base.
+- Setting it changes no rendering, no OOB swap, no cache behavior in this subtask. The flag is inert until #1013 wires it as one of three AND-ed conditions for stamping `hx-preserve="true"` onto a nested root (react-keys disjoint from the dirtied set; the id not itself a dirty/missing candidate in the same walk; `retain_across_parent_swaps` True on the owning class).
+
+## Error paths
+
+None. There is no validation, no coercion, and no rejection at class-definition time — a non-bool assignment is a static typing concern only, consistent with how the neighbouring ClassVars behave. No new exception types, no new messages.
+
+## Tests
+
+Tier per the test-placement rule at `docs/superpowers/rebuild/implementation-overview.md:59` ("Tests mirror the package: `tests/pyjinhx/test_<module>.py` per module, `tests/pyjinhx/reactive/` for the cluster"): all of these are unit tests in the mirrored-package tree, in the existing `tests/pyjinhx/reactive/test_reactive_component.py`, beside the other `ReactiveComponent` ClassVar tests (e.g. the `_pjx_cache_policy` tests already there).
+
+1. `retain_across_parent_swaps` defaults to `True` on `ReactiveComponent` itself — `tests/pyjinhx/reactive/test_reactive_component.py`.
+2. A subclass that does not mention the flag inherits `True` — same file.
+3. A subclass assigning `retain_across_parent_swaps = False` reads back `False`, and `ReactiveComponent` still reads `True` (no base mutation) — same file.
+4. Two sibling subclasses set it independently: one `False`, one left alone, and each keeps its own value — same file.
+
+Not tested here: "a nested class with `retain_across_parent_swaps = False` -> no stamp, even when keys are disjoint" (milestone spec Testing section, lines 174-177). That is Story 1's end-to-end assertion and requires the wired `oob_swaps()` behavior, so it is owned by #1013.

--- a/docs/superpowers/specs/issue-1012-design.md
+++ b/docs/superpowers/specs/issue-1012-design.md
@@ -1,0 +1,54 @@
+# Subtask #1012 — `record_nested_react_keys` on_rendered subscriber
+
+Parent story: #1009 "hx-preserve retention for disjoint nested reactive regions" (milestone 18, "Nested reactive OOB ownership"). Canonical design: `docs/superpowers/specs/2026-08-23-nested-reactive-oob-preserve-design.md`, Story 1 (lines 74-227). This subtask narrows Story 1 step 1 to its first half only: build the per-request map. Nothing consumes it yet.
+
+## Scope
+
+Add one exported function, `record_nested_react_keys(component, level, session)`, to `pyjinhx/reactive/root_attrs.py`, placed beside `stamp_reactive_root_attrs` (currently root_attrs.py:19-52), plus the per-request map it writes into, plus tests.
+
+Signature is fixed by the `on_rendered` callback shape: `Callable[[BaseComponent, RenderedLevel, RenderSession], None]` (`RenderSession.on_rendered`, session.py:242-244; invoked by `emit_rendered`, session.py:267-268). The two existing subscribers of that shape — `stamp_reactive_root_attrs` and `registry.register_rendered_instance` (registry.py:108-124) — are the parity references for docstring shape and for the "unused `session` argument" convention where applicable; here `session` *is* used, as the map's home.
+
+The map's home is a new per-request attribute on `RenderSession`, declared and initialized in `__init__` alongside `css_assets`/`pjx_mounted` (session.py:206-255), suggested name `nested_react_keys: dict[str, tuple[str, ...]]`. This is the one open implementation decision the subtask body leaves to the implementer; #1013 reads whatever name lands here, so the attribute must be named clearly and carry an inline comment explaining what it holds and who consumes it. A per-request map keyed by instance id and scoped to the session is what ADR 0009 (minimal instance registry, reactivity-only) and ADR 0012 (fan-out follows the request, not the return value) require — it must not become module-global or process-lived state.
+
+Map contents: for every `ReactiveComponent` rendered — root and nested alike — `component.id -> type(component)._pjx_react_keys` (a `tuple[str, ...]`, set per class in `__init_subclass__`, component.py:49/104). The key must be the same instance-id string that `fanout.py` resolves through `ChildRef.attrs["id"]` / `_root_instance_id(RenderedLevel)` in `_contained` (fanout.py:267-291), since that is where #1013 cross-references it.
+
+The subtask body says the value is `_pjx_react_keys` alone. The parent story spec's step 1 describes `id -> (react_keys, load_key)`. The subtask body is authoritative for #1012: record react keys only, and flag the discrepancy explicitly in the PR description so #1013 can decide whether it needs `load_key` too.
+
+Explicitly out of scope: any change to `pyjinhx/reactive/fanout.py` (#1013 owns `_contained`, `oob_swaps` at fanout.py:665, the `hx-preserve` splice, and the wiring that attaches this subscriber to the session `_build_dirty` uses); any change to `ReactiveComponent.retain_across_parent_swaps` (#1011, already implemented on branch `m18/task-1011`, PR #1015 — do not re-add); any auto-registration of the new subscriber.
+
+## Observable behavior
+
+- Exported, not auto-registered. Like `stamp_reactive_root_attrs`, callers append it to a session's `on_rendered` list explicitly. A session that never attaches it leaves the map empty; no production code path changes behavior as a result of this subtask.
+- Rendering a `ReactiveComponent` with a session that has the subscriber attached leaves `session.nested_react_keys[component.id]` equal to that class's `_pjx_react_keys` tuple.
+- A class declared with no `react=(...)` records the empty tuple `()` under its id — an entry is still made. Presence in the map means "this id is a reactive component"; the value answers "on what keys".
+- Every reactive component in a tree gets an entry, at every nesting depth, because `emit_rendered` fires once per component. Nested entries are the point of the subtask.
+- Non-reactive components are a no-op that costs one `isinstance` check and nothing else, matching the guard at root_attrs.py:37-38. No entry is written for them.
+- The subscriber composes with the others: attaching it alongside `stamp_reactive_root_attrs` neither perturbs the stamped root attributes nor mutates `level` in any way. `record_nested_react_keys` performs no splice and no rendered-output mutation at all; it is read-only against `component` and `level`.
+- Repeated renders in one session: a second render of the same id overwrites its entry with the same value. This is deliberately silent — unlike `registry.register_instance` (registry.py:95-105), no collision error and no warning, because the value is class-derived and idempotent.
+
+## Error paths
+
+There are none of its own. The function raises nothing, catches nothing, and validates nothing: `component.id` and `_pjx_react_keys` are both guaranteed present on any `ReactiveComponent`. Should it ever raise, `emit_rendered`'s comment (session.py:265-266) applies — exceptions propagate, a half-written session is not swallowed.
+
+## Test list
+
+Test-placement rule for this repo: tests live flat under `tests/pyjinhx/`, one file per source module named `test_<module>.py`, colocated in the matching subpackage directory. There is no unit/integration/reactivity tier split in practice (`tests/unit`, `tests/integration`, `tests/reactivity`, `tests/ui` hold no test files). So every test below goes in the single tier that exists, in `tests/pyjinhx/reactive/test_reactive_root_attrs.py`, added beside the existing `stamp_reactive_root_attrs` coverage — not in `tests/pyjinhx/reactive/test_reactive_fanout.py`, which is #1013's territory.
+
+All tests exercise the subscriber through a real `render_level()` pass against a `RenderSession` with `record_nested_react_keys` appended to `on_rendered`, reusing the module's existing `ReactiveWidget`/`PlainWidget` fixtures and `_descriptor_for` helper.
+
+1. A single reactive component declared with `react=("a", "b")` records `{id: ("a", "b")}` — value equality against the class's normalized `_pjx_react_keys`, not against the raw kwarg.
+2. A reactive component declared with no `react` kwarg records an entry whose value is `()`; the id is present in the map.
+3. A nested tree (reactive parent containing a reactive child, each with distinct `react` keys and distinct ids) records one entry per component, at both depths, with each id mapped to its own class's keys.
+4. A tree of non-reactive components only leaves the map empty.
+5. A mixed tree records entries for the reactive nodes only; non-reactive ids never appear as keys.
+6. The recorded id matches the id `fanout` would resolve for that node — assert the map key equals the `data-pjx-id` stamped onto the level's root tag when `stamp_reactive_root_attrs` is attached to the same session, which is the identity channel `_contained` reads.
+7. Composition/non-interference: with both subscribers attached, the rendered string is byte-identical to the same render with only `stamp_reactive_root_attrs` attached.
+8. Isolation: two independent `RenderSession` instances rendering the same component class each hold their own map; one session's entries never appear in the other's.
+
+## Verification
+
+fullSuite: `uv run pytest tests/pyjinhx/ ; uv run pytest tests/ ; uv venv .venv-min && uv pip install --python .venv-min . pytest && .venv-min/bin/python -m pytest tests/minimal/ -q`
+
+typecheck: `uvx "basedpyright==1.39.9" pyjinhx/`
+
+lint: `ruff format . ; ruff check .`

--- a/pyjinhx/reactive/component.py
+++ b/pyjinhx/reactive/component.py
@@ -61,6 +61,12 @@ class ReactiveComponent(BaseComponent):
     """Field names left out of the state hash. A subclass's value replaces this
     one outright rather than adding to it."""
 
+    retain_across_parent_swaps: ClassVar[bool] = True
+    """Whether this class's rendered region survives an ancestor's OOB swap
+    untouched when nothing it depends on was dirtied. A subclass sets this to
+    False to declare itself fully owned by its parent, so a parent swap always
+    re-renders it rather than preserving what is on the page."""
+
     _pjx_cache_policy: ClassVar[CachePolicy | Literal[False] | None] = None
     """This class's cross-request cache policy: a CachePolicy that overrides the
     process default, False for tier-1-only, or None when the class said nothing

--- a/pyjinhx/reactive/fanout.py
+++ b/pyjinhx/reactive/fanout.py
@@ -202,6 +202,14 @@ RE_ROOT_PJX_ID = re.compile(
     r'data-pjx-id\s*=\s*"([^"]*)"|data-pjx-id\s*=\s*\'([^\']*)\''
 )
 
+RE_ROOT_PJX_TYPE = re.compile(
+    r'data-pjx-type\s*=\s*"([^"]*)"|data-pjx-type\s*=\s*\'([^\']*)\''
+)
+
+RE_ROOT_PJX_LOAD = re.compile(
+    r'data-pjx-load\s*=\s*"([^"]*)"|data-pjx-load\s*=\s*\'([^\']*)\''
+)
+
 
 def _mounted_ids_in(primary_html: object) -> set[str]:
     """Every ``data-pjx-id`` the primary response's markup already carries.
@@ -238,14 +246,13 @@ def _level_of(candidate: FanoutCandidate) -> RenderedLevel | None:
     return None
 
 
-def _root_instance_id(level: RenderedLevel) -> str | None:
-    """The ``data-pjx-id`` on this level's root tag, or None if unstamped.
+def _root_tag_text(level: RenderedLevel) -> str | None:
+    """This level's root opening tag, sliced at the offsets the parse recorded.
 
-    The exact inverse of ``stamp_root_attrs``: one read of the single tag whose
-    offsets the original parse recorded, never a re-parse and never a scan of
-    the rendered markup. ``_fill_children`` replaces a child's ChildRef with its
-    RenderedLevel and the authored ``id`` attr goes with it, so the stamped root
-    tag is the only place a nested level's instance identity still lives.
+    Never a re-parse and never a scan of the rendered markup: one read of the
+    single tag whose span the original parse wrote down. ``root_span`` is an
+    absolute offset into the raw source, so it is rebased by the summed length
+    of any whitespace-only prologue segments walked past first.
     """
     skipped = 0
     root: object = None
@@ -258,23 +265,90 @@ def _root_instance_id(level: RenderedLevel) -> str | None:
     if not isinstance(root, str):
         return None
     start, end = (offset - skipped for offset in level.root_span)
-    match = RE_ROOT_PJX_ID.search(root[start:end])
+    return root[start:end]
+
+
+def _tag_attr(tag_text: str, pattern: re.Pattern[str]) -> str | None:
+    """One attribute's value out of a root tag, double- or single-quoted."""
+    match = pattern.search(tag_text)
     if match is None:
         return None
     return match.group(1) if match.group(1) is not None else match.group(2)
 
 
-def _contained(level: RenderedLevel) -> tuple[set[str], set[int]]:
-    """Every id and every level object nested *strictly inside* this level.
+def _root_instance_id(level: RenderedLevel) -> str | None:
+    """The ``data-pjx-id`` on this level's root tag, or None if unstamped.
+
+    The exact inverse of ``stamp_root_attrs``. ``_fill_children`` replaces a
+    child's ChildRef with its RenderedLevel and the authored ``id`` attr goes
+    with it, so the stamped root tag is the only place a nested level's
+    instance identity still lives.
+    """
+    tag_text = _root_tag_text(level)
+    if tag_text is None:
+        return None
+    return _tag_attr(tag_text, RE_ROOT_PJX_ID)
+
+
+@dataclass(frozen=True)
+class _NestedRoot:
+    """One reactive root nested inside a candidate's level, and what decides its stamp."""
+
+    level: RenderedLevel
+    """The nested level itself, so a stamp can be spliced into that exact object."""
+
+    component_class: type[ReactiveComponent] | None
+    """The class its ``data-pjx-type`` names, or None when the tag names none."""
+
+    react_keys: tuple[str, ...] | None
+    """What ``record_nested_react_keys`` recorded for this id, or None if nothing did."""
+
+    load_key: str | None
+    """This instance's ``data-pjx-load``, or None for an unkeyed class."""
+
+
+def _nested_root(
+    level: RenderedLevel, instance_id: str, session: RenderSession | None
+) -> _NestedRoot:
+    """Everything the preserve pass needs about one nested root, read once.
+
+    The class comes from the tag's own ``data-pjx-type`` — a RenderedLevel's
+    descriptor carries no back-reference to the class that rendered it, and the
+    tag is where ``stamp_reactive_root_attrs`` already wrote the snake_case tag
+    name ``discovery`` is keyed by. The react keys come from the session map
+    ``record_nested_react_keys`` fills, and stay None when nothing recorded this
+    id: absence of information is never read as disjointness.
+    """
+    tag_text = _root_tag_text(level) or ""
+    cls = discovery.get_class(_tag_attr(tag_text, RE_ROOT_PJX_TYPE) or "")
+    reactive = cls if cls is not None and issubclass(cls, ReactiveComponent) else None
+    return _NestedRoot(
+        level=level,
+        component_class=reactive,
+        react_keys=None if session is None else session.nested_react_keys.get(instance_id),
+        load_key=_tag_attr(tag_text, RE_ROOT_PJX_LOAD),
+    )
+
+
+def _contained(
+    level: RenderedLevel, session: RenderSession | None = None
+) -> tuple[set[str], set[int], dict[str, _NestedRoot]]:
+    """Every id, level object, and reactive root nested *strictly inside* this level.
 
     Two identity channels, because a descendant can be either shape: an
     unfilled ChildRef still carries the authored ``id`` attr, while a filled
     RenderedLevel carries its stamped root id — plus object identity, which
     settles the case where a survivor's own level object is literally the node
     sitting in another survivor's tree.
+
+    The third channel is additive and read by the preserve pass alone: one
+    ``_NestedRoot`` per filled nested level, keyed by its stamped id.
+    ``_drop_nested`` ignores it. An unfilled ChildRef contributes nothing to it
+    — there is no level to stamp and no rendered tag to read.
     """
     ids: set[str] = set()
     objects: set[int] = set()
+    nested_roots: dict[str, _NestedRoot] = {}
     stack: list[object] = list(level.segments)
     while stack:
         node = stack.pop()
@@ -287,8 +361,9 @@ def _contained(level: RenderedLevel) -> tuple[set[str], set[int]]:
             nested_id = _root_instance_id(node)
             if nested_id:
                 ids.add(nested_id)
+                nested_roots[nested_id] = _nested_root(node, nested_id, session)
             stack.extend(node.segments)
-    return ids, objects
+    return ids, objects, nested_roots
 
 
 def _drop_nested(candidates: list[FanoutCandidate]) -> list[FanoutCandidate]:
@@ -320,7 +395,7 @@ def _drop_nested(candidates: list[FanoutCandidate]) -> list[FanoutCandidate]:
         level = _level_of(other)
         if level is None:
             continue
-        ids, objects = _contained(level)
+        ids, objects, _nested_roots = _contained(level)
         all_ids |= ids
         all_objects |= objects
     surviving: list[FanoutCandidate] = []

--- a/pyjinhx/reactive/fanout.py
+++ b/pyjinhx/reactive/fanout.py
@@ -96,24 +96,31 @@ def _load_key(cls: type[ReactiveComponent], load: object) -> str | None:
     return coerce_load_key_str(load)
 
 
-def _matches_dirtied(
-    cls: type[ReactiveComponent], load_key: str | None, dirtied_keys: set[str]
+def _keys_match_dirtied(
+    react_keys: tuple[str, ...], load_key: str | None, dirtied_keys: set[str]
 ) -> bool:
-    """Whether any dirtied key names this class, or this exact instance of it.
+    """Whether any dirtied key names these react keys, or this exact instance.
 
     Two shapes reach here. A plain static key (``"todos"``) names every mounted
     instance of a class that declares it. A dynamic key (``reactive_key(TODOS,
     "2")`` -> ``"todos:2"``) names one instance: the mounted region whose own
-    load key is ``"2"``. Narrowing lives here rather than in the caller so the
-    two shapes are decided in one place and a class with no PjxKey field —
-    whose load key is None — simply never matches a dynamic key.
+    load key is ``"2"``. Narrowing lives here rather than in the callers so the
+    two shapes are decided in one place, and an instance with no load key — an
+    unkeyed class — simply never matches a dynamic key.
     """
-    static = set(cls._pjx_react_keys)
+    static = set(react_keys)
     if static & dirtied_keys:
         return True
     if load_key is None:
         return False
     return bool({f"{key}:{load_key}" for key in static} & dirtied_keys)
+
+
+def _matches_dirtied(
+    cls: type[ReactiveComponent], load_key: str | None, dirtied_keys: set[str]
+) -> bool:
+    """Whether any dirtied key names this class, or this exact instance of it."""
+    return _keys_match_dirtied(cls._pjx_react_keys, load_key, dirtied_keys)
 
 
 def _candidate_class(
@@ -737,7 +744,44 @@ def delete_swap(candidate: FanoutCandidate) -> Markup:
     return Markup(f'<div hx-swap-oob="{selector}"></div>')
 
 
-def oob_swaps(candidates: list[FanoutCandidate]) -> Markup:
+def _preserve_nested(
+    level: RenderedLevel,
+    dirtied_keys: set[str],
+    candidate_ids: set[str],
+    session: RenderSession | None,
+) -> None:
+    """Splice ``hx-preserve="true"`` onto each nested root this swap must not disturb.
+
+    A nested reactive region whose keys this request never dirtied is not the
+    parent's to replace: htmx keeps the live element when the incoming markup
+    carries ``hx-preserve``, so the parent's swap lands around it instead of
+    through it. Stamping is deliberately conservative — a nested root is stamped
+    only on positive proof of disjointness, so an unresolvable class or an
+    unrecorded id simply keeps today's behavior.
+
+    ``hx-preserve`` is a documented no-op for an id the client does not already
+    show, so a first-mount nested region needs no special case here.
+
+    Runs after the candidate's own root stamp, never before: the shape where the
+    "nested" root *is* the fragment's own swap target (a parent whose whole
+    template is one reactive child) is exactly the shape ``stamp_root_attrs``
+    already refuses with RootStampCollisionError, so no fragment reaches this
+    pass with its own swap target among the nested roots.
+    """
+    _ids, _objects, nested_roots = _contained(level, session)
+    for _nested_id, nested in nested_roots.items():
+        if nested.react_keys is None:
+            continue
+        if set(nested.react_keys) & dirtied_keys:
+            continue
+        stamp_root_attrs(nested.level, {"hx-preserve": "true"}, nested=True)
+
+
+def oob_swaps(
+    candidates: list[FanoutCandidate],
+    dirtied_keys: Iterable[str] = (),
+    session: RenderSession | None = None,
+) -> Markup:
     """The whole OOB response body for one walk's candidates, in candidate order.
 
     Each dirty candidate's already-built level is stamped with its own
@@ -757,11 +801,25 @@ def oob_swaps(candidates: list[FanoutCandidate]) -> Markup:
         candidates: ``walk_manifest()`` output. Every filter — hash gate, dedup,
             nesting, primary-region exclusion — has already been applied; this
             function re-decides none of them.
+        dirtied_keys: This request's normalized dirtied reactive keys, so a
+            nested region none of them names can be preserved across its
+            parent's swap. Empty by default: a caller that supplies none gets
+            today's behavior, which stamps nothing.
+        session: The session carrying ``nested_react_keys``; defaults to the
+            active ``request_scope()``'s, and to None outside one, in which
+            case nothing is stamped.
 
     Returns:
         The surviving fragments joined by newlines, or ``Markup("")`` when no
         candidate is dirty or missing.
     """
+    dirtied = set(dirtied_keys)
+    render_session = session or current_session()
+    candidate_ids = {
+        candidate.instance_id
+        for candidate in candidates
+        if candidate.status in ("dirty", "missing")
+    }
     fragments: list[str] = []
     for candidate in candidates:
         if candidate.status == "dirty":
@@ -781,7 +839,9 @@ def oob_swaps(candidates: list[FanoutCandidate]) -> Markup:
                 f"outerHTML:[data-pjx-id='{_css_attr_value(candidate.instance_id)}']"
             )
             attrs = {"hx-swap-oob": selector, "data-pjx-hash": candidate.fresh_hash}
-            fragments.append(serialize(stamp_root_attrs(level, attrs)))
+            stamp_root_attrs(level, attrs)
+            _preserve_nested(level, dirtied, candidate_ids, render_session)
+            fragments.append(serialize(level))
         elif candidate.status == "missing":
             fragments.append(delete_swap(candidate))
     return Markup("\n".join(fragments))

--- a/pyjinhx/reactive/fanout.py
+++ b/pyjinhx/reactive/fanout.py
@@ -36,6 +36,7 @@ from pyjinhx.reactive.cache import cache_get, cache_has
 from pyjinhx.reactive.component import ReactiveComponent, coerce_load_arg
 from pyjinhx.reactive.keys import coerce_load_key_str
 from pyjinhx.reactive.load_cost import is_too_cheap_to_thread, note_load_cost
+from pyjinhx.reactive.root_attrs import record_nested_react_keys
 from pyjinhx.rendering import render_level
 from pyjinhx.root_attrs import stamp_root_attrs
 from pyjinhx.segments import ChildRef, RenderedLevel, serialize
@@ -699,6 +700,13 @@ def walk_manifest(
     # one, so a caller inside a request never has its dirty-path render
     # silently point at the wrong template dir.
     render_session = session or current_session() or RenderSession()
+    # Subscribed here rather than inside _build_dirty: one append per walk
+    # covers every build the pass runs, and the guard mirrors the one
+    # responses.py:74 uses for accumulate_assets, so a session that already
+    # carries the recorder — a second walk, or a caller that wired it — never
+    # records the same render twice.
+    if record_nested_react_keys not in render_session.on_rendered:
+        render_session.on_rendered.append(record_nested_react_keys)
     return _reduce_pass(items, _build_pass(items, render_session))
 
 

--- a/pyjinhx/reactive/fanout.py
+++ b/pyjinhx/reactive/fanout.py
@@ -772,6 +772,12 @@ def _preserve_nested(
     ``hx-preserve`` is a documented no-op for an id the client does not already
     show, so a first-mount nested region needs no special case here.
 
+    htmx resolves the live element by the incoming tag's plain ``id`` attribute
+    (``handlePreservedElements`` -> ``getElementById``), not by ``data-pjx-id``,
+    so retention only actually lands for a region whose own template root
+    carries a stable authored ``id``. Stamping one here would not help: the
+    element already on the page came from a render that carried none either.
+
     Runs after the candidate's own root stamp, never before: the shape where the
     "nested" root *is* the fragment's own swap target (a parent whose whole
     template is one reactive child) is exactly the shape ``stamp_root_attrs``

--- a/pyjinhx/reactive/fanout.py
+++ b/pyjinhx/reactive/fanout.py
@@ -769,10 +769,15 @@ def _preserve_nested(
     pass with its own swap target among the nested roots.
     """
     _ids, _objects, nested_roots = _contained(level, session)
-    for _nested_id, nested in nested_roots.items():
+    for nested_id, nested in nested_roots.items():
+        if nested_id in candidate_ids:
+            continue
+        cls = nested.component_class
+        if cls is None or not cls.retain_across_parent_swaps:
+            continue
         if nested.react_keys is None:
             continue
-        if set(nested.react_keys) & dirtied_keys:
+        if _keys_match_dirtied(nested.react_keys, nested.load_key, dirtied_keys):
             continue
         stamp_root_attrs(nested.level, {"hx-preserve": "true"}, nested=True)
 

--- a/pyjinhx/reactive/fanout.py
+++ b/pyjinhx/reactive/fanout.py
@@ -333,7 +333,9 @@ def _nested_root(
     return _NestedRoot(
         level=level,
         component_class=reactive,
-        react_keys=None if session is None else session.nested_react_keys.get(instance_id),
+        react_keys=None
+        if session is None
+        else session.nested_react_keys.get(instance_id),
         load_key=_tag_attr(tag_text, RE_ROOT_PJX_LOAD),
     )
 

--- a/pyjinhx/reactive/root_attrs.py
+++ b/pyjinhx/reactive/root_attrs.py
@@ -55,5 +55,30 @@ def stamp_reactive_root_attrs(
 def record_nested_react_keys(
     component: BaseComponent, level: RenderedLevel, session: RenderSession
 ) -> None:
-    """Record a rendered reactive component's react keys under its instance id."""
-    session.nested_react_keys[component.id] = type(component)._pjx_react_keys  # pyright: ignore[reportAttributeAccessIssue]
+    """Record a rendered reactive component's react keys under its instance id.
+
+    Shaped for ``RenderSession.on_rendered`` and exported rather than
+    auto-registered: a session that never appends it keeps an empty
+    ``nested_react_keys`` map, so nothing in a normal render changes. A
+    non-reactive component returns before anything is read, so a tree with no
+    reactive nodes pays one isinstance check per component and nothing else.
+
+    ``emit_rendered`` fires once per component, so every reactive node lands an
+    entry at every nesting depth — the nested entries are what #1013's fan-out
+    needs to tell a disjoint nested reactive region from part of a parent's own
+    swap. A class declared without ``react=(...)`` records the empty tuple:
+    presence of an id means "this is a reactive component", the value answers
+    "on what keys". A repeat render of one id overwrites in silence — unlike
+    ``registry.register_instance``, there is nothing to collide over, since the
+    value is class-derived and every write for one id is identical.
+
+    Args:
+        component: The component that just finished rendering.
+        level: That component's RenderedLevel (unused; this subscriber splices
+            nothing and leaves the rendered output byte-identical).
+        session: The RenderSession this render ran against; its
+            ``nested_react_keys`` map is where the entry lands.
+    """
+    if not isinstance(component, ReactiveComponent):
+        return
+    session.nested_react_keys[component.id] = type(component)._pjx_react_keys

--- a/pyjinhx/reactive/root_attrs.py
+++ b/pyjinhx/reactive/root_attrs.py
@@ -64,9 +64,9 @@ def record_nested_react_keys(
     reactive nodes pays one isinstance check per component and nothing else.
 
     ``emit_rendered`` fires once per component, so every reactive node lands an
-    entry at every nesting depth — the nested entries are what #1013's fan-out
-    needs to tell a disjoint nested reactive region from part of a parent's own
-    swap. A class declared without ``react=(...)`` records the empty tuple:
+    entry at every nesting depth — the nested entries are what lets the fan-out
+    tell a disjoint nested reactive region from part of a parent's own swap. A
+    class declared without ``react=(...)`` records the empty tuple:
     presence of an id means "this is a reactive component", the value answers
     "on what keys". A repeat render of one id overwrites in silence — unlike
     ``registry.register_instance``, there is nothing to collide over, since the

--- a/pyjinhx/reactive/root_attrs.py
+++ b/pyjinhx/reactive/root_attrs.py
@@ -50,3 +50,10 @@ def stamp_reactive_root_attrs(
         if load_key is not None:
             attrs["data-pjx-load"] = load_key
     stamp_root_attrs(level, attrs)
+
+
+def record_nested_react_keys(
+    component: BaseComponent, level: RenderedLevel, session: RenderSession
+) -> None:
+    """Record a rendered reactive component's react keys under its instance id."""
+    session.nested_react_keys[component.id] = type(component)._pjx_react_keys  # pyright: ignore[reportAttributeAccessIssue]

--- a/pyjinhx/responses.py
+++ b/pyjinhx/responses.py
@@ -81,7 +81,10 @@ def _fan_out(
     )
     parts = [
         primary,
-        str(oob_swaps(candidates)),
+        # dirtied and session both travel: a nested region this request never
+        # dirtied is preserved across its parent's swap, and the session is
+        # where the walk recorded which keys each nested region reacts to.
+        str(oob_swaps(candidates, dirtied, session=session)),
         missing_asset_oob(candidates, session.pjx_assets, session, resolver),
     ]
     # An OOB-only body has nothing for htmx's default swap to place, so htmx would

--- a/pyjinhx/session.py
+++ b/pyjinhx/session.py
@@ -253,6 +253,14 @@ class RenderSession:
         self.pjx_mounted: list[dict[str, Any]] = []
         self.pjx_assets: frozenset[str] = frozenset()
         self.pjx_trigger: dict[str, Any] | None = None
+        # Per-request map of reactive instance id -> that class's
+        # _pjx_react_keys, written by reactive.root_attrs.record_nested_react_keys
+        # when a caller appends it to on_rendered above. #1013's fan-out reads it
+        # to decide which nested reactive regions a parent swap must retain, so
+        # the key is the same instance-id string fanout's _contained resolves
+        # (ChildRef.attrs["id"] / _root_instance_id). Lives on the session, not
+        # module-global: it must die with the request.
+        self.nested_react_keys: dict[str, tuple[str, ...]] = {}
 
     def emit_rendered(self, component: "BaseComponent", level: "RenderedLevel") -> None:
         """Notify subscribers that ``component``'s subtree finished rendering.

--- a/pyjinhx/session.py
+++ b/pyjinhx/session.py
@@ -255,8 +255,8 @@ class RenderSession:
         self.pjx_trigger: dict[str, Any] | None = None
         # Per-request map of reactive instance id -> that class's
         # _pjx_react_keys, written by reactive.root_attrs.record_nested_react_keys
-        # when a caller appends it to on_rendered above. #1013's fan-out reads it
-        # to decide which nested reactive regions a parent swap must retain, so
+        # when a caller appends it to on_rendered above. The fan-out reads it to
+        # decide which nested reactive regions a parent swap must retain, so
         # the key is the same instance-id string fanout's _contained resolves
         # (ChildRef.attrs["id"] / _root_instance_id). Lives on the session, not
         # module-global: it must die with the request.

--- a/tests/pyjinhx/reactive/test_reactive_component.py
+++ b/tests/pyjinhx/reactive/test_reactive_component.py
@@ -771,3 +771,38 @@ def test_cache_alone_does_not_disturb_the_react_keys():
         pass
 
     assert Widget._pjx_react_keys == ()
+
+
+def test_retain_across_parent_swaps_defaults_to_true():
+    assert ReactiveComponent.retain_across_parent_swaps is True
+
+
+def test_retain_across_parent_swaps_is_inherited_by_a_silent_subclass():
+    class Widget(ReactiveComponent):
+        pass
+
+    assert Widget.retain_across_parent_swaps is True
+    assert Widget().retain_across_parent_swaps is True
+
+
+def test_a_subclass_can_opt_out_of_retain_across_parent_swaps_without_mutating_the_base():
+    class Widget(ReactiveComponent):
+        retain_across_parent_swaps = False
+
+    class Child(Widget):
+        pass
+
+    assert Widget.retain_across_parent_swaps is False
+    assert Child.retain_across_parent_swaps is False
+    assert ReactiveComponent.retain_across_parent_swaps is True
+
+
+def test_sibling_subclasses_set_retain_across_parent_swaps_independently():
+    class OptedOut(ReactiveComponent):
+        retain_across_parent_swaps = False
+
+    class Silent(ReactiveComponent):
+        pass
+
+    assert OptedOut.retain_across_parent_swaps is False
+    assert Silent.retain_across_parent_swaps is True

--- a/tests/pyjinhx/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx/reactive/test_reactive_fanout.py
@@ -492,6 +492,33 @@ def stamped_level(instance_id: str, *children) -> RenderedLevel:
     )
 
 
+def reactive_level(
+    instance_id: str,
+    type_name: str = "quiet_widget",
+    load: str | None = None,
+    children: tuple = (),
+) -> RenderedLevel:
+    """A RenderedLevel whose root tag carries the full reactive identity stamp.
+
+    `stamped_level` writes only `data-pjx-id`. The preserve pass also reads
+    `data-pjx-type` (the only place a nested level records its owning class)
+    and `data-pjx-load`, so these tests need a root tag shaped the way
+    `stamp_reactive_root_attrs` shapes a real one.
+    """
+    attrs = (
+        f'data-pjx-id="{instance_id}" data-pjx-type="{type_name}" '
+        f'data-pjx-hash="h-{instance_id}"'
+    )
+    if load is not None:
+        attrs += f' data-pjx-load="{load}"'
+    root = f"<div {attrs}>"
+    return RenderedLevel(
+        segments=[root, *children, "</div>"],
+        root_span=(0, len(root)),
+        descriptor=FanoutWidget.__pjx_descriptor__,
+    )
+
+
 def test_drop_nested_drops_a_child_level_nested_in_a_parent_level():
     child = stamped_level("child")
     parent = stamped_level("parent", child)
@@ -674,6 +701,41 @@ def test_drop_nested_walks_each_candidate_tree_exactly_once(monkeypatch):
     assert [c.instance_id for c in survivors] == [f"n{i}" for i in range(10)] + [
         "no-structure"
     ]
+
+
+def test_contained_reports_a_nested_reactive_root_with_its_class_and_load_key():
+    nested = reactive_level("nested", "fanout_widget", load="todo-9")
+    parent = reactive_level("parent", "fanout_widget", children=(nested,))
+    with scope() as session:
+        session.nested_react_keys["nested"] = ("todos",)
+        ids, objects, nested_roots = fanout._contained(parent, session)
+    assert ids == {"nested"}
+    assert objects == {id(nested)}
+    assert list(nested_roots) == ["nested"]
+    record = nested_roots["nested"]
+    assert record.level is nested
+    assert record.component_class is FanoutWidget
+    assert record.react_keys == ("todos",)
+    assert record.load_key == "todo-9"
+
+
+def test_contained_without_a_session_reports_no_react_keys():
+    """No session, no map: the id is still found, but nothing claims it is disjoint."""
+    nested = reactive_level("nested", "quiet_widget")
+    parent = reactive_level("parent", "fanout_widget", children=(nested,))
+    ids, _objects, nested_roots = fanout._contained(parent)
+    assert ids == {"nested"}
+    assert nested_roots["nested"].react_keys is None
+    assert nested_roots["nested"].component_class is QuietWidget
+
+
+def test_contained_reports_no_class_for_a_nested_root_without_a_pjx_type():
+    """An unstamped nested root resolves to no class, so nothing can be decided about it."""
+    nested = stamped_level("nested")
+    parent = reactive_level("parent", "fanout_widget", children=(nested,))
+    _ids, _objects, nested_roots = fanout._contained(parent)
+    assert nested_roots["nested"].component_class is None
+    assert nested_roots["nested"].load_key is None
 
 
 def test_mounted_ids_in_extracts_both_quote_styles():

--- a/tests/pyjinhx/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx/reactive/test_reactive_fanout.py
@@ -24,6 +24,7 @@ from pyjinhx.reactive.fanout import (
     walk_manifest,
 )
 from pyjinhx.reactive.load_cost import note_load_cost
+from pyjinhx.reactive.root_attrs import record_nested_react_keys
 from pyjinhx.segments import ChildRef, RenderedLevel
 from pyjinhx.session import (
     RenderSession,
@@ -1841,3 +1842,17 @@ def test_root_instance_id_reads_a_root_stamped_behind_a_whitespace_prologue():
     stamp_root_attrs(level, {"data-pjx-id": "abc123"})
 
     assert fanout._root_instance_id(level) == "abc123"
+
+
+def test_walk_manifest_wires_the_nested_react_key_recorder_exactly_once():
+    """The subscriber is appended per walk, guarded the way responses.py guards its own."""
+    with scope() as session:
+        registry.register_instance(FanoutWidget.__name__, "a", "resolved-entry")
+        walk_manifest(
+            [entry("fanout_widget", "a", load="todo-1")], {"todos"}, session=session
+        )
+        walk_manifest(
+            [entry("fanout_widget", "a", load="todo-2")], {"todos"}, session=session
+        )
+    assert session.on_rendered.count(record_nested_react_keys) == 1
+    assert session.nested_react_keys["a"] == ("todos",)

--- a/tests/pyjinhx/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx/reactive/test_reactive_fanout.py
@@ -60,6 +60,12 @@ class QuietWidget(ReactiveComponent, react=("other",)):
     """A reactive component that no test's dirtied keys ever touch."""
 
 
+class OwnedWidget(ReactiveComponent, react=("other",)):
+    """A nested class that declares itself fully owned by its parent's swap."""
+
+    retain_across_parent_swaps = False
+
+
 class LoudWidget(ReactiveComponent, react=("todos",)):
     """A reactive component that reacts to the same keys as FanoutWidget but is
     never measured, so a pass mixing it with a too-cheap class must still thread."""
@@ -130,12 +136,15 @@ def _clean_registries(tmp_path, monkeypatch):
     quiet_path = tmp_path / "quiet_widget.pjx"
     fanout_path.write_text("<div>{{ pjx_key }}</div>")
     quiet_path.write_text("<div>quiet</div>")
+    owned_path = tmp_path / "owned_widget.pjx"
+    owned_path.write_text("<div>owned</div>")
     plain_path = tmp_path / "plain_widget.pjx"
     plain_path.write_text("<div>plain</div>")
     loud_path = tmp_path / "loud_widget.pjx"
     loud_path.write_text("<div>{{ pjx_key }}</div>")
     discovery.build_registry(
-        tmp_path, [FanoutWidget, QuietWidget, PlainWidget, SpyWidget, LoudWidget]
+        tmp_path,
+        [FanoutWidget, QuietWidget, PlainWidget, SpyWidget, LoudWidget, OwnedWidget],
     )
     # `_resolve_template_path` walks the class's *defining module's* directory
     # (this test file's dir), not `template_dir` passed to `build_registry` —
@@ -158,6 +167,9 @@ def _clean_registries(tmp_path, monkeypatch):
     )
     LoudWidget.__pjx_descriptor__ = dataclasses.replace(
         LoudWidget.__pjx_descriptor__, template_path=loud_path
+    )
+    OwnedWidget.__pjx_descriptor__ = dataclasses.replace(
+        OwnedWidget.__pjx_descriptor__, template_path=owned_path
     )
     yield
 
@@ -804,6 +816,66 @@ def test_stamping_a_nested_root_leaves_its_identity_attrs_untouched():
     assert 'data-pjx-hash="h-nested"' in tag
     assert 'data-pjx-load="k-1"' in tag
     assert 'hx-preserve="true"' in tag
+
+
+def test_a_class_opting_out_of_retention_is_never_stamped():
+    nested = reactive_level("nested", "owned_widget")
+    parent = reactive_level("parent", "fanout_widget", children=(nested,))
+    with scope() as session:
+        session.nested_react_keys["nested"] = ("other",)
+        body = str(oob_swaps([dirty_with_level("parent", parent)], {"todos"}, session))
+    assert "hx-preserve" not in body
+
+
+def test_a_nested_root_that_is_itself_a_candidate_is_never_stamped():
+    """Belt and braces, asserted directly.
+
+    A real walk cannot produce this shape — a candidate's own keys always match
+    the dirtied set that made it one — so the guard is driven by a hand-built
+    candidate list whose session map deliberately disagrees with that.
+    """
+    nested = reactive_level("nested", "quiet_widget")
+    parent = reactive_level("parent", "fanout_widget", children=(nested,))
+    with scope() as session:
+        session.nested_react_keys["nested"] = ("other",)
+        body = str(
+            oob_swaps(
+                [
+                    dirty_with_level("parent", parent),
+                    dirty_with_level("nested", nested),
+                ],
+                {"todos"},
+                session,
+            )
+        )
+    assert "hx-preserve" not in body
+
+
+def test_a_nested_root_dirtied_by_the_dynamic_key_form_is_not_stamped():
+    """The `key:load_key` form is folded in from the tag's own data-pjx-load."""
+    nested = reactive_level("nested", "fanout_widget", load="9")
+    parent = reactive_level("parent", "fanout_widget", children=(nested,))
+    with scope() as session:
+        session.nested_react_keys["nested"] = ("todos",)
+        body = str(
+            oob_swaps([dirty_with_level("parent", parent)], {"todos:9"}, session)
+        )
+    assert "hx-preserve" not in body
+
+
+def test_parent_and_child_dirtied_by_one_request_yield_no_preserve_anywhere():
+    """Regression guard for the failure the app's static-attribute workaround hit."""
+    child = reactive_level("child", "fanout_widget")
+    parent = reactive_level("parent", "fanout_widget", children=(child,))
+    with scope() as session:
+        session.nested_react_keys["parent"] = ("todos",)
+        session.nested_react_keys["child"] = ("todos",)
+        survivors = _drop_nested(
+            [dirty_with_level("parent", parent), dirty_with_level("child", child)]
+        )
+        body = str(oob_swaps(survivors, {"todos"}, session))
+    assert [c.instance_id for c in survivors] == ["parent"]
+    assert "hx-preserve" not in body
 
 
 def test_mounted_ids_in_extracts_both_quote_styles():

--- a/tests/pyjinhx/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx/reactive/test_reactive_fanout.py
@@ -519,6 +519,13 @@ def reactive_level(
     )
 
 
+def dirty_with_level(instance_id: str, level: RenderedLevel) -> FanoutCandidate:
+    """A dirty candidate carrying a hand-shaped level and the fresh_hash oob_swaps asserts."""
+    return dataclasses.replace(
+        candidate(instance_id, level=level), fresh_hash="fresh-hash"
+    )
+
+
 def test_drop_nested_drops_a_child_level_nested_in_a_parent_level():
     child = stamped_level("child")
     parent = stamped_level("parent", child)
@@ -736,6 +743,67 @@ def test_contained_reports_no_class_for_a_nested_root_without_a_pjx_type():
     _ids, _objects, nested_roots = fanout._contained(parent)
     assert nested_roots["nested"].component_class is None
     assert nested_roots["nested"].load_key is None
+
+
+def nested_tag_of(body: str, instance_id: str) -> str:
+    """The opening tag of the nested root with this id, out of a serialized body."""
+    start = body.index(f'<div data-pjx-id="{instance_id}"')
+    return body[start : body.index(">", start) + 1]
+
+
+def test_a_disjoint_nested_region_is_stamped_with_hx_preserve():
+    nested = reactive_level("nested", "quiet_widget")
+    parent = reactive_level("parent", "fanout_widget", children=(nested,))
+    with scope() as session:
+        session.nested_react_keys["nested"] = ("other",)
+        body = str(oob_swaps([dirty_with_level("parent", parent)], {"todos"}, session))
+    assert 'hx-preserve="true"' in nested_tag_of(body, "nested")
+    parent_tag = nested_tag_of(body, "parent")
+    assert "hx-swap-oob=\"outerHTML:[data-pjx-id='parent']\"" in parent_tag
+    assert 'data-pjx-hash="fresh-hash"' in parent_tag
+    assert "hx-preserve" not in parent_tag
+
+
+def test_a_regions_own_fragment_never_carries_the_stamp():
+    """Step 3 only ever touches nested ids inside another candidate's fragment."""
+    own = reactive_level("nested", "quiet_widget")
+    with scope() as session:
+        session.nested_react_keys["nested"] = ("other",)
+        body = str(oob_swaps([dirty_with_level("nested", own)], {"todos"}, session))
+    assert "hx-preserve" not in body
+    assert "hx-swap-oob=\"outerHTML:[data-pjx-id='nested']\"" in body
+
+
+def test_a_nested_root_with_no_recorded_react_keys_is_left_byte_identical():
+    """Absence of information is never disjointness: the fragment is today's exactly."""
+    nested = reactive_level("nested", "quiet_widget")
+    parent = reactive_level("parent", "fanout_widget", children=(nested,))
+    baseline_nested = reactive_level("nested", "quiet_widget")
+    baseline_parent = reactive_level(
+        "parent", "fanout_widget", children=(baseline_nested,)
+    )
+    with scope() as session:
+        stamped = str(
+            oob_swaps([dirty_with_level("parent", parent)], {"todos"}, session)
+        )
+        baseline = str(oob_swaps([dirty_with_level("parent", baseline_parent)]))
+    assert "hx-preserve" not in stamped
+    assert stamped == baseline
+
+
+def test_stamping_a_nested_root_leaves_its_identity_attrs_untouched():
+    """The first caller to stamp a *nested* root: no RootStampCollisionError."""
+    nested = reactive_level("nested", "quiet_widget", load="k-1")
+    parent = reactive_level("parent", "fanout_widget", children=(nested,))
+    with scope() as session:
+        session.nested_react_keys["nested"] = ("other",)
+        body = str(oob_swaps([dirty_with_level("parent", parent)], {"todos"}, session))
+    tag = nested_tag_of(body, "nested")
+    assert 'data-pjx-id="nested"' in tag
+    assert 'data-pjx-type="quiet_widget"' in tag
+    assert 'data-pjx-hash="h-nested"' in tag
+    assert 'data-pjx-load="k-1"' in tag
+    assert 'hx-preserve="true"' in tag
 
 
 def test_mounted_ids_in_extracts_both_quote_styles():

--- a/tests/pyjinhx/reactive/test_reactive_root_attrs.py
+++ b/tests/pyjinhx/reactive/test_reactive_root_attrs.py
@@ -589,3 +589,25 @@ def test_reactive_component_without_react_kwarg_records_an_empty_tuple(
 
     assert "u1" in recording_session.nested_react_keys
     assert recording_session.nested_react_keys["u1"] == ()
+
+
+def test_a_tree_of_plain_components_records_nothing(
+    recording_session: RenderSession,
+):
+    """Spec test 4: non-reactive components are a bare isinstance no-op."""
+    render_level(PlainShell(id="ps1", body=PlainWidget(id="pw1")), recording_session)
+
+    assert recording_session.nested_react_keys == {}
+
+
+def test_a_mixed_tree_records_only_its_reactive_nodes(
+    recording_session: RenderSession,
+):
+    """Spec test 5: a plain child of a reactive parent never becomes a key."""
+    render_level(
+        KeyedReactiveShell(id="mix1", body=PlainWidget(id="plain1")),
+        recording_session,
+    )
+
+    assert recording_session.nested_react_keys == {"mix1": ("shell",)}
+    assert "plain1" not in recording_session.nested_react_keys

--- a/tests/pyjinhx/reactive/test_reactive_root_attrs.py
+++ b/tests/pyjinhx/reactive/test_reactive_root_attrs.py
@@ -611,3 +611,70 @@ def test_a_mixed_tree_records_only_its_reactive_nodes(
 
     assert recording_session.nested_react_keys == {"mix1": ("shell",)}
     assert "plain1" not in recording_session.nested_react_keys
+
+
+def test_every_depth_of_a_nested_reactive_tree_gets_its_own_entry(
+    recording_session: RenderSession,
+):
+    """Spec test 3: nested entries are the point — one per component, per class."""
+    child = KeyedReactiveWidget(id="inner-k")
+    parent = KeyedReactiveShell(id="outer-k", body=child)
+
+    render_level(parent, recording_session)
+
+    assert recording_session.nested_react_keys == {
+        "outer-k": ("shell",),
+        "inner-k": ("a", "b"),
+    }
+
+
+def test_the_recorded_id_is_the_id_stamped_as_data_pjx_id():
+    """Spec test 6: the map key is the identity channel fanout's _contained reads."""
+    both = RenderSession()
+    both.on_rendered.append(stamp_reactive_root_attrs)
+    both.on_rendered.append(record_nested_react_keys)
+
+    html = serialize(render_level(KeyedReactiveWidget(id="ident1"), both))
+
+    assert list(both.nested_react_keys) == ["ident1"]
+    assert 'data-pjx-id="ident1"' in html
+
+
+def test_recording_leaves_the_rendered_markup_byte_identical():
+    """Spec test 7: the recorder splices nothing and perturbs no other stamp."""
+    stamp_only = RenderSession()
+    stamp_only.on_rendered.append(stamp_reactive_root_attrs)
+    both = RenderSession()
+    both.on_rendered.append(stamp_reactive_root_attrs)
+    both.on_rendered.append(record_nested_react_keys)
+
+    without = serialize(
+        render_level(
+            KeyedReactiveShell(id="bytes1", body=KeyedReactiveWidget(id="bytes2")),
+            stamp_only,
+        )
+    )
+    with_recorder = serialize(
+        render_level(
+            KeyedReactiveShell(id="bytes1", body=KeyedReactiveWidget(id="bytes2")),
+            both,
+        )
+    )
+
+    assert with_recorder == without
+    assert both.nested_react_keys == {"bytes1": ("shell",), "bytes2": ("a", "b")}
+    assert stamp_only.nested_react_keys == {}
+
+
+def test_two_sessions_never_see_each_others_entries():
+    """Spec test 8: request-scoped state, per ADR 0009/0012."""
+    first = RenderSession()
+    first.on_rendered.append(record_nested_react_keys)
+    second = RenderSession()
+    second.on_rendered.append(record_nested_react_keys)
+
+    render_level(KeyedReactiveWidget(id="s1"), first)
+    render_level(KeyedReactiveWidget(id="s2"), second)
+
+    assert first.nested_react_keys == {"s1": ("a", "b")}
+    assert second.nested_react_keys == {"s2": ("a", "b")}

--- a/tests/pyjinhx/reactive/test_reactive_root_attrs.py
+++ b/tests/pyjinhx/reactive/test_reactive_root_attrs.py
@@ -496,3 +496,19 @@ def test_reactive_in_reactive_collision_message_names_both_components(
     message = str(exc_info.value)
     assert "outer1" in message
     assert "inner_reactive_root" in message
+
+
+def test_fresh_session_starts_with_an_empty_nested_react_keys_map():
+    """#1012's per-request map: empty until a subscriber writes into it."""
+    assert RenderSession().nested_react_keys == {}
+
+
+def test_each_session_owns_its_own_nested_react_keys_map():
+    """Per-request by construction: no shared class-level or module-level dict."""
+    first = RenderSession()
+    second = RenderSession()
+
+    first.nested_react_keys["w"] = ("a",)
+
+    assert second.nested_react_keys == {}
+    assert first.nested_react_keys is not second.nested_react_keys

--- a/tests/pyjinhx/reactive/test_reactive_root_attrs.py
+++ b/tests/pyjinhx/reactive/test_reactive_root_attrs.py
@@ -15,7 +15,10 @@ from pyjinhx import discovery
 from pyjinhx._component import BaseComponent, Slot
 from pyjinhx.descriptor import ClassDescriptor
 from pyjinhx.reactive.component import ReactiveComponent
-from pyjinhx.reactive.root_attrs import stamp_reactive_root_attrs
+from pyjinhx.reactive.root_attrs import (
+    record_nested_react_keys,
+    stamp_reactive_root_attrs,
+)
 from pyjinhx.rendering import render_level
 from pyjinhx.root_attrs import RootStampCollisionError, serialize_attr, stamp_root_attrs
 from pyjinhx.segments import ChildRef, RenderedLevel, VerbatimParser, serialize
@@ -89,6 +92,48 @@ ReactiveShell.__pjx_descriptor__ = ClassDescriptor(
 )
 
 
+class KeyedReactiveWidget(ReactiveComponent, react=("a", "b")):
+    pass
+
+
+class UnkeyedReactiveWidget(ReactiveComponent):
+    pass
+
+
+class KeyedReactiveShell(ReactiveComponent, react=("shell",)):
+    body: Slot = ""
+
+
+class PlainShell(BaseComponent):
+    body: Slot = ""
+
+
+KeyedReactiveWidget.__pjx_descriptor__ = _descriptor_for(
+    KeyedReactiveWidget, "reactive_widget.html"
+)
+UnkeyedReactiveWidget.__pjx_descriptor__ = _descriptor_for(
+    UnkeyedReactiveWidget, "reactive_widget.html"
+)
+KeyedReactiveShell.__pjx_descriptor__ = ClassDescriptor(
+    template_path=_TEMPLATE_DIR / "reactive_shell.html",
+    slot_fields=frozenset({"body"}),
+    children_field=None,
+    css_paths=(),
+    js_paths=(),
+    strict=True,
+    provenance={"template": KeyedReactiveShell},
+)
+PlainShell.__pjx_descriptor__ = ClassDescriptor(
+    template_path=_TEMPLATE_DIR / "reactive_shell.html",
+    slot_fields=frozenset({"body"}),
+    children_field=None,
+    css_paths=(),
+    js_paths=(),
+    strict=True,
+    provenance={"template": PlainShell},
+)
+
+
 class InnerBadge(BaseComponent):
     pass
 
@@ -156,6 +201,14 @@ def session() -> RenderSession:
     """A session with only the reactive root-attr subscriber attached."""
     session = RenderSession()
     session.on_rendered.append(stamp_reactive_root_attrs)
+    return session
+
+
+@pytest.fixture
+def recording_session() -> RenderSession:
+    """A session with only the nested-react-keys recorder attached."""
+    session = RenderSession()
+    session.on_rendered.append(record_nested_react_keys)
     return session
 
 
@@ -512,3 +565,27 @@ def test_each_session_owns_its_own_nested_react_keys_map():
 
     assert second.nested_react_keys == {}
     assert first.nested_react_keys is not second.nested_react_keys
+
+
+def test_records_a_reactive_components_declared_react_keys(
+    recording_session: RenderSession,
+):
+    """Spec test 1: the value is the class's normalized _pjx_react_keys tuple."""
+    component = KeyedReactiveWidget(id="k1")
+
+    render_level(component, recording_session)
+
+    assert recording_session.nested_react_keys == {
+        "k1": KeyedReactiveWidget._pjx_react_keys
+    }
+    assert recording_session.nested_react_keys["k1"] == ("a", "b")
+
+
+def test_reactive_component_without_react_kwarg_records_an_empty_tuple(
+    recording_session: RenderSession,
+):
+    """Spec test 2: presence means 'reactive'; the value answers 'on what keys'."""
+    render_level(UnkeyedReactiveWidget(id="u1"), recording_session)
+
+    assert "u1" in recording_session.nested_react_keys
+    assert recording_session.nested_react_keys["u1"] == ()

--- a/tests/pyjinhx/test_compose_fanout.py
+++ b/tests/pyjinhx/test_compose_fanout.py
@@ -356,3 +356,24 @@ def test_a_disjoint_nested_region_is_preserved_across_a_parent_swap():
     assert "hx-swap-oob=\"outerHTML:[data-pjx-id='shell']\"" in body
     start = body.index('data-pjx-id="side"')
     assert 'hx-preserve="true"' in body[start : body.index(">", start) + 1]
+
+
+def test_a_nested_region_this_request_dirtied_is_not_preserved():
+    """The request's own dirtied keys reach oob_swaps, not an empty default set.
+
+    Sibling of the test above, and the half of the pair that can tell whether
+    `_fan_out` actually hands its dirtied keys on: with none of them travelling,
+    every nested region looks disjoint and gets held back, including this one,
+    which this request dirtied outright.
+    """
+    with request_scope() as session:
+        session.on_rendered.append(stamp_reactive_root_attrs)
+        registry.register_instance(ShellWidget.__name__, "shell", "resolved-entry")
+        add_dirtied(["todos", "sidebar"])
+        session.pjx_mounted = [
+            {"type": "shell_widget", "id": "shell", "load": None, "hash": "stale"}
+        ]
+        body = _compose(None, session=session).body
+    assert "hx-swap-oob=\"outerHTML:[data-pjx-id='shell']\"" in body
+    assert 'data-pjx-id="side"' in body
+    assert "hx-preserve" not in body

--- a/tests/pyjinhx/test_compose_fanout.py
+++ b/tests/pyjinhx/test_compose_fanout.py
@@ -9,6 +9,7 @@ from pyjinhx import discovery, registry
 from pyjinhx.reactive import cache
 from pyjinhx.reactive.cache import cache_get, cache_has, cache_put
 from pyjinhx.reactive.component import PjxKey, ReactiveComponent
+from pyjinhx.reactive.root_attrs import stamp_reactive_root_attrs
 from pyjinhx.responses import PjxResponse, compose
 from pyjinhx.session import RenderSession, add_dirtied, request_scope
 
@@ -27,18 +28,40 @@ class ResponseWidget(ReactiveComponent, react=("todos",)):
         return cls(pjx_key=pjx_key, data=f"data:{pjx_key}")
 
 
+class SidebarWidget(ReactiveComponent, react=("sidebar",)):
+    """A nested reactive region no `todos` mutation ever touches."""
+
+
+class ShellWidget(ReactiveComponent, react=("todos",)):
+    """A dirty parent whose template nests a disjoint reactive region."""
+
+    @classmethod
+    def load(cls) -> "ShellWidget":
+        return cls()
+
+
 @pytest.fixture(autouse=True)
 def _publish_registry(tmp_path, monkeypatch):
     """Publish a tag -> class map for ResponseWidget and point it at a real template."""
     LOAD_CALLS.clear()
     template = tmp_path / "response_widget.pjx"
     template.write_text("<div>{{ pjx_key }}</div>")
-    discovery.build_registry(tmp_path, [ResponseWidget])
+    sidebar = tmp_path / "sidebar_widget.pjx"
+    sidebar.write_text("<aside>sidebar</aside>")
+    shell = tmp_path / "shell_widget.pjx"
+    shell.write_text('<div><SidebarWidget id="side"/></div>')
+    discovery.build_registry(tmp_path, [ResponseWidget, SidebarWidget, ShellWidget])
     # `_resolve_template_path` probes the class's defining module directory, not the
     # dir passed to build_registry; repoint the descriptor at the tmp_path file. The
     # loader is absolute-only, so the descriptor carries the full path.
     ResponseWidget.__pjx_descriptor__ = dataclasses.replace(
         ResponseWidget.__pjx_descriptor__, template_path=template
+    )
+    SidebarWidget.__pjx_descriptor__ = dataclasses.replace(
+        SidebarWidget.__pjx_descriptor__, template_path=sidebar
+    )
+    ShellWidget.__pjx_descriptor__ = dataclasses.replace(
+        ShellWidget.__pjx_descriptor__, template_path=shell
     )
     yield
 
@@ -315,3 +338,21 @@ def test_primary_with_dunder_html_is_used_as_markup():
 
     with request_scope() as session:
         assert _compose(Fragment(), session=session).body == "<p>hi</p>"
+
+
+def test_a_disjoint_nested_region_is_preserved_across_a_parent_swap():
+    """The whole path: recorder wired by the walk, keys compared, stamp emitted."""
+    with request_scope() as session:
+        # A nested root only carries data-pjx-id/-type once stamp_reactive_root_attrs
+        # has run. Production wires it per request (pyjinhx/integrations/fastapi.py);
+        # a bare session in a test does not, so this test wires it the same way.
+        session.on_rendered.append(stamp_reactive_root_attrs)
+        registry.register_instance(ShellWidget.__name__, "shell", "resolved-entry")
+        add_dirtied(["todos"])
+        session.pjx_mounted = [
+            {"type": "shell_widget", "id": "shell", "load": None, "hash": "stale"}
+        ]
+        body = _compose(None, session=session).body
+    assert "hx-swap-oob=\"outerHTML:[data-pjx-id='shell']\"" in body
+    start = body.index('data-pjx-id="side"')
+    assert 'hx-preserve="true"' in body[start : body.index(">", start) + 1]

--- a/tests/pyjinhx/test_import_graph.py
+++ b/tests/pyjinhx/test_import_graph.py
@@ -572,6 +572,7 @@ ALLOWED_INTERNAL_IMPORTS: dict[str, frozenset[str]] = {
             "pyjinhx.reactive.component",
             "pyjinhx.reactive.keys",
             "pyjinhx.reactive.load_cost",
+            "pyjinhx.reactive.root_attrs",
             "pyjinhx.rendering",
             "pyjinhx.root_attrs",
             "pyjinhx.segments",


### PR DESCRIPTION
- docs: record what htmx actually matches an hx-preserve element by
- test: cover the dirtied keys reaching oob_swaps from _fan_out
- chore: format and lint the hx-preserve retention change
- feat: record nested react keys during the walk and pass dirtied keys to oob_swaps
- feat: gate hx-preserve on candidacy, opt-out and dynamic keys
- feat: splice hx-preserve onto disjoint nested reactive roots
- feat: report nested reactive roots from _contained

Closes #1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)