### PR TITLE
design: nested reactive freshness — a cache entry never contains another component

### DIFF
--- a/docs/superpowers/rebuild/README.md
+++ b/docs/superpowers/rebuild/README.md
@@ -1,6 +1,6 @@
 # pyjinhx v2 rebuild — doc index
 
-The documentation set for rebuilding the pyjinhx engine as `src/pyjinhx/`, shipping as pyjinhx 1.0. Everything here is local-only (gitignored with the rest of `docs/superpowers/`).
+The documentation set for rebuilding the pyjinhx engine as `src/pyjinhx/`, shipping as pyjinhx 1.0. `docs/superpowers/` is gitignored, but this directory is un-ignored (`.gitignore:22`) and its docs are tracked; `mkdocs.yml` excludes `superpowers/` from the built site, so nothing here needs to satisfy `--strict`.
 
 ## The set
 
@@ -11,6 +11,7 @@ The documentation set for rebuilding the pyjinhx engine as `src/pyjinhx/`, shipp
 | [architecture-overview.md](./architecture-overview.md) | How it works: hard invariants, the mechanism-interaction map (mermaid), per-layer mechanisms with ship criteria, non-obvious interactions, worked example. *Living* — updated as layers ship; where it and reality disagree, fix the doc. |
 | [feature-port-list.md](./feature-port-list.md) | What ships where: every v0.36 feature with keep/mod/drop verdict and its build layer. The G3 parity checklist; each layer spec must cover its assigned rows. |
 | [implementation-overview.md](./implementation-overview.md) | How it lands as code: architecture style (flat module-per-mechanism + import rule), folder/file structure, render timelines (T0 startup / T1 cold / T2 reactive), load-bearing ordering facts. |
+| [how-pyjinhx-works.md](./how-pyjinhx-works.md) | What the runtime does today, in five mermaid diagrams: the request round trip, the render walk, tag vs slot composition, the two caches, and reactivity. Closes with where the model leaks. *Living*. |
 | [roadmap.md](./roadmap.md) | When and in what order: per-layer deliverables, PR-sized inner steps in dependency order, the two gates, checkboxes + recorded bench numbers. *Living* — check off as things ship. |
 
 Per-layer design docs (RFC role) are not standalone artifacts — the /feature workflow's spec phase (brainstorm + adversarial-doc-review) produces each layer's design just-in-time, saved under `docs/superpowers/specs/`. Decided 2026-07-29.

