### PR TITLE
docs: add runtime decision trees to the rebuild doc set

### DIFF
--- a/docs/superpowers/rebuild/README.md
+++ b/docs/superpowers/rebuild/README.md
@@ -11,6 +11,7 @@ The documentation set for rebuilding the pyjinhx engine as `src/pyjinhx/`, shipp
 | [architecture-overview.md](./architecture-overview.md) | How it works: hard invariants, the mechanism-interaction map (mermaid), per-layer mechanisms with ship criteria, non-obvious interactions, worked example. *Living* — updated as layers ship; where it and reality disagree, fix the doc. |
 | [feature-port-list.md](./feature-port-list.md) | What ships where: every v0.36 feature with keep/mod/drop verdict and its build layer. The G3 parity checklist; each layer spec must cover its assigned rows. |
 | [implementation-overview.md](./implementation-overview.md) | How it lands as code: architecture style (flat module-per-mechanism + import rule), folder/file structure, render timelines (T0 startup / T1 cold / T2 reactive), load-bearing ordering facts. |
+| [runtime-decision-trees.md](./runtime-decision-trees.md) | What the runtime decides, in the order it decides it: the request round-trip, `render_level()`, the two cache tiers, the fan-out's three passes. *Living* — retrace against source when a branch point moves. |
 | [roadmap.md](./roadmap.md) | When and in what order: per-layer deliverables, PR-sized inner steps in dependency order, the two gates, checkboxes + recorded bench numbers. *Living* — check off as things ship. |
 
 Per-layer design docs (RFC role) are not standalone artifacts — the /feature workflow's spec phase (brainstorm + adversarial-doc-review) produces each layer's design just-in-time, saved under `docs/superpowers/specs/`. Decided 2026-07-29.

