### PR TITLE
fix: narrow RootStampCollisionError to actual value mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.9.1 — False-positive root-stamp collision (2026-08-23)
+
+### Fixed
+- A `ReactiveComponent` whose entire template is a single non-reactive child tag raised a
+  false-positive `RootStampCollisionError` when dirtied and rebuilt as an OOB swap candidate
+  under the real FastAPI wiring, where the session's `on_rendered` subscriber and `oob_swaps`'s
+  explicit stamp both write the same reactive identity onto the same tag in one render pass.
+  `stamp_root_attrs`'s nested-branch collision check now only raises when the overlapping
+  `data-pjx-id`/`-type`/`-hash` values actually differ, not merely when all three are already
+  present and about to be rewritten (#1020).
+
 ## 1.9.0 — Nested reactive OOB ownership (2026-08-23)
 
 ### Added

--- a/pyjinhx/root_attrs.py
+++ b/pyjinhx/root_attrs.py
@@ -106,10 +106,15 @@ def stamp_root_attrs(
     Recursing into a nested level crosses a component boundary, so the splice
     there is no longer this component's to make unconditionally: if the nested
     root already carries all of data-pjx-id/-type/-hash and this call would
-    rewrite those same keys, it raises RootStampCollisionError rather than
-    clobbering the inner component's identity. Same-level re-stamping (the
-    ``str`` root branch reached without recursion) still overrides, since
-    there the identity being replaced is the component's own.
+    rewrite any of those same keys to a *different* value, it raises
+    RootStampCollisionError rather than clobbering the inner component's
+    identity. An exact restamp — same id, same type, same hash — is one
+    component's own identity being re-asserted (e.g. a session's
+    ``on_rendered`` subscriber and an explicit OOB stamp both firing in the
+    same render pass), not a boundary violation, so it is a no-op. Same-level
+    re-stamping (the ``str`` root branch reached without recursion) still
+    overrides unconditionally, since there the identity being replaced is the
+    component's own.
     """
     if not attrs:
         return level
@@ -139,7 +144,8 @@ def stamp_root_attrs(
     if nested:
         existing = _reactive_stamps(tag_text)
         if len(existing) == len(_REACTIVE_STAMP_KEYS) and any(
-            name in attrs for name in _REACTIVE_STAMP_KEYS
+            name in attrs and attrs[name] != existing[name]
+            for name in _REACTIVE_STAMP_KEYS
         ):
             raise RootStampCollisionError(
                 "cannot stamp a reactive root tag that another reactive "

--- a/tests/pyjinhx/test_root_attrs.py
+++ b/tests/pyjinhx/test_root_attrs.py
@@ -182,6 +182,32 @@ def test_stamp_root_attrs_nested_reactive_collision_raises():
     assert "outer-456" in str(exc_info.value)
 
 
+def test_stamp_root_attrs_nested_reactive_exact_restamp_is_noop():
+    """A component whose whole template is one child tag can be stamped with
+    the *same* identity values that already sit on the nested root (e.g. the
+    on_rendered subscriber and an explicit OOB stamp both firing in the same
+    render pass) without raising: the values agree, so this is one component
+    re-asserting its own identity, not a boundary violation (issue #1020)."""
+    inner_tag = (
+        '<div data-pjx-id="same-123" data-pjx-type="same_comp" data-pjx-hash="abc">'
+    )
+    inner_level = _level(inner_tag, (0, len(inner_tag)))
+
+    outer_level = RenderedLevel(
+        segments=[inner_level], root_span=(0, len(inner_tag)), descriptor=None
+    )
+
+    stamp_root_attrs(
+        outer_level,
+        {
+            "data-pjx-id": "same-123",
+            "data-pjx-type": "same_comp",
+            "data-pjx-hash": "abc",
+        },
+    )
+    assert outer_level is not None
+
+
 def test_stamp_root_attrs_nested_partial_reactive_does_not_collide():
     """A nested reactive root with only some of the identity attrs (not a
     complete stamp) can still be stamped without collision, allowing partial


### PR DESCRIPTION
## Summary
- Fixes #1020: a `ReactiveComponent` whose entire template is a single non-reactive child tag raised a false-positive `RootStampCollisionError` when both the FastAPI integration's `on_rendered` subscriber (`stamp_reactive_root_attrs`) and `oob_swaps`'s explicit stamp fire on the same `RenderSession` in one render pass.
- `stamp_root_attrs`'s nested-branch collision check now only raises when the overlapping `data-pjx-id`/`-type`/`-hash` values actually *differ* from what's already stamped, not merely when all three keys are present and any are about to be rewritten. An exact restamp is one component re-asserting its own identity, not a boundary violation — this was option 2 from the issue's proposed fixes (the more surgical one).

## Test plan
- [x] Added `test_stamp_root_attrs_nested_reactive_exact_restamp_is_noop`, confirmed it fails against the pre-fix code and passes after
- [x] `uv run pytest tests/pyjinhx/test_root_attrs.py tests/pyjinhx/reactive/test_reactive_root_attrs.py tests/pyjinhx/reactive/test_reactive_fanout.py -q` — 147 passed
- [x] Full suite: `uv run pytest -q` — 3620 passed, 1 skipped, 1 xfailed
- [x] `ruff format` / `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)