### PR TITLE
fix(assets): token inline fragment styles and re-promote after every settle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,18 @@
   inserts it before the first app-owned `<style>` already in `<head>`,
   instead of `appendChild`, so the guarantee holds however the assets arrive
   over a session (#1058).
+- `emit_assets()` inlined `<style>` tags with no `data-pjx-asset` token. For a
+  route returning a component directly as an htmx fragment (the ordinary shape
+  for a poll-and-replace region, `hx-trigger="every ..."` + `hx-swap="outerHTML"`),
+  that style is part of the swapped content and lands wherever the swap lands —
+  and with no token, the client never reported it as loaded (so the server
+  re-sent the full stylesheet on every poll) and `pjx.js`'s relocation/promotion
+  passes couldn't see it to move it to `<head>`, so one orphaned `<style>` node
+  was grafted into the DOM on every poll, forever. Inline CSS now carries the
+  same token the OOB delta uses, and `pjx.js` runs its inline-style promotion
+  pass after every htmx settle instead of only once at init, so a style that
+  lands inside a swapped region is relocated to `<head>` (and deduped against
+  whatever token is already there) before the next swap can delete it (#1057).
 
 ### Behavior change
 - **A bare app selector now always wins a specificity tie against the

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -35,13 +35,21 @@ Assets are collected once per render session. If the same component type is rend
 Rendered output follows this structure:
 
 ```html
-<style>/* component CSS — INLINE mode */</style>
+<style data-pjx-asset="...">/* component CSS — INLINE mode */</style>
 <div id="root-component">...</div>
 <script>/* component JS — INLINE mode */</script>
 ```
 
-- **CSS** is injected **before** the HTML (styles apply immediately)
-- **JS** is injected **after** the HTML (DOM elements exist when scripts run)
+- **CSS** is injected **before** the HTML (styles apply immediately), stamped with a
+  `data-pjx-asset` token — the invariant is that every style pyjinhx puts on a page
+  carries one, and every tokened style ends up in `<head>`. `pjx.js` promotes an
+  inline `<style>` there on load and after every htmx settle, so a style that lands
+  inside a region a later swap replaces survives instead of being deleted with it,
+  and the token also tells the server the browser already has the file (see
+  [Swap-in assets](#swap-in-assets-the-delta)).
+- **JS** is injected **after** the HTML (DOM elements exist when scripts run), untokened —
+  `pjx.js` never relocates a `<script>` node (re-appending one would re-execute it), so
+  a token nobody reads would be dead weight.
 - Nested component assets are aggregated and injected at the root level
 
 ### CSS Ordering Guarantee
@@ -104,7 +112,14 @@ below.
 Full-page renders emit assets once at the layout root. An OOB swap carries markup only — but a region appearing for the first time in this page's life still needs its stylesheet and its script, so the response composer ships the **difference**: the client reports the tokens it already has in `X-PJX-Assets`, `missing_asset_oob()` diffs that against what the walk's candidates require, and the shortfall is appended as head-targeted OOB fragments (`hx-swap-oob="beforeend:head"`, stamped `data-pjx-asset`) that `pjx.js` relocates on arrival. Nothing the client already reports is sent twice.
 
 !!! note "INLINE mode only, today"
-    The delta is built from the session's `css_mode`/`js_mode`, and only `INLINE` is delivered: `compose()` has no URL resolver to hand down, so a `LINK`-mode app ships no swap-in assets and must preload them from the layout shell (see [Layout Preload](#layout-preload-all-components)). `NONE` mode suppresses them as intended. A freshly loaded page also reports an empty token set — `emit_assets()` does not stamp `data-pjx-asset` yet — so it pays one redundant re-delivery on its first reactive response.
+    The delta is built from the session's `css_mode`/`js_mode`, and only `INLINE` is delivered: `compose()` has no URL resolver to hand down, so a `LINK`-mode app ships no swap-in assets and must preload them from the layout shell (see [Layout Preload](#layout-preload-all-components)). `NONE` mode suppresses them as intended.
+
+A component returned directly as an htmx fragment response (rather than nested inside a
+full page) goes through the same `emit_assets()`/`missing_asset_oob()` pair as a full-page
+render — its stylesheet is still tokened, so a poll-and-replace fragment (`hx-trigger="every
+..."`, `hx-swap="outerHTML"`) never grows an unbounded pile of orphaned `<style>` nodes: each
+swap's inline style is promoted to `<head>` on the next settle and deduped against the one
+already there.
 
 ### Client runtime (`pjx.js`)
 

--- a/pyjinhx/assets.py
+++ b/pyjinhx/assets.py
@@ -1,4 +1,13 @@
-"""L2.2 assets — delivery modes, emission, and the manifest of a request's assets."""
+"""L2.2 assets — delivery modes, emission, and the manifest of a request's assets.
+
+Invariant: every style pyjinhx puts on a page carries a ``data-pjx-asset``
+token, and every tokened style ends up in ``<head>``. ``emit_assets()`` stamps
+the token on inline CSS so a style that lands inside a swappable region is
+still visible to ``pjx.js``'s ``pjxLoadedAssets``/``pjxPromoteInlineAssets`` —
+the same token the client already recognized is not paid for twice, and a
+style a swap would otherwise delete is relocated to ``<head>`` before that
+can happen.
+"""
 
 import hashlib
 import os
@@ -27,6 +36,9 @@ def _is_builtin_asset(path: Path) -> bool:
     return path.resolve().is_relative_to(_BUILTIN_ASSET_DIR)
 
 
+BUILTIN_ORIGIN_ATTR = ' data-pjx-origin="builtin"'
+
+
 def _split_by_origin(paths: set[Path]) -> tuple[set[Path], set[Path]]:
     """Partition ``paths`` into (builtin, app) by origin."""
     builtin: set[Path] = set()
@@ -47,14 +59,38 @@ class AssetMode(str, Enum):
     LINK = "link"
 
 
-def _inline_tags(paths: set[Path], open_tag: str, close_tag: str) -> list[str]:
+def _inline_tags(
+    paths: set[Path],
+    open_tag: str,
+    close_tag: str,
+    *,
+    tokened: bool = False,
+    origin_attr: str = "",
+) -> list[str]:
     """Read each path and wrap its contents in the given tag pair, sorted by path.
 
     Sorted because the accumulator stores paths in a set, which has no stable
     iteration order; two renders of the same tree must produce byte-identical
     output. A path that cannot be read raises: an asset silently dropped from
     the page is a styling bug nobody can see in the response.
+
+    Args:
+        tokened: Stamp a ``data-pjx-asset`` attribute on each tag, using the
+            same token ``X-PJX-Assets``/the OOB delta compute. Only CSS asks
+            for this: a script's effect outlives its node, so pjx.js never
+            relocates one, and an untokened script has nothing to gain from
+            carrying an identity nobody reads.
+        origin_attr: Extra markup inserted right after ``data-pjx-asset``, e.g.
+            ``' data-pjx-origin="builtin"'``. An inline style is promoted into
+            ``<head>`` after any settle, so it needs the same origin marker the
+            OOB fragments carry to land ahead of app CSS once there.
     """
+    if tokened:
+        return [
+            f'{open_tag} data-pjx-asset="{asset_token(path)}"{origin_attr}>'
+            f"{path.read_text()}{close_tag}"
+            for path in sorted(paths, key=str)
+        ]
     return [
         f"{open_tag}{path.read_text()}{close_tag}" for path in sorted(paths, key=str)
     ]
@@ -108,7 +144,9 @@ def emit_assets(
     Returns:
         Concatenated CSS tags then JS tags, newline-joined, with the session's
         inline runtime script (if any) leading the JS tags. Empty string when
-        both kinds are NONE or nothing was accumulated.
+        both kinds are NONE or nothing was accumulated. Each inline ``<style>``
+        carries a ``data-pjx-asset`` token; scripts do not, since pjx.js never
+        relocates one and nothing reads the identity.
 
     Raises:
         OSError: If an asset file is missing or unreadable under INLINE mode.
@@ -123,8 +161,14 @@ def emit_assets(
     # reliably beat the builtin it's restyling.
     builtin_css, app_css = _split_by_origin(session.css_assets)
     if session.css_mode is AssetMode.INLINE:
-        tags += _inline_tags(builtin_css, "<style>", "</style>")
-        tags += _inline_tags(app_css, "<style>", "</style>")
+        tags += _inline_tags(
+            builtin_css,
+            "<style",
+            "</style>",
+            tokened=True,
+            origin_attr=BUILTIN_ORIGIN_ATTR,
+        )
+        tags += _inline_tags(app_css, "<style", "</style>", tokened=True)
     elif session.css_mode is AssetMode.LINK:
         css_resolver = _require_resolver(resolver)
         tags += _url_tags(

--- a/pyjinhx/client/pjx.js
+++ b/pyjinhx/client/pjx.js
@@ -65,7 +65,7 @@
   // are single classes on the same element), so whichever lands later in
   // <head> wins the tie -- appendChild alone can't guarantee a bare app
   // selector wins if its builtin counterpart happens to arrive after it.
-  // Builtin styles carry data-pjx-origin="builtin" (server-emitted, #1058);
+  // Builtin styles carry data-pjx-origin="builtin" (server-emitted);
   // inserting one before the first app style already resident keeps builtins
   // ahead of app CSS no matter which one this page saw first.
   function pjxInsertHeadStyle(node) {
@@ -127,10 +127,13 @@
     pjxApplyHeadAssets(xhr && xhr.responseText);
   }
 
-  // A cold render emits <style data-pjx-asset> inline in the body. If that style
-  // sits inside a region that later re-renders, the swap deletes it and the
-  // server -- seeing its token in X-PJX-Assets -- won't resend it, leaving the
-  // content unstyled. <head> is the durable home. Styles only: a <script>'s
+  // A cold render (or a swapped-in fragment) emits <style data-pjx-asset>
+  // inline in the body. If that style sits inside a region that later
+  // re-renders, the swap deletes it and the server -- seeing its token in
+  // X-PJX-Assets -- won't resend it, leaving the content unstyled. <head> is
+  // the durable home, so this also runs after every htmx:afterSettle, not
+  // just at init -- a style arriving inside a swapped region is exactly as
+  // destructible as one from the cold render. Styles only: a <script>'s
   // effect outlives its node, and re-appending it would re-execute it.
   function pjxPromoteInlineAssets() {
     Array.prototype.forEach.call(
@@ -364,4 +367,5 @@
   document.body.addEventListener("htmx:sendError", pjxEndLoading);
   document.body.addEventListener("htmx:abort", pjxEndLoading);
   document.body.addEventListener("htmx:afterSettle", pjxReapplyLoading);
+  document.body.addEventListener("htmx:afterSettle", pjxPromoteInlineAssets);
 })();

--- a/pyjinhx/reactive/assets.py
+++ b/pyjinhx/reactive/assets.py
@@ -18,13 +18,15 @@ from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
 
-from pyjinhx.assets import AssetMode, _sorted_resolved, _split_by_origin, asset_token
+from pyjinhx.assets import (
+    BUILTIN_ORIGIN_ATTR,
+    AssetMode,
+    _sorted_resolved,
+    _split_by_origin,
+    asset_token,
+)
 from pyjinhx.reactive.fanout import FanoutCandidate
 from pyjinhx.session import RenderSession
-
-# TODO: cold renders — emit_assets() does not stamp data-pjx-asset yet, so a
-# freshly loaded page reports an empty token set and pays one redundant
-# re-delivery on its first reactive response.
 
 
 def required_asset_paths(
@@ -155,7 +157,7 @@ def missing_asset_oob(
     # Builtin CSS is stamped data-pjx-origin="builtin" so pjx.js can insert a
     # late-arriving one ahead of app CSS already resident in <head>, instead
     # of appendChild-ing it wherever it happens to land in the document.
-    builtin_origin = ' data-pjx-origin="builtin"'
+    builtin_origin = BUILTIN_ORIGIN_ATTR
     # A resolver-less LINK kind emits nothing rather than raising, unlike
     # emit_assets: a reactive response is a partial update, and taking the whole
     # response down over a missing asset URL would blank a working page.

--- a/tests/examples/test_todo_templates.py
+++ b/tests/examples/test_todo_templates.py
@@ -129,7 +129,7 @@ class TestDesignSystem:
     def test_app_output_inlines_the_stylesheet(self, scope):
         html = render(_app(), scope)
 
-        assert "<style>" in html
+        assert "<style" in html
         assert "--accent" in html
 
     def test_the_palette_is_the_pastel_one(self, scope):

--- a/tests/pyjinhx/client/test_pjx_promote_assets.py
+++ b/tests/pyjinhx/client/test_pjx_promote_assets.py
@@ -60,6 +60,7 @@ def test_promoted_builtin_style_is_inserted_before_resident_app_css(pjx_page):
     )
     assert page.evaluate(HEAD_CSS_ORDER) == ["builtin.css", "app.css"]
 
+
 SWAP_IN_TOKENED_STYLE = """
 () => {
   const region = document.querySelector('[data-pjx-id="badge"]');

--- a/tests/pyjinhx/client/test_pjx_promote_assets.py
+++ b/tests/pyjinhx/client/test_pjx_promote_assets.py
@@ -43,8 +43,8 @@ def test_body_scripts_are_left_alone(pjx_page):
     assert page.evaluate(BODY_TOKENS) == ["card.js"]
 
 
-# --- #1058: a promoted builtin style must not land after app CSS already
-# resident in <head> — same ordering guarantee as the OOB apply path.
+# A promoted builtin style must not land after app CSS already resident in
+# <head> — same ordering guarantee as the OOB apply path.
 
 HEAD_CSS_ORDER = (
     "() => Array.from(document.head.querySelectorAll('style[data-pjx-asset]'))"
@@ -59,3 +59,40 @@ def test_promoted_builtin_style_is_inserted_before_resident_app_css(pjx_page):
         head='<style data-pjx-asset="app.css">.app{padding:8px}</style>',
     )
     assert page.evaluate(HEAD_CSS_ORDER) == ["builtin.css", "app.css"]
+
+SWAP_IN_TOKENED_STYLE = """
+() => {
+  const region = document.querySelector('[data-pjx-id="badge"]');
+  const style = document.createElement('style');
+  style.setAttribute('data-pjx-asset', 'badge.css');
+  style.textContent = '.badge{color:red}';
+  region.after(style);
+  document.body.dispatchEvent(new CustomEvent('htmx:afterSettle', { bubbles: true }));
+}
+"""
+
+
+def test_style_swapped_in_after_init_is_promoted_on_settle(pjx_page):
+    """A tokened style that arrives after init (an htmx fragment swap, not the
+    cold render init already covers) must not wait for the next full load to
+    reach <head> -- pjxPromoteInlineAssets has to run on every settle too."""
+    page = pjx_page('<div data-pjx-id="badge"></div>')
+
+    page.evaluate(SWAP_IN_TOKENED_STYLE)
+
+    assert page.evaluate(HEAD_TOKENS) == ["badge.css"]
+    assert page.evaluate(BODY_TOKENS) == []
+
+
+def test_repeated_swaps_of_the_same_token_never_accumulate_in_the_body(pjx_page):
+    """The polling-fragment case: the same component swaps in on every poll,
+    each time grafting a fresh tokened <style> node into the body. Without a
+    promote pass on every settle these pile up forever instead of being
+    deduped against the copy already in <head>."""
+    page = pjx_page('<div data-pjx-id="badge"></div>')
+
+    for _ in range(5):
+        page.evaluate(SWAP_IN_TOKENED_STYLE)
+
+    assert page.evaluate(HEAD_TOKENS) == ["badge.css"]
+    assert page.evaluate(BODY_TOKENS) == []

--- a/tests/pyjinhx/test_asset_emission.py
+++ b/tests/pyjinhx/test_asset_emission.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from pyjinhx.assets import AssetMode, asset_token
+from pyjinhx.assets import BUILTIN_ORIGIN_ATTR, AssetMode, asset_token
 from pyjinhx.session import RenderSession
 
 _TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
@@ -439,7 +439,7 @@ def test_link_mode_repeated_calls_are_byte_identical(tmp_path):
     assert first.index("/static/q.css") < first.index("/static/a.js")
 
 
-# --- #1058: builtin CSS must emit before app CSS, so a bare app selector wins
+# --- Builtin CSS must emit before app CSS, so a bare app selector wins
 # any specificity tie against a builtin one regardless of accumulation order.
 #
 # The builtin dir is monkeypatched to a subtree that sorts *after* the app
@@ -490,6 +490,28 @@ def test_builtin_css_ordering_holds_with_multiple_paths_on_each_side(
     builtin_index = out.index(".pjx-widget")
     assert builtin_index < out.index(".a {}")
     assert builtin_index < out.index(".z {}")
+
+
+def test_inline_builtin_css_carries_the_origin_marker(tmp_path, monkeypatch):
+    """Emission order alone doesn't survive promotion.
+
+    An inline style is tokened, so pjx.js relocates it into <head> after a
+    settle — and there it is placed by origin, not by the order it was
+    emitted in. Without the marker a builtin style promoted out of a fragment
+    would append after app CSS and lose the tie emission had just won.
+    """
+    builtin_dir = _builtin_dir_under(tmp_path, monkeypatch)
+    builtin_css = builtin_dir / "widget.css"
+    builtin_css.write_text(".pjx-widget {}")
+    app_css = tmp_path / "aaa.css"
+    app_css.write_text(".app-thing {}")
+    session = _session(tmp_path)
+    session.css_assets.update({app_css, builtin_css})
+
+    out = emit_assets(session)
+
+    assert f'data-pjx-asset="{asset_token(builtin_css)}"{BUILTIN_ORIGIN_ATTR}>' in out
+    assert f'data-pjx-asset="{asset_token(app_css)}">' in out
 
 
 def test_emit_assets_puts_runtime_script_before_component_scripts(tmp_path):

--- a/tests/pyjinhx/test_asset_emission.py
+++ b/tests/pyjinhx/test_asset_emission.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from pyjinhx.assets import AssetMode
+from pyjinhx.assets import AssetMode, asset_token
 from pyjinhx.session import RenderSession
 
 _TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
@@ -41,8 +41,36 @@ def test_inline_emits_style_and_script_with_exact_file_contents(tmp_path):
 
     out = emit_assets(session)
 
-    assert "<style>.box { color: red; }</style>" in out
+    token = asset_token(css)
+    assert f'<style data-pjx-asset="{token}">.box {{ color: red; }}</style>' in out
     assert "<script>console.log('box');</script>" in out
+
+
+def test_inline_css_is_tokened_so_a_swapped_style_can_be_relocated(tmp_path):
+    """The token is what makes an inline style visible to pjxLoadedAssets and
+    pjxPromoteInlineAssets on the client — without it a style that lands
+    inside a swapped region is neither reported as loaded nor moved to head."""
+    css = tmp_path / "box.css"
+    css.write_text(".box { color: red; }")
+    session = _session(tmp_path)
+    session.css_assets.add(css)
+
+    out = emit_assets(session)
+
+    assert f'data-pjx-asset="{asset_token(css)}"' in out
+
+
+def test_inline_js_stays_untokened(tmp_path):
+    """Scripts are never relocated by pjx.js (re-appending one re-executes
+    it), so stamping a token nobody reads would be dead weight."""
+    js = tmp_path / "box.js"
+    js.write_text("console.log('box');")
+    session = _session(tmp_path)
+    session.js_assets.add(js)
+
+    out = emit_assets(session)
+
+    assert "data-pjx-asset" not in out
 
 
 def test_none_mode_emits_nothing_for_that_kind(tmp_path):
@@ -71,7 +99,7 @@ def test_mixed_modes_emit_css_only(tmp_path):
 
     out = emit_assets(session)
 
-    assert "<style>" in out
+    assert "<style" in out
     assert "<script>" not in out
 
 
@@ -225,7 +253,8 @@ def test_render_inlines_accumulated_css_and_js(tmp_path):
 
     out = render(EmitBox(), session)
 
-    assert "<style>.box { color: red; }</style>" in out
+    token = asset_token(css)
+    assert f'<style data-pjx-asset="{token}">.box {{ color: red; }}</style>' in out
     assert "<script>console.log('box');</script>" in out
 
 
@@ -553,7 +582,11 @@ def test_nested_render_emits_component_asset_tags_exactly_once(tmp_path):
         session.js_assets.add(js)
         out = _render_parent_with_nested_child(session)
 
-    assert out.count("<style>.nested { color: red; }</style>") == 1
+    token = asset_token(css)
+    assert (
+        out.count(f'<style data-pjx-asset="{token}">.nested {{ color: red; }}</style>')
+        == 1
+    )
     assert out.count("<script>console.log('nested');</script>") == 1
 
 
@@ -567,7 +600,11 @@ def test_single_top_level_render_still_emits_runtime_and_assets(tmp_path):
 
     assert session.runtime_script is not None
     assert out.count(session.runtime_script) == 1
-    assert out.count("<style>.solo { color: blue; }</style>") == 1
+    token = asset_token(css)
+    assert (
+        out.count(f'<style data-pjx-asset="{token}">.solo {{ color: blue; }}</style>')
+        == 1
+    )
 
 
 def test_repeated_independent_top_level_renders_each_emit_assets(tmp_path):
@@ -584,4 +621,10 @@ def test_repeated_independent_top_level_renders_each_emit_assets(tmp_path):
     assert session.runtime_script is not None
     assert first.count(session.runtime_script) == 1
     assert second.count(session.runtime_script) == 1
-    assert second.count("<style>.repeat { color: green; }</style>") == 1
+    token = asset_token(css)
+    assert (
+        second.count(
+            f'<style data-pjx-asset="{token}">.repeat {{ color: green; }}</style>'
+        )
+        == 1
+    )

--- a/tests/pyjinhx/test_concurrency.py
+++ b/tests/pyjinhx/test_concurrency.py
@@ -330,7 +330,7 @@ def test_concurrent_renders_no_filenotfound_races(monkeypatch):
     fail_on_errors(errors)
     assert_no_bleed(observations)
     for observed in observations.values():
-        assert "<style>" in observed.html
+        assert "<style" in observed.html
         assert "<script>" in observed.html
 
 

--- a/tests/pyjinhx/test_gallery_demos.py
+++ b/tests/pyjinhx/test_gallery_demos.py
@@ -63,20 +63,17 @@ def test_every_factory_renders():
         assert isinstance(height, int), name
 
 
-def _descriptor_css_text(cls) -> list[str]:
-    """The on-disk text of every stylesheet the class's descriptor points at."""
-    return [Path(p).read_text() for p in cls.__pjx_descriptor__.css_paths]
-
-
 def test_post_build_inlines_component_css(tmp_path):
+    from pyjinhx.assets import asset_token
     from pyjinhx.builtins.ui.pjx_button import PJXButton
 
     hooks.on_post_build({"site_dir": str(tmp_path)})
     page = (tmp_path / "demos" / "pjx-button.html").read_text()
-    css_texts = _descriptor_css_text(PJXButton)
-    assert css_texts, "PJXButton is expected to carry at least one stylesheet"
-    for text in css_texts:
-        assert f"<style>{text}</style>" in page
+    css_paths = PJXButton.__pjx_descriptor__.css_paths
+    assert css_paths, "PJXButton is expected to carry at least one stylesheet"
+    for p in css_paths:
+        token = asset_token(Path(p))
+        assert f'<style data-pjx-asset="{token}">{Path(p).read_text()}</style>' in page
 
 
 def test_post_build_inlines_component_js(tmp_path):
@@ -98,7 +95,7 @@ def test_multi_component_demo_emits_each_asset_once(tmp_path):
     (css_path,) = PJXSpinner.__pjx_descriptor__.css_paths
     text = Path(css_path).read_text()
     assert page.count(text) == 1  # three spinners, one stylesheet
-    assert page.count("<style>") == len(set(PJXSpinner.__pjx_descriptor__.css_paths))
+    assert page.count("<style ") == len(set(PJXSpinner.__pjx_descriptor__.css_paths))
 
 
 def test_base_css_link_survives_and_output_is_stable(tmp_path):

--- a/tests/pyjinhx/test_gallery_demos.py
+++ b/tests/pyjinhx/test_gallery_demos.py
@@ -64,7 +64,7 @@ def test_every_factory_renders():
 
 
 def test_post_build_inlines_component_css(tmp_path):
-    from pyjinhx.assets import asset_token
+    from pyjinhx.assets import BUILTIN_ORIGIN_ATTR, asset_token
     from pyjinhx.builtins.ui.pjx_button import PJXButton
 
     hooks.on_post_build({"site_dir": str(tmp_path)})
@@ -73,7 +73,10 @@ def test_post_build_inlines_component_css(tmp_path):
     assert css_paths, "PJXButton is expected to carry at least one stylesheet"
     for p in css_paths:
         token = asset_token(Path(p))
-        assert f'<style data-pjx-asset="{token}">{Path(p).read_text()}</style>' in page
+        assert (
+            f'<style data-pjx-asset="{token}"{BUILTIN_ORIGIN_ATTR}>'
+            f"{Path(p).read_text()}</style>" in page
+        )
 
 
 def test_post_build_inlines_component_js(tmp_path):

--- a/tests/pyjinhx/test_render_cache_behavior.py
+++ b/tests/pyjinhx/test_render_cache_behavior.py
@@ -19,6 +19,7 @@ import pytest
 
 from pyjinhx import discovery, rendering
 from pyjinhx._component import BaseComponent, _pascal_to_snake
+from pyjinhx.assets import asset_token
 from pyjinhx.config import configure_pyjinhx, current_settings
 from pyjinhx.descriptor import ClassDescriptor
 from pyjinhx.reactive.backend import InMemoryCacheBackend
@@ -235,9 +236,17 @@ def test_hit_still_emits_css_and_js(spy: SpyBackend, tmp_path: Path):
     assert "SHELLCSS" in cold
     assert "SHELLJS" in cold
     assert warm == cold
-    assert "<style>.shell{color:SHELLCSS}</style>" in warm
+    shell_token = asset_token(shell_css)
+    child_token = asset_token(child_css)
+    assert (
+        f'<style data-pjx-asset="{shell_token}">.shell{{color:SHELLCSS}}</style>'
+        in warm
+    )
     assert "<script>window.SHELLJS=1</script>" in warm
-    assert "<style>.child{color:CHILDCSS}</style>" in warm
+    assert (
+        f'<style data-pjx-asset="{child_token}">.child{{color:CHILDCSS}}</style>'
+        in warm
+    )
     assert "<script>window.CHILDJS=1</script>" in warm
     # The second render really was a hit, so the assertions above are about the
     # replay rather than about a second live render.


### PR DESCRIPTION
## Mechanism

`emit_assets()` inlined `<style>` tags with no `data-pjx-asset` token. For a
route returning a component directly as an htmx fragment (the ordinary shape
for a poll-and-replace region, e.g. `hx-trigger="every 30s"` +
`hx-swap="outerHTML"`), that style is part of the swapped content and lands
wherever the swap lands. Three mechanisms then all declined to clean it up:

- `pjxLoadedAssets()` only reports `[data-pjx-asset]` tokens, so with no token
  the server never learned the client already had the file and re-sent it
  every request.
- `pjxApplyHeadAssets()` only relocates tokened nodes arriving in an OOB
  batch.
- `pjxPromoteInlineAssets()` only promotes `style[data-pjx-asset]`, and ran
  **once**, at init — never again after a swap.

Net effect on a polling fragment: one orphaned `<style>` node grafted into the
DOM per poll, forever, plus the full stylesheet re-sent on every poll.

## Design

Implemented the issue's first two suggested changes:

1. `emit_assets()` now stamps `data-pjx-asset` on inline CSS (`pyjinhx/assets.py`,
   via `_inline_tags`), using the same `asset_token()` the OOB delta already
   computes. This fixes the re-delivery problem directly, and makes every
   inline style visible to the client-side relocation/promotion passes. JS
   stays untokened on purpose — `pjx.js` never relocates a `<script>` node
   (re-appending one would re-execute it), so an identity nobody reads would
   be dead weight.
2. `pjxPromoteInlineAssets()` now runs on every `htmx:afterSettle`, not just
   at init (`pyjinhx/client/pjx.js`). This is what actually stops the DOM
   accumulation: tokening alone isn't enough, because `pjxApplyHeadAssets()`
   only fires when the raw response contains an OOB `beforeend:head` marker,
   which a steady-state poll (nothing missing) never has — so a purely
   tokened style could still ride along on every poll with no promotion path
   until the next full run. Running the promote pass on every settle
   guarantees it always gets relocated to `<head>` (deduped by token) before
   the next swap can delete it.

I did **not** implement the issue's third, explicitly-optional suggestion
("consider not emitting fragment assets inline at all"). Doing so would
require threading a "is this response part of a fan-out?" distinction through
`render()`/`compose()`, since the same `render()` call backs both a standalone
full-page render and a fragment's primary inside `compose()` — a larger,
riskier change for a benefit that's already covered: the client already dedups
by token (both `pjxApplyHeadAssets` and `pjxPromoteInlineAssets` skip a node
whose token is already in `<head>`), so the remaining cost of the current
design is extra response bytes on a request that both inlines an asset *and*
ships it via the OOB delta in the same round trip, not a correctness bug. Left
as a documented follow-up rather than folded into this fix, to keep the
change scoped to the two mechanisms that were actually broken.

## Invariant

Stated in `pyjinhx/assets.py`'s module docstring: every style pyjinhx puts on
a page carries a `data-pjx-asset` token, and every tokened style ends up in
`<head>`. Removed the now-resolved TODO in `pyjinhx/reactive/assets.py`.

## Testing

- New tests in `tests/pyjinhx/test_asset_emission.py` lock the tokening (and
  that scripts stay untokened).
- New Playwright tests in `tests/pyjinhx/client/test_pjx_promote_assets.py`
  simulate a fragment swap injecting a fresh tokened `<style>` node and
  dispatching `htmx:afterSettle`, asserting it's promoted to `<head>` — and,
  repeated 5x, that the body never accumulates duplicate nodes. Verified red
  against the pre-fix `pjx.js` (only the settle wiring reverted), green after.
- Updated existing tests across `test_asset_emission.py`,
  `test_concurrency.py`, `test_gallery_demos.py`, `test_render_cache_behavior.py`,
  and `tests/examples/test_todo_templates.py` that asserted the old untokened
  `<style>` tag shape.

Full suite: `uv run pytest` → 3652 passed, 1 skipped, 1 xfailed, 1 xpassed.
`uv run ruff format .` and `uv run ruff check --fix .` both clean (one file
reformatted, folded into the commit).

Closes #1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)