### PR TITLE
fix: oob_swaps() no longer re-walks containment _drop_nested already computed

### DIFF
--- a/pyjinhx/reactive/fanout.py
+++ b/pyjinhx/reactive/fanout.py
@@ -26,7 +26,7 @@ import time
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextvars import copy_context
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from markupsafe import Markup
@@ -81,6 +81,21 @@ class FanoutCandidate:
     (``stamp_reactive_root_attrs`` is not wired onto the dirty path's session,
     so nothing else does it first), so the next manifest reports the hash the
     client is actually showing.
+    """
+
+    nested_roots: "dict[str, _NestedRoot] | None" = None
+    """This candidate's own tree, pre-walked by ``_drop_nested`` — reused by
+    ``oob_swaps()``'s ``_preserve_nested`` instead of re-walked from scratch.
+
+    ``_drop_nested`` already calls ``_contained()`` over every surviving
+    candidate's level to decide containment; its third return value used to be
+    discarded there and recomputed by ``_preserve_nested`` moments later in the
+    same request — the same tree walked twice per dirty candidate, every
+    request, confirmed by benchmark (#1028). None means "not computed by
+    ``_drop_nested``", either because this candidate carries no level or
+    because a caller built candidates directly without going through
+    ``walk_manifest``; ``_preserve_nested`` falls back to a live walk in
+    that case, so behavior for such a caller is unchanged.
     """
 
 
@@ -376,7 +391,9 @@ def _contained(
     return ids, objects, nested_roots
 
 
-def _drop_nested(candidates: list[FanoutCandidate]) -> list[FanoutCandidate]:
+def _drop_nested(
+    candidates: list[FanoutCandidate], session: RenderSession | None = None
+) -> list[FanoutCandidate]:
     """Drop every candidate whose region sits inside another survivor's region.
 
     The v0.x behavior (a parent's swap already carries its children, so a child
@@ -396,18 +413,41 @@ def _drop_nested(candidates: list[FanoutCandidate]) -> list[FanoutCandidate]:
     instance, and a container side with no tree at all, both simply fail to
     produce that proof and the candidate survives; absence of a check is never
     a drop. Order is preserved and nothing is duplicated.
+
+    The union loop below already calls `_contained` once per candidate with a
+    level, purely to decide containment, and used to discard its third return
+    value — a map of every nested reactive root inside that candidate's own
+    tree. `oob_swaps()`'s `_preserve_nested` would then redo that exact walk
+    per dirty candidate a moment later in the same request. Keeping the map
+    here and attaching it to whichever candidate survives, so
+    `_preserve_nested` can reuse it instead, is what #1028 fixes — at zero
+    added walks, since the union loop's own walk already ran regardless.
+
+    `session` is threaded through so the reused map already carries real
+    `react_keys` (`_nested_root` needs a session to read `nested_react_keys`);
+    omitted, both this walk's containment decision and the reused map behave
+    exactly as they did before session-awareness existed here.
+
+    The single-candidate short-circuit below deliberately keeps the shape it
+    always had — no `_contained` call at all — rather than walking that one
+    candidate's tree just to populate a cache nothing may ever read (a lone
+    *clean* or *missing* candidate never reaches `_preserve_nested`, so that
+    walk would be pure waste); `oob_swaps` falls back to a live walk for it,
+    exactly as it did before this field existed.
     """
     if len(candidates) < 2:
         return candidates
     all_ids: set[str] = set()
     all_objects: set[int] = set()
+    nested_roots_by_id: dict[int, dict[str, _NestedRoot]] = {}
     for other in candidates:
         level = _level_of(other)
         if level is None:
             continue
-        ids, objects, _nested_roots = _contained(level)
+        ids, objects, nested_roots = _contained(level, session)
         all_ids |= ids
         all_objects |= objects
+        nested_roots_by_id[id(other)] = nested_roots
     surviving: list[FanoutCandidate] = []
     for candidate in candidates:
         own_level = _level_of(candidate)
@@ -415,6 +455,9 @@ def _drop_nested(candidates: list[FanoutCandidate]) -> list[FanoutCandidate]:
             own_level is not None and id(own_level) in all_objects
         )
         if not nested:
+            cached = nested_roots_by_id.get(id(candidate))
+            if cached is not None:
+                candidate = replace(candidate, nested_roots=cached)
             surviving.append(candidate)
     return surviving
 
@@ -594,13 +637,19 @@ def _build_pass(
 
 
 def _reduce_pass(
-    items: list[_WorkItem], built: dict[int, _BuildResult]
+    items: list[_WorkItem],
+    built: dict[int, _BuildResult],
+    session: RenderSession | None = None,
 ) -> list[FanoutCandidate]:
     """The surviving candidates, in manifest order, with the late drops applied.
 
     Walking the work items rather than the results dict is what keeps the
     output in manifest order regardless of which build finished first, and it
     is what ``_drop_nested``'s containment logic depends on.
+
+    ``session`` only reaches ``_drop_nested``, which threads it into the
+    containment walk it caches for ``oob_swaps()`` to reuse (#1028); omitted,
+    every non-session-dependent behavior here is unchanged.
     """
     candidates: list[FanoutCandidate] = []
     for item in items:
@@ -646,7 +695,7 @@ def _reduce_pass(
                 fresh_hash=fresh_hash,
             )
         )
-    return _drop_nested(candidates)
+    return _drop_nested(candidates, session)
 
 
 def walk_manifest(
@@ -709,7 +758,7 @@ def walk_manifest(
     # records the same render twice.
     if record_nested_react_keys not in render_session.on_rendered:
         render_session.on_rendered.append(record_nested_react_keys)
-    return _reduce_pass(items, _build_pass(items, render_session))
+    return _reduce_pass(items, _build_pass(items, render_session), render_session)
 
 
 def _css_attr_value(value: str) -> str:
@@ -759,6 +808,7 @@ def _preserve_nested(
     dirtied_keys: set[str],
     candidate_ids: set[str],
     session: RenderSession | None,
+    nested_roots: "dict[str, _NestedRoot] | None" = None,
 ) -> None:
     """Splice ``hx-preserve="true"`` onto each nested root this swap must not disturb.
 
@@ -783,8 +833,17 @@ def _preserve_nested(
     template is one reactive child) is exactly the shape ``stamp_root_attrs``
     already refuses with RootStampCollisionError, so no fragment reaches this
     pass with its own swap target among the nested roots.
+
+    ``nested_roots``, when given, is ``_drop_nested``'s own walk of this exact
+    level, reused instead of re-derived (#1028: the two walks found the same
+    thing every time, since nothing mutates a level's *structure* between the
+    build pass and this call — only its root tag's attrs, which `_contained`
+    never reads). ``None`` means no caller supplied one — a candidate built
+    outside ``walk_manifest``, say — so a live walk runs exactly as it always
+    did.
     """
-    _ids, _objects, nested_roots = _contained(level, session)
+    if nested_roots is None:
+        _ids, _objects, nested_roots = _contained(level, session)
     for nested_id, nested in nested_roots.items():
         if nested_id in candidate_ids:
             continue
@@ -861,7 +920,9 @@ def oob_swaps(
             )
             attrs = {"hx-swap-oob": selector, "data-pjx-hash": candidate.fresh_hash}
             stamp_root_attrs(level, attrs)
-            _preserve_nested(level, dirtied, candidate_ids, render_session)
+            _preserve_nested(
+                level, dirtied, candidate_ids, render_session, candidate.nested_roots
+            )
             fragments.append(serialize(level))
         elif candidate.status == "missing":
             fragments.append(delete_swap(candidate))

--- a/tests/pyjinhx/reactive/test_reactive_fanout.py
+++ b/tests/pyjinhx/reactive/test_reactive_fanout.py
@@ -611,6 +611,10 @@ def test_drop_nested_collapses_three_levels_to_the_outermost():
 
 
 def test_drop_nested_is_a_no_op_on_empty_and_singleton_lists():
+    """The single-candidate short-circuit walks nothing (#1028): a lone
+    candidate might be clean or missing, never reaching `_preserve_nested`, so
+    populating its `nested_roots` cache here would risk pure waste. The
+    returned candidate is the exact original object, unlike the >=2 branch."""
     only = [candidate("a", level=stamped_level("a"))]
     with scope():
         assert _drop_nested([]) == []
@@ -704,9 +708,9 @@ def test_drop_nested_walks_each_candidate_tree_exactly_once(monkeypatch):
     calls: list[int] = []
     real_contained = fanout._contained
 
-    def counting_contained(level):
+    def counting_contained(level, session=None):
         calls.append(id(level))
-        return real_contained(level)
+        return real_contained(level, session)
 
     monkeypatch.setattr(fanout, "_contained", counting_contained)
 
@@ -1087,9 +1091,9 @@ def test_walk_manifest_runs_the_nesting_dedup_on_its_survivors(monkeypatch):
     seen_calls: list[int] = []
     original = _drop_nested
 
-    def spy(candidates):
+    def spy(candidates, session=None):
         seen_calls.append(len(candidates))
-        return original(candidates)
+        return original(candidates, session)
 
     monkeypatch.setattr("pyjinhx.reactive.fanout._drop_nested", spy)
     with scope():

--- a/tests/pyjinhx/test_compose_fanout.py
+++ b/tests/pyjinhx/test_compose_fanout.py
@@ -358,6 +358,51 @@ def test_a_disjoint_nested_region_is_preserved_across_a_parent_swap():
     assert 'hx-preserve="true"' in body[start : body.index(">", start) + 1]
 
 
+def test_compose_walks_the_shells_tree_for_containment_exactly_once(monkeypatch):
+    """#1028: _drop_nested and _preserve_nested used to each walk a dirty
+    candidate's level independently — once during walk_manifest(), again
+    moments later inside oob_swaps() on the very same candidates, every real
+    request with two or more surviving top-level candidates (the shape that
+    actually triggers the bug: _drop_nested's own single-candidate
+    short-circuit never called _contained at all, so this needs a second,
+    unrelated dirty region alongside the shell to exercise the >=2 branch
+    where the redundant walk lived). Pin the count to one call per level with
+    a level through the actual production path (compose()), so the redundant
+    walk cannot silently return.
+    """
+    from pyjinhx.reactive import fanout
+
+    calls: list[int] = []
+    real_contained = fanout._contained
+
+    def counting_contained(level, session=None):
+        calls.append(id(level))
+        return real_contained(level, session)
+
+    monkeypatch.setattr(fanout, "_contained", counting_contained)
+    with request_scope() as session:
+        session.on_rendered.append(stamp_reactive_root_attrs)
+        registry.register_instance(ShellWidget.__name__, "shell", "resolved-entry")
+        registry.register_instance(ResponseWidget.__name__, "resp", "resolved-entry")
+        add_dirtied(["todos"])
+        session.pjx_mounted = [
+            {"type": "shell_widget", "id": "shell", "load": None, "hash": "stale"},
+            {
+                "type": "response_widget",
+                "id": "resp",
+                "load": "r1",
+                "hash": "stale",
+            },
+        ]
+        body = _compose(None, session=session).body
+    assert 'hx-preserve="true"' in body
+    assert "hx-swap-oob=\"outerHTML:[data-pjx-id='resp']\"" in body
+    # One call per level with a level (shell + resp = 2), never one per level
+    # per pass (which would be 4): _drop_nested's own union walk over both
+    # candidates' trees is reused by _preserve_nested instead of repeated.
+    assert len(calls) == 2
+
+
 def test_a_nested_region_this_request_dirtied_is_not_preserved():
     """The request's own dirtied keys reach oob_swaps, not an empty default set.
 


### PR DESCRIPTION
## Summary
- Fixes #1028: a confirmed ~1.5-2x regression in `oob_swaps()` since 1.9.0's nested-reactive-OOB-ownership work (#1018), benchmarked directly against v1.8.0 before fixing.
- Root cause: `_preserve_nested()` (added by #1018) walks each dirty candidate's segment tree via `_contained()` inside `oob_swaps()`. `responses.py` calls `walk_manifest()` — whose `_drop_nested` already walks the same trees to decide containment, for any request with 2+ surviving top-level candidates — then immediately calls `oob_swaps()` on the same candidates. So the walk ran twice per dirty candidate, every such request.
- Fix: `_drop_nested`'s existing union pass keeps (instead of discarding) the nested-roots map its walk already produces, and attaches it to each surviving `FanoutCandidate` (new `nested_roots` field). `_preserve_nested` reuses it when present, falling back to a live walk only for candidates built outside `walk_manifest` (existing direct-`oob_swaps` unit tests) or for the single-candidate case, which never had this bug (its short-circuit never called `_contained` at all, so populating a cache there would be pure added cost for a candidate that may not even reach `_preserve_nested`).
- Verified against the actual production call pattern (`walk_manifest()` then `oob_swaps()`, mirroring `responses.py`), not the existing isolated `bench_oob_swaps` micro-benchmark (which hand-builds candidates and so can't exercise `_drop_nested`'s cache either way regardless of the fix): 200 candidates, 50-span subtrees — master 4.50ms → fixed 2.81ms (**1.60x**).

## Test plan
- [x] New regression-guard test `test_compose_walks_the_shells_tree_for_containment_exactly_once`: pins `_contained`'s call count through `compose()` itself (the real production path) to 2 (once per candidate's level) instead of 4 (once per candidate per pass). Confirmed it fails against unfixed master (4 calls) before this fix.
- [x] Existing `_drop_nested`/`oob_swaps`/`_preserve_nested` tests updated for the new optional `session` param and `nested_roots` field; all pass unchanged in behavior.
- [x] `uv run pytest tests/` — 3621 passed, 1 skipped, 1 xpassed
- [x] `uv run mkdocs build --strict` — clean
- [x] `uv run pytest tests/pyjinhx/test_docs_reference_real_fields.py -q` — 2 passed
- [x] `uvx basedpyright==1.39.9 pyjinhx/` — 0 errors
- [x] `ruff format --check .` / `ruff check .` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>