### PR TITLE
fix(select): move the filter fully outside the scrolling option list

### DIFF
--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.css
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.css
@@ -51,8 +51,6 @@
   left: 0;
   z-index: var(--pjx-select-panel-z);
   min-width: var(--pjx-select-panel-min-w);
-  max-height: var(--pjx-select-panel-max-h);
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
   background: var(--pjx-select-panel-bg);
@@ -63,6 +61,17 @@
 
 .pjx-select__panel[hidden] {
   display: none !important;
+}
+
+/* The scrolling region: only the option list, never the filter above it —
+   moving max-height/overflow here (off .pjx-select__panel) is what keeps the
+   filter fully outside the scrollable area instead of merely pinned within
+   it (a sticky filter still reserves a scrollbar gutter beside itself). */
+.pjx-select__options {
+  overflow-y: auto;
+  max-height: var(--pjx-select-panel-max-h);
+  display: flex;
+  flex-direction: column;
 }
 
 .pjx-select__option {
@@ -131,9 +140,6 @@
 /* ── Search filter ─────────────────────────────────────────────────────────── */
 
 .pjx-select__filter {
-  position: sticky;
-  top: 0;
-  z-index: 1;
   width: 100%;
   box-sizing: border-box;
   margin-bottom: 0.25rem;

--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.pjx
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.pjx
@@ -13,16 +13,19 @@
         already posts the values. -#}
     <span class="pjx-select__label">{% if multiple and selected_options | length > 1 %}<span class="pjx-select__chips">{% for option in selected_options %}<span class="pjx-chip-input__chip"><span class="pjx-chip-input__label">{{ option.label }}</span></span>{% endfor %}</span>{% else %}{{ selected_options[0].label if selected_options else placeholder }}{% endif %}</span>
   </button>
-  <div class="pjx-select__panel" data-pjx-select-panel hidden role="listbox">
+  <div class="pjx-select__panel" data-pjx-select-panel hidden>
     {#- Long lists get a search box; short ones are faster to scan than to type
         into, so the input is omitted from the markup rather than hidden. It
         carries no name: the native <select> is what posts.
         Threshold mirrors PJXSelect._FILTER_THRESHOLD; the docstring there is
         the contract, and test_filter_threshold_matches_the_template guards
-        the two staying in step. -#}
+        the two staying in step. Sits outside .pjx-select__options on purpose
+        — it must never scroll away with the list it filters. -#}
     {% if options | length > 8 %}<input type="search" class="pjx-select__filter" data-pjx-select-filter placeholder="Search…" autocomplete="off"{% if disabled %} disabled{% endif %}>
     {% endif %}
-    {% for option in options %}<button type="button" class="pjx-select__option" data-pjx-select-option data-value="{{ option.value }}" aria-selected="{{ 'true' if option.value in selected_values else 'false' }}" role="option">{% if multiple %}<input type="checkbox"{% if disabled %} disabled{% endif %}{% if option.value in selected_values %} checked{% endif %} class="pjx-select__checkbox" tabindex="-1" aria-hidden="true">{% endif %}{{ option.label }}</button>
-    {% endfor %}
+    <div class="pjx-select__options" role="listbox">
+      {% for option in options %}<button type="button" class="pjx-select__option" data-pjx-select-option data-value="{{ option.value }}" aria-selected="{{ 'true' if option.value in selected_values else 'false' }}" role="option">{% if multiple %}<input type="checkbox"{% if disabled %} disabled{% endif %}{% if option.value in selected_values %} checked{% endif %} class="pjx-select__checkbox" tabindex="-1" aria-hidden="true">{% endif %}{{ option.label }}</button>
+      {% endfor %}
+    </div>
   </div>
 </div>

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_filter.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_filter.py
@@ -47,11 +47,12 @@ class TestFields:
         ).read_text()
         assert f"options | length > {PJXSelect._FILTER_THRESHOLD}" in template
 
-    def test_filter_is_sticky_above_the_scrolling_option_list(self):
-        """The filter renders first inside .pjx-select__panel, which scrolls
-        (overflow-y: auto) once the option list overflows its max-height —
-        without `position: sticky` the filter scrolls out of view along with
-        the options instead of staying pinned above them."""
+    def test_only_the_option_list_scrolls_not_the_whole_panel(self):
+        """The option list — not .pjx-select__panel itself — owns
+        overflow-y/max-height, so the filter (a sibling, outside that
+        scrolling wrapper) never scrolls out of view nor reserves a
+        scrollbar gutter beside itself the way a merely-`sticky` filter
+        inside the scrolling container would."""
         from pathlib import Path
 
         css = (
@@ -62,9 +63,12 @@ class TestFields:
             / "pjx_select"
             / "pjx_select.css"
         ).read_text()
-        filter_rule = css.split(".pjx-select__filter {", 1)[1].split("}", 1)[0]
-        assert "position: sticky" in filter_rule
-        assert "top: 0" in filter_rule
+        panel_rule = css.split(".pjx-select__panel {", 1)[1].split("}", 1)[0]
+        options_rule = css.split(".pjx-select__options {", 1)[1].split("}", 1)[0]
+        assert "overflow-y" not in panel_rule
+        assert "max-height" not in panel_rule
+        assert "overflow-y: auto" in options_rule
+        assert "max-height" in options_rule
 
 
 @pytest.fixture
@@ -106,6 +110,19 @@ class TestRender:
         html = _html(session)
         panel = html[html.index("data-pjx-select-panel") :]
         assert "data-pjx-select-filter" in panel[: panel.index("</div>")]
+
+    def test_filter_sits_outside_the_scrolling_options_wrapper(self, session):
+        """The filter must precede <div class="pjx-select__options">, not be
+        nested inside it — that wrapper is what scrolls."""
+        html = _html(session)
+        assert html.index("data-pjx-select-filter") < html.index(
+            'class="pjx-select__options"'
+        )
+
+    def test_options_render_inside_their_own_scrolling_wrapper(self, session):
+        html = _html(session)
+        options_wrapper = html[html.index('class="pjx-select__options"') :]
+        assert "data-pjx-select-option" in options_wrapper
 
     def test_filter_is_a_search_input(self, session):
         html = _html(session)


### PR DESCRIPTION
## Summary
- 1.9.5 (#1049) made `.pjx-select__filter` `position: sticky` inside the same `overflow-y: auto` panel as the options — it stayed visible while scrolling, but it still shared that scroll container, so it kept the scrollbar gutter beside it. Follow-up feedback: it needs to be fully outside the scrollable container, not just pinned within it.
- Moves `overflow-y`/`max-height` off `.pjx-select__panel` onto a new `.pjx-select__options` wrapper around just the option buttons. `.pjx-select__panel` is now a plain non-scrolling flex column; the filter and `.pjx-select__options` are its two children, so the filter is a true sibling outside the scroll area rather than merely pinned inside it.
- `role="listbox"` moves from the panel onto `.pjx-select__options` (the element that now actually holds the `role="option"` children).
- Updates the 1.9.5 regression test to assert the new structural invariant instead of the sticky CSS, plus two new render-based tests confirming the filter precedes and sits outside `.pjx-select__options`.

## Test plan
- [x] `uv run pytest tests/pyjinhx/builtins/pjx_select/` — 108 passed
- [x] `uv run pytest tests/pyjinhx/` — 3518 passed (1 unrelated pre-existing flaky xfail flipped to xpass, tracked in #888/#892)
- [x] `ruff format --check .` / `ruff check .` — clean