--- a/docs/superpowers/rebuild/how-pyjinhx-works.md
+++ b/docs/superpowers/rebuild/how-pyjinhx-works.md
@@ -1,0 +1,173 @@
+# How pyjinhx works — the runtime in five diagrams
+
+A high-level tour of the request round trip, the render walk, the two composition
+forms, the caches, and reactivity. *Living* — where this and reality disagree, fix
+the doc.
+
+Published as an artifact: <https://claude.ai/code/artifact/b9e2deec-951e-4c27-82a6-f7c0de56d9b9>
+
+## 1. The round trip
+
+One handler return becomes one response. Everything pyjinhx does happens between
+those two points, inside a request scope.
+
+```mermaid
+flowchart TD
+  A["HTTP request"] --> B["request_scope&lpar;&rpar;<br/>ContextVar spine"]
+  B --> C["your handler"]
+  C --> D{"what did it return?"}
+  D -->|component| E["render&lpar;&rpar;"]
+  D -->|str / __html__| F["use as-is"]
+  D -->|None| G["empty primary"]
+  D -->|anything else| H["PASSTHROUGH<br/>framework keeps it"]
+  E --> I["primary markup"]
+  F --> I
+  G --> I
+  I --> J["fan-out<br/>attach OOB legs"]
+  J --> K["PjxResponse<br/>body + htmx headers"]
+```
+
+`responses.py` · `compose()` → `_fan_out()`
+
+## 2. Inside one render
+
+`render_level()` is the single recursive path. Every component — page, shell, leaf
+— goes through the same gates.
+
+```mermaid
+flowchart TD
+  S["render_level&lpar;component&rpar;"] --> CY{"same class 32x<br/>on this path?"}
+  CY -->|yes| ERR["ValueError: cycle"]
+  CY -->|no| RC{"render cache eligible?"}
+  RC -->|"reactive class"| OFF["no cache —<br/>renders every time"]
+  RC -->|"too cheap to cache"| OFF
+  RC -->|"holds slot components"| OFF
+  RC -->|eligible| LOOK{"cache hit?"}
+  LOOK -->|hit| REST["restore shell segments<br/>child holes stay holes"]
+  LOOK -->|miss| PARSE
+  OFF --> PARSE["render template once<br/>split into segments"]
+  PARSE --> FILL["for each child hole"]
+  REST --> FILL
+  FILL --> REC["render_level&lpar;child&rpar;"]
+  REC -.recurse.-> S
+  FILL --> OUT["RenderedLevel<br/>children as objects, not text"]
+```
+
+`rendering.py` · `render_level()` · `_finish_cached_level()` · `_fill_children()`
+
+A cache hit restores *only the shell*. Children are still holes, so they resolve
+and recurse exactly as on a fresh render. Measured on a cacheable `Shell`
+containing `<Leaf/>`:
+
+```text
+render #1  templates built: ['Shell', 'Leaf']
+render #2  templates built: ['Leaf']
+render #3  templates built: ['Leaf']
+```
+
+## 3. Two ways a child gets in
+
+This distinction drives most of the runtime's behaviour — and most of its sharp
+edges.
+
+```mermaid
+flowchart TD
+  subgraph TAG["TAG composition"]
+    T1["Shell.load&lpar;&rpar; → shell"] --> T2["template says &lt;Child /&gt;"]
+    T2 --> T3["ChildRef — a HOLE"]
+    T3 --> T4["renderer resolves class<br/>binds props → key"]
+    T4 --> T5["Child.load&lpar;&rpar; runs here"]
+  end
+  subgraph SLOT["SLOT composition"]
+    S1["Shell.load&lpar;&rpar; builds the child<br/>in Python"] --> S2["content = Child&lpar;already loaded&rpar;"]
+    S2 --> S3["no hole — it is data"]
+    S3 --> S4["renderer just interpolates it"]
+  end
+```
+
+**Tag → a hole.** The child is a reference until render time. The runtime knows
+its class and its key before it loads, so it can decide what to do with it.
+
+**Slot → already data.** The child is a fully-loaded instance living inside the
+parent's return value. There is no decision point left, because there is nothing
+to decide about.
+
+## 4. The caches
+
+Two independent stores. A component uses one or the other, never both — and
+**neither one ever caches a subtree.** Both stop at the component boundary.
+
+```mermaid
+flowchart LR
+  subgraph L["LOAD CACHE — reactive classes"]
+    direction TB
+    L0["Component.load&lpar;key&rpar;"] --> L1{"tier 1<br/>request dict"}
+    L1 -->|hit| LH["return"]
+    L1 -->|miss| L2{"tier 2<br/>cross-request backend"}
+    L2 -->|hit| LH
+    L2 -->|miss| L3["run load&lpar;&rpar; body"]
+    L3 --> LH
+  end
+  subgraph R["RENDER CACHE — plain classes"]
+    direction TB
+    R0["render_level"] --> R1{"backend hit?"}
+    R1 -->|hit| R2["restore shell only"]
+    R1 -->|miss| R3["render template"]
+  end
+```
+
+| | stores | children |
+|---|---|---|
+| **Load cache** | the instance `load()` returned; the cache key *is* the load key | not in it |
+| **Render cache** | that component's own shell segments | still holes |
+
+Because neither store holds a composed subtree, a hit can never short-circuit the
+descent: there is no cached artifact containing the children, so the renderer must
+go and get them.
+
+## 5. Reactivity
+
+Components declare keys. A mutation dirties keys. Everything downstream is that one
+match.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant C as client
+  participant H as handler
+  participant K as dirtied keys
+  participant X as caches
+  participant F as fan-out
+  C->>H: htmx request
+  H->>K: mutation marks "todos" dirty
+  H-->>F: returns primary component
+  K->>X: invalidate&lpar;dirtied&rpar; — both tiers
+  F->>F: walk client manifest
+  F->>F: keep regions whose keys were dirtied
+  F->>F: preserve nested regions that were not
+  F-->>C: primary + OOB fragments
+```
+
+`reactive/cache.py` · `reactive/fanout.py` · `responses.py`
+
+**What keys decide:** which cache entries get evicted, and which client regions get
+swapped out-of-band.
+
+**What they don't:** which `load()` bodies actually run. That is decided by cache
+residency and by position in the render tree — `get_dirtied()` is read in exactly
+one production path (`responses.py:61`), which runs *after* the primary render.
+
+## 6. Where the model leaks
+
+| Intent | Status | What actually happens |
+|---|---|---|
+| A parent's `load()` never triggers a child's | literally true | No `load()` calls another. But the *renderer* does, at full depth — and a cache hit does not stop it, because no cache holds a subtree. |
+| Reactivity follows declared keys | for swaps | True for eviction and for OOB region selection. Not true for which loads execute. |
+| A cached shell serves fresh children | tags ✓ slots ✗ | Tag children re-resolve through their holes. Slot children are frozen inside the parent's cached value and never reload. |
+
+The common thread: the runtime knows each parent→child edge at the moment it fills
+a hole, but never records it — so anything needing that edge later has to re-derive
+it, or fails.
+
+The fix is specified in
+[`../specs/2026-08-25-nested-freshness-design.md`](../specs/2026-08-25-nested-freshness-design.md).

--- a/docs/superpowers/specs/2026-08-25-fixed-at-the-hole.md
+++ b/docs/superpowers/specs/2026-08-25-fixed-at-the-hole.md
@@ -1,0 +1,267 @@
+# Fixed at the hole — the five scenarios, before and after
+
+Companion to [`2026-08-25-nested-freshness-design.md`](./2026-08-25-nested-freshness-design.md).
+Each scenario as it behaves today and as it behaves once every child is resolved at
+the moment its hole is filled.
+
+Published as an artifact: <https://claude.ai/code/artifact/7849ea42-67b6-4a94-baf2-3f47dbd34133>
+
+Panes are marked **measured** (a real run against v1.9.1, from the scratchpad
+repros) or **designed** (a consequence of the spec, not an observation).
+
+> **A cache entry never contains another component.**
+>
+> The render cache already obeys this — a hit restores the shell and leaves child
+> holes as holes. The load cache does not. Every scenario below is a consequence of
+> that one asymmetry.
+
+## 1. Clean children still load — *unfiled*
+
+Five reactive components nested in a chain, each declaring its own key. Nothing
+dirtied, everything already on the client.
+
+```python
+class Level0(ReactiveComponent, react=("key0",)): ...   # <Level1/> in its template
+class Level1(ReactiveComponent, react=("key1",)): ...   # <Level2/> in its template
+```
+
+**Today** *(measured)*
+
+```text
+cold render                loads: L0 L1 L2 L3 L4  (5)
+L0 cached, rest evicted    loads:    L1 L2 L3 L4  (4)
+no backend, request 2      loads: L0 L1 L2 L3 L4  (5)
+```
+
+A fully cached parent does not stop the descent — no cache holds a subtree, so the
+renderer must go and get the children.
+
+**After** *(designed)*
+
+```text
+nothing dirtied, client holds every region    loads: —   (0)
+
+each hole emits:
+<div id="level1" hx-preserve="true"></div>
+```
+
+The gate asks about dirtiness *before* loading. A clean subtree costs one
+placeholder no matter how deep it goes.
+
+## 2. Tag composition serves a stale key — *#1026*
+
+The child's identity flows through the parent's data. The user moves from
+conversation 1 to 2, dirtying `conversation`.
+
+```python
+class Shell(ReactiveComponent, react=("view",)):   # does NOT declare 'conversation'
+    ...
+```
+
+```jinja
+<div id="shell"><Child conversation="{{ conversation }}"/></div>
+```
+
+**Today** *(measured)*
+
+```text
+A  baseline           child.load: ['1']   stale: True
+B  child cache=False  child.load: ['1']   stale: True
+C  parent declares it child.load: ['2']   stale: False
+```
+
+The child's entry *is* evicted and its body *does* run — against a key read off a
+parent that was not. Opting the child out of caching changes nothing.
+
+**After** *(designed)*
+
+```text
+Shell (template: shell.pjx): child Child reacts to 'conversation', which this
+request dirtied — but Shell was served from the load cache, so the props it
+passed down are from an earlier request.
+
+    react=("view", "conversation")
+```
+
+The parent depends on every key it passes down as an identity. The error says so,
+and names the fix — which is scenario C, already working today.
+
+## 3. Slot composition freezes the child — *#1026*
+
+The parent builds its child in Python, so the child arrives already loaded. There is
+no hole, and therefore no decision point.
+
+**Today** *(measured)*
+
+```python
+content=Child.load(conversation=view)
+```
+
+```text
+WITH a tier-2 backend
+   shell.load() ran : False
+   child.load() keys: NEVER
+   serves stale     : True
+```
+
+The child's data sits inside the parent's cache entry. Nothing left to load — the
+answer is already in the field.
+
+**After** *(designed)*
+
+```python
+content=Child.ref(conversation=view)
+```
+
+```text
+cached value holds:
+   Ref(Child, {"conversation": "1"})
+   ^ an instruction, not an answer
+
+child.load() keys: ['2']
+serves stale     : False
+```
+
+A reference cannot freeze. The parent's entry names the child; it doesn't contain
+it.
+
+## 4. A fresh parent names a different child — *condition 3*
+
+The subtle one. `view` is dirtied but `conversation` is not — yet the reloaded
+parent now points at a different conversation.
+
+**A naive skip gate** *(designed)*
+
+```text
+Shell reloads    -> passes conversation="2"
+Child's own keys -> clean
+                 -> PRESERVE
+
+client keeps markup for conversation="1"
+```
+
+A skip gate that only asked "were your keys dirtied?" would introduce a brand-new
+staleness bug in the act of fixing the others.
+
+**With the load-key match** *(designed)*
+
+```text
+manifest region load key : "1"
+child now resolves to    : "2"
+                         -> mismatch
+                         -> condition 3 fails
+                         -> the child loads
+```
+
+Condition 3 does two jobs: does the client have this region, and is it still the
+same child.
+
+## 5. A list where one row changed
+
+Fifty rows, one dirtied. Each element is its own hole with its own decision.
+
+```python
+content=[Messages.ref(conversation=c) for c in ids]
+```
+
+```jinja
+{% for c in content %}{{ c }}{% endfor %}
+```
+
+**Today** *(measured)*
+
+```text
+50 rows rendered
+50 load() bodies run
+49 results discarded by fan-out
+```
+
+Fan-out correctly ships only the one changed row. The other forty-nine were
+fetched, formatted, rendered, and thrown away.
+
+**After** *(designed)*
+
+```text
+1  loads and renders
+49 emit <li id="row-7" hx-preserve="true">
+
+REQUIRES a stable authored id per row:
+   <li id="row-{{ conversation }}">
+```
+
+With auto `pjx-N` ids the gate fails and all fifty load — correct, no savings. This
+is the one thing to get right for lists.
+
+## What this does not fix
+
+### Auto ids get no islands
+
+`_auto_id()` is a process-unique counter (`_component.py:47`), so the same logical
+region gets a new id on every render:
+
+```text
+same region, three consecutive requests:
+  request 1: <section id="pjx-1">msgs-7</section>
+  request 2: <section id="pjx-2">msgs-7</section>
+  request 3: <section id="pjx-3">msgs-7</section>
+```
+
+htmx resolves a preserved element by the plain `id` via `getElementById`. A
+placeholder saying `pjx-2` would find no live node called `pjx-2`, `hx-preserve`
+would no-op, and the empty placeholder would ship — wiping the region. Conditions 3
+and 4 both catch this, so the child simply loads instead. Correct, no savings, no
+signal.
+
+| No islands | Islands |
+|---|---|
+| `<section>{{ body }}</section>` | `<section id="messages-{{ conversation }}">{{ body }}</section>` |
+| id minted per render → `pjx-1`, `pjx-2`, … | id stable across requests → preservable |
+
+Worth a dev-mode warning for a reactive class whose root carries no authored id, so
+the degradation is visible rather than silent.
+
+### #1022 / #1027 — the fan-out double build
+
+A different pipeline. Both regions are in the client's manifest, and `TodoList` is
+nested inside `Shell`. Dirty a key they both react to:
+
+```text
+manifest: [ {id: "shell", type: shell},  {id: "todos", type: todo_list} ]
+dirtied:  {"todos"}
+
+walk_manifest -> both survive the filter pass
+  _build_pass renders "shell"  -> descends -> TodoList.load() + render   (1)
+  _build_pass renders "todos"  -> TodoList.load() + render               (2)
+  _drop_nested  -> prunes the "todos" candidate from the OOB output
+
+net: one wasted load + render + registry write, every request
+```
+
+The skip gate cannot help: `TodoList` **is** dirty — that is why it is a candidate.
+Avoiding the redundant build needs containment knowledge *before* the build pass,
+which the design deliberately declines to record. PR #1025 quiets the resulting
+registry collision; #1027 is the follow-up that would skip the build.
+
+### The handler's return always loads
+
+Everything beneath the returned component is gated. The returned component itself is
+not — you asked for it.
+
+```python
+@app.post("/todos")
+async def add_todo():
+    dirty("todos")
+    return Shell.load(view="home")   # Shell.load() runs, Shell's template renders
+                                     # children preserved, TodoList swapped OOB
+```
+
+Both narrower returns avoid even that:
+
+```python
+return TodoList.load(todos="home")   # primary = just the changed island
+return None                          # primary = ""; fan-out ships OOB legs alone,
+                                     # _fan_out sets HX-Reswap: none
+```
+
+Framework limit, or authoring choice? The latter — returning the shell when only a
+region changed is asking for the shell.

--- a/docs/superpowers/specs/2026-08-25-nested-freshness-design.md
+++ b/docs/superpowers/specs/2026-08-25-nested-freshness-design.md
@@ -198,9 +198,20 @@ Messages  bare construct OK   -> Messages(conversation='1', body='', unread=0)
 Invoice   bare construct FAILS -> ValidationError: total  Field required
 ```
 
-That failure's obvious workaround is `Invoice.load(...)`, which is exactly what
-now raises. `ref()` records props rather than building a model, so it works for
-both classes identically.
+`Messages` constructs because every load-supplied field has a default. `Invoice`
+does not, because an invoice *has* a total — "an Invoice that has not been fetched
+yet" is not expressible in its own type.
+
+That squeezes a strictly-typed class out of both spellings: bare construction
+raises on validation, and `Invoice.load(...)` raises under section 1's rule
+because the instance it returns carries `total=1234.5` — the child's data. `ref()`
+is the way out, and the reason it is public API rather than sugar: it records
+props without constructing the model, so `total` is never missing and arrives at
+the hole when `load()` runs.
+
+The alternative needing no new API is a plain dict, since the annotation already
+names the class (`content={"conversation": view}`). Rejected: untyped, invisible
+to an IDE, and reads like configuration rather than composition.
 
 ### What a parent may still read
 
@@ -309,6 +320,25 @@ field, not a new mechanism.
   everywhere → the whole tree loads. No special case.
 - **Slots join here.** `_splice_slot_nodes` hands a `Ref` to the same gate a
   `ChildRef` goes through.