--- a/docs/superpowers/rebuild/runtime-decision-trees.md
+++ b/docs/superpowers/rebuild/runtime-decision-trees.md
@@ -1,0 +1,209 @@
+# pyjinhx runtime decision trees
+
+What the library decides, in the order it decides it. Traced from source
+against `2ded3808`, covering the request round-trip, the render core, the two
+cache tiers, and the reactive fan-out.
+
+pyjinhx turns *one handler return value* into *one HTTP response*. A component
+is a Pydantic model plus a Jinja template sitting next to it. The library's
+whole job is: render that thing, and — if it's reactive — figure out what
+*else* on the user's page just went stale and ship patches for those regions
+too, in the same response.
+
+Everything below is that sentence expanded.
+
+Companion to [architecture-overview.md](./architecture-overview.md), which maps
+how the mechanisms *interact*; this one walks the branch points inside them.
+
+---
+
+## Top level: what a request becomes
+
+```text
+  browser (htmx)                                            server
+      │  POST /todos/toggle                                    │
+      │  + X-PJX-Mounted   ("here's what's on my page")         │
+      │  + X-PJX-Assets    ("here's the CSS/JS I already have") │
+      └────────────────────────────────────────────────────────►│
+                                                     PjxScopeMiddleware
+                                                   opens request_scope()
+                                                (ContextVars: registry,
+                                                 caches, dirtied set…)
+                                                            │
+                                                       your handler
+                                                    (@mutates marks
+                                                     state keys dirty)
+                                                            │
+                                                       compose(result)
+                                                            │
+                                    ┌───────────────────────┴──────────┐
+                                    ▼                                  ▼
+                            render the primary                    fan out
+                          (the thing you returned)         (everything else on
+                                    │                        the page that went
+                                    │                          stale)
+                                    └───────────────┬──────────────────┘
+                                                    ▼
+                                    body = primary + OOB swaps + assets
+      ◄─────────────────────────────────────────────┘
+```
+
+---
+
+## 1. `compose()` — is this even mine?
+
+`pyjinhx/responses.py`
+
+```text
+handler returned …
+├── a BaseComponent ──────────► render it → primary
+├── None ─────────────────────► primary = ""      (OOB-only response)
+├── a str / has __html__ ─────► wrap in Markup → primary
+└── anything else ────────────► PASSTHROUGH — not pyjinhx's, hand it back
+                                (this is how your redirects survive)
+
+then, on every path that produced a body:
+    invalidate(dirtied)   ← evict caches BEFORE walking, never after
+    fan out
+    primary empty? ──yes──► header HX-Reswap: none  (or htmx wipes the trigger)
+```
+
+---
+
+## 2. `render_level()` — rendering one component
+
+`pyjinhx/rendering.py`
+
+This is the recursive core. Static and reactive, primary and OOB —
+**everything** funnels through here. There is no second renderer.
+
+```text
+render_level(component)
+│
+├─ cycle guard: same class 32 times on ONE path? ──► raise ValueError
+│     (Card > Row > Card is perfectly fine, and so is 31 of them — what
+│      trips it is a path that never terminates, i.e. Card > Card > Card…)
+│
+├─ TIER-2 RENDER CACHE — eligible?
+│   ├─ is it reactive (has _pjx_key_field)? ──yes──► OFF
+│   │     (reactive caches its load() instead; caching both would key one
+│   │      component against two independently-invalidated stores)
+│   ├─ measured cheaper to render than to cache? ──yes──► OFF
+│   ├─ holds a component in a slot/children field? ──yes──► OFF
+│   │     (slot tokens are only valid for the one template.render() call)
+│   └─ still on? ──► look up
+│         ├─ HIT ──► _finish_cached_level() ── RETURN, template never runs
+│         └─ MISS ─► fall through ↓
+│
+├─ build context  (model_dump + slots)
+├─ Jinja render   (autoescape ON)
+├─ ONE parse      (VerbatimParser) → segments + root_span
+├─ single-root rule: 0 or 2+ roots? ──► raise ValueError
+├─ maybe save to render cache (only if no auto-generated id leaked into output)
+│
+├─ FILL CHILDREN — each <PascalCase/> tag is a hole:
+│     ├─ unknown tag ──────────► stays literal text, hole closes
+│     ├─ plain component ──────► constructor
+│     └─ reactive component ───► its cache-routed load()   ─┐
+│         then ── recurse into render_level ────────────────┘
+│         (children enter as whole objects, never text spliced into text —
+│          that's what keeps a child's markup un-reparsed and un-escaped)
+│
+├─ splice slot nodes
+└─ emit_rendered(component, level)   ← fires LAST, bottom-up
+      subscribers: stamp data-pjx-* attrs · accumulate CSS/JS · register instance
+```
+
+---
+
+## 3. `load()` — the two cache tiers
+
+`pyjinhx/reactive/component.py`, `pyjinhx/reactive/cache.py`
+
+Every reactive class's `load()` is silently wrapped at class-definition time.
+Both the primary render and every OOB region go through this same wrapper.
+
+```text
+load(key)
+│
+├─ TIER 1 (request-scoped dict) hit? ──yes──► RETURN
+│
+├─ derive react keys:  ("todos",)  +  ("todos:1",) if this call has a load key
+│     both forms, because @mutates(key=...) dirties only the composite
+│
+├─ TIER 2 (cross-request: disk/redis/sqlite) configured?
+│     ├─ backend degraded (a previous evict() raised)? ──► skip reads
+│     ├─ get() raised? ──► note failure, treat as miss   (a cache never errors a request)
+│     └─ HIT ──► promote into tier 1 ──► RETURN
+│
+├─ call your real load()
+├─ returned wrong type? ──► TypeError
+├─ put into tier 1 (reverse-indexed by react keys)
+└─ put into tier 2 (same keys become the backend's tags, + ttl)
+```
+
+---
+
+## 4. Fan-out — what else on the page is stale?
+
+`pyjinhx/reactive/fanout.py`
+
+Three passes, deliberately not one loop.
+
+```text
+X-PJX-Mounted = [{id, type, load, hash}, …]   ← what the browser says it's showing
+
+FILTER PASS (all the cheap checks, no I/O)
+  for each mounted region:
+    ├─ already inside the primary body?  ──► skip (else it'd swap twice)
+    ├─ unknown tag?                      ──► skip
+    ├─ no dirtied key touches its class? ──► skip
+    ├─ duplicate (type, load-key)?       ──► skip (one load per pair)
+    └─ keep → clean = "is it still in the load cache?"
+
+BUILD PASS (the only expensive part)
+    every pending class measured as cheaper-than-a-thread?
+      ├─ yes ──► run inline on this thread
+      └─ no  ──► ThreadPoolExecutor, each build in copy_context()
+                 (a bare thread would see empty ContextVars and write
+                  its caches into a throwaway dict)
+
+REDUCE PASS — assign each survivor a status
+    ├─ was clean            ──► "clean"    → emits NOTHING
+    ├─ load() raised LookupError ──► "missing" → <div hx-swap-oob="delete:…">
+    ├─ re-rendered, hash unchanged ──► DROP (keys changed, output didn't)
+    └─ otherwise            ──► "dirty"   → outerHTML swap
+    then: nested inside another survivor's region? ──► DROP (parent carries it)
+
+OOB_SWAPS — stamp and serialize
+    for each dirty region:
+      stamp hx-swap-oob + data-pjx-hash onto the root tag (one splice, no re-parse)
+      walk it for nested reactive regions this request did NOT dirty
+        └─► stamp hx-preserve="true" so the parent's swap lands *around* them
+```
+
+---
+
+## The notes that matter
+
+- **The ContextVar spine is the real architecture.** `request_scope()` is a
+  single context manager that opens the instance registry, both cache tiers,
+  the dirtied set, and the load context. Nothing is passed as a parameter — it
+  is all read from ContextVars. Clean and non-duplicated, but *invisible*: code
+  that runs outside a request scope silently gets defaults instead of failing,
+  which is exactly why the fan-out has to copy the context into every worker
+  thread.
+
+- **`ReactiveComponent` is a subclass, not a parallel system.** Reactivity is
+  caching + stamping + fan-out bolted onto the one render path. That is the
+  single biggest thing keeping this codebase from having two of everything.
+
+- **Four tiers of adoption, and you can stop at any of them:** components alone
+  (no framework) → request scoping → reactive HTMX → full wiring (context
+  factory, cache backends, dev warnings). Tier 1 does not even need a web
+  server. See [usage-tiers.md](../../guide/usage-tiers.md).
+
+- **The nesting blind spot sits in two places on these trees** — the "nested
+  inside another survivor?" line in the reduce pass (#1027's wasted work), and
+  the tier-2 box in tree 3 (#1026's stale replay). Neither box knows the
+  containment relation up front; both discover it, or fail to, after the fact.

--- a/docs/superpowers/rebuild/runtime-decision-trees.md
+++ b/docs/superpowers/rebuild/runtime-decision-trees.md
@@ -50,6 +50,46 @@ how the mechanisms *interact*; this one walks the branch points inside them.
 
 ---
 
+## How the four trees relate
+
+The numbering is execution order of the *entry points*, but the trees are
+nested, not a flat pipeline. Trees 1, 2 and 4 do run in that sequence; tree 3
+is not a stage at all — it is a subroutine the other two call.
+
+```text
+TREE 1  compose()
+          │
+          ├─ primary render ──► TREE 2  render_level()
+          │                        │  recurses into itself per child
+          │                        └─ reactive child ──► TREE 3  load()
+          │
+          └─ _fan_out()
+               ├─ invalidate(dirtied)
+               ├─ walk_manifest ──► BUILD PASS
+               │                      └─ per region: TREE 3  load()
+               │                                     TREE 2  render_level()
+               └─ TREE 4  oob_swaps()
+```
+
+- **Tree 2 runs many times per request**, once per component level, and
+  recursively — a page with 200 components ran it 200 times. Trees 1 and 4 run
+  exactly once.
+
+- **Tree 3 is reached from two directions:** from inside tree 2's fill-children
+  step during the primary render, and again from tree 4's build pass for each
+  stale region. That is why the tier-1 request dict matters — the second visit
+  for the same key is a dict hit.
+
+- **Tree 4 re-enters tree 2.** The fan-out's build pass has no renderer of its
+  own; it loads the region and calls `render_level()` on it, same as the
+  primary did. That is the "there is no second renderer" point — the OOB legs
+  go through the identical decision tree, cycle guard and all.
+
+So read top to bottom for the order things start in, but tree 3 sits *inside*
+the other two rather than after them.
+
+---
+
 ## 1. `compose()` — is this even mine?
 
 `pyjinhx/responses.py`


### PR DESCRIPTION
Records what the runtime decides, in the order it decides it — traced against current source, not reconstructed from the older maps.

Covers:
- the request round-trip (middleware → handler → `compose()`)
- `compose()`'s return-value dispatch, including the PASSTHROUGH path
- `render_level()`: the cycle guard (32 repeats on one path, not "no reuse"), the four tier-2 render-cache eligibility gates, and the bottom-up `emit_rendered` hook
- `load()`'s two cache tiers, including the degraded-backend and failed-`get()` paths
- the fan-out's filter / build / reduce passes and the `hx-preserve` stamping in `oob_swaps()`

Lands in `docs/superpowers/rebuild/` — the one tracked subtree under `docs/superpowers/` — and is indexed in that set's README as a living doc.

Docs-only; `mkdocs build --strict` passes (`superpowers/` is excluded from the site build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQyufpcPJGYd5sWLBzeh7W