### PR TITLE
feat(chip-input): expose buildChip on window.pjx, document exposure policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@
   removal behavior (e.g. `hx-post`) onto the button itself, mirroring
   `PJXTab`'s `closeable` pattern. The default (non-removable) render is
   unchanged (#1055).
+- `PJXChipInput`'s internal chip-building helper is now exposed as
+  `pjx.buildChip(root, value)`, so an app composing its own chip-shaped UI
+  (e.g. a ref picker fed by async search results) can reuse the same
+  label/hidden-input/remove-button markup instead of re-deriving it (#1056).
+  Documented alongside the rest of the `window.pjx` namespace in
+  `docs/guide/builtin-conventions.md`, which also now states the general
+  policy: an internal helper a consuming app is likely to want to compose
+  (DOM construction, positioning math) defaults to exposed rather than
+  closure-private.
 
 ## 1.9.7 — Tooltip shows inside an open dialog (2026-08-27)
 

--- a/docs/guide/builtin-conventions.md
+++ b/docs/guide/builtin-conventions.md
@@ -20,6 +20,12 @@ Every pyjinhx builtin follows the same contract, so knowing one means knowing al
 4. **All copy is props.** Every user-visible string, aria-labels included, has an English default
    you can replace: `PJXModalHeader(title="Excluir?", close_label="Fechar")`.
 5. **JS is headless.** Builtin JavaScript never writes inline styles for state — visibility and variants are classes/attributes; computed positioning coordinates (tooltip/popover placement) are the one sanctioned inline-style use. Communication is through `pjx:*` DOM events and `data-pjx-*` attributes; programmatic APIs live under the single `window.pjx` namespace.
+   An internal helper defaults to exposed, not closure-private, whenever a consuming app is
+   likely to want to compose it — DOM construction for a builtin's own markup shape
+   (`pjx.buildChip`), geometry/positioning math (`pjx.popoverPosition`), and the like. Keep the
+   helper's own name as its `pjx.*` property name (`pjx.popoverPosition = popoverPosition;`); only
+   reach for a per-builtin namespace object (`pjx.modal`, `pjx.drawer`) when there's more than one
+   related entry point to group.
    Async-state JS follows the runtime's concurrency pattern: a ref-count per scope,
    release keyed to each request's `loadend` (terminal on load, error, abort, and
    timeout), and state re-applied after `htmx:afterSettle` for nodes a swap replaced
@@ -67,7 +73,8 @@ document.getElementById("confirm-del").addEventListener("pjx:modal:before-close"
 ## The `window.pjx` namespace
 
 `pjx.modal` · `pjx.drawer` · `pjx.popover` · `pjx.notification` · `pjx.loader.region` (region busy-state) ·
-`pjx.pageLoader` (page navigation) · `pjx.toast`. Open/close/show/hide
+`pjx.pageLoader` (page navigation) · `pjx.toast` · `pjx.popoverPosition` (trigger/panel/viewport
+geometry) · `pjx.buildChip` (a chip's label/hidden-input/remove-button markup). Open/close/show/hide
 functions return `false` when a `before-*` hook canceled the action.
 
 ## Attribute pass-through

--- a/pyjinhx/builtins/ui/pjx_chip_input/pjx_chip_input.js
+++ b/pyjinhx/builtins/ui/pjx_chip_input/pjx_chip_input.js
@@ -28,6 +28,14 @@
         return root.dataset.removeLabel || 'Remove';
     }
 
+    /**
+     * Build one chip element — label span, hidden input, remove button —
+     * matching PJXChipInput's own markup shape.
+     *
+     * Exposed on `window.pjx` so an app building its own chip-shaped UI (e.g.
+     * a ref picker fed by async search results, not free-text entry) can
+     * reuse the same DOM construction instead of re-deriving it.
+     */
     function buildChip(root, value) {
         const chip = document.createElement('span');
         chip.className = 'pjx-chip-input__chip';
@@ -54,6 +62,8 @@
 
         return chip;
     }
+
+    pjx.buildChip = buildChip;
 
     function commit(root, field) {
         const value = field.value.trim().replace(/,$/, '');

--- a/tests/pyjinhx/builtins/pjx_chip_input/test_pjx_chip_input_build_chip.py
+++ b/tests/pyjinhx/builtins/pjx_chip_input/test_pjx_chip_input_build_chip.py
@@ -1,0 +1,79 @@
+"""window.pjx.buildChip(): the chip DOM builder, exposed for reuse.
+
+An app composing its own chip-shaped UI (e.g. an async ref picker) needs the
+same markup PJXChipInput builds internally. The function is DOM-bound, so the
+tests run the real file in real chromium rather than asserting on source
+strings — same approach as test_pjx_popover_position.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+SOURCE = (
+    Path(__file__).resolve().parents[4]
+    / "pyjinhx"
+    / "builtins"
+    / "ui"
+    / "pjx_chip_input"
+    / "pjx_chip_input.js"
+)
+
+
+@pytest.fixture(autouse=True)
+def _require_chromium(request: pytest.FixtureRequest) -> None:
+    if "chip_page" not in set(request.fixturenames):
+        return
+    pytest.importorskip("playwright")
+    browser_type: Any = request.getfixturevalue("browser_type")
+    if not Path(browser_type.executable_path).exists():
+        pytest.skip(
+            "chromium is not installed (run: uv run playwright install chromium)"
+        )
+
+
+@pytest.fixture
+def chip_page(page: Page) -> Page:
+    page.set_content('<body><div data-pjx-chip-input data-name="tags"></div></body>')
+    page.add_script_tag(content=SOURCE.read_text())
+    return page
+
+
+def test_returns_a_chip_with_the_expected_shape(chip_page: Page):
+    outer = chip_page.evaluate(
+        "pjx.buildChip(document.querySelector('[data-pjx-chip-input]'), 'red').outerHTML"
+    )
+    assert 'data-pjx-chip=""' in outer
+    assert 'class="pjx-chip-input__chip"' in outer
+    assert '<span class="pjx-chip-input__label">red</span>' in outer
+    assert '<input type="hidden" name="tags" value="red">' in outer
+    assert 'data-pjx-chip-remove=""' in outer
+    assert 'aria-label="Remove"' in outer
+
+
+def test_honours_the_roots_remove_label(chip_page: Page):
+    chip_page.evaluate(
+        "document.querySelector('[data-pjx-chip-input]')"
+        ".setAttribute('data-remove-label', 'Delete')"
+    )
+    outer = chip_page.evaluate(
+        "pjx.buildChip(document.querySelector('[data-pjx-chip-input]'), 'x').outerHTML"
+    )
+    assert 'aria-label="Delete"' in outer
+
+
+def test_appending_it_produces_a_working_chip_in_the_dom(chip_page: Page):
+    chip_page.evaluate(
+        "document.querySelector('[data-pjx-chip-input]')"
+        ".appendChild(pjx.buildChip(document.querySelector('[data-pjx-chip-input]'), 'blue'))"
+    )
+    assert chip_page.query_selector("[data-pjx-chip]") is not None
+    assert (
+        chip_page.eval_on_selector('input[type="hidden"]', "el => el.value") == "blue"
+    )


### PR DESCRIPTION
## Summary

- `PJXChipInput`'s `buildChip(root, value)` was closure-private, so an app building its own chip-shaped UI (e.g. a ref picker fed by async search results, not free-text entry) had no way to reuse it and ended up re-deriving the same chip markup/DOM construction from scratch.
- Exposed it as `pjx.buildChip(root, value)`, following the exact convention `pjx.popoverPosition` already uses: the internal function keeps its own name and is assigned onto `window.pjx` unchanged (`pjx.buildChip = buildChip;`), no per-builtin namespace wrapper since there's only one entry point to expose.
- Surveyed everything currently on `window.pjx` before picking the shape (`pjx.modal`, `pjx.drawer`, `pjx.popover`, `pjx.notification`, `pjx.loader.region`, `pjx.pageLoader`, `pjx.toast`, `pjx.popoverPosition`, `pjx.confirm`, `pjx.prompt`) so the addition matches existing conventions rather than inventing a new one.

## Policy

Documented the general convention the issue asks for in `docs/guide/builtin-conventions.md` (item 5, "JS is headless", which already mentioned the `window.pjx` namespace): an internal helper defaults to exposed rather than closure-private whenever a consuming app is likely to want to compose it — DOM construction for a builtin's own markup shape, geometry/positioning math, and the like. Also updated the "`window.pjx` namespace" list in the same doc to include `pjx.buildChip` (and `pjx.popoverPosition`, which was missing from that list already).

An ADR was not the right home — the two existing ADRs (`docs/decisions/`) record big engine-level architecture decisions (OOB swap mechanism, cache backend architecture), not per-builtin JS authoring conventions; `docs/guide/builtin-conventions.md` is where the rest of the JS/DOM contract already lives. `docs/reference/public-api.md` documents Python's `__all__`, not the `window.pjx` client surface, so it wasn't the right spot either.

## Test plan

- [x] New browser-driven test (`tests/pyjinhx/builtins/pjx_chip_input/test_pjx_chip_input_build_chip.py`, same pattern as `test_pjx_popover_position.py`) written first and confirmed to fail (`pjx.buildChip is not a function`) before the implementation change.
- [x] `uv run pytest` — full suite: 3651 passed, 1 skipped, 2 xfailed.
- [x] `uv run ruff format .` — 1 file reformatted (the new test), committed.
- [x] `uv run ruff check --fix .` — all checks passed.

Closes #1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)