+- **Only the handler's return pays unconditionally.** Every component beneath it
+  is a hole and is gated, backend or not — an ancestor on the path to a dirty
+  descendant is preserved along with everything under it, and the dirty
+  descendant still gets its own OOB leg because `walk_manifest` builds it
+  standalone from the manifest entry:
+
+  ```
+  handler returns Page;  TodoList dirty,  Shell clean
+
+  Page      primary -> load runs, template renders
+    Shell   hole -> clean, client holds it -> PRESERVED, load never runs
+      TodoList  never visited on this path
+  TodoList  built standalone by fan-out, swapped OOB
+  ```
+
+  The one remaining load is an authoring choice, not a framework limit: returning
+  the shell when only a region changed is asking for the shell. Return the
+  narrowest component that changed, or `None` and let fan-out ship OOB legs —
+  `_fan_out` already sets `HX-Reswap: none` for an empty primary.
 
 ## Section 3 — Provenance and the 2a error
 
@@ -454,6 +484,33 @@ Per mechanism:
   ClassVar opt-out silences it.
 - **No eager** — assigning a loaded reactive component to a component-typed field
   raises; loading inside `load()` without storing it does not.
+
+## What this does not deliver
+
+Three gaps stand between this design and unqualified island reactivity. None are
+regressions; all should be read as scope, not as covered.
+
+**1. Preservation requires a stable authored id.** Condition 4 is a real gate, not
+a footnote: a region whose root falls back to an auto `pjx-N` id is never
+preserved and always loads. Components get islands only if their template root
+carries an authored id, which makes this as much a documentation problem as a code
+one. Lists are where it bites hardest — the difference between one load and fifty.
+Worth considering a dev-mode warning for a reactive class whose root has no
+authored id, so the degradation is visible rather than silent.
+
+**2. #1022 / #1027 remain open.** They live in a different pipeline:
+`walk_manifest`'s parallel build pass renders a candidate that is *also* a strict
+descendant of another surviving candidate's tree, and `_drop_nested` prunes only
+the output — after both renders already ran. The skip gate does not help, because
+in that scenario the nested candidate **is** dirty; that is why it is a candidate.
+So the *dirty* term stays inflated by redundant renders. PR #1025 quiets the
+resulting registry collisions; #1027 is the follow-up that would avoid the build.
+Closing it needs containment knowledge before the build pass, which this design
+deliberately declines to record.
+
+**3. The handler's returned component always loads and renders.** Inherent, and
+addressed by authoring guidance rather than machinery (see section 2's
+consequences).
 
 ## Corrections owed
 

