### PR TITLE
fix: tooltip clamps to viewport, not just its clipping ancestor

### DIFF
--- a/pyjinhx/builtins/ui/pjx_tooltip/pjx_tooltip.js
+++ b/pyjinhx/builtins/ui/pjx_tooltip/pjx_tooltip.js
@@ -15,25 +15,37 @@
         return Math.max(min, Math.min(value, max));
     }
 
-    /** Bounds the tip must stay inside: the trigger's nearest clipping ancestor. */
+    /**
+     * Bounds the tip must stay inside: the trigger's nearest clipping ancestor,
+     * intersected with the viewport. A clipping ancestor (e.g. a wide/tall
+     * scrollable table wrapper) can itself extend past the visible window, so
+     * clamping to it alone would still let the tip spill off-screen.
+     */
     function boundsFor(trigger) {
-        let node = trigger.parentElement;
-        while (node && node !== document.documentElement) {
-            const cs = getComputedStyle(node);
-            if (cs.overflowX !== 'visible' || cs.overflowY !== 'visible') {
-                return node.getBoundingClientRect();
-            }
-            node = node.parentElement;
-        }
-        // Nothing clips the trigger, so the viewport is the bound. We synthesize
-        // the rect instead of measuring documentElement: its rect tracks content
-        // height, which on a long page is far taller than the visible box.
-        return {
+        // We synthesize the viewport rect instead of measuring documentElement:
+        // its rect tracks content height, which on a long page is far taller
+        // than the visible box.
+        const viewport = {
             left: 0,
             top: 0,
             right: window.innerWidth,
             bottom: window.innerHeight,
         };
+        let node = trigger.parentElement;
+        while (node && node !== document.documentElement) {
+            const cs = getComputedStyle(node);
+            if (cs.overflowX !== 'visible' || cs.overflowY !== 'visible') {
+                const rect = node.getBoundingClientRect();
+                return {
+                    left: Math.max(rect.left, viewport.left),
+                    top: Math.max(rect.top, viewport.top),
+                    right: Math.min(rect.right, viewport.right),
+                    bottom: Math.min(rect.bottom, viewport.bottom),
+                };
+            }
+            node = node.parentElement;
+        }
+        return viewport;
     }
 
     function place(tip, root) {

--- a/tests/pyjinhx/builtins/pjx_tooltip/test_pjx_tooltip_collision.py
+++ b/tests/pyjinhx/builtins/pjx_tooltip/test_pjx_tooltip_collision.py
@@ -158,6 +158,28 @@ def test_container_too_tight_clamps_to_padded_container_bounds(page: Page):
     assert box["right"] <= BOX["right"]
 
 
+def test_container_larger_than_viewport_clamps_to_the_viewport(page: Page):
+    # The container overhangs the viewport on the right and bottom (e.g. a
+    # wide/tall scrollable table wrapper). Clamping to the container alone
+    # lets the tip spill past the actual browser window edge; it must also
+    # respect the viewport.
+    page.set_viewport_size({"width": 800, "height": 600})
+    page.set_content(
+        BOXED.replace("PLACEMENT", "top")
+        .replace("LEFT", "950")
+        .replace("TOP", "500")
+        .replace("OVERFLOW", "hidden")
+        .replace("left: 100px; top: 200px;", "left: -200px; top: -200px;")
+        .replace("width: 300px; height: 200px;", "width: 1200px; height: 1000px;")
+    )
+    page.add_script_tag(content=CONTROLLER.read_text())
+    page.hover(".pjx-tooltip__trigger")
+    page.wait_for_selector(".pjx-tooltip__tip--visible")
+    box = page.evaluate(RECT)
+    assert box["right"] <= 800
+    assert box["bottom"] <= 600
+
+
 def test_no_clipping_ancestor_keeps_viewport_behavior(page: Page):
     # No overflow ancestor anywhere: the fallback bounds are the viewport, so
     # a trigger with room on every side lands on the plain default placement.


### PR DESCRIPTION
## Summary
- `PJXTooltip.boundsFor()` clamped the tip against only its nearest clipping ancestor (e.g. a scrollable table wrapper), which can itself extend past the visible window — letting the tooltip render partly off-screen when hovering an item inside such a container.
- `boundsFor()` now intersects the clipping ancestor's rect with the viewport before clamping/flipping.
- Popover/dropdown were checked and already clamp against the viewport directly, so no change was needed there.

## Test plan
- [x] Added `test_container_larger_than_viewport_clamps_to_the_viewport`, reproducing the off-screen overflow (confirmed it failed before the fix)
- [x] `uv run pytest tests/pyjinhx/builtins/pjx_tooltip/` — 28 passed
- [x] `ruff format --check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)