### PR TITLE
fix(select): portal, panel width match, native events, autofocus, empty-string value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,29 @@
   portalled popover instead of leaving it visually detached from its trigger,
   and closing while the original host has been removed drops the panel
   instead of leaving it dangling on `document.body` (#1053).
+- `PJXSelect` gained a `portal` prop mirroring `PJXTooltip`'s: with
+  `portal=True`, opening reparents the whole root to `document.body` (fixed at
+  its pre-move position, so the trigger doesn't visibly jump) and restores it
+  on close, so an `overflow: hidden`/`auto` ancestor can no longer clip the
+  panel (#1054).
+
+### Fixed
+- The open panel now always matches the trigger's rendered width instead of
+  sizing to its own content, so a stretched (`width: 100%`) select gets a
+  panel the same width as the control it opens from (#1054).
+- `pjx_select.pjx` compared `value` against Jinja truthiness, so `value=""` —
+  a common "all"/"no selection" sentinel — never matched its own option and
+  fell back to the untranslated `placeholder` instead. Selection now compares
+  against `None`, so `""` is a legitimate, matchable value (#1054).
+- `syncNative()` set the hidden native `<select>`'s value via the `.selected`
+  IDL property, which fires no `change`/`input` event, so `hx-trigger="change
+  from:select"` and vanilla listeners went silent. It now dispatches real
+  `change`/`input` events on the hidden `<select>` after resyncing it (#1054).
+- Opening a searchable select (more options than `PJXSelect._FILTER_THRESHOLD`)
+  never focused its filter input, for either a mouse or a keyboard-triggered
+  open. `open()` now focuses the filter when present, and the trigger's own
+  keyboard handler defers to it instead of jumping straight to an option
+  (#1054).
 
 ## 1.9.7 — Tooltip shows inside an open dialog (2026-08-27)
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1873,9 +1873,10 @@ A styled replacement for a bare `<select>`, single-choice or multi. A hidden nat
     | `multiple` | `bool` | `False` | Multi-select: checkbox per row, chip summary on the trigger. |
     | `placeholder` | `str` | `"Select…"` | Trigger text when nothing is selected. |
     | `disabled` | `bool` | `False` | Marks the root, the trigger, the native `<select>`, and the filter input. |
+    | `portal` | `bool` | `False` | Reparent the whole root to `document.body` while open, so an `overflow: hidden`/`auto` ancestor can't clip the panel. |
     | `class_name` | `AttrValue` | `""` | Appended to the root's classes. |
 
-    Panels with more than 8 options render a search input above the list; shorter lists render without one. The input is UI-only — it hides option buttons and never posts.
+    Panels with more than 8 options render a search input above the list; shorter lists render without one. The input is UI-only — it hides option buttons and never posts. Opening focuses that input when present, for both mouse and keyboard opens.
 
 ??? note "Style tokens"
 
@@ -1897,9 +1898,11 @@ A styled replacement for a bare `<select>`, single-choice or multi. A hidden nat
 
 ??? note "DOM & classes"
 
-    Root `[data-pjx-select]`, carrying `data-name`, plus `data-multiple` and `data-placeholder` in multi mode and `data-disabled` when disabled. Trigger: `[data-pjx-select-trigger]` with `aria-haspopup="listbox"` and `aria-expanded` synced by JS. Panel: `[data-pjx-select-panel]` with `role="listbox"`, `hidden` when closed; the JS writes inline `left`/`top` only when the panel would otherwise overflow the viewport (flip/clamp), and removes them on close. Options: `[data-pjx-select-option]` with `data-value`, `role="option"`, and `aria-selected` as the selection state. Filter: `[data-pjx-select-filter]`, presentation-only — it hides option buttons and never changes selection. A hidden native `<select name="…">` inside the root is the form's source of truth and is re-derived from the option buttons on every change; without JS it submits on its own.
+    Root `[data-pjx-select]`, carrying `data-name`, plus `data-multiple` and `data-placeholder` in multi mode, `data-disabled` when disabled, and `data-pjx-select-portal` when `portal=True`. Trigger: `[data-pjx-select-trigger]` with `aria-haspopup="listbox"` and `aria-expanded` synced by JS. Panel: `[data-pjx-select-panel]` with `role="listbox"`, `hidden` when closed; opening always sets its width to match the trigger's rendered width and writes inline `left`/`top` on top of that only when the panel would otherwise overflow the viewport (flip/clamp), removing everything on close. Options: `[data-pjx-select-option]` with `data-value`, `role="option"`, and `aria-selected` as the selection state. Filter: `[data-pjx-select-filter]`, presentation-only — it hides option buttons and never changes selection; opening focuses it when present, from either a mouse or a keyboard open. A hidden native `<select name="…">` inside the root is the form's source of truth and is re-derived from the option buttons on every change, dispatching real `change`/`input` events on itself so `hx-trigger="change from:select"` and vanilla listeners still fire; without JS it submits on its own.
 
-    Keyboard: ArrowDown/ArrowUp/Home/End move focus among options (wrapping); ArrowDown/ArrowUp/Enter/Space on the trigger open the panel and focus an edge option; type-ahead jumps to the next option whose label starts with the typed prefix (case-insensitive, buffer resets after a pause); Enter/Space selects and closes in single mode, toggles and stays open in multi mode; Escape closes and returns focus to the trigger from anywhere inside the root, including the filter input.
+    With `portal=True`, opening reparents the whole root (not just the panel) to `document.body`, fixed at its pre-move screen position so the trigger doesn't visibly jump, and moves it back to its original parent on close — the same escape hatch `PJXTooltip`'s `portal` prop offers for a clipping `overflow: hidden`/`auto` ancestor.
+
+    Keyboard: ArrowDown/ArrowUp/Home/End move focus among options (wrapping); ArrowDown/ArrowUp/Enter/Space on the trigger open the panel and focus the filter input if present, otherwise an edge option; type-ahead jumps to the next option whose label starts with the typed prefix (case-insensitive, buffer resets after a pause); Enter/Space selects and closes in single mode, toggles and stays open in multi mode; Escape closes and returns focus to the trigger from anywhere inside the root, including the filter input.
 
     **Classes:** `pjx-select`, `pjx-select__trigger`, `pjx-select__label`, `pjx-select__chips`, `pjx-select__panel`, `pjx-select__filter`, `pjx-select__option`, `pjx-select__checkbox`. Chips reuse `pjx-chip-input__chip` / `pjx-chip-input__label`.
 

--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.js
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.js
@@ -115,8 +115,48 @@
         };
     }
 
+    // Keyed by root, not panel: the panel is a child of root (unlike the
+    // tooltip's tip, a sibling of its trigger), so moving the whole root
+    // keeps the panel's absolute positioning relative to it intact and
+    // `.closest('[data-pjx-select]')` lookups keep resolving wherever it lands.
+    const portalled = new WeakMap();
+
+    function isPortalled(root) {
+        return root.dataset.pjxSelectPortal !== undefined;
+    }
+
+    function portalRoot(root) {
+        if (!isPortalled(root) || portalled.has(root)) return;
+        const rect = root.getBoundingClientRect();
+        portalled.set(root, { parent: root.parentElement, next: root.nextSibling });
+        // Fixed positioning at the pre-move rect keeps the trigger visually in
+        // place even though it's no longer a descendant of its original,
+        // possibly clipping, ancestor.
+        root.style.position = 'fixed';
+        root.style.left = rect.left + 'px';
+        root.style.top = rect.top + 'px';
+        root.style.width = rect.width + 'px';
+        document.body.appendChild(root);
+    }
+
+    function unportalRoot(root) {
+        const entry = portalled.get(root);
+        if (!entry) return;
+        portalled.delete(root);
+        root.style.position = '';
+        root.style.left = '';
+        root.style.top = '';
+        root.style.width = '';
+        entry.parent.insertBefore(root, entry.next);
+    }
+
     function position(panel, trigger) {
         const t = trigger.getBoundingClientRect();
+        // Stretched triggers (width: 100%) would otherwise leave the panel
+        // sized to its own content instead of matching the control it opens
+        // from; set it before measuring so the flip/clamp math below sees the
+        // width the panel will actually render at.
+        panel.style.width = t.width + 'px';
         const p = panel.getBoundingClientRect();
         const result = pjx.popoverPosition({
             trigger: { top: t.top, left: t.left, width: t.width, height: t.height },
@@ -125,8 +165,10 @@
             align: 'start',
         });
         // A prior open may have left inline coordinates behind; drop them so a
-        // since-fixed layout falls back to the CSS default.
+        // since-fixed layout falls back to the CSS default, then reapply the
+        // width match dropped along with them.
         panel.removeAttribute('style');
+        panel.style.width = t.width + 'px';
         if (result.adjusted !== true) return;
         panel.style.left = result.left + 'px';
         panel.style.top = result.top + 'px';
@@ -135,6 +177,7 @@
     function open(root) {
         const parts = partsOf(root);
         if (!parts.panel || !parts.panel.hidden) return;
+        portalRoot(root);
         parts.panel.hidden = false;
         if (parts.trigger) {
             parts.trigger.setAttribute('aria-expanded', 'true');
@@ -142,6 +185,8 @@
             // same synchronous block, so the unpositioned panel never paints.
             position(parts.panel, parts.trigger);
         }
+        const filter = root.querySelector('[data-pjx-select-filter]');
+        if (filter) filter.focus();
     }
 
     function close(root) {
@@ -157,6 +202,7 @@
             applyFilter(root, '');
         }
         if (parts.trigger) parts.trigger.setAttribute('aria-expanded', 'false');
+        unportalRoot(root);
     }
 
     function isMultiple(root) {
@@ -192,6 +238,11 @@
         Array.prototype.forEach.call(parts.native.options, function (nativeOption) {
             nativeOption.selected = values.indexOf(nativeOption.value) !== -1;
         });
+        // The .selected writes above are silent IDL property sets, unlike a
+        // real user pick, so nothing downstream (hx-trigger="change
+        // from:select", a vanilla change listener) hears about them otherwise.
+        parts.native.dispatchEvent(new Event('input', { bubbles: true }));
+        parts.native.dispatchEvent(new Event('change', { bubbles: true }));
     }
 
     // Mirrors the template's trigger branch: 2+ selections become a chip row,
@@ -360,6 +411,10 @@
         if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             open(root);
+            // A searchable panel already took focus itself (open() focuses
+            // the filter when present); only a plain option list needs the
+            // trigger's own arrow-direction focus here.
+            if (root.querySelector('[data-pjx-select-filter]')) return;
             const options = visibleOptions(root);
             if (!options.length) return;
             options[e.key === 'ArrowUp' ? options.length - 1 : 0].focus();

--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.pjx
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.pjx
@@ -1,6 +1,6 @@
-{% set selected_values = (value or []) if multiple else ([value] if value else []) -%}
+{% set selected_values = (value if value is not none else []) if multiple else ([value] if value is not none else []) -%}
 {% set selected_options = options | selectattr("value", "in", selected_values) | list -%}
-<div id="{{ id }}" class="pjx-select{% if class_name %} {{ class_name }}{% endif %}" data-pjx-select data-name="{{ name }}"{% if multiple %} data-multiple data-placeholder="{{ placeholder }}"{% endif %}{% if disabled %} data-disabled{% endif %}{% for extra_name, extra_value in extra_attrs.items() %} {{ extra_name }}="{{ extra_value }}"{% endfor %}>
+<div id="{{ id }}" class="pjx-select{% if class_name %} {{ class_name }}{% endif %}" data-pjx-select data-name="{{ name }}"{% if multiple %} data-multiple data-placeholder="{{ placeholder }}"{% endif %}{% if disabled %} data-disabled{% endif %}{% if portal %} data-pjx-select-portal{% endif %}{% for extra_name, extra_value in extra_attrs.items() %} {{ extra_name }}="{{ extra_value }}"{% endfor %}>
   <select name="{{ name }}"{% if multiple %} multiple{% endif %} hidden{% if disabled %} disabled{% endif %}>
     {% for option in options %}<option value="{{ option.value }}"{% if option.value in selected_values %} selected{% endif %}>{{ option.label }}</option>
     {% endfor %}

--- a/pyjinhx/builtins/ui/pjx_select/pjx_select.py
+++ b/pyjinhx/builtins/ui/pjx_select/pjx_select.py
@@ -26,6 +26,10 @@ class PJXSelect(BaseComponent):
     Panels holding strictly more than ``_FILTER_THRESHOLD`` options open with a
     search input above the list; shorter lists render without one. The input is
     UI-only — it hides option buttons in the browser and never posts.
+
+    ``portal=True`` reparents the whole root to ``document.body`` while open,
+    the same escape hatch ``PJXTooltip`` offers, so the panel isn't clipped by
+    an ``overflow: hidden``/``auto`` ancestor.
     """
 
     # Below this many options a filter adds more chrome than it saves, so the
@@ -38,6 +42,7 @@ class PJXSelect(BaseComponent):
     multiple: bool = False
     placeholder: str = "Select…"
     disabled: bool = False
+    portal: bool = False
     class_name: AttrValue = ""
     extra_attrs: ExtraAttrs = Field(default_factory=dict)
 

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select.py
@@ -23,6 +23,7 @@ class TestFields:
         assert sel.value is None
         assert sel.placeholder == "Select…"
         assert sel.disabled is False
+        assert sel.portal is False
         assert sel.class_name == ""
 
     def test_name_is_required(self):
@@ -160,3 +161,54 @@ class TestRender:
 
     def test_empty_class_name_adds_nothing(self, session):
         assert 'class="pjx-select"' in _html(session)
+
+    def test_portal_is_off_by_default(self, session):
+        assert "data-pjx-select-portal" not in _html(session)
+
+    def test_portal_true_adds_the_data_attribute(self, session):
+        html = _html(session, portal=True)
+        assert "data-pjx-select-portal" in html[: html.index(">")]
+
+    def test_portal_rejects_a_non_boolean(self):
+        with pytest.raises(ValidationError):
+            PJXSelect(id="s", name="fruit", options=OPTIONS, portal="yes please")  # type: ignore[arg-type]
+
+
+OPTIONS_WITH_BLANK = [
+    SelectOption(value="", label="All fruit"),
+    SelectOption(value="a", label="Apple"),
+]
+
+
+class TestEmptyStringValue:
+    """An <option value=""> sentinel ("all"/"no selection") must match like any other value."""
+
+    def test_empty_string_value_is_marked_selected_on_the_native_select(self, session):
+        html = render(
+            PJXSelect(id="s", name="fruit", options=OPTIONS_WITH_BLANK, value=""),
+            session,
+        )
+        assert '<option value="" selected>' in html
+
+    def test_empty_string_value_shows_its_own_label_not_the_placeholder(self, session):
+        html = render(
+            PJXSelect(
+                id="s",
+                name="fruit",
+                options=OPTIONS_WITH_BLANK,
+                value="",
+                placeholder="Select…",
+            ),
+            session,
+        )
+        trigger = html[html.index("data-pjx-select-trigger") :]
+        assert "All fruit" in trigger[: trigger.index("</button>")]
+        assert "Select…" not in trigger[: trigger.index("</button>")]
+
+    def test_empty_string_value_marks_its_option_row_selected(self, session):
+        html = render(
+            PJXSelect(id="s", name="fruit", options=OPTIONS_WITH_BLANK, value=""),
+            session,
+        )
+        assert 'data-value="" aria-selected="true"' in html
+        assert 'data-value="a" aria-selected="false"' in html

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_collision.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_collision.py
@@ -111,7 +111,16 @@ def _open_at(
     page.set_viewport_size({"width": width, "height": height})
     page.set_content(STYLE + markup.replace("LEFT", str(left)).replace("TOP", str(top)))
     page.add_script_tag(content=CONTROLLER.read_text())
-    page.click("[data-pjx-select-trigger]")
+    # A raw coordinate click, not page.click(): a trigger placed to spill past
+    # the viewport (the whole point of these edge-case tests) would otherwise
+    # have Playwright scroll it into view first, shifting every coordinate in
+    # the test by however much it scrolled.
+    trigger = page.evaluate(
+        "document.querySelector('[data-pjx-select-trigger]').getBoundingClientRect().toJSON()"
+    )
+    page.mouse.click(
+        trigger["left"] + trigger["width"] / 2, trigger["top"] + trigger["height"] / 2
+    )
     return page.evaluate(
         "() => { const r = document.getElementById('panel').getBoundingClientRect();"
         " return {left: r.left, top: r.top, right: r.right, bottom: r.bottom}; }"
@@ -119,12 +128,14 @@ def _open_at(
 
 
 def test_panel_flips_or_clamps_at_right_edge(page: Page):
-    # Trigger at x=250 in a 400px viewport: a 200px panel aligned to the
-    # trigger's left edge would end at 450, so it flips to end alignment.
-    box = _open_at(page, viewport=(400, 400), left=250, top=10)
-    assert page.evaluate("document.getElementById('panel').style.left") == "-100px"
-    assert box["left"] == 150
-    assert box["right"] == 350
+    # The panel now matches the trigger's own width (100px), so start- and
+    # end-aligned x land on the same spot — flipping can't help here. A
+    # trigger at x=320 in a 400px viewport still overflows (420 > 400), so
+    # this exercises the padded clamp instead.
+    box = _open_at(page, viewport=(400, 400), left=320, top=10)
+    assert page.evaluate("document.getElementById('panel').style.left") == "-28px"
+    assert box["left"] == 292
+    assert box["right"] == 392
 
 
 def test_panel_flips_above_at_bottom_edge(page: Page):
@@ -138,24 +149,40 @@ def test_panel_flips_above_at_bottom_edge(page: Page):
 
 
 def test_a_viewport_too_tight_for_the_panel_clamps_within_bounds(page: Page):
-    # 260x220 viewport: the 200x150 panel fits the viewport but not at the
-    # trigger, and neither flip helps (end alignment lands at x=-20, above
-    # lands at y=-54), so only the padded clamp keeps it fully on-screen.
-    box = _open_at(page, viewport=(260, 220), left=80, top=100)
+    # 120x220 viewport: the width-matched 100px panel fits the viewport but
+    # not at the trigger (neither alignment helps, since matching the
+    # trigger's width makes start and end identical), and 150px of panel
+    # height overflows too, so only the padded clamp keeps it fully on-screen.
+    box = _open_at(page, viewport=(120, 220), left=65, top=100)
     assert box["left"] >= 0
     assert box["top"] >= 0
-    assert box["right"] <= 260
+    assert box["right"] <= 120
     assert box["bottom"] <= 220
-    assert (box["left"], box["top"]) == (52, 62)  # clamped to the 8px inset
+    assert (box["left"], box["top"]) == (12, 62)  # clamped to the 8px inset
 
 
-def test_trigger_with_room_on_all_sides_gets_no_inline_styles(page: Page):
-    # With room on every side the primitive lands on the CSS default, so the
-    # controller writes nothing and the panel keeps the stylesheet's geometry.
+def test_trigger_with_room_on_all_sides_only_gets_the_width_match(page: Page):
+    # With room on every side the position primitive lands on the CSS
+    # default, so left/top stay unset — but width always tracks the
+    # trigger (100px per STYLE), regardless of whether placement needed
+    # adjusting.
     _open_at(page, viewport=(1000, 800), left=450, top=385)
     assert (
-        page.evaluate("document.getElementById('panel').getAttribute('style')") is None
+        page.evaluate("document.getElementById('panel').getAttribute('style')")
+        == "width: 100px;"
     )
+
+
+def test_panel_width_matches_the_stretched_trigger(page: Page):
+    # STYLE's panel is 200px by default, wider than the 100px trigger; opened
+    # with plenty of room, it should still shrink to the trigger's own width
+    # rather than keep its own static CSS width.
+    _open_at(page, viewport=(1000, 800), left=100, top=100)
+    assert page.evaluate("document.getElementById('panel').style.width") == "100px"
+    box = page.evaluate(
+        "() => document.getElementById('panel').getBoundingClientRect().toJSON()"
+    )
+    assert box["width"] == 100
 
 
 def test_panel_position_unaffected_in_multiple_mode(page: Page):

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_keyboard.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_keyboard.py
@@ -182,6 +182,14 @@ SINGLE = """
 </div>
 """
 
+# Same options as SINGLE but with no filter box, so opening still lands
+# keyboard focus on the first/last *option* — the pre-autofocus behavior,
+# still correct for panels short enough to skip the search input.
+SINGLE_NO_FILTER = SINGLE.replace(
+    '    <input type="search" class="pjx-select__filter" data-pjx-select-filter placeholder="Search…">\n',
+    "",
+)
+
 MULTIPLE = """
 <div id="root" class="pjx-select" data-pjx-select data-name="fruit" data-multiple
      data-placeholder="Select…">
@@ -235,18 +243,18 @@ class TestArrowNavigationRealDom:
     def test_arrowdown_on_the_trigger_opens_the_panel_and_focuses_the_first_option(
         self, page: Page
     ):
-        _load(page, SINGLE)
+        _load(page, SINGLE_NO_FILTER)
         page.keyboard.press("ArrowDown")
         assert page.evaluate("document.getElementById('panel').hidden") is False
         assert _active_value(page) == "a"
 
     def test_arrowup_on_the_trigger_opens_at_the_last_option(self, page: Page):
-        _load(page, SINGLE)
+        _load(page, SINGLE_NO_FILTER)
         page.keyboard.press("ArrowUp")
         assert _active_value(page) == "c"
 
     def test_arrowdown_moves_focus_forward_and_wraps(self, page: Page):
-        _load(page, SINGLE)
+        _load(page, SINGLE_NO_FILTER)
         page.keyboard.press("ArrowDown")  # opens on "a"
         page.keyboard.press("ArrowDown")  # -> b
         page.keyboard.press("ArrowDown")  # -> c
@@ -254,7 +262,7 @@ class TestArrowNavigationRealDom:
         assert _active_value(page) == "a"
 
     def test_home_and_end_jump_to_the_edges(self, page: Page):
-        _load(page, SINGLE)
+        _load(page, SINGLE_NO_FILTER)
         page.keyboard.press("ArrowDown")  # opens on "a"
         page.keyboard.press("End")
         assert _active_value(page) == "c"
@@ -264,13 +272,13 @@ class TestArrowNavigationRealDom:
 
 class TestTypeAheadRealDom:
     def test_typing_a_letter_jumps_to_the_matching_option(self, page: Page):
-        _load(page, SINGLE)
+        _load(page, SINGLE_NO_FILTER)
         page.keyboard.press("ArrowDown")  # opens on "a" (Apple)
         page.keyboard.press("c")
         assert _active_value(page) == "c"
 
     def test_type_ahead_is_case_insensitive(self, page: Page):
-        _load(page, SINGLE)
+        _load(page, SINGLE_NO_FILTER)
         page.keyboard.press("ArrowDown")
         page.keyboard.press("B")
         assert _active_value(page) == "b"
@@ -278,7 +286,7 @@ class TestTypeAheadRealDom:
     def test_type_ahead_with_no_match_is_a_no_op_and_does_not_throw(self, page: Page):
         errors: list[str] = []
         page.on("pageerror", lambda exc: errors.append(str(exc)))
-        _load(page, SINGLE)
+        _load(page, SINGLE_NO_FILTER)
         page.keyboard.press("ArrowDown")  # opens on "a"
         page.keyboard.press("z")
         assert _active_value(page) == "a"  # focus unchanged
@@ -289,7 +297,7 @@ class TestCommitRealDom:
     def test_enter_selects_the_focused_option_and_closes_in_single_mode(
         self, page: Page
     ):
-        _load(page, SINGLE)
+        _load(page, SINGLE_NO_FILTER)
         page.keyboard.press("ArrowDown")  # opens on "a"
         page.keyboard.press("ArrowDown")  # -> b
         page.keyboard.press("Enter")
@@ -317,6 +325,43 @@ class TestCommitRealDom:
             )
             == "true"
         )
+
+
+class TestFilterAutofocusRealDom:
+    def test_arrowdown_on_the_trigger_focuses_the_filter_when_present(self, page: Page):
+        _load(page, SINGLE)
+        page.keyboard.press("ArrowDown")
+        assert page.evaluate("document.getElementById('panel').hidden") is False
+        assert page.evaluate(
+            "document.activeElement.hasAttribute('data-pjx-select-filter')"
+        )
+
+    def test_arrowup_on_the_trigger_also_focuses_the_filter(self, page: Page):
+        _load(page, SINGLE)
+        page.keyboard.press("ArrowUp")
+        assert page.evaluate(
+            "document.activeElement.hasAttribute('data-pjx-select-filter')"
+        )
+
+    def test_clicking_the_trigger_focuses_the_filter(self, page: Page):
+        _load(page, SINGLE)
+        page.click("[data-pjx-select-trigger]")
+        assert page.evaluate(
+            "document.activeElement.hasAttribute('data-pjx-select-filter')"
+        )
+
+    def test_arrowdown_from_the_filter_still_reaches_the_first_option(self, page: Page):
+        # Filter takes the initial focus, but its own ArrowDown handling
+        # (unchanged by this fix) still hands off into the option list.
+        _load(page, SINGLE)
+        page.keyboard.press("ArrowDown")  # focuses the filter
+        page.keyboard.press("ArrowDown")  # -> first option
+        assert _active_value(page) == "a"
+
+    def test_no_filter_falls_back_to_focusing_the_first_option(self, page: Page):
+        _load(page, SINGLE_NO_FILTER)
+        page.keyboard.press("ArrowDown")
+        assert _active_value(page) == "a"
 
 
 class TestEscapeRealDom:

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_native_events.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_native_events.py
@@ -1,0 +1,127 @@
+"""PJXSelect — syncNative() bridges to real ``change``/``input`` events.
+
+Setting an ``<option>``'s ``.selected`` IDL property, unlike a real user pick,
+fires nothing — so anything downstream that listens for ``change``/``input``
+"from:select" (htmx's ``hx-trigger``, a vanilla listener) needs the hidden
+native ``<select>`` to dispatch those events itself once its options are
+resynced.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+CONTROLLER = (
+    Path(__file__).resolve().parents[4]
+    / "pyjinhx"
+    / "builtins"
+    / "ui"
+    / "pjx_select"
+    / "pjx_select.js"
+)
+
+STYLE = """
+<style>
+  .pjx-select { position: relative; display: inline-block; }
+  .pjx-select__panel[hidden] { display: none !important; }
+</style>
+"""
+
+SINGLE = """
+<div id="root" class="pjx-select" data-pjx-select data-name="fruit">
+  <select name="fruit" hidden>
+    <option value="a">Apple</option>
+    <option value="b">Banana</option>
+  </select>
+  <button type="button" class="pjx-select__trigger" data-pjx-select-trigger
+          aria-haspopup="listbox" aria-expanded="false">
+    <span class="pjx-select__label">Select…</span>
+  </button>
+  <div id="panel" class="pjx-select__panel" data-pjx-select-panel hidden role="listbox">
+    <button type="button" class="pjx-select__option" data-pjx-select-option
+            data-value="a" aria-selected="false" role="option">Apple</button>
+    <button type="button" class="pjx-select__option" data-pjx-select-option
+            data-value="b" aria-selected="false" role="option">Banana</button>
+  </div>
+</div>
+"""
+
+MULTIPLE = """
+<div id="root" class="pjx-select" data-pjx-select data-name="fruit" data-multiple
+     data-placeholder="Select…">
+  <select name="fruit" multiple hidden>
+    <option value="a">Apple</option>
+    <option value="b">Banana</option>
+  </select>
+  <button type="button" class="pjx-select__trigger" data-pjx-select-trigger
+          aria-haspopup="listbox" aria-expanded="false">
+    <span class="pjx-select__label">Select…</span>
+  </button>
+  <div id="panel" class="pjx-select__panel" data-pjx-select-panel hidden role="listbox">
+    <button type="button" class="pjx-select__option" data-pjx-select-option
+            data-value="a" aria-selected="false" role="option">
+      <input type="checkbox" class="pjx-select__checkbox" tabindex="-1" aria-hidden="true">Apple</button>
+    <button type="button" class="pjx-select__option" data-pjx-select-option
+            data-value="b" aria-selected="false" role="option">
+      <input type="checkbox" class="pjx-select__checkbox" tabindex="-1" aria-hidden="true">Banana</button>
+  </div>
+</div>
+"""
+
+
+@pytest.fixture(autouse=True)
+def _require_chromium(request: pytest.FixtureRequest) -> None:
+    if "page" not in set(request.fixturenames):
+        return
+    pytest.importorskip("playwright")
+    browser_type: Any = request.getfixturevalue("browser_type")
+    if not Path(browser_type.executable_path).exists():
+        pytest.skip(
+            "chromium is not installed (run: uv run playwright install chromium)"
+        )
+
+
+def _load(page: Page, markup: str) -> None:
+    page.set_content(STYLE + markup)
+    page.add_script_tag(content=CONTROLLER.read_text())
+    page.evaluate(
+        """
+        () => {
+            window.__events = [];
+            const native = document.querySelector('select');
+            native.addEventListener('input', (e) => window.__events.push('input'));
+            native.addEventListener('change', (e) => window.__events.push('change'));
+        }
+        """
+    )
+
+
+def test_selecting_an_option_dispatches_change_and_input_on_the_native_select(
+    page: Page,
+):
+    _load(page, SINGLE)
+    page.click("[data-pjx-select-trigger]")
+    page.click('[data-pjx-select-option][data-value="b"]')
+    assert page.evaluate("window.__events") == ["input", "change"]
+    assert page.evaluate("document.querySelector('select').value") == "b"
+
+
+def test_toggling_a_checkbox_in_multiple_mode_dispatches_the_events_too(page: Page):
+    _load(page, MULTIPLE)
+    page.click("[data-pjx-select-trigger]")
+    page.click('[data-pjx-select-option][data-value="a"]')
+    assert page.evaluate("window.__events") == ["input", "change"]
+
+
+def test_each_pick_fires_its_own_pair_of_events(page: Page):
+    _load(page, MULTIPLE)
+    page.click("[data-pjx-select-trigger]")
+    page.click('[data-pjx-select-option][data-value="a"]')
+    page.click('[data-pjx-select-option][data-value="b"]')
+    assert page.evaluate("window.__events") == ["input", "change", "input", "change"]

--- a/tests/pyjinhx/builtins/pjx_select/test_pjx_select_portal.py
+++ b/tests/pyjinhx/builtins/pjx_select/test_pjx_select_portal.py
@@ -1,0 +1,136 @@
+"""PJXSelect — ``portal`` reparents the whole root to escape a clipping ancestor.
+
+Unlike PJXTooltip's tip (a sibling of its trigger), the select's panel is a
+*child* of its root, so moving the whole root — not just the panel — keeps
+the panel's absolute positioning relative to it unchanged and every
+``.closest('[data-pjx-select]')`` lookup resolving wherever it lands.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+CONTROLLER = (
+    Path(__file__).resolve().parents[4]
+    / "pyjinhx"
+    / "builtins"
+    / "ui"
+    / "pjx_select"
+    / "pjx_select.js"
+)
+
+STYLE = """
+<style>
+  body { margin: 0; }
+  .pjx-select { position: relative; display: inline-block; }
+  .pjx-select__panel { position: absolute; top: calc(100% + 4px); left: 0; }
+  .pjx-select__panel[hidden] { display: none !important; }
+</style>
+"""
+
+# A narrow, clipping ancestor around the select: the #1054 scenario (a drawer,
+# a scrollable list, a modal) that clips an unportalled panel.
+BOXED = """
+<div id="box" style="position: relative; width: 60px; height: 60px; overflow: hidden;">
+  <div id="root" class="pjx-select" data-pjx-select data-name="fruit" PORTAL>
+    <select name="fruit" hidden>
+      <option value="a">Apple</option>
+      <option value="b">Banana</option>
+    </select>
+    <button type="button" class="pjx-select__trigger" data-pjx-select-trigger
+            aria-haspopup="listbox" aria-expanded="false">
+      <span class="pjx-select__label">Select…</span>
+    </button>
+    <div id="panel" class="pjx-select__panel" data-pjx-select-panel hidden role="listbox">
+      <button type="button" class="pjx-select__option" data-pjx-select-option
+              data-value="a" aria-selected="false" role="option">Apple</button>
+      <button type="button" class="pjx-select__option" data-pjx-select-option
+              data-value="b" aria-selected="false" role="option">Banana</button>
+    </div>
+  </div>
+</div>
+"""
+
+PORTAL = BOXED.replace("PORTAL", "data-pjx-select-portal")
+NO_PORTAL = BOXED.replace(" PORTAL", "")
+
+
+@pytest.fixture(autouse=True)
+def _require_chromium(request: pytest.FixtureRequest) -> None:
+    if "page" not in set(request.fixturenames):
+        return
+    pytest.importorskip("playwright")
+    browser_type: Any = request.getfixturevalue("browser_type")
+    if not Path(browser_type.executable_path).exists():
+        pytest.skip(
+            "chromium is not installed (run: uv run playwright install chromium)"
+        )
+
+
+def _load(page: Page, markup: str) -> None:
+    page.set_content(STYLE + markup)
+    page.add_script_tag(content=CONTROLLER.read_text())
+
+
+def test_without_portal_the_root_stays_put_while_open(page: Page):
+    _load(page, NO_PORTAL)
+    page.click("[data-pjx-select-trigger]")
+    assert page.evaluate(
+        "document.getElementById('root').parentElement === document.getElementById('box')"
+    )
+
+
+def test_portal_reparents_the_whole_root_to_document_body_while_open(page: Page):
+    _load(page, PORTAL)
+    page.click("[data-pjx-select-trigger]")
+    assert page.evaluate(
+        "document.getElementById('root').parentElement === document.body"
+    )
+
+
+def test_portal_restores_the_root_to_its_original_parent_on_close(page: Page):
+    _load(page, PORTAL)
+    page.click("[data-pjx-select-trigger]")
+    page.click("body")  # clicking outside closes the select
+    assert page.evaluate(
+        "document.getElementById('root').parentElement === document.getElementById('box')"
+    )
+
+
+def test_portal_keeps_the_trigger_visually_in_place(page: Page):
+    _load(page, PORTAL)
+    before = page.evaluate(
+        "document.querySelector('[data-pjx-select-trigger]').getBoundingClientRect().toJSON()"
+    )
+    page.click("[data-pjx-select-trigger]")
+    after = page.evaluate(
+        "document.querySelector('[data-pjx-select-trigger]').getBoundingClientRect().toJSON()"
+    )
+    assert after["left"] == before["left"]
+    assert after["top"] == before["top"]
+
+
+def test_clicking_an_option_still_selects_it_after_reparenting(page: Page):
+    # Regression guard for the live-DOM-containment lookups (rootOf/partsOf):
+    # they must still resolve correctly once the root is no longer a
+    # descendant of its original parent.
+    _load(page, PORTAL)
+    page.click("[data-pjx-select-trigger]")
+    page.click('[data-pjx-select-option][data-value="b"]')
+    assert (
+        page.evaluate(
+            "document.querySelector('[data-value=\"b\"]').getAttribute('aria-selected')"
+        )
+        == "true"
+    )
+    assert page.evaluate("document.getElementById('panel').hidden") is True
+    # And it closed back into its original parent, not stranded on body.
+    assert page.evaluate(
+        "document.getElementById('root').parentElement === document.getElementById('box')"
+    )


### PR DESCRIPTION
## Context

Migrating an app off native `<select>` onto `PJXSelect` surfaced five related gaps. All five land here per #1054.

## 1. Portal support

`.pjx-select__panel` is `position: absolute` and never reparented, so it clips inside an `overflow: hidden`/`auto` ancestor (a drawer, a scrollable list, a modal). Added a `portal` prop that mirrors `PJXTooltip`'s `portal="true"` mechanism: opening reparents the whole `[data-pjx-select]` root — not just the panel — to `document.body`, fixed at its pre-move screen position so the trigger doesn't visibly jump, and restores it to its original parent on close.

The whole root moves (rather than just the panel, as the tooltip does with its tip) because the panel is a *child* of root here, unlike the tooltip's tip, which is a sibling of its trigger. Moving the whole root keeps the panel's absolute positioning relative to root intact, and every `.closest('[data-pjx-select]')` lookup in `pjx_select.js` keeps resolving correctly wherever the root lands.

Does not touch any `PJXPopover` files — the sibling `portal` work for popover (#1053) is independent.

## 2. Panel width matches trigger

The open panel is now always sized to the trigger's rendered width (`panel.style.width = trigger rect width`) instead of its own content, computed as part of the existing `position()` flip/clamp logic. A stretched (`width: 100%`) select's panel now stretches to match instead of looking undersized/oversized relative to the control it opens from.

## 3. Empty-string `value` bug

`pjx_select.pjx`'s `{% set selected_values = (value or []) if multiple else ([value] if value else []) %}` treated `value=""` as falsy, so an `<option value="">` sentinel (a common "all"/"no selection" pattern) never matched — the trigger fell back to the untranslated `placeholder` instead of that option's own label. Fixed by comparing against `None` (`value is not none`) instead of truthiness, so `""` is a legitimate, matchable selection.

**Behavior change**: no existing test asserted the old truthiness behavior, so nothing needed updating for correctness — but this is worth flagging since any caller relying on `value=""` silently falling back to the placeholder will now see that option's own label instead.

## 4. Native event bridging

`syncNative()` set the hidden native `<select>`'s value via the `.selected` IDL property on its `<option>`s, which fires no `change`/`input` event — so `hx-trigger="change from:select"` and vanilla `change`/`input` listeners went silent. `syncNative()` now dispatches real `change` and `input` events on the hidden `<select>` after resyncing it.

## 5. Filter autofocus

A searchable select (more options than `_FILTER_THRESHOLD`, which renders `<input data-pjx-select-filter>`) never focused that input on open — `open()` didn't touch it, and `onTriggerKey()` moved focus straight to the first/last option instead. `open()` now focuses the filter when present, for both mouse and keyboard-triggered opens; `onTriggerKey()` defers to it (only falling back to focusing an edge option when there's no filter).

Existing keyboard tests that hard-coded a filter into their fixture but asserted the *old* first/last-option-on-open behavior were updated to use a no-filter fixture for that scenario (still correct — panels short enough to skip the filter). New tests cover the filter getting focus when present, for both trigger keys and a mouse click.

## Testing

- `docs/components.md`: updated Props & API and DOM & classes sections for `PJXSelect`.
- `CHANGELOG.md`: added a `1.9.8` entry (no version bump in `pyproject.toml`, per convention — the bump lands in its own follow-up commit).
- New test files: `test_pjx_select_portal.py`, `test_pjx_select_native_events.py`.
- Updated: `test_pjx_select.py` (portal prop + empty-string value tests), `test_pjx_select_collision.py` (width-match assertions), `test_pjx_select_keyboard.py` (filter-autofocus behavior, no-filter fallback fixture).

```
uv run pytest -q
# 3668 passed, 1 skipped, 1 xfailed, 1 xpassed (known ~12% flaky test, #892; unrelated)

uv run ruff format --check .
# 486 files already formatted

uv run ruff check .
# All checks passed!
```

Closes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)