--- a/docs/superpowers/specs/2026-08-25-nested-freshness-design.md
+++ b/docs/superpowers/specs/2026-08-25-nested-freshness-design.md
@@ -1,0 +1,429 @@
+# Design: nested reactive freshness — resolve at the hole
+
+**Date:** 2026-08-25
+**Status:** Approved, pending implementation plan
+**Issues:** #1022, #1026, #1027, #1028
+**Breaking:** yes — lands additively in a 1.x minor, enforced in 2.0
+
+## Problem
+
+Three defects share one cause. The runtime knows each parent→child edge at the
+moment it fills a child hole, and never acts on it there — so freshness and
+skip decisions are either made too late or not at all.
+
+### 1. Clean children still load
+
+Island reactivity promises two savings. Fan-out delivers one: a region whose
+declared keys were not dirtied never reaches the wire. The other is not built —
+every clean component still runs `load()` on the server, renders its template,
+and has the markup discarded by fan-out.
+
+The reason is structural, not an oversight. `get_dirtied()` is read in exactly
+one production path (`responses.py:61`, inside `_fan_out`), which runs *after*
+the primary render. By the time anything asks what was dirtied, every `load()`
+has already executed. Neither `rendering.py` nor `_wrap_load` reads it at all.
+
+Measured on a five-level reactive chain, each level declaring its own key:
+
+```
+cold render                              loads: L0 L1 L2 L3 L4   (5)
+L0 fully cached, descendants evicted     loads:    L1 L2 L3 L4   (4)
+only 'key0' dirtied                      loads: L0               (1, all 5 asked)
+no tier-2 backend, request 2, nothing dirtied
+                                         loads: L0 L1 L2 L3 L4   (5)
+```
+
+Output is always correct. This is a missing optimization, not wrong data — but
+it is the optimization the library's design intent was written around.
+
+### 2a. Tag composition serves a stale load key
+
+A child whose key flows through its parent's data inherits that parent's
+staleness. Confirmed by repro:
+
+```
+dirtied 'conversation'; user moved from conversation 1 -> 2
+
+A  baseline (parent reacts to 'view' only)   child.load called: ['1']  stale: True
+B  child given cache=False                   child.load called: ['1']  stale: True
+C  parent reacts to ('view','conversation')  child.load called: ['2']  stale: False
+```
+
+The child's entry *is* evicted and its body *does* run — against a key read off
+a parent that was not evicted. Opting the child out of caching does not rescue
+it; only widening the parent's react set does.
+
+### 2b. Slot composition freezes the child entirely
+
+When a parent builds its child in Python, the child is a fully-loaded instance
+inside the parent's cached `load()` result. There is no hole, so there is no
+decision point:
+
+```
+WITH a tier-2 load cache backend
+   shell.load() ran : False
+   child.load() keys: NEVER
+   serves stale     : True
+
+WITHOUT any backend (the default)
+   shell.load() ran : True
+   child.load() keys: ['2']
+   serves stale     : False
+```
+
+`holds_spliced_components` does not cover this. It is a *render*-cache gate, and
+a reactive class turns the render cache off at the first check
+(`rendering.py:336`), so the slot gate three lines down is never evaluated for
+the components that have this bug. The freeze is in the **load** cache.
+
+ADR 0003 makes every component-typed field a slot structurally, so this surface
+is every nested component built in Python — not an opt-in few.
+
+## The shared cause
+
+A cached parent's data decides what its children are: the child's **key** in tag
+form, the child **itself** in slot form. Either way staleness propagates
+downward and nothing checks it. And because nothing consults dirtiness during
+the render walk, no child can be skipped.
+
+## Decision
+
+Make `_fill_children` the single freshness decision point, for tags and slots
+alike, at the moment the hole is filled and before the child loads.
+
+```
+_fill_children reaches a child hole
+   |- resolve class -> declared react keys
+   |- bind props    -> load key value
+   |- dirtied this request?  -- no --+- client manifest holds it? -- yes -> PRESERVE
+   |                                 \- no ------------------------------> load
+   \- yes -> parent served from cache?
+               |- no  -> load (fresh props)
+               \- yes -> raise (provenance error)
+```
+
+Two facts make this feasible without new plumbing:
+
+- `session.pjx_mounted` is populated by middleware *before* the handler runs
+  (`integrations/fastapi.py:213`, inside `request_scope`, before `call_next`),
+  so a hole-time decision can already ask what the client holds.
+- `_load_reactive_child` (`rendering.py:111`) already resolves the class, pulls
+  the key attr out of the props, and coerces it to the field's declared type —
+  all before `cls.load(**key_args)`. That line is the decision point.
+
+No template scanner, no recorded edge map, no ancestor rollup. The parent→child
+edge is consumed at the instant it exists and never stored, because nothing
+downstream needs it.
+
+## Section 1 — The Ref contract
+
+`ReactiveComponent` gains one classmethod:
+
+```python
+class Shell(ReactiveComponent, react=("view",)):
+    content: Child | None = None
+
+    @classmethod
+    def load(cls, view: str) -> "Shell":
+        return cls(id="shell", content=Child.ref(conversation=view))
+```
+
+`Child.ref(**props)` returns a frozen `(class, props)` pair. It runs no
+`load()`, touches no cache, holds no data — the Python spelling of what
+`<Child conversation="…"/>` already produces as a `ChildRef` (`segments.py:12`).
+Component-typed slot fields accept it alongside a real instance; those fields are
+already detected structurally at registration (ADR 0003), which is where the
+widening goes.
+
+What ends up in the parent's cached value is the whole point:
+
+```python
+# eager — caches the child's DATA. This is 2b.
+Shell(content=Child(conversation="1", body="messages-of-1"))
+
+# ref — caches an INSTRUCTION. Re-decided every request.
+Shell(content=Ref(Child, {"conversation": "1"}))
+```
+
+### Legal field values
+
+| value | when | freshness | islands |
+|---|---|---|---|
+| `Child.ref(...)` | default, recommended | resolved at the hole | yes |
+| bare `Child(...)` | works where it validates | resolved at the hole | yes |
+| `Child.load(...)` | parent needs the data | eager, parent uncacheable | no |
+| plain component | non-reactive child | no load, no staleness | n/a |
+
+A bare constructor call is already an unloaded instance — `load()` is a separate
+classmethod — so it gets the same treatment at the hole. It is accepted but not
+documented as the way, because it fails on any class with a required
+load-supplied field:
+
+```
+Messages  bare construct OK   -> Messages(conversation='1', body='', unread=0)
+Invoice   bare construct FAILS -> ValidationError: total  Field required
+```
+
+That failure's obvious workaround is `Invoice.load(...)`, which silently costs
+islands and parent cacheability. `ref()` records props rather than building a
+model, so it works for both classes identically.
+
+### The eager escape hatch
+
+A parent that genuinely needs its child's data — to sort, filter, or decide
+whether to include it — keeps writing `Child.load(...)` and declares the field
+eager:
+
+```python
+from pyjinhx import Eager   # exported alongside PjxKey / Slot / Children
+
+content: Annotated[Child | None, Eager()] = None
+```
+
+Two rules attach to it:
+
+- **A `load()` result holding a loaded reactive instance is not tier-2
+  cacheable.** This is what makes 2b's remaining surface correct instead of
+  silently stale: the parent renders live every request, and the reason is
+  visible in the annotation.
+- **Assigning a loaded reactive instance to a non-eager slot field raises**, so
+  forgetting `ref()` is a loud failure rather than a silent downgrade:
+
+```
+Shell (template: shell.pjx): field 'content' was assigned a loaded Child.
+A slot child is resolved at render time — assign Child.ref(conversation=…)
+instead. If this child must be loaded inside Shell.load() (you need its data
+to sort or filter it), declare the field eager:
+    content: Annotated[Child | None, Eager()] = None
+```
+
+`ref()` is reactive-only. A plain component in a slot has no `load()` and
+therefore no freshness problem.
+
+## Section 2 — The decision at the hole
+
+### Constraint
+
+`hx-preserve` is resolved by htmx through the incoming tag's plain `id`
+(`getElementById`), not `data-pjx-id` (`fanout.py:825`). Preservation therefore
+only lands for a region whose template root carries a stable authored id. And
+`hx-preserve` is a no-op for an id the client does not already show — which for
+a placeholder means shipping an empty element. **The manifest check is
+mandatory, not an optimization.**
+
+### The skip gate
+
+Skip a child only on positive proof of all five conditions:
+
+| # | condition | existing machinery |
+|---|---|---|
+| 1 | reactive class | `_pjx_key_field` |
+| 2 | no declared key dirtied this request | `_keys_match_dirtied` |
+| 3 | manifest holds this id, type, load key | `session.pjx_mounted` |
+| 4 | root id is authored, not auto | `has_auto_id` |
+| 5 | class opts in | `retain_across_parent_swaps` (default `True`) |
+
+Four of five already exist. `retain_across_parent_swaps` is already the
+per-class switch for this question in the OOB path; reusing it means one flag
+governs preservation everywhere rather than two that can disagree. Its default
+of `True` means existing components get islands without opting in.
+
+Any failed condition falls back to loading and rendering, exactly as today —
+the same conservative posture `_preserve_nested` takes: skip only on proof,
+never on absence of evidence.
+
+### What gets emitted
+
+```html
+<div id="messages" hx-preserve="true"></div>
+```
+
+One new requirement: manifest entries gain the region's **root tag name**, so the
+placeholder matches the live element. `pjx.js` has it at mount time; an added
+field, not a new mechanism.
+
+### Consequences
+
+- **Descendants are independent.** `walk_manifest` reads the client's manifest,
+  not what was rendered, so a dirty grandchild under a skipped parent still gets
+  its own OOB leg — and `_drop_nested` will not swallow it, because the skipped
+  parent's placeholder does not contain it.
+- **Cold loads are correct by construction.** Empty manifest → condition 3 fails
+  everywhere → the whole tree loads. No special case.
+- **Slots join here.** `_splice_slot_nodes` hands a `Ref` to the same gate a
+  `ChildRef` goes through. This is the payoff of section 1.
+
+## Section 3 — Provenance and the 2a error
+
+### The stamp
+
+`_wrap_load` already branches on `cache_has(...)`. Mark instances returned from
+either tier with `_pjx_from_cache = True`. One assignment, one place — the only
+new state in this design.
+
+### The check
+
+At the same hole, once the skip gate has decided the child must load:
+
+```
+child's declared key dirtied this request?
+  \- yes -> was the parent that supplied these props served from cache?
+              \- yes -> raise
+```
+
+`_fill_children` currently takes only the level; the parent component is threaded
+through from `render_level`. Both call sites (`render_level` and
+`_finish_cached_level`) already hold it.
+
+### The message
+
+```
+Shell (template: shell.pjx): child Child reacts to 'conversation', which this
+request dirtied — but Shell was served from the load cache, so the props it
+passed down are from an earlier request and Child's key may be stale.
+
+Shell's data determines which Child is shown, so Shell depends on
+'conversation' too:
+    class Shell(ReactiveComponent, react=("view", "conversation")):
+
+If Shell genuinely does not depend on it, silence this for the class:
+    trust_cached_props: ClassVar[bool] = True
+```
+
+### Why raise rather than repair
+
+The repair — evict the parent, re-run its `load()` — is always correct and needs
+no analysis, but it fires on every interaction in the exact shape this library is
+built for (shell plus keyed region). The shell would reload every request: the
+cascade section 2 exists to kill, reintroduced through the back door. Raising
+costs nothing at runtime and states the true fact — the parent depends on that
+key. Repro scenario C is that fix, and it already works today.
+
+### Accepted false positive
+
+A literal key (`<Leaf leaf="x"/>`) under a cached parent whose `leaf` was dirtied
+has no data flow, and this rule raises anyway. Two filters were considered and
+rejected as premature: a template scan (precise for tags, structurally blind to
+refs) and a value-membership test against the parent's fields (covers both,
+misses computed keys). Both are two mechanisms where one would do, for a case
+that hardcodes an identity into markup. Ship the coarse rule and the ClassVar
+opt-out; add a filter only if real code trips it.
+
+### Blast radius
+
+The check can only fire when a parent came from cache, which requires a tier-2
+backend. The default configuration has none, so no default-configured app can
+hit this — and the apps that can are exactly those silently serving stale data
+today.
+
+Refs get this for free: a `Ref` built inside a cached parent's `load()` carries
+the same staleness as an interpolated tag attr, and the same stamp on the same
+parent catches it. One rule, both composition forms.
+
+## Section 4 — Migration
+
+Five changes, in descending blast radius:
+
+1. **A loaded reactive instance in a slot field raises.** Mechanical migration:
+   `Child.load(x)` → `Child.ref(x)`. Where the parent needs the data, mark the
+   field `Annotated[Child | None, Eager()]`.
+2. **An `Eager` field makes its parent tier-2 uncacheable.** No error, a slower
+   parent, and the reason visible in the annotation.
+3. **The 2a provenance raise.** Unreachable without a tier-2 backend.
+4. **Clean children stop running `load()`.** The real semantic break: any
+   `load()` with side effects — a hit counter, a lazy write, an audit log —
+   silently loses them. Needs a prominent migration note. `load()` is a read,
+   and the runtime now holds authors to it.
+5. **Manifest gains a root tag name.** An old client sending the old manifest
+   fails condition 3, so those children load exactly as today. Graceful
+   degradation, no version negotiation.
+
+**Release order:** ship `ref()` and `Eager()` additively in a 1.x minor with no
+enforcement so authors can migrate at their own pace; flip the raises and the
+skip gate on in 2.0. One extra release turns a cliff into a ramp.
+
+## Implementation phases
+
+The release order in section 4 gives two natural plans. Each is independently
+shippable and independently testable.
+
+**Phase 1 — additive, 1.x minor. No behavior change.**
+
+1. `Ref` type and `ReactiveComponent.ref()`.
+2. Slot fields accept a `Ref`; `_splice_slot_nodes` resolves one through the
+   same path a `ChildRef` takes.
+3. `Eager()` annotation; a `load()` result holding a loaded reactive instance is
+   not tier-2 cacheable.
+4. `_pjx_from_cache` stamp in `_wrap_load`.
+5. Manifest gains the root tag name; `pjx.js` emits it.
+
+At the end of phase 1 every new spelling works, nothing raises, and no child is
+skipped. 2b's staleness is already fixed for anyone who has migrated, because a
+`Ref` cannot freeze.
+
+**Phase 2 — enforcing, 2.0.**
+
+6. The skip gate in `_fill_children`, all five conditions, plus the preserved
+   placeholder.
+7. The provenance raise and its `trust_cached_props` opt-out.
+8. The raise on assigning a loaded reactive instance to a non-eager slot field.
+9. Migration note for side-effecting `load()` bodies.
+
+Phase 2 is where the invariant test flips from 4 descendant loads to 0.
+
+## Section 5 — Testing
+
+The existing scratchpad repros are the corpus: `repro_1026_full.py`,
+`blindspot_slot.py`, `invariants.py`, `what_is_cached.py`.
+
+**The invariant test, first and loudest.** The five-level chain, asserting the
+original design intent: *no `load()` body runs for a child whose keys were clean
+and whose region the client holds.* Currently 4 descendant loads; should become
+0. The one test that fails today for the right reason.
+
+Per mechanism:
+
+- **Skip gate** — five tests, one per condition, each proving a failed condition
+  falls back to loading. Conservative-by-default is tested as the default, not
+  assumed.
+- **Preserve output** — placeholder carries the authored id, `hx-preserve="true"`,
+  and the manifest's root tag.
+- **Cold load** — empty manifest, whole tree loads.
+- **Descendant independence** — dirty grandchild under a skipped parent gets its
+  own OOB leg and is not swallowed by `_drop_nested`.
+- **Slot refs** — `blindspot_slot.py` inverted: child loads with key `2`, no
+  stale markup.
+- **Provenance** — repro A raises with the right message; scenario C does not;
+  the ClassVar opt-out silences it.
+- **Eager escape hatch** — the field works, and its parent is provably absent
+  from both tier-2 caches.
+
+## Corrections owed
+
+- PR #1031's strict xfail `test_dirtying_a_nested_regions_key_reaches_that_region`
+  encodes "this should eventually pass." Under this design it should **raise**.
+  Rewrite as part of this work.
+- The #1026 comment describes only the tag mechanism. It needs the slot mechanism
+  added, and the note that `holds_spliced_components` is unreachable for reactive
+  classes.
+- `docs/superpowers/rebuild/runtime-decision-trees.md` and the published runtime
+  artifact both state that only slots go stale. Both need the two-mechanism
+  correction.
+
+## Rejected alternatives
+
+- **Ancestor rollup** (dirty a child's key → evict the parents that embed it).
+  Correct, but reloads the shell on every interaction — the anti-island. It was
+  the original consumer for a recorded edge map; the hole-time decision is a
+  better one, in the opposite direction.
+- **Guard without unifying** (refuse to cache slot-holding parents, add the skip
+  gate for tags only). Smaller diff, but permanently forks tags and slots — which
+  is where every one of these bugs came from — and makes shell components, the
+  ones most worth caching, exactly the ones that cannot be.
+- **Keys never flow downward** (a child's load key must come from the request,
+  never a parent field). Kills 2a by construction, and forbids passing an id
+  down, which is the normal way to build a page.
+- **Static template scanner as a freshness mechanism.** Validated at 10/10 on
+  constructed shapes and 0.7 ms over 70 real templates, but structurally blind to
+  slot composition. Retained only as a possible false-positive filter for
+  section 3, not as load-bearing machinery.

--- a/docs/superpowers/specs/2026-08-25-nested-freshness-design.md
+++ b/docs/superpowers/specs/2026-08-25-nested-freshness-design.md
@@ -1,27 +1,48 @@
-# Design: nested reactive freshness — resolve at the hole
+# Design: nested reactive freshness — a cache entry never contains another component
 
 **Date:** 2026-08-25
 **Status:** Approved, pending implementation plan
 **Issues:** #1022, #1026, #1027, #1028
 **Breaking:** yes — lands additively in a 1.x minor, enforced in 2.0
 
+## The rule
+
+> **A cache entry never contains another component.**
+> A component-typed field holds a *reference*, never a loaded component.
+
+The render cache already obeys this. `_finish_cached_level` restores a level's
+own segments and leaves its child holes as `ChildRef`s, so a hit rebuilds
+children live. Measured on a cacheable `Shell` containing `<Leaf/>`, rendered
+three times:
+
+```
+render #1  templates built: ['Shell', 'Leaf']
+render #2  templates built: ['Leaf']      <- Shell restored, Leaf rebuilt
+render #3  templates built: ['Leaf']
+```
+
+The load cache does not obey it. A slot-composing parent's cached `load()` result
+holds the loaded child instance — the child's *data*, cached one level too high.
+
+That asymmetry is the whole problem. Everything below follows from making the
+load cache obey the same rule the render cache always has.
+
 ## Problem
 
-Three defects share one cause. The runtime knows each parent→child edge at the
-moment it fills a child hole, and never acts on it there — so freshness and
-skip decisions are either made too late or not at all.
+Three defects share one cause: the runtime knows each parent→child edge at the
+moment it fills a child hole, and never acts on it there.
 
 ### 1. Clean children still load
 
 Island reactivity promises two savings. Fan-out delivers one: a region whose
 declared keys were not dirtied never reaches the wire. The other is not built —
-every clean component still runs `load()` on the server, renders its template,
-and has the markup discarded by fan-out.
+every clean component still runs `load()`, renders its template, and has the
+markup discarded by fan-out.
 
-The reason is structural, not an oversight. `get_dirtied()` is read in exactly
-one production path (`responses.py:61`, inside `_fan_out`), which runs *after*
-the primary render. By the time anything asks what was dirtied, every `load()`
-has already executed. Neither `rendering.py` nor `_wrap_load` reads it at all.
+The reason is structural. `get_dirtied()` is read in exactly one production path
+(`responses.py:61`, inside `_fan_out`), which runs *after* the primary render. By
+the time anything asks what was dirtied, every `load()` has already executed.
+Neither `rendering.py` nor `_wrap_load` reads it at all.
 
 Measured on a five-level reactive chain, each level declaring its own key:
 
@@ -33,13 +54,13 @@ no tier-2 backend, request 2, nothing dirtied
                                          loads: L0 L1 L2 L3 L4   (5)
 ```
 
-Output is always correct. This is a missing optimization, not wrong data — but
-it is the optimization the library's design intent was written around.
+Output is always correct. This is a missing optimization — but it is the one the
+library's design intent was written around.
 
 ### 2a. Tag composition serves a stale load key
 
 A child whose key flows through its parent's data inherits that parent's
-staleness. Confirmed by repro:
+staleness:
 
 ```
 dirtied 'conversation'; user moved from conversation 1 -> 2
@@ -49,15 +70,21 @@ B  child given cache=False                   child.load called: ['1']  stale: Tr
 C  parent reacts to ('view','conversation')  child.load called: ['2']  stale: False
 ```
 
-The child's entry *is* evicted and its body *does* run — against a key read off
-a parent that was not evicted. Opting the child out of caching does not rescue
-it; only widening the parent's react set does.
+The child's entry *is* evicted and its body *does* run — against a key read off a
+parent that was not evicted. Opting the child out of caching does not rescue it;
+only widening the parent's react set does.
+
+What scenario C buys is **fresh props**, not a reload. The child reloads either
+way — that is defect 1. The rule it implies: *a parent depends on every key whose
+value it passes down as an identity.* Not all its children's keys — a child
+reacting to `("conversation", "unread")` whose parent only feeds `conversation`
+leaves `unread` to the child's own eviction.
 
 ### 2b. Slot composition freezes the child entirely
 
 When a parent builds its child in Python, the child is a fully-loaded instance
-inside the parent's cached `load()` result. There is no hole, so there is no
-decision point:
+inside the parent's cached `load()` result. There is no hole, so no decision
+point:
 
 ```
 WITH a tier-2 load cache backend
@@ -73,18 +100,11 @@ WITHOUT any backend (the default)
 
 `holds_spliced_components` does not cover this. It is a *render*-cache gate, and
 a reactive class turns the render cache off at the first check
-(`rendering.py:336`), so the slot gate three lines down is never evaluated for
-the components that have this bug. The freeze is in the **load** cache.
+(`rendering.py:336`), so the slot gate three lines down is never evaluated for the
+components that have this bug. The freeze is in the **load** cache.
 
-ADR 0003 makes every component-typed field a slot structurally, so this surface
-is every nested component built in Python — not an opt-in few.
-
-## The shared cause
-
-A cached parent's data decides what its children are: the child's **key** in tag
-form, the child **itself** in slot form. Either way staleness propagates
-downward and nothing checks it. And because nothing consults dirtiness during
-the render walk, no child can be skipped.
+ADR 0003 makes every component-typed field a slot structurally, so this surface is
+every nested component built in Python — not an opt-in few.
 
 ## Decision
 
@@ -95,8 +115,8 @@ alike, at the moment the hole is filled and before the child loads.
 _fill_children reaches a child hole
    |- resolve class -> declared react keys
    |- bind props    -> load key value
-   |- dirtied this request?  -- no --+- client manifest holds it? -- yes -> PRESERVE
-   |                                 \- no ------------------------------> load
+   |- dirtied this request?  -- no --+- client holds THIS child? -- yes -> PRESERVE
+   |                                 \- no -----------------------------> load
    \- yes -> parent served from cache?
                |- no  -> load (fresh props)
                \- yes -> raise (provenance error)
@@ -105,17 +125,16 @@ _fill_children reaches a child hole
 Two facts make this feasible without new plumbing:
 
 - `session.pjx_mounted` is populated by middleware *before* the handler runs
-  (`integrations/fastapi.py:213`, inside `request_scope`, before `call_next`),
-  so a hole-time decision can already ask what the client holds.
-- `_load_reactive_child` (`rendering.py:111`) already resolves the class, pulls
-  the key attr out of the props, and coerces it to the field's declared type —
-  all before `cls.load(**key_args)`. That line is the decision point.
+  (`integrations/fastapi.py:213`, inside `request_scope`, before `call_next`), so a
+  hole-time decision can already ask what the client holds.
+- `_load_reactive_child` (`rendering.py:111`) already resolves the class, pulls the
+  key attr out of the props, and coerces it to the field's declared type — all
+  before `cls.load(**key_args)`. That line is the decision point.
 
 No template scanner, no recorded edge map, no ancestor rollup. The parent→child
-edge is consumed at the instant it exists and never stored, because nothing
-downstream needs it.
+edge is consumed at the instant it exists and never stored.
 
-## Section 1 — The Ref contract
+## Section 1 — References
 
 `ReactiveComponent` gains one classmethod:
 
@@ -128,88 +147,105 @@ class Shell(ReactiveComponent, react=("view",)):
         return cls(id="shell", content=Child.ref(conversation=view))
 ```
 
-`Child.ref(**props)` returns a frozen `(class, props)` pair. It runs no
-`load()`, touches no cache, holds no data — the Python spelling of what
+`Child.ref(**props)` returns a frozen `(class, props)` pair. It runs no `load()`,
+touches no cache, holds no data — the Python spelling of what
 `<Child conversation="…"/>` already produces as a `ChildRef` (`segments.py:12`).
-Component-typed slot fields accept it alongside a real instance; those fields are
-already detected structurally at registration (ADR 0003), which is where the
-widening goes.
+Component-typed fields are detected structurally at registration (ADR 0003), which
+is where acceptance of a `Ref` goes.
 
 What ends up in the parent's cached value is the whole point:
 
 ```python
-# eager — caches the child's DATA. This is 2b.
+# eager — caches the child's DATA one level too high. This is 2b.
 Shell(content=Child(conversation="1", body="messages-of-1"))
 
 # ref — caches an INSTRUCTION. Re-decided every request.
 Shell(content=Ref(Child, {"conversation": "1"}))
 ```
 
-### Legal field values
+### No eager escape hatch
 
-| value | when | freshness | islands |
-|---|---|---|---|
-| `Child.ref(...)` | default, recommended | resolved at the hole | yes |
-| bare `Child(...)` | works where it validates | resolved at the hole | yes |
-| `Child.load(...)` | parent needs the data | eager, parent uncacheable | no |
-| plain component | non-reactive child | no load, no staleness | n/a |
+Assigning a **loaded** reactive component to a component-typed field raises. There
+is no opt-out annotation.
 
-A bare constructor call is already an unloaded instance — `load()` is a separate
-classmethod — so it gets the same treatment at the hole. It is accepted but not
-documented as the way, because it fails on any class with a required
-load-supplied field:
+A parent that needs a child's data depends on that data, and should declare and
+fetch it as its own concern. Sanctioning an eager field would sanction exactly the
+undeclared dependency section 3 raises about.
+
+Loading *inside* `load()` is still fine — what is forbidden is storing the result
+in a field:
+
+```python
+@classmethod
+def load(cls, view: str) -> "Shell":
+    ids = fetch_ids(view)
+    ids.sort(key=lambda i: Invoice.load(invoice=i).total)      # read it
+    return cls(content=[Invoice.ref(invoice=i) for i in ids])  # store refs
+```
+
+Tier 1 dedups within the request, so each child hits cache at its hole rather than
+re-fetching. No double query.
+
+### Bare construction
+
+A bare `Child(...)` is already an unloaded instance — `load()` is a separate
+classmethod — so it is accepted at the hole on the same terms as a `Ref`. It is not
+documented as the way, because it fails on any class with a required load-supplied
+field:
 
 ```
 Messages  bare construct OK   -> Messages(conversation='1', body='', unread=0)
 Invoice   bare construct FAILS -> ValidationError: total  Field required
 ```
 
-That failure's obvious workaround is `Invoice.load(...)`, which silently costs
-islands and parent cacheability. `ref()` records props rather than building a
-model, so it works for both classes identically.
+That failure's obvious workaround is `Invoice.load(...)`, which is exactly what
+now raises. `ref()` records props rather than building a model, so it works for
+both classes identically.
 
-### The eager escape hatch
+### What a parent may still read
 
-A parent that genuinely needs its child's data — to sort, filter, or decide
-whether to include it — keeps writing `Child.load(...)` and declares the field
-eager:
+`.props` keeps working, because props are precisely what a reference holds. Only
+load-supplied fields become unreachable — the intended discipline, and the same
+argument ADR 0003 already makes about a child's markup, applied one layer down to
+a child's data.
+
+### Collections
+
+`list[Child]` and `dict[str, Child]` are already slots (`_holds_component` checks
+both). The container is a plain Python object — only its elements are opaque — so
+iteration was never restricted:
 
 ```python
-from pyjinhx import Eager   # exported alongside PjxKey / Slot / Children
-
-content: Annotated[Child | None, Eager()] = None
+content=[Messages.ref(conversation=c) for c in ids]
 ```
 
-Two rules attach to it:
-
-- **A `load()` result holding a loaded reactive instance is not tier-2
-  cacheable.** This is what makes 2b's remaining surface correct instead of
-  silently stale: the parent renders live every request, and the reason is
-  visible in the annotation.
-- **Assigning a loaded reactive instance to a non-eager slot field raises**, so
-  forgetting `ref()` is a loud failure rather than a silent downgrade:
-
-```
-Shell (template: shell.pjx): field 'content' was assigned a loaded Child.
-A slot child is resolved at render time — assign Child.ref(conversation=…)
-instead. If this child must be loaded inside Shell.load() (you need its data
-to sort or filter it), declare the field eager:
-    content: Annotated[Child | None, Eager()] = None
+```jinja
+{% for c in content %}{{ c }}{% endfor %}
 ```
 
-`ref()` is reactive-only. A plain component in a slot has no `load()` and
-therefore no freshness problem.
+Each `{{ c }}` becomes its own hole with its own freshness decision: a 50-row list
+where one row changed loads 1 and preserves 49.
+
+Two consequences:
+
+- `build_context` must wrap a `Ref` the way it wraps a component, so `{{ c }}`
+  emits a slot token.
+- Preservation needs a stable authored id **per element** (section 2, condition 4).
+  Rows normally have one from their data (`<li id="row-{{ conversation }}">`). With
+  auto `pjx-N` ids the gate fails and every element simply loads — correct, no
+  savings. This is the single thing to get right for lists, and belongs in the docs
+  as such.
 
 ## Section 2 — The decision at the hole
 
 ### Constraint
 
 `hx-preserve` is resolved by htmx through the incoming tag's plain `id`
-(`getElementById`), not `data-pjx-id` (`fanout.py:825`). Preservation therefore
-only lands for a region whose template root carries a stable authored id. And
-`hx-preserve` is a no-op for an id the client does not already show — which for
-a placeholder means shipping an empty element. **The manifest check is
-mandatory, not an optimization.**
+(`getElementById`), not `data-pjx-id` (`fanout.py:825`). Preservation therefore only
+lands for a region whose template root carries a stable authored id. And
+`hx-preserve` is a no-op for an id the client does not already show — which for a
+placeholder means shipping an empty element. **The manifest check is mandatory, not
+an optimization.**
 
 ### The skip gate
 
@@ -219,18 +255,39 @@ Skip a child only on positive proof of all five conditions:
 |---|---|---|
 | 1 | reactive class | `_pjx_key_field` |
 | 2 | no declared key dirtied this request | `_keys_match_dirtied` |
-| 3 | manifest holds this id, type, load key | `session.pjx_mounted` |
+| 3 | manifest holds this id, type, **and load key** | `session.pjx_mounted` |
 | 4 | root id is authored, not auto | `has_auto_id` |
 | 5 | class opts in | `retain_across_parent_swaps` (default `True`) |
 
-Four of five already exist. `retain_across_parent_swaps` is already the
-per-class switch for this question in the OOB path; reusing it means one flag
-governs preservation everywhere rather than two that can disagree. Its default
-of `True` means existing components get islands without opting in.
+Four of five already exist. `retain_across_parent_swaps` is already the per-class
+switch for this question in the OOB path; reusing it means one flag governs
+preservation everywhere. Its default of `True` means existing components get
+islands without opting in.
 
-Any failed condition falls back to loading and rendering, exactly as today —
-the same conservative posture `_preserve_nested` takes: skip only on proof,
-never on absence of evidence.
+Any failed condition falls back to loading and rendering, exactly as today — the
+same conservative posture `_preserve_nested` takes: skip only on proof.
+
+### Condition 3 does two jobs
+
+It answers "does the client have this region" **and** "is it still the same child."
+The second is load-bearing for correctness, not just for savings:
+
+```
+'view' dirtied, 'conversation' NOT dirtied
+  Shell reloads (declares 'view')  ->  now passes conversation="2"
+  Child's own keys clean           ->  would preserve...
+  ...but the mounted region's load key is "1" and the child now resolves to "2"
+  -> condition 3 fails -> the child loads
+```
+
+Without the load-key half of the match, a fresh parent naming a different child
+would serve the old one. The full rule a child loads under:
+
+```
+child loads  <=>  its keys were dirtied
+              or  the parent now names a different one
+              or  the client does not have it
+```
 
 ### What gets emitted
 
@@ -244,22 +301,22 @@ field, not a new mechanism.
 
 ### Consequences
 
-- **Descendants are independent.** `walk_manifest` reads the client's manifest,
-  not what was rendered, so a dirty grandchild under a skipped parent still gets
-  its own OOB leg — and `_drop_nested` will not swallow it, because the skipped
-  parent's placeholder does not contain it.
+- **Descendants are independent.** `walk_manifest` reads the client's manifest, not
+  what was rendered, so a dirty grandchild under a skipped parent still gets its own
+  OOB leg — and `_drop_nested` will not swallow it, because the skipped parent's
+  placeholder does not contain it.
 - **Cold loads are correct by construction.** Empty manifest → condition 3 fails
   everywhere → the whole tree loads. No special case.
 - **Slots join here.** `_splice_slot_nodes` hands a `Ref` to the same gate a
-  `ChildRef` goes through. This is the payoff of section 1.
+  `ChildRef` goes through.
 
 ## Section 3 — Provenance and the 2a error
 
 ### The stamp
 
 `_wrap_load` already branches on `cache_has(...)`. Mark instances returned from
-either tier with `_pjx_from_cache = True`. One assignment, one place — the only
-new state in this design.
+either tier with `_pjx_from_cache = True`. One assignment, one place — the only new
+state in this design.
 
 ### The check
 
@@ -292,70 +349,67 @@ If Shell genuinely does not depend on it, silence this for the class:
 
 ### Why raise rather than repair
 
-The repair — evict the parent, re-run its `load()` — is always correct and needs
-no analysis, but it fires on every interaction in the exact shape this library is
-built for (shell plus keyed region). The shell would reload every request: the
-cascade section 2 exists to kill, reintroduced through the back door. Raising
-costs nothing at runtime and states the true fact — the parent depends on that
-key. Repro scenario C is that fix, and it already works today.
+The repair — evict the parent, re-run its `load()` — is always correct and needs no
+analysis, but it fires on every interaction in the exact shape this library is built
+for (shell plus keyed region). The shell would reload every request: the cascade
+section 2 exists to kill, reintroduced through the back door. Raising costs nothing
+at runtime and states the true fact — the parent depends on that key. Repro scenario
+C is that fix, and it already works today.
 
 ### Accepted false positive
 
-A literal key (`<Leaf leaf="x"/>`) under a cached parent whose `leaf` was dirtied
-has no data flow, and this rule raises anyway. Two filters were considered and
-rejected as premature: a template scan (precise for tags, structurally blind to
-refs) and a value-membership test against the parent's fields (covers both,
-misses computed keys). Both are two mechanisms where one would do, for a case
-that hardcodes an identity into markup. Ship the coarse rule and the ClassVar
-opt-out; add a filter only if real code trips it.
+A literal key (`<Leaf leaf="x"/>`) under a cached parent whose `leaf` was dirtied has
+no data flow, and this rule raises anyway. Two filters were considered and rejected as
+premature: a template scan (precise for tags, structurally blind to refs) and a
+value-membership test against the parent's fields (covers both, misses computed keys).
+Both are two mechanisms where one would do, for a case that hardcodes an identity into
+markup. Ship the coarse rule and the ClassVar opt-out; add a filter only if real code
+trips it.
 
 ### Blast radius
 
 The check can only fire when a parent came from cache, which requires a tier-2
