### PR TITLE
fix(select): pin search filter above the scrolling option list

### DIFF
--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.css
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.css
@@ -131,6 +131,9 @@
 /* ── Search filter ─────────────────────────────────────────────────────────── */
 
 .pjx-select__filter {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   width: 100%;
   box-sizing: border-box;
   margin-bottom: 0.25rem;

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_filter.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_filter.py
@@ -47,6 +47,25 @@ class TestFields:
         ).read_text()
         assert f"options | length > {PJXSelect._FILTER_THRESHOLD}" in template
 
+    def test_filter_is_sticky_above_the_scrolling_option_list(self):
+        """The filter renders first inside .pjx-select__panel, which scrolls
+        (overflow-y: auto) once the option list overflows its max-height —
+        without `position: sticky` the filter scrolls out of view along with
+        the options instead of staying pinned above them."""
+        from pathlib import Path
+
+        css = (
+            Path(__file__).resolve().parents[4]
+            / "pyjinhx"
+            / "builtins"
+            / "ui"
+            / "pjx_select"
+            / "pjx_select.css"
+        ).read_text()
+        filter_rule = css.split(".pjx-select__filter {", 1)[1].split("}", 1)[0]
+        assert "position: sticky" in filter_rule
+        assert "top: 0" in filter_rule
+
 
 @pytest.fixture
 def session():


### PR DESCRIPTION
## Summary
- `.pjx-select__panel` scrolls (`overflow-y: auto`) once its option list exceeds `max-height`, but `.pjx-select__filter` had no `position: sticky` — the search box scrolled away with the options instead of staying pinned above the list.
- Adds `position: sticky; top: 0; z-index: 1;` to `.pjx-select__filter`, plus a regression test asserting the CSS rule stays in place.

Found while wiring `PJXSelect(search)` into a consuming app (a member picker with >8 options).

## Test plan
- [x] `uv run pytest tests/pyjinhx/builtins/pjx_select/` — 106 passed
- [x] `uv run pytest tests/pyjinhx/` — 3516 passed, 2 xfailed
- [x] `ruff format --check .` / `ruff check .` — clean