-backend. The default configuration has none, so no default-configured app can
-hit this — and the apps that can are exactly those silently serving stale data
-today.
+backend. The default configuration has none, so no default-configured app can hit
+this — and the apps that can are exactly those silently serving stale data today.
 
-Refs get this for free: a `Ref` built inside a cached parent's `load()` carries
-the same staleness as an interpolated tag attr, and the same stamp on the same
-parent catches it. One rule, both composition forms.
+Refs get this for free: a `Ref` built inside a cached parent's `load()` carries the
+same staleness as an interpolated tag attr, and the same stamp on the same parent
+catches it. One rule, both composition forms.
 
 ## Section 4 — Migration
 
 Five changes, in descending blast radius:
 
-1. **A loaded reactive instance in a slot field raises.** Mechanical migration:
-   `Child.load(x)` → `Child.ref(x)`. Where the parent needs the data, mark the
-   field `Annotated[Child | None, Eager()]`.
-2. **An `Eager` field makes its parent tier-2 uncacheable.** No error, a slower
-   parent, and the reason visible in the annotation.
+1. **A loaded reactive component in a component-typed field raises.** Mechanical
+   migration: `Child.load(x)` → `Child.ref(x)`. Where the parent needs the child's
+   data, it declares and fetches that data as its own field — or reads it inside
+   `load()` without storing the instance.
+2. **A parent can no longer read a child's load-supplied fields.** `.props` still
+   works; anything `load()` filled does not. Parents that relied on it declare the
+   value themselves.
 3. **The 2a provenance raise.** Unreachable without a tier-2 backend.
-4. **Clean children stop running `load()`.** The real semantic break: any
-   `load()` with side effects — a hit counter, a lazy write, an audit log —
-   silently loses them. Needs a prominent migration note. `load()` is a read,
-   and the runtime now holds authors to it.
-5. **Manifest gains a root tag name.** An old client sending the old manifest
-   fails condition 3, so those children load exactly as today. Graceful
-   degradation, no version negotiation.
+4. **Clean children stop running `load()`.** The real semantic break: any `load()`
+   with side effects — a hit counter, a lazy write, an audit log — silently loses
+   them. Needs a prominent migration note. `load()` is a read, and the runtime now
+   holds authors to it.
+5. **Manifest gains a root tag name.** An old client sending the old manifest fails
+   condition 3, so those children load exactly as today. Graceful degradation, no
+   version negotiation.
 
-**Release order:** ship `ref()` and `Eager()` additively in a 1.x minor with no
-enforcement so authors can migrate at their own pace; flip the raises and the
-skip gate on in 2.0. One extra release turns a cliff into a ramp.
+**Release order:** ship `ref()` additively in a 1.x minor with no enforcement so
+authors can migrate at their own pace; flip the raises and the skip gate on in 2.0.
+One extra release turns a cliff into a ramp.
 
 ## Implementation phases
-
-The release order in section 4 gives two natural plans. Each is independently
-shippable and independently testable.
 
 **Phase 1 — additive, 1.x minor. No behavior change.**
 
 1. `Ref` type and `ReactiveComponent.ref()`.
-2. Slot fields accept a `Ref`; `_splice_slot_nodes` resolves one through the
-   same path a `ChildRef` takes.
-3. `Eager()` annotation; a `load()` result holding a loaded reactive instance is
-   not tier-2 cacheable.
-4. `_pjx_from_cache` stamp in `_wrap_load`.
-5. Manifest gains the root tag name; `pjx.js` emits it.
+2. Component-typed fields accept a `Ref`; `build_context` wraps one so `{{ c }}`
+   emits a slot token; `_splice_slot_nodes` resolves it through the same path a
+   `ChildRef` takes.
+3. `_pjx_from_cache` stamp in `_wrap_load`.
+4. Manifest gains the root tag name; `pjx.js` emits it.
 
 At the end of phase 1 every new spelling works, nothing raises, and no child is
 skipped. 2b's staleness is already fixed for anyone who has migrated, because a
@@ -363,40 +417,43 @@ skipped. 2b's staleness is already fixed for anyone who has migrated, because a
 
 **Phase 2 — enforcing, 2.0.**
 
-6. The skip gate in `_fill_children`, all five conditions, plus the preserved
+5. The skip gate in `_fill_children`, all five conditions, plus the preserved
    placeholder.
-7. The provenance raise and its `trust_cached_props` opt-out.
-8. The raise on assigning a loaded reactive instance to a non-eager slot field.
-9. Migration note for side-effecting `load()` bodies.
+6. The provenance raise and its `trust_cached_props` opt-out.
+7. The raise on assigning a loaded reactive component to a component-typed field.
+8. Migration note for side-effecting `load()` bodies.
 
 Phase 2 is where the invariant test flips from 4 descendant loads to 0.
 
 ## Section 5 — Testing
 
 The existing scratchpad repros are the corpus: `repro_1026_full.py`,
-`blindspot_slot.py`, `invariants.py`, `what_is_cached.py`.
+`blindspot_slot.py`, `invariants.py`, `what_is_cached.py`, `autostrip.py`.
 
 **The invariant test, first and loudest.** The five-level chain, asserting the
-original design intent: *no `load()` body runs for a child whose keys were clean
-and whose region the client holds.* Currently 4 descendant loads; should become
-0. The one test that fails today for the right reason.
+original design intent: *no `load()` body runs for a child whose keys were clean and
+whose region the client holds.* Currently 4 descendant loads; should become 0. The
+one test that fails today for the right reason.
 
 Per mechanism:
 
 - **Skip gate** — five tests, one per condition, each proving a failed condition
-  falls back to loading. Conservative-by-default is tested as the default, not
-  assumed.
+  falls back to loading. Conservative-by-default is tested as the default.
+- **Identity change** — parent dirty, child clean, child's load key changed: the
+  child must load. Guards condition 3's second job.
 - **Preserve output** — placeholder carries the authored id, `hx-preserve="true"`,
   and the manifest's root tag.
 - **Cold load** — empty manifest, whole tree loads.
-- **Descendant independence** — dirty grandchild under a skipped parent gets its
-  own OOB leg and is not swallowed by `_drop_nested`.
-- **Slot refs** — `blindspot_slot.py` inverted: child loads with key `2`, no
-  stale markup.
-- **Provenance** — repro A raises with the right message; scenario C does not;
-  the ClassVar opt-out silences it.
-- **Eager escape hatch** — the field works, and its parent is provably absent
-  from both tier-2 caches.
+- **Descendant independence** — dirty grandchild under a skipped parent gets its own
+  OOB leg and is not swallowed by `_drop_nested`.
+- **Slot refs** — `blindspot_slot.py` inverted: child loads with key `2`, no stale
+  markup.
+- **Collections** — `{% for c in content %}` over a list of refs: one dirty element
+  loads, the rest preserve; and with auto ids, all load.
+- **Provenance** — repro A raises with the right message; scenario C does not; the
+  ClassVar opt-out silences it.
+- **No eager** — assigning a loaded reactive component to a component-typed field
+  raises; loading inside `load()` without storing it does not.
 
 ## Corrections owed
 
@@ -412,18 +469,25 @@ Per mechanism:
 
 ## Rejected alternatives
 
+- **An eager escape hatch** (`Annotated[Child | None, Eager()]`, with eager parents
+  made uncacheable). Sanctions the same undeclared dependency section 3 raises about,
+  and costs a second rule for a case the sort-then-ref pattern already covers.
+- **Automatic strip on cache write** — replace any loaded child in a field with a
+  `Ref` at write time, requiring no new API and no migration. Fails because the load
+  key is recoverable but the parent's own props are not. Given
+  `Messages(conversation='1', body='msgs-1', variant='compact')`, where `body` came
+  from `load()` and `variant` from the parent, nothing on the instance distinguishes
+  them: store the key alone and `variant` is silently dropped; store every field and
+  the child's data is back in the parent's entry, which is 2b. Explicit `ref()`
+  resolves the ambiguity by having the only party who knows state the props — the same
+  convention `_load_reactive_child` already applies to tag attrs.
 - **Ancestor rollup** (dirty a child's key → evict the parents that embed it).
-  Correct, but reloads the shell on every interaction — the anti-island. It was
-  the original consumer for a recorded edge map; the hole-time decision is a
-  better one, in the opposite direction.
-- **Guard without unifying** (refuse to cache slot-holding parents, add the skip
-  gate for tags only). Smaller diff, but permanently forks tags and slots — which
-  is where every one of these bugs came from — and makes shell components, the
-  ones most worth caching, exactly the ones that cannot be.
-- **Keys never flow downward** (a child's load key must come from the request,
-  never a parent field). Kills 2a by construction, and forbids passing an id
+  Correct, but reloads the shell on every interaction — the anti-island.
+- **Guard without unifying** (refuse to cache slot-holding parents, skip gate for tags
+  only). Permanently forks tags and slots, and makes shell components — the ones most
+  worth caching — exactly the ones that cannot be.
+- **Keys never flow downward.** Kills 2a by construction, and forbids passing an id
   down, which is the normal way to build a page.
 - **Static template scanner as a freshness mechanism.** Validated at 10/10 on
-  constructed shapes and 0.7 ms over 70 real templates, but structurally blind to
-  slot composition. Retained only as a possible false-positive filter for
-  section 3, not as load-bearing machinery.
+  constructed shapes and 0.7 ms over 70 real templates, but structurally blind to slot
+  composition. Retained only as a possible false-positive filter for section 3.

--- a/tests/pyjinhx/reactive/test_tier2_nested_ownership.py
+++ b/tests/pyjinhx/reactive/test_tier2_nested_ownership.py
@@ -1,0 +1,216 @@
+"""#1026: a tier-2 cache hit on an ancestor feeds its nested child a stale load key.
+
+The shape is a shell that reacts to something broad (``view``) wrapping content
+that reacts to something narrower (``conversation``), with the shell threading
+the narrow value down as the child's load key. Dirtying the narrow key evicts
+the child's entry but not the shell's, so the next request rebuilds the child
+from the shell's stale field.
+
+These tests pin the *mechanism*, because the mechanism is not what it looks
+like from the outside: the child's ``load()`` is not skipped. It runs, and it
+returns the current truth for whatever key it was handed — which is the stale
+one. Anything that fixes this has to make the ancestor's entry stop surviving a
+dirtied descendant key; re-rendering the nested region on a hit would change
+nothing, since it already re-renders.
+"""
+
+import dataclasses
+from typing import Annotated
+
+import pytest
+
+from pyjinhx import discovery
+from pyjinhx.config import configure_pyjinhx, current_settings
+from pyjinhx.reactive.backend import InMemoryCacheBackend
+from pyjinhx.reactive.cache import invalidate
+from pyjinhx.reactive.component import PjxKey, ReactiveComponent
+from pyjinhx.rendering import render
+from pyjinhx.session import request_scope
+
+STORE = {"conversation": "1"}
+CHILD_LOAD_KEYS: list[str] = []
+PARENT_LOADS: list[None] = []
+
+
+class NestedChild(ReactiveComponent, react=("conversation",)):
+    """Content keyed by the conversation it belongs to."""
+
+    conversation: Annotated[str, PjxKey()] = ""
+    body: str = ""
+
+    @classmethod
+    def load(cls, conversation: str) -> "NestedChild":
+        CHILD_LOAD_KEYS.append(conversation)
+        return cls(conversation=conversation, body=f"messages-of-{conversation}")
+
+
+class BroadShell(ReactiveComponent, react=("view",)):
+    """A shell that reads `conversation` but only reacts to `view`."""
+
+    conversation: str = ""
+
+    @classmethod
+    def load(cls) -> "BroadShell":
+        PARENT_LOADS.append(None)
+        return cls(id="shell", conversation=STORE["conversation"])
+
+
+@pytest.fixture(autouse=True)
+def _publish(tmp_path):
+    """Register the pair against real templates and a fresh tier-2 backend."""
+    STORE["conversation"] = "1"
+    CHILD_LOAD_KEYS.clear()
+    PARENT_LOADS.clear()
+
+    shell = tmp_path / "broad_shell.pjx"
+    shell.write_text(
+        '<div id="{{ id }}"><NestedChild id="child" conversation="{{ conversation }}"/></div>'
+    )
+    child = tmp_path / "nested_child.pjx"
+    child.write_text('<section id="{{ id }}">{{ body }}</section>')
+    discovery.build_registry(tmp_path, [BroadShell, NestedChild])
+    # build_registry probes each class's defining module dir, not tmp_path, so
+    # the descriptors are repointed at the files written above.
+    BroadShell.__pjx_descriptor__ = dataclasses.replace(
+        BroadShell.__pjx_descriptor__, template_path=shell
+    )
+    NestedChild.__pjx_descriptor__ = dataclasses.replace(
+        NestedChild.__pjx_descriptor__, template_path=child
+    )
+
+    previous = current_settings()
+    configure_pyjinhx(previous.merge(cache_backend=InMemoryCacheBackend()))
+    yield
+    configure_pyjinhx(previous)
+
+
+def _first_request() -> str:
+    """One request with the store on conversation 1, warming both tier-2 entries."""
+    with request_scope():
+        return render(BroadShell(id="shell"))
+
+
+def _second_request() -> str:
+    """A later request, after the store moved on and `conversation` was dirtied.
+
+    A fresh scope, so tier 1 is empty and only the cross-request tier answers.
+    invalidate() stands in for what the response composer does with the
+    request's dirtied keys.
+    """
+    with request_scope():
+        invalidate(["conversation"])
+        return render(BroadShell(id="shell"))
+
+
+def test_the_shells_entry_survives_a_dirtied_key_only_its_child_reacts_to():
+    """The shell is served from tier 2 because no dirtied key is tagged on it."""
+    _first_request()
+    STORE["conversation"] = "2"
+    PARENT_LOADS.clear()
+
+    _second_request()
+
+    assert PARENT_LOADS == []
+
+
+def test_the_nested_child_still_loads_but_against_the_shells_stale_key():
+    """The child's load() is reached — with the key the stale shell handed down.
+
+    This is the fact the issue's problem statement gets wrong. A non-empty list
+    here is positive proof that no cached subtree replayed verbatim: the shell's
+    template re-rendered and re-filled its child hole. The child did real work
+    and answered correctly. It was asked about the wrong conversation.
+    """
+    _first_request()
+    STORE["conversation"] = "2"
+    CHILD_LOAD_KEYS.clear()
+
+    _second_request()
+
+    assert CHILD_LOAD_KEYS == ["1"]
+
+
+def test_a_cache_opt_out_on_the_child_does_not_rescue_it():
+    """cache=False on the child changes nothing: its caching was never the problem.
+
+    Declared inline rather than on the module's NestedChild so the opt-out is
+    the only difference from the test above.
+    """
+
+    class OptedOutChild(ReactiveComponent, react=("conversation",), cache=False):
+        conversation: Annotated[str, PjxKey()] = ""
+        body: str = ""
+
+        @classmethod
+        def load(cls, conversation: str) -> "OptedOutChild":
+            CHILD_LOAD_KEYS.append(conversation)
+            return cls(conversation=conversation, body=f"messages-of-{conversation}")
+
+    template = NestedChild.__pjx_descriptor__.template_path
+    assert template is not None
+    OptedOutChild.__pjx_descriptor__ = dataclasses.replace(
+        OptedOutChild.__pjx_descriptor__, template_path=template
+    )
+    discovery.build_registry(template.parent, [BroadShell, OptedOutChild])
+    shell_template = BroadShell.__pjx_descriptor__.template_path
+    assert shell_template is not None
+    shell_template.write_text(
+        '<div id="{{ id }}"><OptedOutChild id="child" conversation="{{ conversation }}"/></div>'
+    )
+
+    _first_request()
+    STORE["conversation"] = "2"
+    CHILD_LOAD_KEYS.clear()
+
+    _second_request()
+
+    assert CHILD_LOAD_KEYS == ["1"]
+
+
+def test_a_shell_reacting_to_its_childs_key_too_stays_correct():
+    """The control: make the shell's react set a superset and the staleness goes.
+
+    This is suggested fix 1 simulated by hand, and it is why that fix is the one
+    that addresses this — not the walk-the-cached-tree option, which would leave
+    the stale key flowing down untouched.
+    """
+
+    class SupersetShell(ReactiveComponent, react=("view", "conversation")):
+        conversation: str = ""
+
+        @classmethod
+        def load(cls) -> "SupersetShell":
+            return cls(id="shell", conversation=STORE["conversation"])
+
+    template = BroadShell.__pjx_descriptor__.template_path
+    assert template is not None
+    SupersetShell.__pjx_descriptor__ = dataclasses.replace(
+        SupersetShell.__pjx_descriptor__, template_path=template
+    )
+    discovery.build_registry(template.parent, [SupersetShell, NestedChild])
+
+    with request_scope():
+        render(SupersetShell(id="shell"))
+    STORE["conversation"] = "2"
+    CHILD_LOAD_KEYS.clear()
+    with request_scope():
+        invalidate(["conversation"])
+        html = render(SupersetShell(id="shell"))
+
+    assert CHILD_LOAD_KEYS == ["2"]
+    assert "messages-of-2" in html
+
+
+@pytest.mark.xfail(
+    reason="#1026: the shell's tier-2 entry is not tagged with its nested "
+    "child's react keys, so a dirtied 'conversation' never evicts it",
+    strict=True,
+)
+def test_dirtying_a_nested_regions_key_reaches_that_region():
+    """What should happen, and does not yet. Flips to a pass when #1026 lands."""
+    _first_request()
+    STORE["conversation"] = "2"
+
+    html = _second_request()
+
+    assert "messages-of-2" in html


### PR DESCRIPTION
Docs only. No code changes.

## What this adds

- `docs/superpowers/specs/2026-08-25-nested-freshness-design.md` — the design spec for milestone #19 (phase 1) and the 2.0 phase that follows it.
- `docs/superpowers/specs/2026-08-25-fixed-at-the-hole.md` — the five scenarios, before and after, each pane marked **measured** or **designed**.
- `docs/superpowers/rebuild/how-pyjinhx-works.md` — what the runtime does today, in five mermaid diagrams.
- Corrects `rebuild/README.md`'s claim that everything under `rebuild/` is local-only — the directory is un-ignored at `.gitignore:22` and its docs are tracked.

Also carries `aeaa5323`, the #1026 regression tests from #1031, since this branch was cut from that one.

## Why it should land before milestone #19 starts

Every story and subtask in #19 names this spec in its reading order. Worktrees root at `master`, so until this merges those cards point at a file their checkout does not have.

## What it establishes

**A cache entry never contains another component.** The render cache already obeys it — `_finish_cached_level` restores a level's own segments and leaves child holes as `ChildRef`s. The load cache does not: a parent that builds its child in Python stores the loaded instance, which is the child's data cached one level too high.

Three defects follow from that asymmetry, all measured against v1.9.1:

| | mechanism |
|---|---|
| clean children still load | `get_dirtied()` is read once, in `_fan_out`, *after* the primary render |
| tag composition serves a stale key (#1026) | child's key read off a parent that was not evicted |
| slot composition freezes the child (#1026) | no hole, so no decision point |

`holds_spliced_components` does not cover the third: it is a render-cache gate, and a reactive class turns the render cache off at the first check (`rendering.py:336`), so the slot gate three lines down is never evaluated for the components that have the bug.

## Corrections this makes to earlier work

The spec's "Corrections owed" section lists three, none of them addressed here:

- #1031's strict xfail encodes "this should eventually pass"; under this design it should **raise**.
- The #1026 body describes only the tag mechanism, and says a cached ancestor "replays its entire previously-rendered subtree verbatim" — true for slots, not for tags.
- `rebuild/runtime-decision-trees.md` (on #1030) states that only slots go stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQyufpcPJGYd5sWLBzeh7W
